### PR TITLE
fix: add workflow_call trigger to unit-test.yml

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,6 +11,7 @@ on:
       - main
       - development
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-and-test-v5:


### PR DESCRIPTION
## Summary

- The release workflow calls `unit-test.yml` as a reusable workflow (`uses: ./.github/workflows/unit-test.yml`)
- GitHub requires the callee to declare `workflow_call:` in its `on:` triggers
- Without it the release run fails immediately with "workflow file issue"
- Adds `workflow_call:` to `unit-test.yml`

## Test plan

- [x] CI passes on this PR
- [ ] After merge, re-run release by re-tagging `v0.1.0` (delete + re-push) or pushing `v0.1.0-patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)