### PR TITLE
fix: openssl-legacy-provider for webpack 4 + remove missing environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
         run: npm install --include=dev
       - name: Build release
         run: npm run build:release
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
@@ -82,7 +84,6 @@ jobs:
     name: Publish to VS Marketplace
     needs: package
     runs-on: ubuntu-latest
-    environment: marketplace
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Two fixes for the release workflow:

- **OpenSSL**: Webpack 4 uses MD4 hashing which was removed in OpenSSL 3 (Node 18+). Add `NODE_OPTIONS=--openssl-legacy-provider` to the Build release bundle step.
- **Environment gate**: `environment: marketplace` referenced a GitHub Actions environment that doesn't exist in the repo. Removed — `TFX_PAT` secret is sufficient.

## Test plan

- [x] CI passes on this PR
- [ ] After merge, re-tag `v0.1.0` to re-trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)