### PR TITLE
fix: rename service endpoint types to avoid Marketplace naming conflicts

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV1/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV1/task.json
@@ -101,7 +101,7 @@
         },
         {
             "name": "environmentServiceNameAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "visibleRule": "provider = aws && command != init && command != validate",
@@ -109,7 +109,7 @@
         },
         {
             "name": "environmentServiceNameGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "visibleRule": "provider = gcp && command != init && command != validate",
@@ -166,7 +166,7 @@
         },
         {
             "name": "backendServiceAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "helpMarkDown": "Amazon Web Services connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup an Amazon Web Services service connection using the 'Add' or 'Manage' button.",
@@ -193,7 +193,7 @@
         },
         {
             "name": "backendServiceGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "helpMarkDown": "Google Cloud Platform connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Google Cloud Platform service connection using the 'Add' or 'Manage' button.",

--- a/Tasks/TerraformTask/TerraformTaskV1/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV1/task.loc.json
@@ -102,7 +102,7 @@
     },
     {
       "name": "environmentServiceNameAWS",
-      "type": "connectedService:AWSServiceEndpoint",
+      "type": "connectedService:SBAWSServiceEndpoint",
       "label": "ms-resource:loc.input.label.environmentServiceNameAWS",
       "required": true,
       "visibleRule": "provider = aws && command != init && command != validate",
@@ -110,7 +110,7 @@
     },
     {
       "name": "environmentServiceNameGCP",
-      "type": "connectedService:GoogleCloudServiceEndpoint",
+      "type": "connectedService:SBGoogleCloudServiceEndpoint",
       "label": "ms-resource:loc.input.label.environmentServiceNameGCP",
       "required": true,
       "visibleRule": "provider = gcp && command != init && command != validate",
@@ -167,7 +167,7 @@
     },
     {
       "name": "backendServiceAWS",
-      "type": "connectedService:AWSServiceEndpoint",
+      "type": "connectedService:SBAWSServiceEndpoint",
       "label": "ms-resource:loc.input.label.backendServiceAWS",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.backendServiceAWS",
@@ -194,7 +194,7 @@
     },
     {
       "name": "backendServiceGCP",
-      "type": "connectedService:GoogleCloudServiceEndpoint",
+      "type": "connectedService:SBGoogleCloudServiceEndpoint",
       "label": "ms-resource:loc.input.label.backendServiceGCP",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.backendServiceGCP",

--- a/Tasks/TerraformTask/TerraformTaskV2/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV2/task.json
@@ -101,7 +101,7 @@
         },
         {
             "name": "environmentServiceNameAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "visibleRule": "provider = aws && command != init && command != validate",
@@ -109,7 +109,7 @@
         },
         {
             "name": "environmentServiceNameGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "visibleRule": "provider = gcp && command != init && command != validate",
@@ -166,7 +166,7 @@
         },
         {
             "name": "backendServiceAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "helpMarkDown": "Amazon Web Services connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup an Amazon Web Services service connection using the 'Add' or 'Manage' button.",
@@ -193,7 +193,7 @@
         },
         {
             "name": "backendServiceGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "helpMarkDown": "Google Cloud Platform connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Google Cloud Platform service connection using the 'Add' or 'Manage' button.",

--- a/Tasks/TerraformTask/TerraformTaskV2/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV2/task.loc.json
@@ -102,7 +102,7 @@
     },
     {
       "name": "environmentServiceNameAWS",
-      "type": "connectedService:AWSServiceEndpoint",
+      "type": "connectedService:SBAWSServiceEndpoint",
       "label": "ms-resource:loc.input.label.environmentServiceNameAWS",
       "required": true,
       "visibleRule": "provider = aws && command != init && command != validate",
@@ -110,7 +110,7 @@
     },
     {
       "name": "environmentServiceNameGCP",
-      "type": "connectedService:GoogleCloudServiceEndpoint",
+      "type": "connectedService:SBGoogleCloudServiceEndpoint",
       "label": "ms-resource:loc.input.label.environmentServiceNameGCP",
       "required": true,
       "visibleRule": "provider = gcp && command != init && command != validate",
@@ -167,7 +167,7 @@
     },
     {
       "name": "backendServiceAWS",
-      "type": "connectedService:AWSServiceEndpoint",
+      "type": "connectedService:SBAWSServiceEndpoint",
       "label": "ms-resource:loc.input.label.backendServiceAWS",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.backendServiceAWS",
@@ -194,7 +194,7 @@
     },
     {
       "name": "backendServiceGCP",
-      "type": "connectedService:GoogleCloudServiceEndpoint",
+      "type": "connectedService:SBGoogleCloudServiceEndpoint",
       "label": "ms-resource:loc.input.label.backendServiceGCP",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.backendServiceGCP",

--- a/Tasks/TerraformTask/TerraformTaskV3/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV3/task.json
@@ -146,7 +146,7 @@
         },
         {
             "name": "environmentServiceNameAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "visibleRule": "provider = aws && command != init && command != validate",
@@ -154,7 +154,7 @@
         },
         {
             "name": "environmentServiceNameGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "visibleRule": "provider = gcp && command != init && command != validate",
@@ -211,7 +211,7 @@
         },
         {
             "name": "backendServiceAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "helpMarkDown": "Amazon Web Services connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup an Amazon Web Services service connection using the 'Add' or 'Manage' button.",
@@ -238,7 +238,7 @@
         },
         {
             "name": "backendServiceGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "helpMarkDown": "Google Cloud Platform connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Google Cloud Platform service connection using the 'Add' or 'Manage' button.",

--- a/Tasks/TerraformTask/TerraformTaskV3/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV3/task.loc.json
@@ -148,7 +148,7 @@
     },
     {
       "name": "environmentServiceNameAWS",
-      "type": "connectedService:AWSServiceEndpoint",
+      "type": "connectedService:SBAWSServiceEndpoint",
       "label": "ms-resource:loc.input.label.environmentServiceNameAWS",
       "required": true,
       "visibleRule": "provider = aws && command != init && command != validate",
@@ -156,7 +156,7 @@
     },
     {
       "name": "environmentServiceNameGCP",
-      "type": "connectedService:GoogleCloudServiceEndpoint",
+      "type": "connectedService:SBGoogleCloudServiceEndpoint",
       "label": "ms-resource:loc.input.label.environmentServiceNameGCP",
       "required": true,
       "visibleRule": "provider = gcp && command != init && command != validate",
@@ -213,7 +213,7 @@
     },
     {
       "name": "backendServiceAWS",
-      "type": "connectedService:AWSServiceEndpoint",
+      "type": "connectedService:SBAWSServiceEndpoint",
       "label": "ms-resource:loc.input.label.backendServiceAWS",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.backendServiceAWS",
@@ -240,7 +240,7 @@
     },
     {
       "name": "backendServiceGCP",
-      "type": "connectedService:GoogleCloudServiceEndpoint",
+      "type": "connectedService:SBGoogleCloudServiceEndpoint",
       "label": "ms-resource:loc.input.label.backendServiceGCP",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.backendServiceGCP",

--- a/Tasks/TerraformTask/TerraformTaskV4/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV4/task.json
@@ -168,7 +168,7 @@
         },
         {
             "name": "environmentServiceNameAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "visibleRule": "provider = aws && command != init && command != validate",
@@ -176,7 +176,7 @@
         },
         {
             "name": "environmentServiceNameGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "visibleRule": "provider = gcp && command != init && command != validate",
@@ -184,7 +184,7 @@
         },
         {
             "name": "environmentServiceNameOCI",
-            "type": "connectedService:OracleCloudInfrastructureServiceEndpoint",
+            "type": "connectedService:SBOCIServiceEndpoint",
 
             "label": "Oracle Cloud Platform connection",
             "required": true,
@@ -262,7 +262,7 @@
         },
         {
             "name": "backendServiceAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "helpMarkDown": "Amazon Web Services connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup an Amazon Web Services service connection using the 'Add' or 'Manage' button.",
@@ -289,7 +289,7 @@
         },
         {
             "name": "backendServiceGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "helpMarkDown": "Google Cloud Platform connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Google Cloud Platform service connection using the 'Add' or 'Manage' button.",
@@ -316,7 +316,7 @@
         },
         {
             "name": "backendServiceOCI",
-            "type": "connectedService:OracleCloudInfrastructureServiceEndpoint",
+            "type": "connectedService:SBOCIServiceEndpoint",
             "label": "Oracle Cloud Infrastructure connection",
             "required": true,
             "helpMarkDown": "Oracle Cloud Infrastructure connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Oracle Cloud Platform service connection using the 'Add' or 'Manage' button.",

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -289,7 +289,7 @@
         },
         {
             "name": "environmentServiceNameAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "visibleRule": "provider = aws && command != init && command != validate && command != workspace && command != state && command != fmt && command != get",
@@ -338,7 +338,7 @@
         },
         {
             "name": "environmentServiceNameGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "visibleRule": "provider = gcp && command != init && command != validate && command != workspace && command != state && command != fmt && command != get",
@@ -394,7 +394,7 @@
         },
         {
             "name": "environmentServiceNameOCI",
-            "type": "connectedService:OracleCloudInfrastructureServiceEndpoint",
+            "type": "connectedService:SBOCIServiceEndpoint",
             "label": "Oracle Cloud Platform connection",
             "required": true,
             "visibleRule": "provider = oci && command != init && command != validate && command != workspace && command != state && command != fmt && command != get",
@@ -486,7 +486,7 @@
         },
         {
             "name": "backendServiceAWS",
-            "type": "connectedService:AWSServiceEndpoint",
+            "type": "connectedService:SBAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
             "helpMarkDown": "Amazon Web Services connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup an Amazon Web Services service connection using the 'Add' or 'Manage' button.",
@@ -513,7 +513,7 @@
         },
         {
             "name": "backendServiceGCP",
-            "type": "connectedService:GoogleCloudServiceEndpoint",
+            "type": "connectedService:SBGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
             "helpMarkDown": "Google Cloud Platform connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Google Cloud Platform service connection using the 'Add' or 'Manage' button.",
@@ -556,7 +556,7 @@
         },
         {
             "name": "backendServiceOCI",
-            "type": "connectedService:OracleCloudInfrastructureServiceEndpoint",
+            "type": "connectedService:SBOCIServiceEndpoint",
             "label": "Oracle Cloud Infrastructure connection",
             "required": true,
             "helpMarkDown": "Oracle Cloud Infrastructure connection for the terraform backend configuration.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Oracle Cloud Platform service connection using the 'Add' or 'Manage' button.",

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -138,7 +138,7 @@
                 "ms.vss-endpoint.endpoint-types"
             ],
             "properties": {
-                "name": "AWSServiceEndpoint",
+                "name": "SBAWSServiceEndpoint",
                 "displayName": "AWS for Terraform",
                 "url": {
                     "displayName": "Server Url",
@@ -218,7 +218,7 @@
                 "ms.vss-endpoint.endpoint-types"
             ],
             "properties": {
-                "name": "GoogleCloudServiceEndpoint",
+                "name": "SBGoogleCloudServiceEndpoint",
                 "displayName": "GCP for Terraform",
                 "helpMarkDown": "[Get JSON Key File](https://console.cloud.google.com/iam-admin/serviceaccounts)",
                 "url": {
@@ -288,7 +288,7 @@
                 "ms.vss-endpoint.endpoint-types"
             ],
             "properties": {
-                "name": "OracleCloudInfrastructureServiceEndpoint",
+                "name": "SBOCIServiceEndpoint",
                 "displayName": "OCI for Terraform",
                 "helpMarkDown": "",
                 "url": {


### PR DESCRIPTION
## Summary

VS Marketplace requires globally unique service endpoint type names across all publishers. The upstream `ms-devlabs.custom-terraform-tasks` extension already claims `AWSServiceEndpoint`, `GoogleCloudServiceEndpoint`, and `OracleCloudInfrastructureServiceEndpoint`.

Renamed to unique names throughout all task versions (V1–V5) and the extension manifest:

| Old name | New name |
|---|---|
| `AWSServiceEndpoint` | `SBAWSServiceEndpoint` |
| `GoogleCloudServiceEndpoint` | `SBGoogleCloudServiceEndpoint` |
| `OracleCloudInfrastructureServiceEndpoint` | `SBOCIServiceEndpoint` |

## Test plan

- [x] CI passes on this PR
- [ ] After merge, re-tag `v0.1.0` to trigger release — publish should succeed this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)