### PR TITLE
fix: bump to v0.1.1 — unique endpoint names and release workflow fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
+## [0.1.1] - 2026-03-07
+
+### Fixed
+
+- Renamed service endpoint contribution types to be globally unique in the VS Marketplace (`SBAWSServiceEndpoint`, `SBGoogleCloudServiceEndpoint`, `SBOCIServiceEndpoint`) — the original names were already claimed by the upstream `ms-devlabs` extension
+- Added `workflow_call:` trigger to CI workflow so the release workflow can call it as a reusable workflow
+- Added `NODE_OPTIONS=--openssl-legacy-provider` to release build step for webpack 4 compatibility with Node 18 OpenSSL 3
+- Removed nonexistent `marketplace` environment gate from release workflow
+
+---
+
 ## [0.1.0] - 2026-03-06
 
 First published release of the `sethbacon.pipeline-tasks-terraform` fork.

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "sethbacon",
     "targets": [
         {


### PR DESCRIPTION
## Summary

v0.1.0 hit three issues during release. All three were fixed via hotfix PRs (#2, #3, #4). This PR bumps to v0.1.1 so the extension can be published fresh without conflicting with any partially-created v0.1.0 state in the Marketplace.

### Changes

- `azure-devops-extension.json`: version `0.1.0` → `0.1.1`
- `CHANGELOG.md`: added `[0.1.1]` entry documenting the release fixes

## Test plan

- [x] CI passes on this PR
- [ ] After merge, tag `v0.1.1` → release workflow publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)