### PR TITLE
fix: bump to v0.1.2 — visibleRule syntax fix for Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-03-07
+
+### Fixed
+
+- Simplified  expressions in  to use only supported syntax (no  or parentheses — Marketplace validator requires  /  and  chains only)
+
 ---
 
 ## [0.1.1] - 2026-03-07

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "publisher": "sethbacon",
     "targets": [
         {


### PR DESCRIPTION
## Summary

Bumps extension version from 0.1.1 to 0.1.2. The previous 0.1.1 is now in the Marketplace (failed validation due to visibleRule syntax, but the extension record exists). Publishing 0.1.2 updates it cleanly.

## Test plan

- [x] CI passes
- [ ] After merge, tag v0.1.2 → release

🤖 Generated with [Claude Code](https://claude.com/claude-code)