### PR TITLE
fix: assign unique task IDs to avoid Marketplace conflicts

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "a4789e5d-f6e8-431f-add9-379d640a883c",
+    "id": "310afe61-60d3-49bd-b4b8-7abb989a38fc",
     "name": "TerraformInstaller",
     "friendlyName": "Terraform tool installer",
     "description": "Find in cache or download a specific version of Terraform and prepend it to the PATH",

--- a/Tasks/TerraformTask/TerraformTaskV1/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV1/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "FE504ACC-6115-40CB-89FF-191386B5E7BF",
+    "id": "981E87CD-B686-4A9E-B09E-B4AFDEDF126B",
     "name": "TerraformTaskV1",
     "friendlyName": "Terraform",
     "description": "Execute terraform commands to manage resources on AzureRM, Amazon Web Services(AWS) and Google Cloud Platform(GCP)",

--- a/Tasks/TerraformTask/TerraformTaskV2/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV2/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "FE504ACC-6115-40CB-89FF-191386B5E7BF",
+    "id": "981E87CD-B686-4A9E-B09E-B4AFDEDF126B",
     "name": "TerraformTaskV2",
     "friendlyName": "Terraform",
     "description": "Execute terraform commands to manage resources on AzureRM, Amazon Web Services(AWS) and Google Cloud Platform(GCP)",

--- a/Tasks/TerraformTask/TerraformTaskV3/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV3/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "FE504ACC-6115-40CB-89FF-191386B5E7BF",
+    "id": "981E87CD-B686-4A9E-B09E-B4AFDEDF126B",
     "name": "TerraformTaskV3",
     "friendlyName": "Terraform",
     "description": "Execute terraform commands to manage resources on AzureRM, Amazon Web Services(AWS) and Google Cloud Platform(GCP)",

--- a/Tasks/TerraformTask/TerraformTaskV4/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV4/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "FE504ACC-6115-40CB-89FF-191386B5E7BF",
+    "id": "981E87CD-B686-4A9E-B09E-B4AFDEDF126B",
     "name": "TerraformTaskV4",
     "friendlyName": "Terraform",
     "description": "Execute terraform commands to manage resources on AzureRM, Amazon Web Services(AWS), Google Cloud Platform(GCP) and Oracle Cloud Infrastructure(OCI). v4.241.11",

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "FE504ACC-6115-40CB-89FF-191386B5E7BF",
+    "id": "981E87CD-B686-4A9E-B09E-B4AFDEDF126B",
     "name": "TerraformTask",
     "friendlyName": "Terraform",
     "description": "Execute terraform commands to manage resources on Microsoft Azure, Amazon Web Services(AWS), Google Cloud Platform(GCP) and Oracle Cloud Infrastructure(OCI).",


### PR DESCRIPTION
## Summary

Marketplace validation rejected the extension because both task IDs were already claimed by `ms-devlabs.custom-terraform-tasks`.

| Task | Old ID (ms-devlabs) | New ID |
|---|---|---|
| TerraformTask (V1–V5) | `FE504ACC-6115-40CB-89FF-191386B5E7BF` | `981E87CD-B686-4A9E-B09E-B4AFDEDF126B` |
| TerraformInstallerV1 | `a4789e5d-f6e8-431f-add9-379d640a883c` | `310afe61-60d3-49bd-b4b8-7abb989a38fc` |

All V1–V5 of TerraformTask share the same new ID (ADO uses the shared ID to group task versions).

## Test plan

- [x] CI passes
- [ ] After merge, move v0.1.0 tag to new HEAD and trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)