### PR TITLE
chore: bump to v0.1.1

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "sethbacon",
     "targets": [
         {


### PR DESCRIPTION
v0.1.0 was registered in the Marketplace by a prior (failed) publish attempt. Bumping to 0.1.1 to get past the version-must-increase check.