### PR TITLE
fix: align InstallerV0 task ID with InstallerV1

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV0/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV0/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "a4789e5d-f6e8-431f-add9-379d640a883c",
+    "id": "310afe61-60d3-49bd-b4b8-7abb989a38fc",
     "name": "TerraformInstaller",
     "friendlyName": "Terraform tool installer",
     "description": "Find in cache or download a specific version of Terraform and prepend it to the PATH",


### PR DESCRIPTION
Marketplace requires all versions of a task contribution to share the same task ID. V0 still had the upstream ms-devlabs ID; updated to match V1's new unique ID \.