### PR TITLE
chore: bump extension to v0.1.2

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "publisher": "sethbacon",
     "targets": [
         {


### PR DESCRIPTION
0.1.1 was registered by the prior failed publish; bumping to 0.1.2.