### PR TITLE
fix: add skipLibCheck to InstallerV0 tsconfig

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV0/tsconfig.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV0/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES6",
-        "module": "commonjs"
+        "module": "commonjs",
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
## Summary

- Add `skipLibCheck: true` to InstallerV0's tsconfig.json
- The release build globbing picks up all task tsconfigs, and InstallerV0's old `@types/node` is incompatible with TypeScript 5
- All other legacy tasks (V1-V4) already had `skipLibCheck: true`