### PR TITLE
chore: bump extension version to 0.3.0

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "0.2.3",
+    "version": "0.3.0",
     "publisher": "sethbacon",
     "targets": [
         {


### PR DESCRIPTION
Bump azure-devops-extension.json version from 0.2.3 to 0.3.0 for marketplace publishing.