### PR TITLE
test: add 15 new test cases for expanded coverage

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
@@ -1,0 +1,42 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AWSApplyWIFSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+tr.setInput('environmentAuthSchemeAWS', 'WorkloadIdentityFederation');
+tr.setInput('awsRoleArn', 'arn:aws:iam::123456789012:role/MyTerraformRole');
+tr.setInput('awsRegion', 'us-east-1');
+tr.setInput('awsSessionName', 'AzureDevOps-Terraform');
+
+tr.registerMock('./id-token-generator', {
+    generateIdToken: (serviceConnectionId: string) => {
+        return Promise.resolve('mock-oidc-token-12345');
+    }
+});
+
+tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider aws"
+        },
+        "terraform apply -auto-approve": {
+            "code": 0,
+            "stdout": "Apply complete!"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAWS } from './../../../src/aws-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAWS = new TerraformCommandHandlerAWS();
+
+export async function run() {
+    try {
+        const response = await handler.apply();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'AWSApplyWIFSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'AWSApplyWIFSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error: any) {
+        tl.setResult(tl.TaskResult.Failed, 'AWSApplyWIFSuccessL0 should have succeeded but failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
@@ -1,0 +1,43 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './GCPApplyWIFSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'gcp');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameGCP', 'GCP');
+tr.setInput('environmentAuthSchemeGCP', 'WorkloadIdentityFederation');
+tr.setInput('gcpProjectNumber', '123456789012');
+tr.setInput('gcpWorkloadIdentityPoolId', 'my-wif-pool');
+tr.setInput('gcpWorkloadIdentityProviderId', 'my-oidc-provider');
+tr.setInput('gcpServiceAccountEmail', 'terraform@my-project.iam.gserviceaccount.com');
+
+tr.registerMock('./id-token-generator', {
+    generateIdToken: (serviceConnectionId: string) => {
+        return Promise.resolve('mock-oidc-token-12345');
+    }
+});
+
+tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider google"
+        },
+        "terraform apply -auto-approve": {
+            "code": 0,
+            "stdout": "Apply complete!"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerGCP } from './../../../src/gcp-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerGCP = new TerraformCommandHandlerGCP();
+
+export async function run() {
+    try {
+        const response = await handler.apply();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'GCPApplyWIFSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'GCPApplyWIFSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error: any) {
+        tl.setResult(tl.TaskResult.Failed, 'GCPApplyWIFSuccessL0 should have succeeded but failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
@@ -1,0 +1,42 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AWSDestroyWIFSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'destroy');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+tr.setInput('environmentAuthSchemeAWS', 'WorkloadIdentityFederation');
+tr.setInput('awsRoleArn', 'arn:aws:iam::123456789012:role/MyTerraformRole');
+tr.setInput('awsRegion', 'us-east-1');
+tr.setInput('awsSessionName', 'AzureDevOps-Terraform');
+
+tr.registerMock('./id-token-generator', {
+    generateIdToken: (serviceConnectionId: string) => {
+        return Promise.resolve('mock-oidc-token-12345');
+    }
+});
+
+tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider aws"
+        },
+        "terraform destroy -auto-approve": {
+            "code": 0,
+            "stdout": "Destroy complete!"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAWS } from './../../../src/aws-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAWS = new TerraformCommandHandlerAWS();
+
+export async function run() {
+    try {
+        const response = await handler.destroy();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'AWSDestroyWIFSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'AWSDestroyWIFSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error: any) {
+        tl.setResult(tl.TaskResult.Failed, 'AWSDestroyWIFSuccessL0 should have succeeded but failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
@@ -1,0 +1,43 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './GCPDestroyWIFSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'gcp');
+tr.setInput('command', 'destroy');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameGCP', 'GCP');
+tr.setInput('environmentAuthSchemeGCP', 'WorkloadIdentityFederation');
+tr.setInput('gcpProjectNumber', '123456789012');
+tr.setInput('gcpWorkloadIdentityPoolId', 'my-wif-pool');
+tr.setInput('gcpWorkloadIdentityProviderId', 'my-oidc-provider');
+tr.setInput('gcpServiceAccountEmail', 'terraform@my-project.iam.gserviceaccount.com');
+
+tr.registerMock('./id-token-generator', {
+    generateIdToken: (serviceConnectionId: string) => {
+        return Promise.resolve('mock-oidc-token-12345');
+    }
+});
+
+tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider google"
+        },
+        "terraform destroy -auto-approve": {
+            "code": 0,
+            "stdout": "Destroy complete!"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerGCP } from './../../../src/gcp-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerGCP = new TerraformCommandHandlerGCP();
+
+export async function run() {
+    try {
+        const response = await handler.destroy();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'GCPDestroyWIFSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'GCPDestroyWIFSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error: any) {
+        tl.setResult(tl.TaskResult.Failed, 'GCPDestroyWIFSuccessL0 should have succeeded but failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -1284,6 +1284,51 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    it('workspace new should succeed', async () => {
+        let tp = path.join(__dirname, './WorkspaceTests/WorkspaceNewSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 0, 'should have no warnings');
+            assert(tr.stdOutContained('WorkspaceNewSuccessL0 should have succeeded.'), 'Should have printed: WorkspaceNewSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('workspace delete should succeed', async () => {
+        let tp = path.join(__dirname, './WorkspaceTests/WorkspaceDeleteSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 0, 'should have no warnings');
+            assert(tr.stdOutContained('WorkspaceDeleteSuccessL0 should have succeeded.'), 'Should have printed: WorkspaceDeleteSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('workspace show should succeed', async () => {
+        let tp = path.join(__dirname, './WorkspaceTests/WorkspaceShowSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 0, 'should have no warnings');
+            assert(tr.stdOutContained('WorkspaceShowSuccessL0 should have succeeded.'), 'Should have printed: WorkspaceShowSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
     /* terraform state tests */
 
     it('state list should succeed', async () => {
@@ -1312,6 +1357,66 @@ describe('Terraform Test Suite', function () {
             assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.warningIssues.length >= 1, 'should have at least one warning');
+        }, tr);
+    });
+
+    it('state show should succeed', async () => {
+        let tp = path.join(__dirname, './StateTests/StateShowSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 0, 'should have no warnings');
+            assert(tr.stdOutContained('StateShowSuccessL0 should have succeeded.'), 'Should have printed: StateShowSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('state mv should succeed', async () => {
+        let tp = path.join(__dirname, './StateTests/StateMvSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 0, 'should have no warnings');
+            assert(tr.stdOutContained('StateMvSuccessL0 should have succeeded.'), 'Should have printed: StateMvSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('state rm should succeed', async () => {
+        let tp = path.join(__dirname, './StateTests/StateRmSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 0, 'should have no warnings');
+            assert(tr.stdOutContained('StateRmSuccessL0 should have succeeded.'), 'Should have printed: StateRmSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('state pull should succeed', async () => {
+        let tp = path.join(__dirname, './StateTests/StatePullSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 0, 'should have no warnings');
+            assert(tr.stdOutContained('StatePullSuccessL0 should have succeeded.'), 'Should have printed: StatePullSuccessL0 should have succeeded.');
         }, tr);
     });
 
@@ -1467,6 +1572,66 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    /* aws/gcp workload identity federation apply tests */
+
+    it('aws apply should succeed with workload identity federation', async () => {
+        let tp = path.join(__dirname, './ApplyTests/AWS/AWSApplyWIFSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AWSApplyWIFSuccessL0 should have succeeded.'), 'Should have printed: AWSApplyWIFSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('gcp apply should succeed with workload identity federation', async () => {
+        let tp = path.join(__dirname, './ApplyTests/GCP/GCPApplyWIFSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('GCPApplyWIFSuccessL0 should have succeeded.'), 'Should have printed: GCPApplyWIFSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    /* aws/gcp workload identity federation destroy tests */
+
+    it('aws destroy should succeed with workload identity federation', async () => {
+        let tp = path.join(__dirname, './DestroyTests/AWS/AWSDestroyWIFSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AWSDestroyWIFSuccessL0 should have succeeded.'), 'Should have printed: AWSDestroyWIFSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('gcp destroy should succeed with workload identity federation', async () => {
+        let tp = path.join(__dirname, './DestroyTests/GCP/GCPDestroyWIFSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('GCPDestroyWIFSuccessL0 should have succeeded.'), 'Should have printed: GCPDestroyWIFSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
     /* terraform show tests */
 
     it('azure show to console should succeed', async () => {
@@ -1497,6 +1662,34 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    it('aws show to console should succeed', async () => {
+        let tp = path.join(__dirname, './ShowTests/AWSShowConsoleSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AWSShowConsoleSuccessL0 should have succeeded.'), 'Should have printed: AWSShowConsoleSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('gcp show to console should succeed', async () => {
+        let tp = path.join(__dirname, './ShowTests/GCPShowConsoleSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('GCPShowConsoleSuccessL0 should have succeeded.'), 'Should have printed: GCPShowConsoleSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
     /* terraform output tests */
 
     it('azure output should succeed', async () => {
@@ -1510,6 +1703,34 @@ describe('Terraform Test Suite', function () {
             assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.stdOutContained('AzureOutputSuccessL0 should have succeeded.'), 'Should have printed: AzureOutputSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('aws output should succeed', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AWSOutputSuccessL0 should have succeeded.'), 'Should have printed: AWSOutputSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('gcp output should succeed', async () => {
+        let tp = path.join(__dirname, './OutputTests/GCPOutputSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('GCPOutputSuccessL0 should have succeeded.'), 'Should have printed: GCPOutputSuccessL0 should have succeeded.');
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSuccess.ts
@@ -1,0 +1,31 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AWSOutputSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"test_output\": { \"value\": \"hello\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAWS = new TerraformCommandHandlerAWS();
+
+export async function run() {
+    try {
+        const response = await handler.output();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'AWSOutputSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'AWSOutputSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'AWSOutputSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/GCPOutputSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/GCPOutputSuccess.ts
@@ -1,0 +1,33 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './GCPOutputSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'gcp');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameGCP', 'GCP');
+
+process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
+process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'test-project';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'test@test.iam.gserviceaccount.com';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'https://oauth2.googleapis.com/token';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'test-private-key';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'https://www.googleapis.com/auth/cloud-platform';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"test_output\": { \"value\": \"hello\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/GCPOutputSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/GCPOutputSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerGCP } from './../../src/gcp-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerGCP = new TerraformCommandHandlerGCP();
+
+export async function run() {
+    try {
+        const response = await handler.output();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'GCPOutputSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'GCPOutputSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'GCPOutputSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowConsoleSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowConsoleSuccess.ts
@@ -1,0 +1,33 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AWSShowConsoleSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'show');
+tr.setInput('outputTo', 'console');
+tr.setInput('outputFormat', '');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform show": {
+            "code": 0,
+            "stdout": "Terraform show output"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowConsoleSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowConsoleSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAWS = new TerraformCommandHandlerAWS();
+
+export async function run() {
+    try {
+        const response = await handler.show();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'AWSShowConsoleSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'AWSShowConsoleSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'AWSShowConsoleSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/GCPShowConsoleSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/GCPShowConsoleSuccess.ts
@@ -1,0 +1,35 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './GCPShowConsoleSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'gcp');
+tr.setInput('command', 'show');
+tr.setInput('outputTo', 'console');
+tr.setInput('outputFormat', '');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameGCP', 'GCP');
+
+process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
+process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'test-project';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'test@test.iam.gserviceaccount.com';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'https://oauth2.googleapis.com/token';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'test-private-key';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'https://www.googleapis.com/auth/cloud-platform';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform show": {
+            "code": 0,
+            "stdout": "Terraform show output"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/GCPShowConsoleSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/GCPShowConsoleSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerGCP } from './../../src/gcp-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerGCP = new TerraformCommandHandlerGCP();
+
+export async function run() {
+    try {
+        const response = await handler.show();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'GCPShowConsoleSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'GCPShowConsoleSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'GCPShowConsoleSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateMvSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateMvSuccess.ts
@@ -1,0 +1,27 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './StateMvSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'state');
+tr.setInput('stateSubCommand', 'mv');
+tr.setInput('stateAddress', 'aws_instance.old aws_instance.new');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform state mv aws_instance.old aws_instance.new": {
+            "code": 0,
+            "stdout": "Move \"aws_instance.old\" to \"aws_instance.new\"\nSuccessfully moved 1 object(s)."
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateMvSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateMvSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAzureRM = new TerraformCommandHandlerAzureRM();
+
+export async function run() {
+    try {
+        const response = await handler.state();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'StateMvSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'StateMvSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'StateMvSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StatePullSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StatePullSuccess.ts
@@ -1,0 +1,26 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './StatePullSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'state');
+tr.setInput('stateSubCommand', 'pull');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform state pull": {
+            "code": 0,
+            "stdout": "{ \"version\": 4 }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StatePullSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StatePullSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAzureRM = new TerraformCommandHandlerAzureRM();
+
+export async function run() {
+    try {
+        const response = await handler.state();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'StatePullSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'StatePullSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'StatePullSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateRmSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateRmSuccess.ts
@@ -1,0 +1,27 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './StateRmSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'state');
+tr.setInput('stateSubCommand', 'rm');
+tr.setInput('stateAddress', 'aws_instance.example');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform state rm aws_instance.example": {
+            "code": 0,
+            "stdout": "Removed aws_instance.example\nSuccessfully removed 1 resource instance(s)."
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateRmSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateRmSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAzureRM = new TerraformCommandHandlerAzureRM();
+
+export async function run() {
+    try {
+        const response = await handler.state();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'StateRmSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'StateRmSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'StateRmSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateShowSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateShowSuccess.ts
@@ -1,0 +1,27 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './StateShowSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'state');
+tr.setInput('stateSubCommand', 'show');
+tr.setInput('stateAddress', 'aws_instance.example');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform state show aws_instance.example": {
+            "code": 0,
+            "stdout": "resource \"aws_instance\" \"example\" { ami = \"abc-123\" }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateShowSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/StateTests/StateShowSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAzureRM = new TerraformCommandHandlerAzureRM();
+
+export async function run() {
+    try {
+        const response = await handler.state();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'StateShowSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'StateShowSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'StateShowSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceDeleteSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceDeleteSuccess.ts
@@ -1,0 +1,27 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './WorkspaceDeleteSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'workspace');
+tr.setInput('workspaceSubCommand', 'delete');
+tr.setInput('workspaceName', 'staging');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform workspace delete staging": {
+            "code": 0,
+            "stdout": "Deleted workspace \"staging\"!"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceDeleteSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceDeleteSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAzureRM = new TerraformCommandHandlerAzureRM();
+
+export async function run() {
+    try {
+        const response = await handler.workspace();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'WorkspaceDeleteSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'WorkspaceDeleteSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'WorkspaceDeleteSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceNewSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceNewSuccess.ts
@@ -1,0 +1,27 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './WorkspaceNewSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'workspace');
+tr.setInput('workspaceSubCommand', 'new');
+tr.setInput('workspaceName', 'staging');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform workspace new staging": {
+            "code": 0,
+            "stdout": "Created and switched to workspace \"staging\"!"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceNewSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceNewSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAzureRM = new TerraformCommandHandlerAzureRM();
+
+export async function run() {
+    try {
+        const response = await handler.workspace();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'WorkspaceNewSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'WorkspaceNewSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'WorkspaceNewSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceShowSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceShowSuccess.ts
@@ -1,0 +1,26 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './WorkspaceShowSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'workspace');
+tr.setInput('workspaceSubCommand', 'show');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform workspace show": {
+            "code": 0,
+            "stdout": "default"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceShowSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/WorkspaceTests/WorkspaceShowSuccessL0.ts
@@ -1,0 +1,19 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import tl = require('azure-pipelines-task-lib');
+
+let handler: TerraformCommandHandlerAzureRM = new TerraformCommandHandlerAzureRM();
+
+export async function run() {
+    try {
+        const response = await handler.workspace();
+        if (response === 0) {
+            tl.setResult(tl.TaskResult.Succeeded, 'WorkspaceShowSuccessL0 should have succeeded.');
+        } else {
+            tl.setResult(tl.TaskResult.Failed, 'WorkspaceShowSuccessL0 should have succeeded but failed.');
+        }
+    } catch(error) {
+        tl.setResult(tl.TaskResult.Failed, 'WorkspaceShowSuccessL0 should have succeeded but failed.');
+    }
+}
+
+run();


### PR DESCRIPTION
## Summary
- Add 15 new test cases across show, output, workspace, state, apply (WIF), and destroy (WIF) commands
- New tests cover AWS and GCP providers for show and output commands
- Add workspace subcommand tests (new, delete, show)
- Add state subcommand tests (show, mv, rm, pull)
- Add WIF authentication tests for apply and destroy (AWS and GCP)
- Total test count increases from 102 to 117

## Test plan
- [x] All 117 tests pass locally (`npm test`)
- [x] TypeScript compiles without errors