### PR TITLE
fix: mask OCI private key with tasks.setSecret()

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -13,6 +13,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     }
 
     private getPrivateKeyFilePath(privateKey: string) {
+        tasks.setSecret(privateKey);
         // This is a bit of a hack but spaces need to be converted to line breaks to make it work
         privateKey = privateKey.replace('-----BEGIN PRIVATE KEY-----', '_begin_');
         privateKey = privateKey.replace('-----END PRIVATE KEY-----', '_end_');


### PR DESCRIPTION
## Changelog
- **Security:** Add `tasks.setSecret()` call for OCI private key content to prevent leaking in pipeline logs

Closes #30