### PR TITLE
fix: improve installer robustness and consistency

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Strings/resources.resjson/en-US/resources.resjson
@@ -24,5 +24,6 @@
   "loc.messages.InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed.",
   "loc.messages.RegistryRequestFailed": "Registry request failed for %s. HTTP status: %s",
   "loc.messages.Sha256VerificationFailed": "SHA256 verification failed. Expected: %s, Got: %s",
-  "loc.messages.ResolvingLatestFromRegistry": "Resolving latest Terraform version from registry: %s"
+  "loc.messages.ResolvingLatestFromRegistry": "Resolving latest Terraform version from registry: %s",
+  "loc.messages.ResolvedVersionFromRegistry": "Resolved latest version from registry: %s"
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -11,7 +11,9 @@ const HttpsProxyAgent = require('https-proxy-agent');
 
 const terraformToolName = "terraform";
 const isWindows = os.type().match(/^Win/);
-const proxy = tasks.getHttpProxyConfiguration();
+
+/** Fallback version used when the HashiCorp checkpoint API is unreachable. Update periodically. */
+const FALLBACK_TERRAFORM_VERSION = '1.9.8';
 
 export async function downloadTerraform(inputVersion: string): Promise<string> {
     const downloadSource = tasks.getInput("downloadSource") || "hashicorp";
@@ -88,10 +90,13 @@ async function resolveVersionFromHashiCorp(inputVersion: string): Promise<string
     console.log(tasks.loc("GettingLatestTerraformVersion"));
     try {
         const data = await fetchJson<{ current_version: string }>('https://checkpoint-api.hashicorp.com/v1/check/terraform');
+        if (!data.current_version) {
+            throw new Error("HashiCorp checkpoint API returned invalid response: missing current_version");
+        }
         return data.current_version;
     } catch {
         console.warn(tasks.loc("TerraformVersionNotFound"));
-        return '1.9.8';
+        return FALLBACK_TERRAFORM_VERSION;
     }
 }
 
@@ -102,7 +107,10 @@ async function resolveVersionFromRegistry(inputVersion: string, registryUrl: str
     console.log(tasks.loc("ResolvingLatestFromRegistry", registryUrl));
     const latestUrl = `${registryUrl}/terraform/binaries/${mirrorName}/versions/latest`;
     const data = await fetchJson<{ version: string }>(latestUrl);
-    console.log(`Resolved latest version from registry: ${data.version}`);
+    if (!data.version) {
+        throw new Error(`Registry API returned invalid response: missing version field from ${latestUrl}`);
+    }
+    console.log(tasks.loc("ResolvedVersionFromRegistry", data.version));
     return data.version;
 }
 
@@ -134,6 +142,9 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     const infoUrl = `${registryUrl}/terraform/binaries/${mirrorName}/versions/${version}/${osPlatform}/${arch}`;
 
     const data = await fetchJson<{ download_url: string; sha256: string }>(infoUrl);
+    if (!data.download_url || !data.sha256) {
+        throw new Error(`Registry API returned invalid response: missing download_url or sha256 from ${infoUrl}`);
+    }
     // data.download_url = pre-signed storage URL (15-minute TTL)
     // data.sha256       = hex SHA256 of the zip
 
@@ -173,7 +184,7 @@ async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Pr
         const expectedHash = await fetchExpectedSha256(sha256SumsUrl, zipFileName);
         await verifySha256(zipPath, expectedHash);
     } catch (error) {
-        console.warn(`SHA256 verification skipped for mirror download: ${error instanceof Error ? error.message : error}`);
+        tasks.warning(`SHA256 verification skipped for mirror download: ${error instanceof Error ? error.message : error}`);
     }
 
     return zipPath;
@@ -182,8 +193,9 @@ async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Pr
 // --- Helpers ---
 
 function buildProxyUrl(): string | null {
+    const proxy = tasks.getHttpProxyConfiguration();
     if (!proxy) return null;
-    if (proxy.proxyUsername != "") {
+    if (proxy.proxyUsername !== "") {
         const url = new URL(proxy.proxyUrl);
         url.username = proxy.proxyUsername ?? "";
         url.password = proxy.proxyPassword ?? "";

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -97,6 +97,7 @@
         "InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed.",
         "RegistryRequestFailed": "Registry request failed for %s. HTTP status: %s",
         "Sha256VerificationFailed": "SHA256 verification failed. Expected: %s, Got: %s",
-        "ResolvingLatestFromRegistry": "Resolving latest Terraform version from registry: %s"
+        "ResolvingLatestFromRegistry": "Resolving latest Terraform version from registry: %s",
+        "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s"
     }
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.loc.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.loc.json
@@ -98,6 +98,7 @@
     "InsecureUrlRejected": "ms-resource:loc.messages.InsecureUrlRejected",
     "RegistryRequestFailed": "ms-resource:loc.messages.RegistryRequestFailed",
     "Sha256VerificationFailed": "ms-resource:loc.messages.Sha256VerificationFailed",
-    "ResolvingLatestFromRegistry": "ms-resource:loc.messages.ResolvingLatestFromRegistry"
+    "ResolvingLatestFromRegistry": "ms-resource:loc.messages.ResolvingLatestFromRegistry",
+    "ResolvedVersionFromRegistry": "ms-resource:loc.messages.ResolvedVersionFromRegistry"
   }
 }


### PR DESCRIPTION
## Summary

- Extract `FALLBACK_TERRAFORM_VERSION` named constant replacing hardcoded `'1.9.8'` (#38)
- Localize the registry version resolution log message via `tasks.loc()` (#39)
- Add runtime validation for external JSON responses from HashiCorp checkpoint, registry latest, and registry download APIs (#40)
- Defer `tasks.getHttpProxyConfiguration()` into `buildProxyUrl()` so proxy config is read at download time, not module load; fix loose `!=` to strict `!==` (#47)
- Replace `console.warn()` with `tasks.warning()` for mirror SHA256 skip message (#33)

## Changelog

- **#38** Extract `FALLBACK_TERRAFORM_VERSION` constant
- **#39** Localize registry resolution log string (`ResolvedVersionFromRegistry`)
- **#40** Validate `current_version`, `version`, `download_url`, and `sha256` fields in API responses
- **#47** Defer proxy configuration lookup to download time; fix loose equality
- **#33** Promote mirror SHA256 skip message to `tasks.warning()`

## Test plan

- [x] TypeScript compiles cleanly (`tsc -b tsconfig.json`)
- [x] ESLint passes with zero errors
- [x] All 8 existing unit tests pass

Closes #33
Closes #38
Closes #39
Closes #40
Closes #47