### PR TITLE
fix: upgrade uuid v3→v9 and resolve all ESLint warnings

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CachedInstallSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CachedInstallSuccess.ts
@@ -18,7 +18,7 @@ tr.registerMock('node-fetch', async (url: string, _options?: any) => {
     throw new Error('node-fetch should not be called when tool is cached. Called with: ' + url);
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
@@ -33,7 +33,7 @@ tr.registerMock('node-fetch', async (url: string, _options?: any) => {
     throw new Error('Unexpected fetch URL: ' + url);
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 // fs: readFileSync for verifySha256, chmodSync skipped on Windows

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
@@ -26,7 +26,7 @@ tr.registerMock('node-fetch', async (url: string, _options?: any) => {
     throw new Error('node-fetch should not be called for a specific version. Called with: ' + url);
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 // fs: readFileSync for verifySha256, chmodSync skipped on Windows

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlReject.ts
@@ -18,7 +18,7 @@ tr.registerMock('node-fetch', async (_url: string, _options?: any) => {
     throw new Error('node-fetch should not be called');
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InvalidVersionFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InvalidVersionFail.ts
@@ -17,7 +17,7 @@ tr.registerMock('node-fetch', async (_url: string, _options?: any) => {
     throw new Error('node-fetch should not be called for an invalid version');
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
@@ -19,7 +19,7 @@ tr.registerMock('node-fetch', async (url: string, _options?: any) => {
     throw new Error('node-fetch should not be called for mirror download. Called with: ' + url);
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
@@ -33,7 +33,7 @@ tr.registerMock('node-fetch', async (url: string, _options?: any) => {
     throw new Error('Unexpected fetch URL: ' + url);
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 // fs: mock readFileSync (for verifySha256) and chmodSync (no-op, Windows mock)

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
@@ -32,7 +32,7 @@ tr.registerMock('node-fetch', async (url: string, _options?: any) => {
     throw new Error('Unexpected fetch URL: ' + url);
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('https-proxy-agent', function () { return {}; });
 
 // fs: readFileSync returns some content

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -12,11 +12,13 @@
         "azure-pipelines-task-lib": "^4.1.0",
         "azure-pipelines-tool-lib": "^2.0.0-preview",
         "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.7",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
         "@types/node": "^20.11.0",
+        "@types/uuid": "^9.0.8",
         "eslint": "^9.0.0",
         "mocha": "^11.2.0",
         "ts-node": "^10.9.1",
@@ -417,9 +419,10 @@
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.13.tgz",
-      "integrity": "sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -849,6 +852,16 @@
         "uuid": "^3.0.1"
       }
     },
+    "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
@@ -863,6 +876,12 @@
         "typed-rest-client": "^1.8.6",
         "uuid": "^3.3.2"
       }
+    },
+    "node_modules/azure-pipelines-tool-lib/node_modules/@types/uuid": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.13.tgz",
+      "integrity": "sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
       "version": "5.2.8",
@@ -902,6 +921,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/azure-pipelines-tool-lib/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/balanced-match": {
@@ -3344,13 +3373,16 @@
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -17,15 +17,17 @@
     "azure-pipelines-task-lib": "^4.1.0",
     "azure-pipelines-tool-lib": "^2.0.0-preview",
     "https-proxy-agent": "^5.0.0",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
     "@types/node": "^20.11.0",
+    "@types/uuid": "^9.0.8",
+    "eslint": "^9.0.0",
     "mocha": "^11.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0",
-    "eslint": "^9.0.0",
     "typescript-eslint": "^8.0.0"
   }
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -5,7 +5,7 @@ import os = require('os');
 import fs = require('fs');
 import crypto = require('crypto');
 
-const uuidV4 = require('uuid/v4');
+import { v4 as uuidV4 } from 'uuid';
 const fetch = require('node-fetch');
 const HttpsProxyAgent = require('https-proxy-agent');
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
@@ -21,7 +21,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
@@ -22,7 +22,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
@@ -21,7 +21,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
@@ -22,7 +22,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid', { v4: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid', { v4: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid', { v4: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid', { v4: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanWIFSuccess.ts
@@ -20,7 +20,7 @@ var mock = {
 };
 
 tr.registerMock('./id-token-generator', mock);
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanWIFSuccess.ts
@@ -21,7 +21,7 @@ var mock = {
 };
 
 tr.registerMock('./id-token-generator', mock);
-tr.registerMock('uuid/v4', () => 'test-uuid-1234');
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/eslint.config.mjs
+++ b/Tasks/TerraformTask/TerraformTaskV5/eslint.config.mjs
@@ -10,7 +10,7 @@ export default tseslint.config(
         },
         rules: {
             'no-unused-vars': 'off',
-            '@typescript-eslint/no-unused-vars': 'warn',
+            '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
             '@typescript-eslint/no-explicit-any': 'warn',
             '@typescript-eslint/no-require-imports': 'off',
             'prefer-const': 'warn',

--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -11,12 +11,13 @@
       "dependencies": {
         "azure-devops-node-api": "^12.0.0",
         "azure-pipelines-task-lib": "^4.1.0",
-        "azure-pipelines-tasks-artifacts-common": "^2.225.0"
+        "azure-pipelines-tasks-artifacts-common": "^2.225.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
         "@types/node": "^20.11.0",
-        "@types/uuid": "^8.3.1",
+        "@types/uuid": "^9.0.8",
         "eslint": "^9.0.0",
         "mocha": "^11.2.0",
         "ts-loader": "^9.5.2",
@@ -492,9 +493,9 @@
       }
     },
     "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1186,6 +1187,16 @@
         "uuid": "^3.0.1"
       }
     },
+    "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/azure-pipelines-tasks-artifacts-common": {
       "version": "2.270.0",
       "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-artifacts-common/-/azure-pipelines-tasks-artifacts-common-2.270.0.tgz",
@@ -1299,6 +1310,16 @@
       },
       "engines": {
         "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/balanced-match": {
@@ -4283,13 +4304,16 @@
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -16,17 +16,17 @@
     "azure-devops-node-api": "^12.0.0",
     "azure-pipelines-task-lib": "^4.1.0",
     "azure-pipelines-tasks-artifacts-common": "^2.225.0",
-    "uuid": "^3.4.0"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
     "@types/node": "^20.11.0",
-    "@types/uuid": "^8.3.1",
+    "@types/uuid": "^9.0.8",
+    "eslint": "^9.0.0",
     "mocha": "^11.2.0",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0",
-    "eslint": "^9.0.0",
     "typescript-eslint": "^8.0.0"
   }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -5,7 +5,7 @@ import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
 import { generateIdToken } from './id-token-generator';
 import path = require('path');
-import * as uuidV4 from 'uuid/v4';
+import { v4 as uuidV4 } from 'uuid';
 
 export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
     constructor() {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -125,7 +125,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
     }
 
     private getServicePrincipalCredentials(serviceConnectionID: string): ServicePrincipalCredentials {
-        let servicePrincipalCredentials: ServicePrincipalCredentials = {
+        const servicePrincipalCredentials: ServicePrincipalCredentials = {
             servicePrincipalId: tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalid", true)!,
             servicePrincipalKey: tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalkey", true)!
         }
@@ -133,7 +133,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
     }
 
     private async getWorkloadIdentityFederationCredentials(serviceConnectionID: string, getIdToken: boolean): Promise<WorkloadIdentityFederationCredentials> {
-        let workloadIdentityFederationCredentials: WorkloadIdentityFederationCredentials = {
+        const workloadIdentityFederationCredentials: WorkloadIdentityFederationCredentials = {
             servicePrincipalId: tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalid", true)!,
             oidcToken: ""
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -1,9 +1,9 @@
 import { TerraformToolHandler, ITerraformToolHandler } from './terraform';
-import { ToolRunner, IExecOptions, IExecSyncOptions, IExecSyncResult } from 'azure-pipelines-task-lib/toolrunner';
+import { ToolRunner, IExecOptions, IExecSyncOptions } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformBaseCommandInitializer, TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import tasks = require('azure-pipelines-task-lib/task');
 import path = require('path');
-import * as uuidV4 from 'uuid/v4';
+import { v4 as uuidV4 } from 'uuid';
 import fs = require('fs');
 
 export abstract class BaseTerraformCommandHandler {
@@ -40,17 +40,17 @@ export abstract class BaseTerraformCommandHandler {
         let terraformPath;
         try {
             terraformPath = tasks.which("terraform", true);
-        } catch (err) {
+        } catch {
             throw new Error(tasks.loc("TerraformToolNotFound"));
         }
 
-        let terraformToolRunner: ToolRunner = tasks.tool(terraformPath);
+        const terraformToolRunner: ToolRunner = tasks.tool(terraformPath);
         terraformToolRunner.arg("providers");
-        let commandOutput = terraformToolRunner.execSync(<IExecSyncOptions>{
+        const commandOutput = terraformToolRunner.execSync(<IExecSyncOptions>{
             cwd: tasks.getInput("workingDirectory") || ''
         });
 
-        let countProviders = ["aws", "azurerm", "google", "oracle"].filter(provider => commandOutput.stdout.includes(provider)).length;
+        const countProviders = ["aws", "azurerm", "google", "oracle"].filter(provider => commandOutput.stdout.includes(provider)).length;
 
         tasks.debug(countProviders.toString());
         if (countProviders > 1) {
@@ -59,7 +59,7 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public getServiceProviderNameFromProviderInput(): string {
-        let provider: string = tasks.getInput("provider", true)!;
+        const provider: string = tasks.getInput("provider", true)!;
 
         switch (provider) {
             case "azurerm": return "AzureRM";
@@ -94,15 +94,13 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async init(): Promise<number> {
-        let initCommand = new TerraformBaseCommandInitializer(
+        const initCommand = new TerraformBaseCommandInitializer(
             "init",
             tasks.getInput("workingDirectory") || '',
             tasks.getInput("commandOptions")
         );
 
-        let terraformTool;
-
-        terraformTool = this.terraformToolHandler.createToolRunner(initCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(initCommand);
         await this.handleBackend(terraformTool);
 
         return await terraformTool.execAsync(<IExecOptions>{
@@ -110,7 +108,7 @@ export abstract class BaseTerraformCommandHandler {
         });
     }
     public async show(): Promise<number> {
-        let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
+        const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
         let cmd;
         const outputTo = tasks.getInput("outputTo");
         const outputFormat = tasks.getInput("outputFormat");
@@ -120,14 +118,13 @@ export abstract class BaseTerraformCommandHandler {
             cmd = tasks.getInput("commandOptions") != null ? tasks.getInput("commandOptions") : ``;
         }
 
-        let showCommand = new TerraformAuthorizationCommandInitializer(
+        const showCommand = new TerraformAuthorizationCommandInitializer(
             "show",
             tasks.getInput("workingDirectory") || '',
             tasks.getInput(serviceName, true)!,
             cmd
         );
-        let terraformTool;
-        terraformTool = this.terraformToolHandler.createToolRunner(showCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(showCommand);
         await this.handleProvider(showCommand);
 
         if (outputTo == "console") {
@@ -136,7 +133,7 @@ export abstract class BaseTerraformCommandHandler {
             });
         } else if (outputTo == "file") {
             const showFilePath = path.resolve(showCommand.workingDirectory, tasks.getInput("filename") || '');
-            let commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
+            const commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
                 cwd: showCommand.workingDirectory,
             });
 
@@ -148,22 +145,21 @@ export abstract class BaseTerraformCommandHandler {
         throw new Error("Invalid outputTo value. Must be 'console' or 'file'.");
     }
     public async output(): Promise<number> {
-        let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
-        let commandOptions = tasks.getInput("commandOptions") != null ? `-json ${tasks.getInput("commandOptions")}` : `-json`
+        const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
+        const commandOptions = tasks.getInput("commandOptions") != null ? `-json ${tasks.getInput("commandOptions")}` : `-json`
 
-        let outputCommand = new TerraformAuthorizationCommandInitializer(
+        const outputCommand = new TerraformAuthorizationCommandInitializer(
             "output",
             tasks.getInput("workingDirectory") || '',
             tasks.getInput(serviceName, true)!,
             commandOptions
         );
 
-        let terraformTool;
-        terraformTool = this.terraformToolHandler.createToolRunner(outputCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(outputCommand);
         await this.handleProvider(outputCommand);
 
         const jsonOutputVariablesFilePath = path.resolve(outputCommand.workingDirectory, `output-${uuidV4()}.json`);
-        let commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
+        const commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
             cwd: outputCommand.workingDirectory,
         });
 
@@ -174,25 +170,24 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async plan(): Promise<number> {
-        let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
+        const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
         let commandOptions = tasks.getInput("commandOptions") != null ? `${tasks.getInput("commandOptions")} -detailed-exitcode` : `-detailed-exitcode`
         const replaceAddress = tasks.getInput("replaceAddress", false);
         if (replaceAddress) {
             commandOptions = `-replace=${replaceAddress} ${commandOptions}`;
         }
-        let planCommand = new TerraformAuthorizationCommandInitializer(
+        const planCommand = new TerraformAuthorizationCommandInitializer(
             "plan",
             tasks.getInput("workingDirectory") || '',
             tasks.getInput(serviceName, true)!,
             commandOptions
         );
 
-        let terraformTool;
-        terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
         await this.handleProvider(planCommand);
         this.warnIfMultipleProviders();
 
-        let result = await terraformTool.execAsync(<IExecOptions>{
+        const result = await terraformTool.execAsync(<IExecOptions>{
             cwd: planCommand.workingDirectory,
             ignoreReturnCode: true
         });
@@ -206,16 +201,15 @@ export abstract class BaseTerraformCommandHandler {
 
     public async custom(): Promise<number> {
         const outputTo = tasks.getInput("outputTo");
-        let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
-        let customCommand = new TerraformAuthorizationCommandInitializer(
+        const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
+        const customCommand = new TerraformAuthorizationCommandInitializer(
             tasks.getInput("customCommand", true)!,
             tasks.getInput("workingDirectory") || '',
             tasks.getInput(serviceName, true)!,
             tasks.getInput("commandOptions")
         );
 
-        let terraformTool;
-        terraformTool = this.terraformToolHandler.createToolRunner(customCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(customCommand);
         await this.handleProvider(customCommand);
 
         if (outputTo == "console") {
@@ -224,7 +218,7 @@ export abstract class BaseTerraformCommandHandler {
             });
         } else if (outputTo == "file") {
             const customFilePath = path.resolve(customCommand.workingDirectory, tasks.getInput("filename") || '');
-            let commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
+            const commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
                 cwd: customCommand.workingDirectory
             });
 
@@ -236,9 +230,8 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async apply(): Promise<number> {
-        let terraformTool;
-        let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
-        let autoApprove: string = '-auto-approve';
+        const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
+        const autoApprove: string = '-auto-approve';
         let additionalArgs: string = tasks.getInput("commandOptions") || autoApprove;
 
         if (additionalArgs.includes(autoApprove) === false) {
@@ -249,14 +242,14 @@ export abstract class BaseTerraformCommandHandler {
             additionalArgs = `-replace=${replaceAddress} ${additionalArgs}`;
         }
 
-        let applyCommand = new TerraformAuthorizationCommandInitializer(
+        const applyCommand = new TerraformAuthorizationCommandInitializer(
             "apply",
             tasks.getInput("workingDirectory") || '',
             tasks.getInput(serviceName, true)!,
             additionalArgs
         );
 
-        terraformTool = this.terraformToolHandler.createToolRunner(applyCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(applyCommand);
         await this.handleProvider(applyCommand);
         this.warnIfMultipleProviders();
 
@@ -267,40 +260,38 @@ export abstract class BaseTerraformCommandHandler {
 
     public async destroy(): Promise<number> {
 
-        let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
-        let autoApprove: string = '-auto-approve';
+        const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
+        const autoApprove: string = '-auto-approve';
         let additionalArgs: string = tasks.getInput("commandOptions") || autoApprove;
 
         if (additionalArgs.includes(autoApprove) === false) {
             additionalArgs = `${autoApprove} ${additionalArgs}`;
         }
 
-        let destroyCommand = new TerraformAuthorizationCommandInitializer(
+        const destroyCommand = new TerraformAuthorizationCommandInitializer(
             "destroy",
             tasks.getInput("workingDirectory") || '',
             tasks.getInput(serviceName, true)!,
             additionalArgs
         );
 
-        let terraformTool;
-        terraformTool = this.terraformToolHandler.createToolRunner(destroyCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(destroyCommand);
         await this.handleProvider(destroyCommand);
         this.warnIfMultipleProviders();
 
         return await terraformTool.execAsync(<IExecOptions>{
             cwd: destroyCommand.workingDirectory
         });
-    };
+    }
 
     public async validate(): Promise<number> {
-        let validateCommand = new TerraformBaseCommandInitializer(
+        const validateCommand = new TerraformBaseCommandInitializer(
             "validate",
             tasks.getInput("workingDirectory") || '',
             tasks.getInput("commandOptions")
         );
 
-        let terraformTool;
-        terraformTool = this.terraformToolHandler.createToolRunner(validateCommand);
+        const terraformTool = this.terraformToolHandler.createToolRunner(validateCommand);
 
         return await terraformTool.execAsync(<IExecOptions>{
             cwd: validateCommand.workingDirectory
@@ -312,7 +303,7 @@ export abstract class BaseTerraformCommandHandler {
         const workspaceName = tasks.getInput("workspaceName", false);
         const commandOptions = tasks.getInput("commandOptions");
 
-        let additionalArgs = workspaceName
+        const additionalArgs = workspaceName
             ? `${workspaceName}${commandOptions ? ` ${commandOptions}` : ''}`
             : commandOptions || undefined;
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -5,7 +5,7 @@ import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
 import { generateIdToken } from './id-token-generator';
 import path = require('path');
-import * as uuidV4 from 'uuid/v4';
+import { v4 as uuidV4 } from 'uuid';
 
 export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
     constructor() {
@@ -17,12 +17,12 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         // Get credentials for json file
         const jsonKeyFilePath = path.resolve(`credentials-${uuidV4()}.json`);
 
-        let clientEmail = tasks.getEndpointAuthorizationParameter(serviceName, "Issuer", false);
-        let tokenUri = tasks.getEndpointAuthorizationParameter(serviceName, "Audience", false);
-        let privateKey = tasks.getEndpointAuthorizationParameter(serviceName, "PrivateKey", false);
+        const clientEmail = tasks.getEndpointAuthorizationParameter(serviceName, "Issuer", false);
+        const tokenUri = tasks.getEndpointAuthorizationParameter(serviceName, "Audience", false);
+        const privateKey = tasks.getEndpointAuthorizationParameter(serviceName, "PrivateKey", false);
 
         // Create json string and write it to the file
-        let jsonCredsString = JSON.stringify({
+        const jsonCredsString = JSON.stringify({
             type: "service_account",
             private_key: privateKey,
             client_email: clientEmail,
@@ -41,17 +41,17 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             this.backendConfig.set('prefix', prefix);
         }
 
-        let jsonKeyFilePath = this.getJsonKeyFilePath(backendServiceName);
+        const jsonKeyFilePath = this.getJsonKeyFilePath(backendServiceName);
 
         this.backendConfig.set('credentials', jsonKeyFilePath);
     }
 
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
         tasks.debug('Setting up backend GCP.');
-        let backendServiceName = tasks.getInput("backendServiceGCP", true)!;
+        const backendServiceName = tasks.getInput("backendServiceGCP", true)!;
         this.setupBackend(backendServiceName);
 
-        for (let [key, value] of this.backendConfig.entries()) {
+        for (const [key, value] of this.backendConfig.entries()) {
             terraformToolRunner.arg(`-backend-config=${key}=${value}`);
         }
         tasks.debug('Finished setting up backend GCP.');
@@ -64,7 +64,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             await this.handleProviderWIF(command);
         } else {
             if (command.serviceProvidername) {
-                let jsonKeyFilePath = this.getJsonKeyFilePath(command.serviceProvidername);
+                const jsonKeyFilePath = this.getJsonKeyFilePath(command.serviceProvidername);
 
                 EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_CREDENTIALS", jsonKeyFilePath);
                 EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_PROJECT", tasks.getEndpointDataParameter(command.serviceProvidername, "project", false) || '');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
@@ -1,7 +1,7 @@
 import tasks = require('azure-pipelines-task-lib/task');
-import {ToolRunner} from 'azure-pipelines-task-lib/toolrunner';
-import {TerraformAuthorizationCommandInitializer} from './terraform-commands';
-import {BaseTerraformCommandHandler} from './base-terraform-command-handler';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
+import { TerraformAuthorizationCommandInitializer } from './terraform-commands';
+import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 
 export class TerraformCommandHandlerGeneric extends BaseTerraformCommandHandler {
     constructor() {
@@ -9,7 +9,7 @@ export class TerraformCommandHandlerGeneric extends BaseTerraformCommandHandler 
         this.providerName = "generic";
     }
 
-    public async handleBackend(terraformToolRunner: ToolRunner) : Promise<void> {
+    public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
         const configFile = tasks.getInput("backendConfigFile", false);
         if (configFile && configFile.trim()) {
             terraformToolRunner.arg(`-backend-config=${configFile.trim()}`);
@@ -26,7 +26,7 @@ export class TerraformCommandHandlerGeneric extends BaseTerraformCommandHandler 
         }
     }
 
-    public async handleProvider(command: TerraformAuthorizationCommandInitializer) : Promise<void> {
+    public async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> {
         // No provider credentials needed for generic/local backend type
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
@@ -10,7 +10,7 @@ export class TerraformCommandHandlerHCP extends BaseTerraformCommandHandler {
         this.providerName = "hcp";
     }
 
-    public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
+    public async handleBackend(_terraformToolRunner: ToolRunner): Promise<void> {
         const token = tasks.getInput("backendHCPToken", true)!;
         if (token) { tasks.setSecret(token); }
         EnvironmentVariableHelper.setEnvironmentVariable("TF_TOKEN_app_terraform_io", token);
@@ -26,7 +26,7 @@ export class TerraformCommandHandlerHCP extends BaseTerraformCommandHandler {
         }
     }
 
-    public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {
+    public async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> {
         // No-op: HCP backend does not provide cloud provider credentials for plan/apply
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
@@ -5,7 +5,7 @@ import path = require('path');
 async function run() {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
 
-    let parentHandler = new ParentCommandHandler();
+    const parentHandler = new ParentCommandHandler();
     try {
         await parentHandler.execute(tasks.getInput("provider", true)!, tasks.getInput("command", true)!);
         tasks.setResult(tasks.TaskResult.Succeeded, "");

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -4,7 +4,7 @@ import { TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
 import path = require('path');
-import * as uuidV4 from 'uuid/v4';
+import { v4 as uuidV4 } from 'uuid';
 
 export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     constructor() {
@@ -28,7 +28,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         return privateKeyFilePath;
     }
 
-    private setupBackend(backendServiceName: string) {
+    private setupBackend(_backendServiceName: string) {
         // Unfortunately this seems not to work with OCI provider for the tf statefile
         // https://developer.hashicorp.com/terraform/language/settings/backends/configuration#command-line-key-value-pairs
         //this.backendConfig.set('address', tasks.getInput("PAR url", true));
@@ -39,7 +39,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         // Instead, will create a backend.tf config file for it in-flight when generate option was selected 'yes' (the default setting)
         if (tasks.getInput("backendOCIConfigGenerate", true) == 'yes') {
             tasks.debug('Generating backend tf statefile config.');
-            var config = "";
+            let config = "";
             config = config + "terraform {\n backend \"http\" {\n";
             config = config + " address = \"" + tasks.getInput("backendOCIPar", true) + "\"\n";
             config = config + " update_method = \"PUT\"\n }\n }\n";
@@ -53,17 +53,17 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     }
 
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
-        let backendServiceName = tasks.getInput("backendServiceOCI", true)!;
+        const backendServiceName = tasks.getInput("backendServiceOCI", true)!;
         this.setupBackend(backendServiceName);
 
-        for (let [key, value] of this.backendConfig.entries()) {
+        for (const [key, value] of this.backendConfig.entries()) {
             terraformToolRunner.arg(`-backend-config=${key}=${value}`);
         }
     }
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {
         if (command.serviceProvidername) {
-            let privateKeyFilePath = this.getPrivateKeyFilePath(tasks.getEndpointDataParameter(command.serviceProvidername, "privateKey", false)!);
+            const privateKeyFilePath = this.getPrivateKeyFilePath(tasks.getEndpointDataParameter(command.serviceProvidername, "privateKey", false)!);
             EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_tenancy_ocid", tasks.getEndpointDataParameter(command.serviceProvidername, "tenancy", false) || '');
             EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_user_ocid", tasks.getEndpointDataParameter(command.serviceProvidername, "user", false) || '');
             EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_region", tasks.getEndpointDataParameter(command.serviceProvidername, "region", false) || '');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
@@ -16,11 +16,11 @@ export class TerraformToolHandler implements ITerraformToolHandler {
         let terraformPath;
         try {
             terraformPath = this.tasks.which("terraform", true);
-        } catch (err) {
+        } catch {
             throw new Error(this.tasks.loc("TerraformToolNotFound"));
         }
 
-        let terraformToolRunner: ToolRunner = this.tasks.tool(terraformPath);
+        const terraformToolRunner: ToolRunner = this.tasks.tool(terraformPath);
         if (command) {
             terraformToolRunner.arg(command.name);
             if (command.additionalArgs) {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/types.d.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/types.d.ts
@@ -1,5 +1,0 @@
-declare module 'uuid/v4' {
-    function v4(): string;
-    namespace v4 {}
-    export = v4;
-}


### PR DESCRIPTION
## Summary

- Upgrades `uuid` from v3 (`^3.4.0`) to v9 (`^9.0.1`) across both V5 and InstallerV1 tasks
- Changes all uuid imports from legacy `uuid/v4` to named `{ v4 as uuidV4 } from 'uuid'`
- Deletes the `src/types.d.ts` ambient declaration shim (no longer needed with uuid v9)
- Resolves all 61 ESLint warnings that were appearing in CI:
  - `prefer-const`: converted `let` → `const` for all `terraformTool` declarations and other variables
  - `@typescript-eslint/no-unused-vars`: prefixed unused params with `_` convention, removed unused catch bindings
  - Added `argsIgnorePattern: "^_"` and `varsIgnorePattern: "^_"` to ESLint config
- Updates all 10 test mock registrations from `registerMock('uuid/v4', ...)` to `registerMock('uuid', { v4: ... })`

## Changelog

- **fix**: Upgrade uuid v3→v9 and resolve all ESLint warnings (#35, #36, #37)

## Test plan

- [x] `npm run compile` — zero TypeScript errors
- [x] `npx eslint src/` — zero warnings
- [x] `npm test` — 117 tests passing, 0 failing
- [x] CI should pass with 0 ESLint warnings