### PR TITLE
refactor: strict equality operators and OCI HCL escaping

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -24,15 +24,15 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
         // Setup the optional backend configuration for the storage account blob location with subscription ID and resource group name (set as backend config to ensure it is cached)
         const resourceGroupName = tasks.getInput("backendAzureRmResourceGroupName", false);
-        if (resourceGroupName != null && resourceGroupName != "") {
+        if (resourceGroupName) {
             this.backendConfig.set("resource_group_name", resourceGroupName);
         }
 
         let subscriptionId = tasks.getInput("backendAzureRmOverrideSubscriptionID", false);
-        if (subscriptionId == null || subscriptionId == "") {
+        if (!subscriptionId) {
             subscriptionId = tasks.getEndpointDataParameter(serviceConnectionID, "subscriptionid", true);
         }
-        if (subscriptionId != null && subscriptionId != "" && resourceGroupName != null && resourceGroupName != "") {
+        if (subscriptionId && resourceGroupName) {
             this.backendConfig.set("subscription_id", subscriptionId);
         }
 
@@ -62,10 +62,10 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
         // Setup required provider configuration for subscription ID
         let subscriptionId = tasks.getInput("environmentAzureRmOverrideSubscriptionID", false);
-        if (subscriptionId == null || subscriptionId == "") {
+        if (!subscriptionId) {
             subscriptionId = tasks.getEndpointDataParameter(serviceConnectionID, "subscriptionid", true);
         }
-        if (subscriptionId != null && subscriptionId != "") {
+        if (subscriptionId) {
             EnvironmentVariableHelper.setEnvironmentVariable("ARM_SUBSCRIPTION_ID", subscriptionId);
         }
 
@@ -144,20 +144,20 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
     }
 
     private mapAuthorizationScheme(authorizationScheme: string): AuthorizationScheme {
-        if (authorizationScheme == undefined) {
+        if (authorizationScheme === undefined) {
             tasks.warning("The authorization scheme could not be found for your Service Connection, using Workload identity federation by default, but this could cause issues.");
             return AuthorizationScheme.WorkloadIdentityFederation;
         }
 
-        if (authorizationScheme.toLowerCase() == AuthorizationScheme.ServicePrincipal) {
+        if (authorizationScheme.toLowerCase() === AuthorizationScheme.ServicePrincipal) {
             return AuthorizationScheme.ServicePrincipal;
         }
 
-        if (authorizationScheme.toLowerCase() == AuthorizationScheme.ManagedServiceIdentity) {
+        if (authorizationScheme.toLowerCase() === AuthorizationScheme.ManagedServiceIdentity) {
             return AuthorizationScheme.ManagedServiceIdentity;
         }
 
-        if (authorizationScheme.toLowerCase() == AuthorizationScheme.WorkloadIdentityFederation) {
+        if (authorizationScheme.toLowerCase() === AuthorizationScheme.WorkloadIdentityFederation) {
             return AuthorizationScheme.WorkloadIdentityFederation;
         }
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -112,10 +112,10 @@ export abstract class BaseTerraformCommandHandler {
         let cmd;
         const outputTo = tasks.getInput("outputTo");
         const outputFormat = tasks.getInput("outputFormat");
-        if (outputFormat == "json") {
-            cmd = tasks.getInput("commandOptions") != null ? `-json  ${tasks.getInput("commandOptions")}` : `-json`;
+        if (outputFormat === "json") {
+            cmd = tasks.getInput("commandOptions") ? `-json  ${tasks.getInput("commandOptions")}` : `-json`;
         } else {
-            cmd = tasks.getInput("commandOptions") != null ? tasks.getInput("commandOptions") : ``;
+            cmd = tasks.getInput("commandOptions") ? tasks.getInput("commandOptions") : ``;
         }
 
         const showCommand = new TerraformAuthorizationCommandInitializer(
@@ -127,11 +127,11 @@ export abstract class BaseTerraformCommandHandler {
         const terraformTool = this.terraformToolHandler.createToolRunner(showCommand);
         await this.handleProvider(showCommand);
 
-        if (outputTo == "console") {
+        if (outputTo === "console") {
             return await terraformTool.execAsync(<IExecOptions>{
                 cwd: showCommand.workingDirectory
             });
-        } else if (outputTo == "file") {
+        } else if (outputTo === "file") {
             const showFilePath = path.resolve(showCommand.workingDirectory, tasks.getInput("filename") || '');
             const commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
                 cwd: showCommand.workingDirectory,
@@ -146,7 +146,7 @@ export abstract class BaseTerraformCommandHandler {
     }
     public async output(): Promise<number> {
         const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
-        const commandOptions = tasks.getInput("commandOptions") != null ? `-json ${tasks.getInput("commandOptions")}` : `-json`
+        const commandOptions = tasks.getInput("commandOptions") ? `-json ${tasks.getInput("commandOptions")}` : `-json`
 
         const outputCommand = new TerraformAuthorizationCommandInitializer(
             "output",
@@ -171,7 +171,7 @@ export abstract class BaseTerraformCommandHandler {
 
     public async plan(): Promise<number> {
         const serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
-        let commandOptions = tasks.getInput("commandOptions") != null ? `${tasks.getInput("commandOptions")} -detailed-exitcode` : `-detailed-exitcode`
+        let commandOptions = tasks.getInput("commandOptions") ? `${tasks.getInput("commandOptions")} -detailed-exitcode` : `-detailed-exitcode`
         const replaceAddress = tasks.getInput("replaceAddress", false);
         if (replaceAddress) {
             commandOptions = `-replace=${replaceAddress} ${commandOptions}`;
@@ -212,11 +212,11 @@ export abstract class BaseTerraformCommandHandler {
         const terraformTool = this.terraformToolHandler.createToolRunner(customCommand);
         await this.handleProvider(customCommand);
 
-        if (outputTo == "console") {
+        if (outputTo === "console") {
             return await terraformTool.execAsync(<IExecOptions>{
                 cwd: customCommand.workingDirectory
             });
-        } else if (outputTo == "file") {
+        } else if (outputTo === "file") {
             const customFilePath = path.resolve(customCommand.workingDirectory, tasks.getInput("filename") || '');
             const commandOutput = await terraformTool.execSync(<IExecSyncOptions>{
                 cwd: customCommand.workingDirectory

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -37,11 +37,12 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         //PAR = OCI Object Storage preauthenticated request (for the statefile bucket)
 
         // Instead, will create a backend.tf config file for it in-flight when generate option was selected 'yes' (the default setting)
-        if (tasks.getInput("backendOCIConfigGenerate", true) == 'yes') {
+        if (tasks.getInput("backendOCIConfigGenerate", true) === 'yes') {
             tasks.debug('Generating backend tf statefile config.');
+            const parUrl = (tasks.getInput("backendOCIPar", true) || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"');
             let config = "";
             config = config + "terraform {\n backend \"http\" {\n";
-            config = config + " address = \"" + tasks.getInput("backendOCIPar", true) + "\"\n";
+            config = config + " address = \"" + parUrl + "\"\n";
             config = config + " update_method = \"PUT\"\n }\n }\n";
 
             const workingDirectory = tasks.getInput("workingDirectory") || '';


### PR DESCRIPTION
## Summary

- Replace all loose equality operators (`==`, `!=`) with strict equivalents (`===`, `!==`) or truthiness checks across azure, base, and oci handlers
- Escape backslash and double-quote characters in OCI PAR URLs before embedding in generated HCL backend config to prevent injection

## Changelog

- **refactor**: Strict equality operators and OCI HCL escaping (#36, #42)

## Test plan

- [x] `npx tsc -b tsconfig.json` — zero errors
- [x] `npx eslint src/` — zero warnings
- [x] `npm test` — 117 tests passing

Closes #36, closes #42