### PR TITLE
refactor: extract backend config loop and async warnIfMultipleProviders

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -29,10 +29,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
         const backendServiceName = tasks.getInput("backendServiceAWS", true)!;
         this.setupBackend(backendServiceName);
-
-        for (const [key, value] of this.backendConfig.entries()) {
-            terraformToolRunner.arg(`-backend-config=${key}=${value}`);
-        }
+        this.applyBackendConfig(terraformToolRunner);
     }
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -47,9 +47,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
         await this.setCommonVariables(authorizationScheme, serviceConnectionID, fallbackToIdTokenGeneration, backendAzureRmUseCliFlagsForAuthentication);
 
-        for (const [key, value] of this.backendConfig.entries()) {
-            terraformToolRunner.arg(`-backend-config=${key}=${value}`);
-        }
+        this.applyBackendConfig(terraformToolRunner);
 
         tasks.debug("Finished setting up backend for authorization scheme: " + authorizationScheme + ".");
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -36,7 +36,7 @@ export abstract class BaseTerraformCommandHandler {
         this.tempFiles = [];
     }
 
-    public warnIfMultipleProviders(): void {
+    public async warnIfMultipleProviders(): Promise<void> {
         let terraformPath;
         try {
             terraformPath = tasks.which("terraform", true);
@@ -55,6 +55,12 @@ export abstract class BaseTerraformCommandHandler {
         tasks.debug(countProviders.toString());
         if (countProviders > 1) {
             tasks.warning("Multiple provider blocks specified in the .tf files in the current working directory.");
+        }
+    }
+
+    protected applyBackendConfig(terraformToolRunner: ToolRunner): void {
+        for (const [key, value] of this.backendConfig.entries()) {
+            terraformToolRunner.arg(`-backend-config=${key}=${value}`);
         }
     }
 
@@ -185,7 +191,7 @@ export abstract class BaseTerraformCommandHandler {
 
         const terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
         await this.handleProvider(planCommand);
-        this.warnIfMultipleProviders();
+        await this.warnIfMultipleProviders();
 
         const result = await terraformTool.execAsync(<IExecOptions>{
             cwd: planCommand.workingDirectory,
@@ -251,7 +257,7 @@ export abstract class BaseTerraformCommandHandler {
 
         const terraformTool = this.terraformToolHandler.createToolRunner(applyCommand);
         await this.handleProvider(applyCommand);
-        this.warnIfMultipleProviders();
+        await this.warnIfMultipleProviders();
 
         return await terraformTool.execAsync(<IExecOptions>{
             cwd: applyCommand.workingDirectory
@@ -277,7 +283,7 @@ export abstract class BaseTerraformCommandHandler {
 
         const terraformTool = this.terraformToolHandler.createToolRunner(destroyCommand);
         await this.handleProvider(destroyCommand);
-        this.warnIfMultipleProviders();
+        await this.warnIfMultipleProviders();
 
         return await terraformTool.execAsync(<IExecOptions>{
             cwd: destroyCommand.workingDirectory

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -50,10 +50,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         tasks.debug('Setting up backend GCP.');
         const backendServiceName = tasks.getInput("backendServiceGCP", true)!;
         this.setupBackend(backendServiceName);
-
-        for (const [key, value] of this.backendConfig.entries()) {
-            terraformToolRunner.arg(`-backend-config=${key}=${value}`);
-        }
+        this.applyBackendConfig(terraformToolRunner);
         tasks.debug('Finished setting up backend GCP.');
     }
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -56,10 +56,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
         const backendServiceName = tasks.getInput("backendServiceOCI", true)!;
         this.setupBackend(backendServiceName);
-
-        for (const [key, value] of this.backendConfig.entries()) {
-            terraformToolRunner.arg(`-backend-config=${key}=${value}`);
-        }
+        this.applyBackendConfig(terraformToolRunner);
     }
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {


### PR DESCRIPTION
## Summary

- Extract duplicated backend config loop from all 4 provider handlers (Azure, AWS, GCP, OCI) into a `protected applyBackendConfig()` method on `BaseTerraformCommandHandler`
- Make `warnIfMultipleProviders()` async for interface consistency

## Changelog

- **refactor**: Extract backend config loop to base class method (#41)
- **refactor**: Make warnIfMultipleProviders() async (#43)

## Test plan

- [x] `npx tsc -b tsconfig.json` — zero errors
- [x] `npx eslint src/` — zero warnings
- [x] `npm test` — 117 tests passing

Closes #41, closes #43