### PR TITLE
fix: security hardening for credential handling

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessMalformedAuthenticationSchemeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessMalformedAuthenticationSchemeL0.ts
@@ -1,4 +1,4 @@
 import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
 import { runCommand } from '../../test-l0-helpers';
 
-runCommand(new TerraformCommandHandlerAzureRM(), 'init', 'AzureInitSuccessMalformedAuthenticationSchemeL0');
+runCommand(new TerraformCommandHandlerAzureRM(), 'init', 'AzureInitSuccessMalformedAuthenticationSchemeL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -86,18 +86,16 @@ describe('Terraform Test Suite', function () {
     });
 
 
-    it('azure init should succeed with malformed authentication scheme', async () => {
+    it('azure init should fail with malformed authentication scheme', async () => {
         let tp = path.join(__dirname, './InitTests/Azure/AzureInitSuccessMalformedAuthenticationScheme.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         await tr.runAsync();
 
         runValidations(() => {
-            assert(tr.succeeded, 'task should have succeeded');
-            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
-            assert(tr.errorIssues.length === 0, 'should have no errors');
-            assert(tr.warningIssues.length === 1, 'should have 1 warning');
-            assert(tr.stdOutContained('AzureInitSuccessMalformedAuthenticationSchemeL0 should have succeeded.'), 'Should have printed: AzureInitSuccessMalformedAuthenticationSchemeL0 should have succeeded.');
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have errors');
+            assert(tr.stdOutContained('AzureInitSuccessMalformedAuthenticationSchemeL0 should have failed.'), 'Should have printed: AzureInitSuccessMalformedAuthenticationSchemeL0 should have failed.');
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -53,7 +53,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
         tasks.setSecret(oidcToken);
 
         const tokenFilePath = path.resolve(`aws-oidc-token-${uuidV4()}.jwt`);
-        tasks.writeFile(tokenFilePath, oidcToken);
+        require('fs').writeFileSync(tokenFilePath, oidcToken, { mode: 0o600 });
         this.tempFiles.push(tokenFilePath);
 
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_ARN", tasks.getInput("awsRoleArn", true)!);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -159,8 +159,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             return AuthorizationScheme.WorkloadIdentityFederation;
         }
 
-        tasks.debug("No matching authorization scheme was found, using ServicePrincipal by default, but this could cause issues.");
-        return AuthorizationScheme.ServicePrincipal;
+        throw new Error(`Unrecognized authorization scheme '${authorizationScheme}'. Supported schemes: WorkloadIdentityFederation, ManagedServiceIdentity, ServicePrincipal.`);
     }
 }
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -20,6 +20,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         const clientEmail = tasks.getEndpointAuthorizationParameter(serviceName, "Issuer", false);
         const tokenUri = tasks.getEndpointAuthorizationParameter(serviceName, "Audience", false);
         const privateKey = tasks.getEndpointAuthorizationParameter(serviceName, "PrivateKey", false);
+        if (privateKey) { tasks.setSecret(privateKey); }
 
         // Create json string and write it to the file
         const jsonCredsString = JSON.stringify({
@@ -28,7 +29,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             client_email: clientEmail,
             token_uri: tokenUri
         });
-        tasks.writeFile(jsonKeyFilePath, jsonCredsString);
+        require('fs').writeFileSync(jsonKeyFilePath, jsonCredsString, { mode: 0o600 });
         this.tempFiles.push(jsonKeyFilePath);
 
         return jsonKeyFilePath;
@@ -74,7 +75,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         tasks.setSecret(oidcToken);
 
         const tokenFilePath = path.resolve(`gcp-oidc-token-${uuidV4()}.jwt`);
-        tasks.writeFile(tokenFilePath, oidcToken);
+        require('fs').writeFileSync(tokenFilePath, oidcToken, { mode: 0o600 });
         this.tempFiles.push(tokenFilePath);
 
         const projectNumber = tasks.getInput("gcpProjectNumber", true)!;
@@ -94,7 +95,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         };
 
         const credentialsFilePath = path.resolve(`gcp-wif-credentials-${uuidV4()}.json`);
-        tasks.writeFile(credentialsFilePath, JSON.stringify(credentials));
+        require('fs').writeFileSync(credentialsFilePath, JSON.stringify(credentials), { mode: 0o600 });
         this.tempFiles.push(credentialsFilePath);
 
         EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_CREDENTIALS", credentialsFilePath);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -23,7 +23,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         privateKey = privateKey.replace('_begin_', '-----BEGIN PRIVATE KEY-----');
         privateKey = privateKey.replace('_end_', '-----END PRIVATE KEY-----');
         const privateKeyFilePath = path.resolve(`keyfile-${uuidV4()}.pem`);
-        tasks.writeFile(privateKeyFilePath, privateKey);
+        require('fs').writeFileSync(privateKeyFilePath, privateKey, { mode: 0o600 });
         this.tempFiles.push(privateKeyFilePath);
         return privateKeyFilePath;
     }
@@ -39,10 +39,20 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         // Instead, will create a backend.tf config file for it in-flight when generate option was selected 'yes' (the default setting)
         if (tasks.getInput("backendOCIConfigGenerate", true) === 'yes') {
             tasks.debug('Generating backend tf statefile config.');
-            const parUrl = (tasks.getInput("backendOCIPar", true) || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            const parUrl = (tasks.getInput("backendOCIPar", true) || '');
+
+            // Validate PAR URL: must be HTTPS and must not contain HCL interpolation sequences
+            if (!parUrl.startsWith('https://')) {
+                throw new Error("OCI PAR URL must use HTTPS scheme.");
+            }
+            if (parUrl.includes('${') || parUrl.includes('%{')) {
+                throw new Error("OCI PAR URL contains invalid characters ('${' or '%{' are not allowed).");
+            }
+
+            const escapedParUrl = parUrl.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
             let config = "";
             config = config + "terraform {\n backend \"http\" {\n";
-            config = config + " address = \"" + parUrl + "\"\n";
+            config = config + " address = \"" + escapedParUrl + "\"\n";
             config = config + " update_method = \"PUT\"\n }\n }\n";
 
             const workingDirectory = tasks.getInput("workingDirectory") || '';


### PR DESCRIPTION
## Summary
- Mask GCP private key with `setSecret()` for log masking parity with OCI/AWS/HCP (#60)
- Validate OCI PAR URL: require HTTPS, reject HCL injection sequences `${` / `%{` (#61)
- Set file permissions `0o600` on all credential temp files (PEM, JSON, JWT) (#62)
- Throw error on unrecognized Azure auth scheme instead of silent ServicePrincipal fallback (#63)

## Changelog
### Security
- **GCP private key masking** — `tasks.setSecret()` now called for GCP private key, matching all other providers
- **OCI PAR URL validation** — HTTPS required; HCL interpolation sequences rejected to prevent expression injection
- **Credential file permissions** — All temp credential files now written with mode `0o600` (owner-only)
- **Auth scheme validation** — Unrecognized Azure auth schemes now throw a clear error instead of silently falling back to ServicePrincipal

## Test plan
- [x] All 120 existing tests pass
- [x] Malformed auth scheme test updated to expect failure