### PR TITLE
fix: add missing outputVariables, drop Node16

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -68,9 +68,6 @@
         }
     ],
     "execution": {
-        "Node16": {
-            "target": "src/index.js"
-        },
         "Node20_1": {
             "target": "src/index.js"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -19,9 +19,6 @@
     },
     "instanceNameFormat": "Terraform : $(provider)",
     "execution": {
-        "Node16": {
-            "target": "src/index.js"
-        },
         "Node20_1": {
             "target": "src/index.js"
         }
@@ -636,6 +633,14 @@
         {
             "name": "changesPresent",
             "description": "A boolean indicating if the terraform plan found any changes to apply."
+        },
+        {
+            "name": "showFilePath",
+            "description": "The location of the file containing the terraform show output.<br><br>Note: This variable will only be set if 'command' is 'show' and 'outputTo' is 'file'."
+        },
+        {
+            "name": "customFilePath",
+            "description": "The location of the file containing the terraform custom command output.<br><br>Note: This variable will only be set if 'command' is 'custom' and 'outputTo' is 'file'."
         }
     ],
     "messages": {


### PR DESCRIPTION
## Summary
- Add `showFilePath` and `customFilePath` to V5 `task.json` outputVariables (#65)
- Remove `Node16` execution target from both V5 and InstallerV1 tasks (#67)

## Changelog
### Fixed
- **Output variables** — `showFilePath` and `customFilePath` now discoverable in ADO task UI
### Changed
- **Node16 removed** — Both tasks now target Node20 only (Node 16 EOL Sep 2023)

## Test plan
- [x] Task JSON validates correctly
- [x] No runtime changes — output variables were already set in code