### PR TITLE
test: expand test/custom command coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,29 @@ Tests are organized by command x provider: `InitTests/`, `PlanTests/`, `ApplyTes
 
 When adding new commands or providers, add corresponding test pairs.
 
+### Writing new tests
+
+Use the helper pattern for all new tests:
+
+**L0 file** (`<Name>L0.ts`): use `runCommand()` from `test-l0-helpers.ts`:
+
+```typescript
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'plan', 'AWSPlanSuccessL0');
+```
+
+For failure tests, pass `false` as the fourth argument:
+
+```typescript
+runCommand(new TerraformCommandHandlerAWS(), 'init', 'AWSInitFailL0', false);
+```
+
+**Mock-setup file** (`<Name>.ts`): configure inputs, env vars, and mock answers, then call `tr.run()`.
+
+**L0.ts registration**: add an `it()` block in the main `Tests/L0.ts` file near the other tests for the same command.
+
 ## Release Process
 
 Releases are triggered by pushing a semver tag to `main`. The automated workflow handles packaging and publishing.

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CustomTests/AWSCustomConsoleSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CustomTests/AWSCustomConsoleSuccess.ts
@@ -1,0 +1,36 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AWSCustomConsoleSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'custom');
+tr.setInput('customCommand', 'graph');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('outputTo', 'console');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'DummyUsername';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'DummyPassword';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform graph": {
+            "code": 0,
+            "stdout": "digraph { }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CustomTests/AWSCustomConsoleSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CustomTests/AWSCustomConsoleSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'custom', 'AWSCustomConsoleSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -1750,6 +1750,20 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    it('aws custom command to console should succeed', async () => {
+        let tp = path.join(__dirname, './CustomTests/AWSCustomConsoleSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AWSCustomConsoleSuccessL0 should have succeeded.'), 'Should have printed: AWSCustomConsoleSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
     /* terraform test command tests */
 
     it('azure test command should succeed', async () => {
@@ -1763,6 +1777,48 @@ describe('Terraform Test Suite', function () {
             assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.stdOutContained('AzureTestSuccessL0 should have succeeded.'), 'Should have printed: AzureTestSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('aws test command should succeed', async () => {
+        let tp = path.join(__dirname, './TestCommandTests/AWSTestSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AWSTestSuccessL0 should have succeeded.'), 'Should have printed: AWSTestSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('gcp test command should succeed', async () => {
+        let tp = path.join(__dirname, './TestCommandTests/GCPTestSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('GCPTestSuccessL0 should have succeeded.'), 'Should have printed: GCPTestSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('oci test command should succeed', async () => {
+        let tp = path.join(__dirname, './TestCommandTests/OCITestSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('OCITestSuccessL0 should have succeeded.'), 'Should have printed: OCITestSuccessL0 should have succeeded.');
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AWSTestSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AWSTestSuccess.ts
@@ -1,0 +1,34 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AWSTestSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'test');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'DummyUsername';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'DummyPassword';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform test": {
+            "code": 0,
+            "stdout": "Success! 0 passed, 0 failed."
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AWSTestSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AWSTestSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'test', 'AWSTestSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/GCPTestSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/GCPTestSuccess.ts
@@ -1,0 +1,37 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './GCPTestSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'gcp');
+tr.setInput('command', 'test');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameGCP', 'GCP');
+
+process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
+process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'DummyClientEmail';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'https://oauth2.googleapis.com/token';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'https://www.googleapis.com/auth/cloud-platform';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform test": {
+            "code": 0,
+            "stdout": "Success! 0 passed, 0 failed."
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/GCPTestSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/GCPTestSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerGCP } from './../../src/gcp-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerGCP(), 'test', 'GCPTestSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccess.ts
@@ -1,0 +1,36 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCITestSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'test');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'DummyTenancy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'DummyUser';
+process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'DummyFingerprint';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- DummyKey -----END PRIVATE KEY-----';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform test": {
+            "code": 0,
+            "stdout": "Success! 0 passed, 0 failed."
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../src/oci-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'test', 'OCITestSuccessL0');


### PR DESCRIPTION
## Summary
- Add `test` command tests for AWS, GCP, OCI providers (#66)
- Add `custom` command test for AWS provider (#66)
- Document standard test helper pattern in CONTRIBUTING.md (#69)

## Changelog
### Tests
- **test command** — AWS, GCP, OCI provider coverage (was Azure-only)
- **custom command** — AWS provider coverage (was Azure-only)
- **124 total tests** (up from 120)
### Documentation
- **CONTRIBUTING.md** — Added "Writing new tests" section with helper pattern examples

## Test plan
- [x] All 124 tests pass