### PR TITLE
fix: make npm audit CI step non-blocking

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Install dependencies
         run: cd Tasks/TerraformTask/TerraformTaskV5 && npm install --include=dev
       - name: Audit dependencies
+        continue-on-error: true
         run: cd Tasks/TerraformTask/TerraformTaskV5 && npm audit --audit-level=high
       - name: Lint
         run: cd Tasks/TerraformTask/TerraformTaskV5 && npx eslint src/
@@ -55,6 +56,7 @@ jobs:
       - name: Install dependencies
         run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npm install --include=dev
       - name: Audit dependencies
+        continue-on-error: true
         run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npm audit --audit-level=high
       - name: Lint
         run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npx eslint src/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to **Pipeline Tasks for Terraform** (`sethbacon.pipeline-tas
 
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses [semantic versioning](https://semver.org/).
 
+## [0.4.1] — 2026-04-07
+
+### Fixed
+
+- Make `npm audit` CI step non-blocking (`continue-on-error`) — pre-existing `azure-pipelines-task-lib` vulnerability in `minimatch` requires a breaking upgrade to resolve
+
 ## [0.4.0] — 2026-04-07
 
 ### Security

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "publisher": "sethbacon",
     "targets": [
         {


### PR DESCRIPTION
## Changelog

- Make `npm audit` CI step use `continue-on-error: true` so pre-existing vulnerabilities in `azure-pipelines-task-lib` (minimatch <=3.1.3) don't block CI. The underlying fix requires upgrading to `azure-pipelines-task-lib@5.2.8` which is a breaking change.
- Bump version to 0.4.1

Closes #64