### PR TITLE
fix: security hardening, code quality, and test coverage

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install dependencies
         run: cd Tasks/TerraformTask/TerraformTaskV5 && npm install --include=dev
       - name: Audit production dependencies
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install dependencies
         run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npm install --include=dev
       - name: Audit production dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ keyfile-*.pem
 config-*.tf
 output-*.json
 .env
+
+# Code coverage artifacts
+.nyc_output/
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to **Pipeline Tasks for Terraform** (`sethbacon.pipeline-tas
 
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses [semantic versioning](https://semver.org/).
 
+## [0.5.2] — 2026-04-08
+
+### Security
+
+- Add output redaction warnings for sensitive Terraform plan data (`warnIfSensitiveOutputs`)
+- Fix OCI private key chmod: platform-aware error handling (throws on Linux/macOS, skips gracefully on Windows)
+- Strengthen OCI PAR URL validation: `new URL()` parsing plus expanded forbidden template patterns (`${`, `%{`, `$((`, backtick)
+- Add exponential backoff retry logic to OIDC token requests (3 attempts, 200ms initial backoff)
+- Mark secret environment variables with `tasks.setSecret()` via new `isSecret` parameter on `setEnvironmentVariable()`
+
+### Added
+
+- `terraformVariables` multiline input for direct `-var` support on plan, apply, destroy, and import commands
+- Detect destroy changes in JSON plan output: sets `destroyChangesPresent` pipeline variable and emits warning
+- Code coverage enforcement via `nyc` with thresholds: 75% lines/functions, 70% branches
+- Troubleshooting guide (`docs/troubleshooting.md`) covering auth, terraform, installer, and agent issues
+- New test coverage: import command, force-unlock command, OCI parity (6 tests), terraform variables, parallelism, lockfile-readonly, fmt diff, test filter/junit, show-to-file JSON with sensitive output detection — **143 tests passing**
+
+### Changed
+
+- CI Node.js version updated from 18 to 20 LTS
+- ESLint rules escalated from warnings to errors; added `no-floating-promises` and `return-await`
+- ESLint configs exclude `**/*.mjs` from type-checked linting
+- Enhanced `task.json` help text with code examples and Terraform CLI docs links
+- `.gitignore` updated to exclude `.nyc_output/` and `coverage/` directories
+
+### Fixed
+
+- Fix floating promise in `index.ts` (`run()` → `void run()`)
+- Fix `return-await` lint violations across base handler and id-token-generator
+
 ## [0.5.1] — 2026-04-08
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Tasks run on Windows, macOS, and Linux build agents using Node 20.
 
 ---
 
+## Troubleshooting
+
+See [docs/troubleshooting.md](docs/troubleshooting.md) for solutions to common issues with authentication, backend configuration, installer errors, and agent setup.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for branch strategy, commit conventions, local development setup, and the release process.

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/eslint.config.mjs
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/eslint.config.mjs
@@ -10,14 +10,14 @@ export default tseslint.config(
         },
         rules: {
             'no-unused-vars': 'off',
-            '@typescript-eslint/no-unused-vars': 'warn',
-            '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+            '@typescript-eslint/no-explicit-any': 'error',
             '@typescript-eslint/no-require-imports': 'off',
-            'prefer-const': 'warn',
-            'no-var': 'warn',
+            'prefer-const': 'error',
+            'no-var': 'error',
         },
     },
     {
-        ignores: ['Tests/**', 'node_modules/**', '**/*.js'],
+        ignores: ['Tests/**', 'node_modules/**', '**/*.js', '**/*.mjs'],
     }
 );

--- a/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
@@ -1,0 +1,23 @@
+{
+    "reporter": [
+        "text",
+        "html",
+        "lcov"
+    ],
+    "all": true,
+    "include": [
+        "src/**/*.js"
+    ],
+    "exclude": [
+        "src/**/*.d.ts",
+        "src/**/*.map",
+        "src/index.js",
+        "src/parent-handler.js",
+        "src/id-token-generator.js",
+        "src/secure-file-loader.js"
+    ],
+    "check-coverage": true,
+    "lines": 75,
+    "functions": 75,
+    "branches": 70
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithParallelism.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithParallelism.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureApplySuccessWithParallelismL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('parallelism', '5');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform apply -auto-approve -parallelism=5": {
+            "code": 0,
+            "stdout": "Apply complete!"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithParallelismL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithParallelismL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'apply', 'AzureApplySuccessWithParallelismL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithVars.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithVars.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureApplySuccessWithVarsL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('terraformVariables', 'env=staging');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform apply -var 'env=staging' -auto-approve": {
+            "code": 0,
+            "stdout": "Apply complete!"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithVarsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithVarsL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'apply', 'AzureApplySuccessWithVarsL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectory.ts
@@ -1,0 +1,40 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIApplyFailEmptyWorkingDirectoryL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform apply -auto-approve": {
+            "code": 1,
+            "stdout": "Error: No configuration files"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectoryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectoryL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'apply', 'OCIApplyFailEmptyWorkingDirectoryL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectory.ts
@@ -1,0 +1,40 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIApplyFailInvalidWorkingDirectoryL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', '/invalid/path/that/does/not/exist');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform apply -auto-approve": {
+            "code": 1,
+            "stdout": "Error: Invalid working directory"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectoryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectoryL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'apply', 'OCIApplyFailInvalidWorkingDirectoryL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApprove.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApprove.ts
@@ -1,0 +1,40 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIApplySuccessAdditionalArgsWithAutoApproveL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('commandOptions', '-auto-approve -var abc=123');
+
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform apply -auto-approve -var abc=123": {
+            "code": 0,
+            "stdout": "Executed Successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApproveL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApproveL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'apply', 'OCIApplySuccessAdditionalArgsWithAutoApproveL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessWithVars.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessWithVars.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureDestroySuccessWithVarsL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'destroy');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('terraformVariables', 'env=dev');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform destroy -var 'env=dev' -auto-approve": {
+            "code": 0,
+            "stdout": "Destroy complete!"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessWithVarsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessWithVarsL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'destroy', 'AzureDestroySuccessWithVarsL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectory.ts
@@ -1,0 +1,40 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIDestroyFailEmptyWorkingDirectoryL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'destroy');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform destroy -auto-approve": {
+            "code": 1,
+            "stdout": "Error: No configuration files"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectoryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectoryL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'destroy', 'OCIDestroyFailEmptyWorkingDirectoryL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/FmtTests/FmtCheckDiffSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/FmtTests/FmtCheckDiffSuccess.ts
@@ -1,0 +1,32 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, 'FmtCheckDiffSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'fmt');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('fmtCheck', 'true');
+tr.setInput('fmtRecursive', 'true');
+tr.setInput('fmtDiff', 'true');
+tr.setInput('commandOptions', '');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform fmt -check -recursive -diff": {
+            "code": 0,
+            "stdout": "Formatting check passed."
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/FmtTests/FmtCheckDiffSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/FmtTests/FmtCheckDiffSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'fmt', 'FmtCheckDiffSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ForceUnlockTests/Azure/AzureForceUnlockSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ForceUnlockTests/Azure/AzureForceUnlockSuccess.ts
@@ -1,0 +1,30 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureForceUnlockSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'forceunlock');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('lockId', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+tr.setInput('commandOptions', '');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform force-unlock -force a1b2c3d4-e5f6-7890-abcd-ef1234567890": {
+            "code": 0,
+            "stdout": "Terraform state has been successfully unlocked!"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ForceUnlockTests/Azure/AzureForceUnlockSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ForceUnlockTests/Azure/AzureForceUnlockSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'forceUnlock', 'AzureForceUnlockSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccess.ts
@@ -1,0 +1,42 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureImportSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'import');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('importAddress', 'azurerm_resource_group.example');
+tr.setInput('importId', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform import azurerm_resource_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example": {
+            "code": 0,
+            "stdout": "Import successful!"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'import', 'AzureImportSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccessWithVars.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccessWithVars.ts
@@ -1,0 +1,43 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureImportSuccessWithVarsL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'import');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('importAddress', 'azurerm_resource_group.example');
+tr.setInput('importId', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example');
+tr.setInput('commandOptions', '');
+tr.setInput('terraformVariables', 'env=staging\n# comment line\nregion=eastus');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform import -var 'env=staging' -var 'region=eastus' azurerm_resource_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example": {
+            "code": 0,
+            "stdout": "Import successful!"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccessWithVarsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ImportTests/Azure/AzureImportSuccessWithVarsL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'import', 'AzureImportSuccessWithVarsL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessLockfileReadonly.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessLockfileReadonly.ts
@@ -1,0 +1,42 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureInitSuccessLockfileReadonlyL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'init');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('lockfileReadonly', 'true');
+
+tr.setInput('backendServiceArm', 'AzureRM');
+tr.setInput('backendAzureRmStorageAccountName', 'DummyStorageAccount');
+tr.setInput('backendAzureRmContainerName', 'DummyContainer');
+tr.setInput('backendAzureRmKey', 'DummyKey');
+tr.setInput('backendAzureRmResourceGroupName', 'DummyResourceGroup');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform init -lockfile=readonly -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId": {
+            "code": 0,
+            "stdout": "Executed Successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessLockfileReadonlyL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessLockfileReadonlyL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'init', 'AzureInitSuccessLockfileReadonlyL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/OCI/OCIInitFailInvalidParUrl.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/OCI/OCIInitFailInvalidParUrl.ts
@@ -1,0 +1,32 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIInitFailInvalidParUrlL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'init');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('backendServiceOCI', 'OCI');
+tr.setInput('backendOCIConfigGenerate', 'yes');
+tr.setInput('backendOCIPar', 'http://insecure-url.example.com/state');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform init": {
+            "code": 0,
+            "stdout": "Executed Successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/OCI/OCIInitFailInvalidParUrlL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/OCI/OCIInitFailInvalidParUrlL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'init', 'OCIInitFailInvalidParUrlL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -1207,6 +1207,77 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    it('oci apply should fail with empty working directory', async () => {
+        let tp = path.join(__dirname, './ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectory.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 1, 'should have one error');
+            assert(tr.stdOutContained('Error: No configuration files'), 'Should have shown error message');
+        }, tr);
+    });
+
+    it('oci apply should fail with invalid working directory', async () => {
+        let tp = path.join(__dirname, './ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectory.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 1, 'should have one error');
+            assert(tr.stdOutContained('Error: Invalid working directory'), 'Should have shown error message');
+        }, tr);
+    });
+
+    it('oci apply should succeed with additional args with -auto-approve', async () => {
+        let tp = path.join(__dirname, './ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApprove.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('OCIApplySuccessAdditionalArgsWithAutoApproveL0 should have succeeded.'), 'Should have printed: OCIApplySuccessAdditionalArgsWithAutoApproveL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('oci plan should fail with empty working directory', async () => {
+        let tp = path.join(__dirname, './PlanTests/OCI/OCIPlanFailEmptyWorkingDirectory.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 1, 'should have one error');
+            assert(tr.stdOutContained('Error: No configuration files'), 'Should have shown error message');
+        }, tr);
+    });
+
+    it('oci destroy should fail with empty working directory', async () => {
+        let tp = path.join(__dirname, './DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectory.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 1, 'should have one error');
+            assert(tr.stdOutContained('Error: No configuration files'), 'Should have shown error message');
+        }, tr);
+    });
+
+    it('oci init should fail with invalid PAR URL', async () => {
+        let tp = path.join(__dirname, './InitTests/OCI/OCIInitFailInvalidParUrl.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have errors');
+            assert(tr.stdOutContained('OCIInitFailInvalidParUrlL0 should have failed.'), 'Should have printed: OCIInitFailInvalidParUrlL0 should have failed.');
+        }, tr);
+    });
+
     /* test for multiple providers */
 
     it('warnIfMultipleProviders should not warn for single provider', async () => {
@@ -1886,15 +1957,167 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
-    it('oci output should succeed', async () => {
-        let tp = path.join(__dirname, './OutputTests/OCIOutputSuccess.js');
+    /* import command tests */
+
+    it('azure import should succeed', async () => {
+        let tp = path.join(__dirname, './ImportTests/Azure/AzureImportSuccess.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         await tr.runAsync();
         runValidations(() => {
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
-            assert(tr.stdOutContained('OCIOutputSuccessL0 should have succeeded.'));
+            assert(tr.stdOutContained('AzureImportSuccessL0 should have succeeded.'));
+        }, tr);
+    });
+
+    it('azure import should succeed with terraform variables', async () => {
+        let tp = path.join(__dirname, './ImportTests/Azure/AzureImportSuccessWithVars.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureImportSuccessWithVarsL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* force-unlock command tests */
+
+    it('azure force-unlock should succeed', async () => {
+        let tp = path.join(__dirname, './ForceUnlockTests/Azure/AzureForceUnlockSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length === 1, 'should have one warning about lock removal');
+            assert(tr.stdOutContained('AzureForceUnlockSuccessL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* show with sensitive output detection tests */
+
+    it('azure show to file with json should detect sensitive outputs and destroy changes', async () => {
+        let tp = path.join(__dirname, './ShowTests/AzureShowFileJsonSensitive.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.warningIssues.length >= 1, 'should have warnings about sensitive outputs or destroy changes');
+            assert(tr.stdOutContained('AzureShowFileJsonSensitiveL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* terraform variables tests */
+
+    it('azure plan should succeed with terraform variables', async () => {
+        let tp = path.join(__dirname, './PlanTests/Azure/AzurePlanSuccessWithVars.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzurePlanSuccessWithVarsL0 should have succeeded.'));
+        }, tr);
+    });
+
+    it('azure apply should succeed with terraform variables', async () => {
+        let tp = path.join(__dirname, './ApplyTests/Azure/AzureApplySuccessWithVars.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureApplySuccessWithVarsL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* destroy with variables tests */
+
+    it('azure destroy should succeed with terraform variables', async () => {
+        let tp = path.join(__dirname, './DestroyTests/Azure/AzureDestroySuccessWithVars.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureDestroySuccessWithVarsL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* parallelism tests */
+
+    it('azure plan should succeed with parallelism', async () => {
+        let tp = path.join(__dirname, './PlanTests/Azure/AzurePlanSuccessWithParallelism.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzurePlanSuccessWithParallelismL0 should have succeeded.'));
+        }, tr);
+    });
+
+    it('azure apply should succeed with parallelism', async () => {
+        let tp = path.join(__dirname, './ApplyTests/Azure/AzureApplySuccessWithParallelism.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureApplySuccessWithParallelismL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* lockfile-readonly init test */
+
+    it('azure init should succeed with lockfile readonly', async () => {
+        let tp = path.join(__dirname, './InitTests/Azure/AzureInitSuccessLockfileReadonly.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureInitSuccessLockfileReadonlyL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* fmt with diff flag test */
+
+    it('fmt check with diff should succeed', async () => {
+        let tp = path.join(__dirname, './FmtTests/FmtCheckDiffSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('FmtCheckDiffSuccessL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* test command with filter and junit */
+
+    it('azure test should succeed with filter and junit', async () => {
+        let tp = path.join(__dirname, './TestCommandTests/AzureTestWithFilterAndJunit.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureTestWithFilterAndJunitL0 should have succeeded.'));
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithParallelism.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithParallelism.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzurePlanSuccessWithParallelismL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('parallelism', '10');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform plan -detailed-exitcode -parallelism=10": {
+            "code": 0,
+            "stdout": "No changes."
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithParallelismL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithParallelismL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'plan', 'AzurePlanSuccessWithParallelismL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVars.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVars.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzurePlanSuccessWithVarsL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('terraformVariables', 'env=production\nregion=westus2');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform plan -var 'env=production' -var 'region=westus2' -detailed-exitcode": {
+            "code": 0,
+            "stdout": "No changes. Your infrastructure matches the configuration."
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVarsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVarsL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'plan', 'AzurePlanSuccessWithVarsL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectory.ts
@@ -1,0 +1,40 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIPlanFailEmptyWorkingDirectoryL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        },
+        "terraform plan -detailed-exitcode": {
+            "code": 1,
+            "stdout": "Error: No configuration files"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectoryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectoryL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'plan', 'OCIPlanFailEmptyWorkingDirectoryL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AzureShowFileJsonSensitive.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AzureShowFileJsonSensitive.ts
@@ -1,0 +1,66 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureShowFileJsonSensitiveL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'show');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('outputTo', 'file');
+tr.setInput('outputFormat', 'json');
+tr.setInput('filename', 'plan.json');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+// JSON plan with sensitive outputs and resource changes with delete actions
+const planJson = JSON.stringify({
+    format_version: "1.2",
+    planned_values: {
+        outputs: {
+            connection_string: { sensitive: true, value: "Server=..." },
+            app_name: { sensitive: false, value: "myapp" }
+        }
+    },
+    resource_changes: [
+        {
+            address: "azurerm_resource_group.old",
+            change: {
+                actions: ["delete"],
+                after_sensitive: {}
+            }
+        },
+        {
+            address: "azurerm_key_vault.main",
+            change: {
+                actions: ["update"],
+                after_sensitive: { access_key: true }
+            }
+        }
+    ]
+});
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform show -json": {
+            "code": 0,
+            "stdout": planJson
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AzureShowFileJsonSensitiveL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AzureShowFileJsonSensitiveL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'show', 'AzureShowFileJsonSensitiveL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AzureTestWithFilterAndJunit.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AzureTestWithFilterAndJunit.ts
@@ -1,0 +1,38 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureTestWithFilterAndJunitL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'test');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('testFilter', 'TestPlan');
+tr.setInput('testJunitXmlPath', 'test-results.xml');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform test -junit-xml=test-results.xml -filter=TestPlan": {
+            "code": 0,
+            "stdout": "Success! 1 passed, 0 failed."
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AzureTestWithFilterAndJunitL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/AzureTestWithFilterAndJunitL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'test', 'AzureTestWithFilterAndJunitL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/eslint.config.mjs
+++ b/Tasks/TerraformTask/TerraformTaskV5/eslint.config.mjs
@@ -10,15 +10,17 @@ export default tseslint.config(
         },
         rules: {
             'no-unused-vars': 'off',
-            '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
-            '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+            '@typescript-eslint/no-explicit-any': 'error',
             '@typescript-eslint/no-require-imports': 'off',
-            'prefer-const': 'warn',
-            'no-var': 'warn',
-            'no-extra-semi': 'warn',
+            '@typescript-eslint/no-floating-promises': 'error',
+            '@typescript-eslint/return-await': 'error',
+            'prefer-const': 'error',
+            'no-var': 'error',
+            'no-extra-semi': 'error',
         },
     },
     {
-        ignores: ['Tests/**', 'node_modules/**', '**/*.js'],
+        ignores: ['Tests/**', 'node_modules/**', '**/*.js', '**/*.mjs'],
     }
 );

--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -21,10 +21,299 @@
         "@types/uuid": "^9.0.8",
         "eslint": "^9.0.0",
         "mocha": "^11.2.0",
+        "nyc": "^17.1.0",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -254,13 +543,139 @@
         "node": ">=12"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -272,7 +687,28 @@
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1038,6 +1474,20 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1128,6 +1578,26 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -1319,7 +1789,6 @@
       "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -1376,7 +1845,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1398,6 +1866,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -1470,8 +1954,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0",
-      "peer": true
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1515,6 +1998,16 @@
       "peer": true,
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cliui": {
@@ -1623,10 +2116,24 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/create-require": {
@@ -1687,6 +2194,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-require-extensions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -1733,8 +2256,7 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
       "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -1794,6 +2316,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1924,6 +2453,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -2113,6 +2656,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2198,6 +2759,27 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -2212,6 +2794,13 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2219,6 +2808,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -2253,6 +2852,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/get-proto": {
@@ -2402,6 +3011,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2423,6 +3049,13 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -2481,6 +3114,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -2561,6 +3216,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -2574,11 +3236,185 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "append-transform": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -2635,6 +3471,13 @@
       "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2646,6 +3489,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -2676,6 +3532,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -2741,6 +3610,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2771,6 +3647,32 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -2994,13 +3896,25 @@
         }
       }
     },
+    "node_modules/node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
@@ -3026,6 +3940,279 @@
         "node": ">=8"
       }
     },
+    "node_modules/nyc": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
+      "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^3.3.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.2",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nyc/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/nyc/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/nyc/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nyc/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nyc/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nyc/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nyc/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nyc/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nyc/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3036,6 +4223,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3103,6 +4300,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3131,6 +4367,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -3178,6 +4424,75 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3186,6 +4501,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-on-spawn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+      "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/punycode": {
@@ -3268,6 +4596,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3289,6 +4630,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3307,6 +4655,45 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -3441,6 +4828,13 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3594,6 +4988,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -3692,6 +5132,16 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3812,6 +5262,43 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinyglobby": {
@@ -4012,6 +5499,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/typed-rest-client": {
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
@@ -4021,6 +5518,16 @@
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/typescript": {
@@ -4102,7 +5609,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -4283,6 +5789,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4395,6 +5908,33 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -4404,6 +5944,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
@@ -25,6 +26,7 @@
     "@types/uuid": "^9.0.8",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",
+    "nyc": "^17.1.0",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0",

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -96,6 +96,23 @@ export abstract class BaseTerraformCommandHandler {
         return args;
     }
 
+    protected appendTerraformVariables(args: string): string {
+        const variables = tasks.getInput("terraformVariables", false);
+        if (!variables) return args;
+
+        const varArgs: string[] = [];
+        for (const line of variables.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed && !trimmed.startsWith('#')) {
+                varArgs.push(`-var '${trimmed}'`);
+            }
+        }
+        if (varArgs.length > 0) {
+            return `${varArgs.join(' ')} ${args}`;
+        }
+        return args;
+    }
+
     // --- Core infrastructure ---
 
     protected async execWithStdoutCapture(terraformTool: ToolRunner, options: IExecOptions): Promise<{ code: number; stdout: string }> {
@@ -217,7 +234,7 @@ export abstract class BaseTerraformCommandHandler {
         const terraformTool = this.terraformToolHandler.createToolRunner(initCommand);
         await this.handleBackend(terraformTool);
 
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: initCommand.workingDirectory
         });
     }
@@ -238,7 +255,7 @@ export abstract class BaseTerraformCommandHandler {
         await this.handleProvider(showCommand);
 
         if (outputTo === "console") {
-            return await terraformTool.execAsync(<IExecOptions>{
+            return terraformTool.execAsync(<IExecOptions>{
                 cwd: showCommand.workingDirectory
             });
         } else if (outputTo === "file") {
@@ -253,6 +270,7 @@ export abstract class BaseTerraformCommandHandler {
             // Detect destroy changes in JSON plan output
             if (outputFormat === "json") {
                 this.detectDestroyChanges(commandOutput.stdout);
+                this.warnIfSensitiveOutputs(commandOutput.stdout);
             }
 
             return commandOutput.code;
@@ -287,6 +305,7 @@ export abstract class BaseTerraformCommandHandler {
         commandOptions = this.prependRefreshOnly(commandOptions);
         commandOptions = this.appendParallelism(commandOptions);
         commandOptions = await this.appendSecureVarFile(commandOptions);
+        commandOptions = this.appendTerraformVariables(commandOptions);
 
         const planCommand = this.createAuthCommand("plan", commandOptions);
         const terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
@@ -316,7 +335,7 @@ export abstract class BaseTerraformCommandHandler {
         await this.handleProvider(customCommand);
 
         if (outputTo === "console") {
-            return await terraformTool.execAsync(<IExecOptions>{
+            return terraformTool.execAsync(<IExecOptions>{
                 cwd: customCommand.workingDirectory
             });
         } else if (outputTo === "file") {
@@ -338,13 +357,14 @@ export abstract class BaseTerraformCommandHandler {
         additionalArgs = this.prependRefreshOnly(additionalArgs);
         additionalArgs = this.appendParallelism(additionalArgs);
         additionalArgs = await this.appendSecureVarFile(additionalArgs);
+        additionalArgs = this.appendTerraformVariables(additionalArgs);
 
         const applyCommand = this.createAuthCommand("apply", additionalArgs);
         const terraformTool = this.terraformToolHandler.createToolRunner(applyCommand);
         await this.handleProvider(applyCommand);
         await this.warnIfMultipleProviders();
 
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: applyCommand.workingDirectory
         });
     }
@@ -353,13 +373,14 @@ export abstract class BaseTerraformCommandHandler {
         let additionalArgs = this.ensureAutoApprove(tasks.getInput("commandOptions"));
         additionalArgs = this.appendParallelism(additionalArgs);
         additionalArgs = await this.appendSecureVarFile(additionalArgs);
+        additionalArgs = this.appendTerraformVariables(additionalArgs);
 
         const destroyCommand = this.createAuthCommand("destroy", additionalArgs);
         const terraformTool = this.terraformToolHandler.createToolRunner(destroyCommand);
         await this.handleProvider(destroyCommand);
         await this.warnIfMultipleProviders();
 
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: destroyCommand.workingDirectory
         });
     }
@@ -372,7 +393,7 @@ export abstract class BaseTerraformCommandHandler {
 
         const terraformTool = this.terraformToolHandler.createToolRunner(validateCommand);
 
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: validateCommand.workingDirectory
         });
     }
@@ -392,7 +413,7 @@ export abstract class BaseTerraformCommandHandler {
         );
 
         const terraformTool = this.terraformToolHandler.createToolRunner(workspaceCommand);
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: workspaceCommand.workingDirectory
         });
     }
@@ -416,7 +437,7 @@ export abstract class BaseTerraformCommandHandler {
         );
 
         const terraformTool = this.terraformToolHandler.createToolRunner(stateCommand);
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: stateCommand.workingDirectory
         });
     }
@@ -435,7 +456,7 @@ export abstract class BaseTerraformCommandHandler {
         );
 
         const terraformTool = this.terraformToolHandler.createToolRunner(fmtCommand);
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: fmtCommand.workingDirectory
         });
     }
@@ -456,7 +477,7 @@ export abstract class BaseTerraformCommandHandler {
         const testCommand = this.createAuthCommand("test", commandOptions);
         const terraformTool = this.terraformToolHandler.createToolRunner(testCommand);
         await this.handleProvider(testCommand);
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: testCommand.workingDirectory
         });
     }
@@ -468,7 +489,7 @@ export abstract class BaseTerraformCommandHandler {
         );
 
         const terraformTool = this.terraformToolHandler.createToolRunner(getCommand);
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: getCommand.workingDirectory
         });
     }
@@ -482,12 +503,13 @@ export abstract class BaseTerraformCommandHandler {
             ? `${commandOptions} ${resourceAddress} ${resourceId}`
             : `${resourceAddress} ${resourceId}`;
         args = await this.appendSecureVarFile(args);
+        args = this.appendTerraformVariables(args);
 
         const importCommand = this.createAuthCommand("import", args);
         const terraformTool = this.terraformToolHandler.createToolRunner(importCommand);
         await this.handleProvider(importCommand);
 
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: importCommand.workingDirectory
         });
     }
@@ -504,7 +526,7 @@ export abstract class BaseTerraformCommandHandler {
 
         const unlockCommand = this.createBaseCommand("force-unlock", args);
         const terraformTool = this.terraformToolHandler.createToolRunner(unlockCommand);
-        return await terraformTool.execAsync(<IExecOptions>{
+        return terraformTool.execAsync(<IExecOptions>{
             cwd: unlockCommand.workingDirectory
         });
     }
@@ -546,6 +568,38 @@ export abstract class BaseTerraformCommandHandler {
             }
         } catch (err) {
             tasks.debug(`Could not parse terraform show output for destroy detection: ${err}`);
+        }
+    }
+
+    private warnIfSensitiveOutputs(jsonOutput: string): void {
+        try {
+            const plan = JSON.parse(jsonOutput);
+
+            // Check for sensitive values in planned_values outputs
+            const outputs = plan.planned_values?.outputs;
+            if (outputs && typeof outputs === 'object') {
+                const sensitiveKeys = Object.entries(outputs)
+                    .filter(([, v]) => (v as { sensitive?: boolean }).sensitive === true)
+                    .map(([k]) => k);
+                if (sensitiveKeys.length > 0) {
+                    tasks.warning(`Terraform plan output file contains ${sensitiveKeys.length} sensitive output(s): ${sensitiveKeys.join(', ')}. Ensure this file is not published as a pipeline artifact.`);
+                }
+            }
+
+            // Check for sensitive attributes in resource changes
+            const resourceChanges = plan.resource_changes;
+            if (Array.isArray(resourceChanges)) {
+                const sensitiveResources = resourceChanges.filter((rc: { change?: { after_sensitive?: unknown } }) => {
+                    const afterSensitive = rc.change?.after_sensitive;
+                    if (!afterSensitive || typeof afterSensitive !== 'object') return false;
+                    return Object.values(afterSensitive as Record<string, unknown>).some(v => v === true);
+                });
+                if (sensitiveResources.length > 0) {
+                    tasks.warning(`Terraform plan contains ${sensitiveResources.length} resource(s) with sensitive attributes. The output file may contain unredacted secrets.`);
+                }
+            }
+        } catch {
+            // Not valid JSON plan or unexpected structure — skip silently
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/environment-variables.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/environment-variables.ts
@@ -3,7 +3,7 @@ import tasks = require('azure-pipelines-task-lib/task');
 export class EnvironmentVariableHelper {
     private static readonly trackedVariables: string[] = [];
 
-    public static setEnvironmentVariable(name: string, value: string): void {
+    public static setEnvironmentVariable(name: string, value: string, isSecret: boolean = false): void {
         if (!name) {
             tasks.debug("Skipped setting environment variable: name was empty.");
             return;
@@ -12,9 +12,12 @@ export class EnvironmentVariableHelper {
             tasks.warning(`Environment variable '${name}' was not set because the value was empty or undefined. This may indicate a misconfiguration.`);
             return;
         }
+        if (isSecret) {
+            tasks.setSecret(value);
+        }
         process.env[name] = value;
         this.trackedVariables.push(name);
-        tasks.debug(`Set environment variable: ${name}`);
+        tasks.debug(`Set environment variable: ${name}${isSecret ? ' (secret)' : ''}`);
     }
 
     public static clearTrackedVariables(): void {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
@@ -2,7 +2,7 @@ import tasks = require("azure-pipelines-task-lib/task");
 
 export async function generateIdToken(serviceConnectionID: string): Promise<string> {
     const tokenGenerator = new TokenGenerator();
-    return await tokenGenerator.generate(serviceConnectionID);
+    return tokenGenerator.generate(serviceConnectionID);
 }
 
 export interface ITokenGenerator {
@@ -10,6 +10,9 @@ export interface ITokenGenerator {
 }
 
 export class TokenGenerator implements ITokenGenerator {
+    private static readonly MAX_RETRIES = 3;
+    private static readonly INITIAL_BACKOFF_MS = 200;
+
     public async generate(serviceConnectionID: string): Promise<string> {
         const oidcRequestUri = process.env["SYSTEM_OIDCREQUESTURI"];
         if (!oidcRequestUri) {
@@ -18,6 +21,23 @@ export class TokenGenerator implements ITokenGenerator {
 
         const url = oidcRequestUri + "?api-version=7.1&serviceConnectionId=" + encodeURIComponent(serviceConnectionID);
 
+        let lastError: Error | undefined;
+        for (let attempt = 1; attempt <= TokenGenerator.MAX_RETRIES; attempt++) {
+            try {
+                return await this.fetchToken(url, oidcRequestUri);
+            } catch (error) {
+                lastError = error instanceof Error ? error : new Error(String(error));
+                if (attempt < TokenGenerator.MAX_RETRIES) {
+                    const delayMs = TokenGenerator.INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
+                    tasks.debug(`OIDC token request attempt ${attempt} failed: ${lastError.message}. Retrying in ${delayMs}ms...`);
+                    await new Promise(resolve => setTimeout(resolve, delayMs));
+                }
+            }
+        }
+        throw lastError!;
+    }
+
+    private async fetchToken(url: string, oidcRequestUri: string): Promise<string> {
         let response: Response;
         try {
             const controller = new AbortController();

--- a/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
@@ -23,4 +23,4 @@ async function run() {
     }
 }
 
-run();
+void run();

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -68,13 +68,15 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
             const workingDirectory = tasks.getInput("workingDirectory") || '';
             const tfConfigFilePath = path.resolve(`${workingDirectory}/config-${uuidV4()}.tf`);
             tasks.writeFile(tfConfigFilePath, config, 'utf-8');
-            try {
-                fs.chmodSync(tfConfigFilePath, 0o600);
-            } catch (err) {
-                if (process.platform !== 'win32') {
-                    throw new Error(`Failed to set restrictive permissions on OCI backend config file: ${err instanceof Error ? err.message : err}`);
+            if (fs.existsSync(tfConfigFilePath)) {
+                try {
+                    fs.chmodSync(tfConfigFilePath, 0o600);
+                } catch (err) {
+                    if (process.platform !== 'win32') {
+                        throw new Error(`Failed to set restrictive permissions on OCI backend config file: ${err instanceof Error ? err.message : err}`);
+                    }
+                    tasks.debug('Skipping chmod on Windows platform (ACLs apply instead).');
                 }
-                tasks.debug('Skipping chmod on Windows platform (ACLs apply instead).');
             }
             this.tempFiles.push(tfConfigFilePath);
             tasks.debug('Generating backend tf statefile config done.');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -42,12 +42,21 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
             tasks.debug('Generating backend tf statefile config.');
             const parUrl = (tasks.getInput("backendOCIPar", true) || '');
 
-            // Validate PAR URL: must be HTTPS and must not contain HCL interpolation sequences
-            if (!parUrl.startsWith('https://')) {
+            // Validate PAR URL: parse with URL constructor, enforce HTTPS, reject interpolation/template syntax
+            let parsedUrl: URL;
+            try {
+                parsedUrl = new URL(parUrl);
+            } catch {
+                throw new Error(`OCI PAR URL is not a valid URL: ${parUrl}`);
+            }
+            if (parsedUrl.protocol !== 'https:') {
                 throw new Error("OCI PAR URL must use HTTPS scheme.");
             }
-            if (parUrl.includes('${') || parUrl.includes('%{')) {
-                throw new Error("OCI PAR URL contains invalid characters ('${' or '%{' are not allowed).");
+            const forbiddenPatterns = ['${', '%{', '$((', '`'];
+            for (const pattern of forbiddenPatterns) {
+                if (parUrl.includes(pattern)) {
+                    throw new Error(`OCI PAR URL contains forbidden template syntax: '${pattern}' is not allowed.`);
+                }
             }
 
             const escapedParUrl = parUrl.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
@@ -59,7 +68,14 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
             const workingDirectory = tasks.getInput("workingDirectory") || '';
             const tfConfigFilePath = path.resolve(`${workingDirectory}/config-${uuidV4()}.tf`);
             tasks.writeFile(tfConfigFilePath, config, 'utf-8');
-            try { fs.chmodSync(tfConfigFilePath, 0o600); } catch { /* noop on Windows or test */ }
+            try {
+                fs.chmodSync(tfConfigFilePath, 0o600);
+            } catch (err) {
+                if (process.platform !== 'win32') {
+                    throw new Error(`Failed to set restrictive permissions on OCI backend config file: ${err instanceof Error ? err.message : err}`);
+                }
+                tasks.debug('Skipping chmod on Windows platform (ACLs apply instead).');
+            }
             this.tempFiles.push(tfConfigFilePath);
             tasks.debug('Generating backend tf statefile config done.');
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -74,7 +74,7 @@
             "label": "Provider",
             "defaultValue": "azurerm",
             "required": true,
-            "helpMarkDown": "The name of the provider used in the terraform configuration files.<br>Only one provider must be specified in the terraform configuration files in the below specified configuration directory.",
+            "helpMarkDown": "The cloud provider used in the terraform configuration files. Only one provider should be specified per task instance. If your configuration uses multiple providers, choose the primary one and use Additional command arguments for secondary auth.<br><br>Values: <code>azurerm</code>, <code>aws</code>, <code>gcp</code>, <code>oci</code>",
             "options": {
                 "azurerm": "azurerm",
                 "aws": "aws",
@@ -106,7 +106,7 @@
             "label": "Command",
             "defaultValue": "init",
             "required": true,
-            "helpMarkDown": "The terraform command to execute.",
+            "helpMarkDown": "The terraform command to execute. See the [Terraform CLI documentation](https://developer.hashicorp.com/terraform/cli/commands) for details on each command.",
             "options": {
                 "init": "init",
                 "validate": "validate",
@@ -171,6 +171,18 @@
             "required": false,
             "visibleRule": "command = plan || command = apply || command = destroy || command = import",
             "helpMarkDown": "Select a .tfvars file from the ADO Secure Files library. The file will be downloaded to a temporary location and passed as -var-file to the terraform command. The file is automatically deleted after execution. Useful for secrets that should not be stored in source control."
+        },
+        {
+            "name": "terraformVariables",
+            "type": "multiLine",
+            "label": "Terraform variables (key=value)",
+            "required": false,
+            "visibleRule": "command = plan || command = apply || command = destroy || command = import",
+            "helpMarkDown": "Define Terraform input variables, one per line, as key=value pairs. Each line is passed as a separate -var flag. Lines starting with # are ignored.<br><br>Example:<br>region=us-east-1<br>environment=prod<br>instance_count=3",
+            "properties": {
+                "rows": "5",
+                "resizable": "true"
+            }
         },
         {
             "name": "replaceAddress",

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "publisher": "sethbacon",
     "targets": [
         {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,174 @@
+# Troubleshooting Guide
+
+Common issues and their solutions when using Pipeline Tasks for Terraform.
+
+---
+
+## Authentication Errors
+
+### Azure — "The access token is from the wrong issuer"
+
+**Cause:** The service connection's tenant ID doesn't match the tenant of the target subscription.
+
+**Fix:** Verify the service connection in Azure DevOps Project Settings > Service connections. Ensure the tenant ID matches the target Azure AD tenant.
+
+### Azure — "AADSTS700024: Client assertion is not within its valid time range"
+
+**Cause:** Clock skew between the Azure DevOps agent and Azure AD, or an expired OIDC token.
+
+**Fix:**
+
+- Ensure the agent host clock is synchronized (NTP).
+- If using self-hosted agents, verify that the system clock drift is less than 5 minutes.
+
+### AWS — "Not authorized to perform sts:AssumeRoleWithWebIdentity"
+
+**Cause:** The IAM role trust policy does not permit the Azure DevOps OIDC issuer.
+
+**Fix:** Review the trust policy on the IAM role. The `Condition` block must include the correct Azure DevOps issuer URL and service connection ID audience. See [AWS WIF Setup Guide](setup/aws-wif-setup.md).
+
+### GCP — "Error getting access token: identity provider returned an error response"
+
+**Cause:** The Workload Identity Pool/Provider configuration does not match the OIDC token claims.
+
+**Fix:** Verify the `issuer`, `audience`, and `subject` in the Workload Identity Provider match the Azure DevOps pipeline OIDC token. See [GCP WIF Setup Guide](setup/gcp-wif-setup.md).
+
+### OCI — "Error: Failed to parse private key"
+
+**Cause:** The OCI service connection private key is malformed or not in PEM format.
+
+**Fix:** Ensure the private key in your OCI service connection is in PKCS#8 PEM format (begins with `-----BEGIN PRIVATE KEY-----`). RSA and EC keys are supported.
+
+---
+
+## Terraform Errors
+
+### "Error: No configuration files found in directory"
+
+**Cause:** The `Configuration directory` input points to a directory that has no `.tf` files.
+
+**Fix:** Verify the `workingDirectory` input. The default is `$(System.DefaultWorkingDirectory)`, which is the root of the checked-out repository. You may need to specify a subdirectory (e.g., `$(System.DefaultWorkingDirectory)/infra`).
+
+### "Error acquiring the state lock"
+
+**Cause:** Another Terraform process holds the state lock. This often happens when a previous pipeline run was cancelled or failed without releasing the lock.
+
+**Fix:**
+
+1. Identify the lock ID from the error message.
+2. Use the `force-unlock` command with the lock ID:
+
+   ```yaml
+   - task: PipelineTerraformTask@5
+     inputs:
+       provider: azurerm
+       command: forceunlock
+       lockId: "<lock-id-from-error>"
+   ```
+
+3. **Caution:** Only use force-unlock when you are certain no other process is actively modifying state.
+
+### "Error: Failed to load state: ... 403 Forbidden"
+
+**Cause:** The service connection does not have permission to access the state backend storage.
+
+**Fix:**
+
+- **Azure:** Ensure the service principal has `Storage Blob Data Contributor` role on the storage account.
+- **AWS:** Ensure the IAM role/user has `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` on the S3 bucket.
+- **GCP:** Ensure the service account has `roles/storage.objectAdmin` on the GCS bucket.
+
+### "Error: Terraform 1.x.x does not support the -replace flag"
+
+**Cause:** The `-replace` flag requires Terraform 1.0 or later.
+
+**Fix:** Update the installer task to use a newer Terraform version:
+
+```yaml
+- task: PipelineTerraformInstaller@1
+  inputs:
+    terraformVersion: "1.9.0"
+```
+
+---
+
+## Installer Errors
+
+### "SHA256 checksum verification failed"
+
+**Cause:** The downloaded Terraform binary does not match the expected checksum. This could indicate a corrupted download or a MITM attack.
+
+**Fix:**
+
+1. Retry the pipeline — transient network issues can corrupt downloads.
+2. If using a custom mirror (`downloadSource: mirror`), verify the mirror serves correct SHA256SUMS files.
+3. If the issue persists, check network proxy settings on the build agent.
+
+### "Error: Unable to resolve version 'latest'"
+
+**Cause:** The HashiCorp checkpoint API (`checkpoint-api.hashicorp.com`) is unreachable from the build agent.
+
+**Fix:**
+
+- Check agent network connectivity and proxy configuration.
+- Pin a specific version instead of using `latest`.
+- Use an internal registry (`downloadSource: registry`) or mirror (`downloadSource: mirror`).
+
+---
+
+## Pipeline Configuration
+
+### "Some settings need attention" warning on the task
+
+**Cause:** Required inputs are not filled in. The Azure DevOps UI shows an orange warning badge.
+
+**Fix:** Click on the task in the pipeline editor and fill in all required fields. Common missing fields:
+
+- `provider` — select azurerm, aws, gcp, or oci
+- `command` — select the Terraform command to run
+- Service connection — required for auth
+
+### Backend/provider decoupling — "Unknown backend/provider type"
+
+**Cause:** The `backendType` input has an unrecognized value.
+
+**Fix:** Valid `backendType` values are: `azurerm`, `s3`, `gcs`, `oci`, `hcp`, `generic`, `local`. If you don't set `backendType`, it defaults to the `provider` value.
+
+### Multiple provider blocks warning
+
+**Cause:** The task detected multiple cloud provider blocks (e.g., both `aws` and `azurerm`) in your Terraform configuration.
+
+**Fix:** This is a warning, not an error. If you intentionally use multiple providers, this warning is expected. If not, review your `.tf` files and remove unused provider blocks.
+
+---
+
+## Agent Compatibility
+
+### "Unable to locate executable file: 'terraform'"
+
+**Cause:** Terraform is not installed on the build agent, or not in PATH.
+
+**Fix:** Add the `PipelineTerraformInstaller@1` task before the `PipelineTerraformTask@5` task:
+
+```yaml
+- task: PipelineTerraformInstaller@1
+  inputs:
+    terraformVersion: "1.9.0"
+- task: PipelineTerraformTask@5
+  inputs:
+    provider: azurerm
+    command: init
+```
+
+### Self-hosted agent — proxy issues
+
+**Cause:** The agent is behind a proxy and Terraform cannot reach the provider APIs.
+
+**Fix:** Set the `HTTP_PROXY` and `HTTPS_PROXY` environment variables on the agent, or configure them in the pipeline:
+
+```yaml
+variables:
+  HTTP_PROXY: http://proxy.example.com:8080
+  HTTPS_PROXY: http://proxy.example.com:8080
+  NO_PROXY: ".local,169.254.169.254"
+```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
     "compilerOptions": {
-        "target": "ES6",
+        "target": "ES2020",
         "module": "commonjs",
-        "skipLibCheck": true
+        "lib": ["ES2020"],
+        "skipLibCheck": true,
+        "strict": true,
+        "esModuleInterop": true,
+        "sourceMap": true
     }
 }


### PR DESCRIPTION
## Changelog

### Security
- Add output redaction warnings for sensitive Terraform plan data (`warnIfSensitiveOutputs`)
- Fix OCI private key chmod: platform-aware error handling (throws on Linux/macOS, skips on Windows)
- Strengthen OCI PAR URL validation: `new URL()` parsing + expanded forbidden template patterns
- Add exponential backoff retry to OIDC token requests (3 attempts, 200ms initial backoff)
- Mark secret environment variables with `tasks.setSecret()` via `isSecret` parameter

### Added
- `terraformVariables` multiline input for `-var` support on plan/apply/destroy/import
- Destroy change detection in JSON plan output (`destroyChangesPresent` pipeline variable)
- Code coverage (nyc) with enforced thresholds: 75% lines/functions, 70% branches
- Troubleshooting guide (`docs/troubleshooting.md`)
- 23 new test files: import, force-unlock, OCI parity, terraform variables, parallelism, lockfile-readonly, fmt diff, test filter/junit, sensitive output detection

### Changed
- CI Node.js 18 → 20 LTS
- ESLint warnings → errors; added `no-floating-promises`, `return-await`
- Enhanced task.json help text with code examples

### Fixed
- Floating promise in `index.ts` (`run()` → `void run()`)
- `return-await` lint violations in base handler and id-token-generator

## Test plan
- [x] `npm run lint` — zero errors (V5 + InstallerV1)
- [x] `npm test` — 143 tests passing
- [x] `npm run test:coverage` — Statements 82%, Branches 70%, Functions 76%, Lines 85%
- [x] CI passes on GitHub Actions