### PR TITLE
feat: security and quality hardening (Milestone 1)

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/eslint.config.mjs
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/eslint.config.mjs
@@ -13,6 +13,8 @@ export default tseslint.config(
             '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
             '@typescript-eslint/no-explicit-any': 'error',
             '@typescript-eslint/no-require-imports': 'off',
+            '@typescript-eslint/no-floating-promises': 'error',
+            '@typescript-eslint/return-await': 'error',
             'prefer-const': 'error',
             'no-var': 'error',
         },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -12,6 +12,9 @@
   },
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=20"
+  },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.2.8",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/index.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/index.ts
@@ -35,4 +35,4 @@ async function run() {
     }
 }
 
-run();
+void run();

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -13,6 +13,9 @@
   },
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "azure-devops-node-api": "^12.0.0",
     "azure-pipelines-task-lib": "^5.2.8",

--- a/Tasks/TerraformTask/TerraformTaskV5/tsconfig.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "compilerOptions": {
-        "target": "ES6",
+        "target": "ES2020",
         "module": "commonjs",
         "skipLibCheck": true,
         "strict": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true
     },
-    "include": ["src/**/*"]
+    "include": [
+        "src/**/*"
+    ]
 }


### PR DESCRIPTION
## Summary

- Add `no-floating-promises` and `return-await` ESLint rules to InstallerV1 for parity with V5
- Fix floating promise: `run()` → `void run()` in InstallerV1 `index.ts`
- Upgrade TypeScript target from ES6 to ES2020 in V5 (Node 20 supports ES2022+)
- Add `engines` field (`node >=20`) to both `package.json` files

## Changelog

### Security & Quality
- InstallerV1 ESLint parity: enforce `no-floating-promises` and `return-await` as errors
- Fix unhandled promise rejection risk in InstallerV1 entry point

### Changed
- V5 TypeScript target upgraded from ES6 to ES2020 for modern language features
- Both tasks now declare `engines.node >= 20` for early environment mismatch detection

## Test plan
- [ ] `npm test` passes in TerraformTaskV5 (147 tests)
- [ ] `npm test` passes in TerraformInstallerV1 (11 tests)
- [ ] `npm run lint` clean in both tasks