### PR TITLE
feat: refresh command, -var-file and -target inputs (Milestone 2)

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithVars.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplySuccessWithVars.ts
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Executed successfully"
         },
-        "terraform apply -var 'env=staging' -auto-approve": {
+        "terraform apply -auto-approve -var env=staging": {
             "code": 0,
             "stdout": "Apply complete!"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessWithVars.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessWithVars.ts
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Executed successfully"
         },
-        "terraform destroy -var 'env=dev' -auto-approve": {
+        "terraform destroy -auto-approve -var env=dev": {
             "code": 0,
             "stdout": "Destroy complete!"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2121,4 +2121,58 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    /* refresh command tests */
+
+    it('azure refresh should succeed', async () => {
+        let tp = path.join(__dirname, './RefreshTests/Azure/AzureRefreshSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureRefreshSuccessL0 should have succeeded.'));
+        }, tr);
+    });
+
+    it('azure refresh should succeed with var-file and target', async () => {
+        let tp = path.join(__dirname, './RefreshTests/Azure/AzureRefreshSuccessWithVarFileAndTarget.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureRefreshSuccessWithVarFileAndTargetL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* var-file input tests */
+
+    it('azure plan should succeed with var-file', async () => {
+        let tp = path.join(__dirname, './PlanTests/Azure/AzurePlanSuccessWithVarFile.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzurePlanSuccessWithVarFileL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* target resources input tests */
+
+    it('azure plan should succeed with target resources', async () => {
+        let tp = path.join(__dirname, './PlanTests/Azure/AzurePlanSuccessWithTarget.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzurePlanSuccessWithTargetL0 should have succeeded.'));
+        }, tr);
+    });
+
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithTarget.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithTarget.ts
@@ -2,17 +2,15 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-let tp = path.join(__dirname, './AzureImportSuccessWithVarsL0.js');
+let tp = path.join(__dirname, './AzurePlanSuccessWithTargetL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('provider', 'azurerm');
-tr.setInput('command', 'import');
+tr.setInput('command', 'plan');
 tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
-tr.setInput('importAddress', 'azurerm_resource_group.example');
-tr.setInput('importId', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example');
 tr.setInput('commandOptions', '');
-tr.setInput('terraformVariables', 'env=staging\n# comment line\nregion=eastus');
+tr.setInput('targetResources', 'azurerm_resource_group.rg1\nazurerm_storage_account.sa1');
 
 process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
 process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
@@ -32,9 +30,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Executed successfully"
         },
-        "terraform import azurerm_resource_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example -var env=staging -var region=eastus": {
+        "terraform plan -target=azurerm_resource_group.rg1 -target=azurerm_storage_account.sa1 -detailed-exitcode": {
             "code": 0,
-            "stdout": "Import successful!"
+            "stdout": "No changes."
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithTargetL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithTargetL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'plan', 'AzurePlanSuccessWithTargetL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVarFile.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVarFile.ts
@@ -2,17 +2,15 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-let tp = path.join(__dirname, './AzureImportSuccessWithVarsL0.js');
+let tp = path.join(__dirname, './AzurePlanSuccessWithVarFileL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('provider', 'azurerm');
-tr.setInput('command', 'import');
+tr.setInput('command', 'plan');
 tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
-tr.setInput('importAddress', 'azurerm_resource_group.example');
-tr.setInput('importId', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example');
 tr.setInput('commandOptions', '');
-tr.setInput('terraformVariables', 'env=staging\n# comment line\nregion=eastus');
+tr.setInput('varFile', 'prod.tfvars');
 
 process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
 process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
@@ -32,9 +30,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Executed successfully"
         },
-        "terraform import azurerm_resource_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example -var env=staging -var region=eastus": {
+        "terraform plan -var-file=prod.tfvars -detailed-exitcode": {
             "code": 0,
-            "stdout": "Import successful!"
+            "stdout": "No changes."
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVarFileL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVarFileL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'plan', 'AzurePlanSuccessWithVarFileL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVars.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessWithVars.ts
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "Executed successfully"
         },
-        "terraform plan -var 'env=production' -var 'region=westus2' -detailed-exitcode": {
+        "terraform plan -detailed-exitcode -var env=production -var region=westus2": {
             "code": 0,
             "stdout": "No changes. Your infrastructure matches the configuration."
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccess.ts
@@ -2,17 +2,14 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-let tp = path.join(__dirname, './AzureImportSuccessWithVarsL0.js');
+let tp = path.join(__dirname, './AzureRefreshSuccessL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('provider', 'azurerm');
-tr.setInput('command', 'import');
+tr.setInput('command', 'refresh');
 tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
-tr.setInput('importAddress', 'azurerm_resource_group.example');
-tr.setInput('importId', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example');
 tr.setInput('commandOptions', '');
-tr.setInput('terraformVariables', 'env=staging\n# comment line\nregion=eastus');
 
 process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
 process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
@@ -28,13 +25,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "terraform": true
     },
     "exec": {
-        "terraform providers": {
+        "terraform refresh": {
             "code": 0,
             "stdout": "Executed successfully"
-        },
-        "terraform import azurerm_resource_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example -var env=staging -var region=eastus": {
-            "code": 0,
-            "stdout": "Import successful!"
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'refresh', 'AzureRefreshSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccessWithVarFileAndTarget.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccessWithVarFileAndTarget.ts
@@ -2,17 +2,16 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-let tp = path.join(__dirname, './AzureImportSuccessWithVarsL0.js');
+let tp = path.join(__dirname, './AzureRefreshSuccessWithVarFileAndTargetL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('provider', 'azurerm');
-tr.setInput('command', 'import');
+tr.setInput('command', 'refresh');
 tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
-tr.setInput('importAddress', 'azurerm_resource_group.example');
-tr.setInput('importId', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example');
 tr.setInput('commandOptions', '');
-tr.setInput('terraformVariables', 'env=staging\n# comment line\nregion=eastus');
+tr.setInput('varFile', 'dev.tfvars\noverrides.tfvars');
+tr.setInput('targetResources', 'azurerm_resource_group.example');
 
 process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
 process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
@@ -28,13 +27,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "terraform": true
     },
     "exec": {
-        "terraform providers": {
+        "terraform refresh -target=azurerm_resource_group.example -var-file=dev.tfvars -var-file=overrides.tfvars": {
             "code": 0,
             "stdout": "Executed successfully"
-        },
-        "terraform import azurerm_resource_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example -var env=staging -var region=eastus": {
-            "code": 0,
-            "stdout": "Import successful!"
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccessWithVarFileAndTargetL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/RefreshTests/Azure/AzureRefreshSuccessWithVarFileAndTargetL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'refresh', 'AzureRefreshSuccessWithVarFileAndTargetL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -67,6 +67,9 @@ export abstract class BaseTerraformCommandHandler {
     protected prependReplaceFlag(args: string): string {
         const replaceAddress = tasks.getInput("replaceAddress", false);
         if (replaceAddress) {
+            if (!/^[a-zA-Z_][\w.\-]*(\[[^\]]+\])?(\.[a-zA-Z_][\w.\-]*(\[[^\]]+\])?)*$/.test(replaceAddress)) {
+                throw new Error(`Invalid replace address '${replaceAddress}': must be a valid Terraform resource address`);
+            }
             return `-replace=${replaceAddress} ${args}`;
         }
         return args;
@@ -82,7 +85,11 @@ export abstract class BaseTerraformCommandHandler {
     protected appendParallelism(args: string): string {
         const parallelism = tasks.getInput("parallelism", false);
         if (parallelism) {
-            return `${args} -parallelism=${parallelism}`;
+            const n = parseInt(parallelism, 10);
+            if (isNaN(n) || n < 1) {
+                throw new Error(`Invalid parallelism value '${parallelism}': must be a positive integer`);
+            }
+            return `${args} -parallelism=${n}`;
         }
         return args;
     }
@@ -96,21 +103,38 @@ export abstract class BaseTerraformCommandHandler {
         return args;
     }
 
-    protected appendTerraformVariables(args: string): string {
-        const variables = tasks.getInput("terraformVariables", false);
-        if (!variables) return args;
+    protected prependVarFiles(args: string): string {
+        const varFile = tasks.getInput("varFile", false);
+        if (!varFile) return args;
+        const lines = varFile.split('\n').map(l => l.trim()).filter(l => l);
+        const flags = lines.map(f => `-var-file=${f}`).join(' ');
+        return flags ? `${flags} ${args}` : args;
+    }
 
-        const varArgs: string[] = [];
+    protected prependTargetResources(args: string): string {
+        const targetResources = tasks.getInput("targetResources", false);
+        if (!targetResources) return args;
+        const lines = targetResources.split('\n').map(l => l.trim()).filter(l => l);
+        for (const address of lines) {
+            if (!/^[a-zA-Z_][\w.\-]*(\[[^\]]+\])?(\.[a-zA-Z_][\w.\-]*(\[[^\]]+\])?)*$/.test(address)) {
+                throw new Error(`Invalid target address '${address}': must be a valid Terraform resource address`);
+            }
+        }
+        const flags = lines.map(a => `-target=${a}`).join(' ');
+        return flags ? `${flags} ${args}` : args;
+    }
+
+    protected appendTerraformVariables(terraformTool: ToolRunner): void {
+        const variables = tasks.getInput("terraformVariables", false);
+        if (!variables) return;
+
         for (const line of variables.split('\n')) {
             const trimmed = line.trim();
             if (trimmed && !trimmed.startsWith('#')) {
-                varArgs.push(`-var '${trimmed}'`);
+                terraformTool.arg('-var');
+                terraformTool.arg(trimmed);
             }
         }
-        if (varArgs.length > 0) {
-            return `${varArgs.join(' ')} ${args}`;
-        }
-        return args;
     }
 
     // --- Core infrastructure ---
@@ -151,25 +175,29 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async warnIfMultipleProviders(): Promise<void> {
-        const binaryName = getBinaryName(tasks);
-        let toolPath;
         try {
-            toolPath = tasks.which(binaryName, true);
-        } catch {
-            throw new Error(tasks.loc("TerraformToolNotFound"));
-        }
+            const binaryName = getBinaryName(tasks);
+            let toolPath;
+            try {
+                toolPath = tasks.which(binaryName, true);
+            } catch {
+                throw new Error(tasks.loc("TerraformToolNotFound"));
+            }
 
-        const terraformToolRunner: ToolRunner = tasks.tool(toolPath);
-        terraformToolRunner.arg("providers");
-        const commandOutput = await this.execWithStdoutCapture(terraformToolRunner, {
-            cwd: this.getWorkingDirectory()
-        });
+            const terraformToolRunner: ToolRunner = tasks.tool(toolPath);
+            terraformToolRunner.arg("providers");
+            const commandOutput = await this.execWithStdoutCapture(terraformToolRunner, {
+                cwd: this.getWorkingDirectory()
+            });
 
-        const countProviders = ["aws", "azurerm", "google", "oracle"].filter(provider => commandOutput.stdout.includes(provider)).length;
+            const countProviders = ["aws", "azurerm", "google", "oracle"].filter(provider => commandOutput.stdout.includes(provider)).length;
 
-        tasks.debug(countProviders.toString());
-        if (countProviders > 1) {
-            tasks.warning("Multiple provider blocks specified in the .tf files in the current working directory.");
+            tasks.debug(countProviders.toString());
+            if (countProviders > 1) {
+                tasks.warning("Multiple provider blocks specified in the .tf files in the current working directory.");
+            }
+        } catch (error) {
+            tasks.debug(`Multiple provider check failed (non-fatal): ${String(error)}`);
         }
     }
 
@@ -208,6 +236,7 @@ export abstract class BaseTerraformCommandHandler {
             get: () => this.get(),
             import: () => this.import(),
             forceunlock: () => this.forceUnlock(),
+            refresh: () => this.refresh(),
         };
         const fn = commands[command];
         if (!fn) {
@@ -245,7 +274,7 @@ export abstract class BaseTerraformCommandHandler {
 
         let cmd: string;
         if (outputFormat === "json") {
-            cmd = tasks.getInput("commandOptions") ? `-json  ${tasks.getInput("commandOptions")}` : `-json`;
+            cmd = tasks.getInput("commandOptions") ? `-json ${tasks.getInput("commandOptions")}` : `-json`;
         } else {
             cmd = tasks.getInput("commandOptions") ? tasks.getInput("commandOptions")! : ``;
         }
@@ -303,12 +332,14 @@ export abstract class BaseTerraformCommandHandler {
         let commandOptions = tasks.getInput("commandOptions") ? `${tasks.getInput("commandOptions")} -detailed-exitcode` : `-detailed-exitcode`;
         commandOptions = this.prependReplaceFlag(commandOptions);
         commandOptions = this.prependRefreshOnly(commandOptions);
+        commandOptions = this.prependVarFiles(commandOptions);
+        commandOptions = this.prependTargetResources(commandOptions);
         commandOptions = this.appendParallelism(commandOptions);
         commandOptions = await this.appendSecureVarFile(commandOptions);
-        commandOptions = this.appendTerraformVariables(commandOptions);
 
         const planCommand = this.createAuthCommand("plan", commandOptions);
         const terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
+        this.appendTerraformVariables(terraformTool);
         await this.handleProvider(planCommand);
         await this.warnIfMultipleProviders();
 
@@ -355,12 +386,14 @@ export abstract class BaseTerraformCommandHandler {
         let additionalArgs = this.ensureAutoApprove(tasks.getInput("commandOptions"));
         additionalArgs = this.prependReplaceFlag(additionalArgs);
         additionalArgs = this.prependRefreshOnly(additionalArgs);
+        additionalArgs = this.prependVarFiles(additionalArgs);
+        additionalArgs = this.prependTargetResources(additionalArgs);
         additionalArgs = this.appendParallelism(additionalArgs);
         additionalArgs = await this.appendSecureVarFile(additionalArgs);
-        additionalArgs = this.appendTerraformVariables(additionalArgs);
 
         const applyCommand = this.createAuthCommand("apply", additionalArgs);
         const terraformTool = this.terraformToolHandler.createToolRunner(applyCommand);
+        this.appendTerraformVariables(terraformTool);
         await this.handleProvider(applyCommand);
         await this.warnIfMultipleProviders();
 
@@ -371,12 +404,14 @@ export abstract class BaseTerraformCommandHandler {
 
     public async destroy(): Promise<number> {
         let additionalArgs = this.ensureAutoApprove(tasks.getInput("commandOptions"));
+        additionalArgs = this.prependVarFiles(additionalArgs);
+        additionalArgs = this.prependTargetResources(additionalArgs);
         additionalArgs = this.appendParallelism(additionalArgs);
         additionalArgs = await this.appendSecureVarFile(additionalArgs);
-        additionalArgs = this.appendTerraformVariables(additionalArgs);
 
         const destroyCommand = this.createAuthCommand("destroy", additionalArgs);
         const terraformTool = this.terraformToolHandler.createToolRunner(destroyCommand);
+        this.appendTerraformVariables(terraformTool);
         await this.handleProvider(destroyCommand);
         await this.warnIfMultipleProviders();
 
@@ -502,11 +537,12 @@ export abstract class BaseTerraformCommandHandler {
         let args = commandOptions
             ? `${commandOptions} ${resourceAddress} ${resourceId}`
             : `${resourceAddress} ${resourceId}`;
+        args = this.prependVarFiles(args);
         args = await this.appendSecureVarFile(args);
-        args = this.appendTerraformVariables(args);
 
         const importCommand = this.createAuthCommand("import", args);
         const terraformTool = this.terraformToolHandler.createToolRunner(importCommand);
+        this.appendTerraformVariables(terraformTool);
         await this.handleProvider(importCommand);
 
         return terraformTool.execAsync(<IExecOptions>{
@@ -528,6 +564,23 @@ export abstract class BaseTerraformCommandHandler {
         const terraformTool = this.terraformToolHandler.createToolRunner(unlockCommand);
         return terraformTool.execAsync(<IExecOptions>{
             cwd: unlockCommand.workingDirectory
+        });
+    }
+
+    public async refresh(): Promise<number> {
+        let commandOptions = this.getCommandOptions() || '';
+        commandOptions = this.prependVarFiles(commandOptions);
+        commandOptions = this.prependTargetResources(commandOptions);
+        commandOptions = this.appendParallelism(commandOptions);
+        commandOptions = await this.appendSecureVarFile(commandOptions);
+
+        const refreshCommand = this.createAuthCommand("refresh", commandOptions.trim() || undefined);
+        const terraformTool = this.terraformToolHandler.createToolRunner(refreshCommand);
+        this.appendTerraformVariables(terraformTool);
+        await this.handleProvider(refreshCommand);
+
+        return terraformTool.execAsync(<IExecOptions>{
+            cwd: refreshCommand.workingDirectory
         });
     }
 
@@ -598,8 +651,8 @@ export abstract class BaseTerraformCommandHandler {
                     tasks.warning(`Terraform plan contains ${sensitiveResources.length} resource(s) with sensitive attributes. The output file may contain unredacted secrets.`);
                 }
             }
-        } catch {
-            // Not valid JSON plan or unexpected structure — skip silently
+        } catch (error) {
+            tasks.debug(`Failed to check sensitive outputs: ${String(error)}`);
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -122,6 +122,7 @@
                 "fmt": "fmt",
                 "test": "test",
                 "get": "get",
+                "refresh": "refresh",
                 "custom": "custom"
             },
             "properties": {
@@ -169,7 +170,7 @@
             "type": "secureFile",
             "label": "Secure variables file (.tfvars)",
             "required": false,
-            "visibleRule": "command = plan || command = apply || command = destroy || command = import",
+            "visibleRule": "command = plan || command = apply || command = destroy || command = import || command = refresh",
             "helpMarkDown": "Select a .tfvars file from the ADO Secure Files library. The file will be downloaded to a temporary location and passed as -var-file to the terraform command. The file is automatically deleted after execution. Useful for secrets that should not be stored in source control."
         },
         {
@@ -177,7 +178,7 @@
             "type": "multiLine",
             "label": "Terraform variables (key=value)",
             "required": false,
-            "visibleRule": "command = plan || command = apply || command = destroy || command = import",
+            "visibleRule": "command = plan || command = apply || command = destroy || command = import || command = refresh",
             "helpMarkDown": "Define Terraform input variables, one per line, as key=value pairs. Each line is passed as a separate -var flag. Lines starting with # are ignored.<br><br>Example:<br>region=us-east-1<br>environment=prod<br>instance_count=3",
             "properties": {
                 "rows": "5",
@@ -238,9 +239,33 @@
             "name": "parallelism",
             "type": "string",
             "label": "Parallelism",
-            "visibleRule": "command = plan || command = apply || command = destroy",
+            "visibleRule": "command = plan || command = apply || command = destroy || command = refresh",
             "required": false,
             "helpMarkDown": "Limit the number of concurrent Terraform operations. Passed as -parallelism=N. Useful for rate-limited APIs or resource-constrained agents."
+        },
+        {
+            "name": "varFile",
+            "type": "multiLine",
+            "label": "Variable files (.tfvars)",
+            "visibleRule": "command = plan || command = apply || command = destroy || command = import || command = refresh",
+            "required": false,
+            "helpMarkDown": "Paths to .tfvars files, one per line. Each file is passed as -var-file=<path> to the terraform command. Paths are relative to the working directory.",
+            "properties": {
+                "rows": "3",
+                "resizable": "true"
+            }
+        },
+        {
+            "name": "targetResources",
+            "type": "multiLine",
+            "label": "Target resources",
+            "visibleRule": "command = plan || command = apply || command = destroy || command = refresh",
+            "required": false,
+            "helpMarkDown": "Resource addresses to target, one per line. Each address is passed as -target=<address> to the terraform command. Only the specified resources and their dependencies will be included.",
+            "properties": {
+                "rows": "3",
+                "resizable": "true"
+            }
         },
         {
             "name": "testJunitXmlPath",


### PR DESCRIPTION
## Summary

- Add `terraform refresh` command with full provider auth, var-file, target, parallelism, secure var file, and terraform variables support
- Add `varFile` multiline input for `-var-file` flags on plan/apply/destroy/import/refresh
- Add `targetResources` multiline input for `-target` flags on plan/apply/destroy/refresh
- Input validation for target resource addresses and parallelism values

## Changelog

### Added
- `refresh` command — dedicated drift detection command with all standard options
- `varFile` multiline input — first-class `-var-file` support (one path per line), visible for plan/apply/destroy/import/refresh
- `targetResources` multiline input — first-class `-target` support (one address per line), visible for plan/apply/destroy/refresh
- Input validation: target resource addresses validated against Terraform address regex; parallelism validated as positive integer
- 4 new tests: refresh basic, refresh with var-file+target, plan with var-file, plan with target resources

### Changed
- Refactor `appendTerraformVariables()` from string interpolation to `ToolRunner.arg()` for proper shell escaping
- `warnIfMultipleProviders()` now catches errors internally (non-fatal)
- Fix double-space in JSON plan command options string

### Fixed
- Update 4 existing terraform variables test mocks for new `-var` arg ordering (no quotes, appended via ToolRunner)

## Test plan
- [ ] `npm test` passes in TerraformTaskV5 (147 tests, up from 143)
- [ ] `npm run lint` clean in V5
- [ ] Refresh command works with AzureRM provider
- [ ] `-var-file` and `-target` flags appear in correct position in terraform command