### PR TITLE
feat: add publishPlanResults plan attachment publishing

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2175,4 +2175,19 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    it('azure plan should succeed with publishPlanResults set', async () => {
+        let tp = path.join(__dirname, './PlanTests/Azure/AzurePlanSuccessPublishResults.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzurePlanSuccessPublishResultsL0 should have succeeded.'));
+            assert(tr.stdOutContained("Published plan results as 'my-plan'"), 'should have published plan results');
+        }, tr);
+    });
+
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessPublishResults.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessPublishResults.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzurePlanSuccessPublishResultsL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('publishPlanResults', 'my-plan');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider azurerm"
+        },
+        "terraform plan -detailed-exitcode": {
+            "code": 2,
+            "stdout": "Plan: 1 to add, 0 to change, 0 to destroy."
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessPublishResultsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessPublishResultsL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'plan', 'AzurePlanSuccessPublishResultsL0', true, 2);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -343,16 +343,27 @@ export abstract class BaseTerraformCommandHandler {
         await this.handleProvider(planCommand);
         await this.warnIfMultipleProviders();
 
-        const result = await terraformTool.execAsync(<IExecOptions>{
+        const commandOutput = await this.execWithStdoutCapture(terraformTool, <IExecOptions>{
             cwd: planCommand.workingDirectory,
             ignoreReturnCode: true
         });
 
-        if (result !== 0 && result !== 2) {
-            throw new Error(tasks.loc("TerraformPlanFailed", result));
+        if (commandOutput.code !== 0 && commandOutput.code !== 2) {
+            throw new Error(tasks.loc("TerraformPlanFailed", commandOutput.code));
         }
-        tasks.setVariable('changesPresent', (result === 2).toString(), false, true);
-        return result;
+        tasks.setVariable('changesPresent', (commandOutput.code === 2).toString(), false, true);
+
+        const publishPlanResults = tasks.getInput("publishPlanResults");
+        if (publishPlanResults) {
+            const tempDir = tasks.getVariable('Agent.TempDirectory') || require('os').tmpdir();
+            const planFilePath = path.join(tempDir, `tfplan-${Date.now()}.txt`);
+            fs.writeFileSync(planFilePath, commandOutput.stdout);
+            this.tempFiles.push(planFilePath);
+            tasks.addAttachment("terraform-plan-results", publishPlanResults, planFilePath);
+            console.log(`Published plan results as '${publishPlanResults}'`);
+        }
+
+        return commandOutput.code;
     }
 
     public async custom(): Promise<number> {

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -244,6 +244,14 @@
             "helpMarkDown": "Limit the number of concurrent Terraform operations. Passed as -parallelism=N. Useful for rate-limited APIs or resource-constrained agents."
         },
         {
+            "name": "publishPlanResults",
+            "type": "string",
+            "label": "Publish Plan Results",
+            "required": false,
+            "visibleRule": "command = plan",
+            "helpMarkDown": "Name for the published plan. When set, plan output is attached to the pipeline run and visible in the Terraform Plan tab. Multiple plan steps can use different names. Adopted from jason-johnson/azure-pipelines-tasks-terraform for migration compatibility."
+        },
+        {
             "name": "varFile",
             "type": "multiLine",
             "label": "Variable files (.tfvars)",


### PR DESCRIPTION
## Summary
- Adds `publishPlanResults` string input to task.json (visible when command = plan)
- Modifies `plan()` in `base-terraform-command-handler.ts` to capture stdout via `execWithStdoutCapture()` and publish it as a pipeline attachment when `publishPlanResults` is set
- Attachment type `terraform-plan-results` adopted from jason-johnson/azure-pipelines-tasks-terraform for migration compatibility
- New test: `AzurePlanSuccessPublishResults` verifying attachment publishing works with exit code 2 (changes present)

## Attribution
The `publishPlanResults` input name and `terraform-plan-results` attachment type are adopted from [jason-johnson/azure-pipelines-tasks-terraform](https://github.com/jason-johnson/azure-pipelines-tasks-terraform) (MIT license) for migration compatibility with their 39K existing users. No code was copied. Full attribution will be added in PR 2 via THIRD_PARTY_NOTICES.md.

## Changelog
- feat: `publishPlanResults` input on `plan` command publishes stdout as a pipeline attachment for the Terraform Plan tab

## Test plan
- [x] All 148 existing + new tests pass (`npm test`)
- [ ] Manual: verify `.vsix` packaging includes updated `task.json`