### PR TITLE
docs: phase 2 documentation drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,61 @@ runCommand(new TerraformCommandHandlerAWS(), 'init', 'AWSInitFailL0', false);
 
 **L0.ts registration**: add an `it()` block in the main `Tests/L0.ts` file near the other tests for the same command.
 
+## Terraform Plan Tab (build-results-tab)
+
+The extension contributes a **Terraform Plan** tab to the Azure DevOps build results page. The tab reads pipeline attachments named `terraform-plan-results` published by the `plan` command (when `publishPlanResults: true`) and renders the captured `terraform plan` output with ANSI color translated to HTML.
+
+### Source layout
+
+```text
+src/tab/
+├── tabContent.tsx      # React entry point; registers the tab via SDK
+├── tabContent.css      # Tab styling
+├── index.html          # HTML shell loaded by the ADO iframe
+└── tsconfig.json       # TypeScript config used by webpack
+```
+
+The tab is bundled by `webpack.config.js` (at the repo root) alongside packaging of the manifest, images, and compiled task JS into `build/`.
+
+### Build flow
+
+From the repo root:
+
+```bash
+npm install --include=dev            # installs tfx-cli, webpack, ts-loader, glob-exec
+npm run build:release                # clean → deps → compile tasks → prune dev deps → webpack
+```
+
+`build:release` does four things in order:
+
+1. `clean` — removes `build/`.
+2. `deps` — runs `npm install` in each task subdirectory.
+3. `compile` — `tsc -b` each task's `tsconfig.json`.
+4. `deps:prune` — removes dev dependencies from each task (trims the `.vsix`).
+5. `webpack` — bundles `src/tab/tabContent.tsx` → `build/tab/tabContent.js`, copies the manifest, images, `overview.md`, `LICENSE`, `THIRD_PARTY_NOTICES.md`, and `Tasks/` directory (excluding Tests/TS sources) into `build/`.
+
+### Inspecting a dev build locally
+
+Webpack emits to `build/tab/`. You can open `build/tab/tabContent.js` to confirm the bundle was generated, but the tab only renders inside the Azure DevOps iframe — there is currently no static browser harness. To exercise the tab in a real ADO org:
+
+1. `configs/self.json` — see the **Personal Dev Publishing** section above for the schema. The file is gitignored.
+2. `npm run build:release` then `npm run package:self` from the repo root — produces a private `.vsix` prefixed with your publisher.
+3. Upload the `.vsix` to your publisher page as a **Private** extension and share it with a test Azure DevOps organization.
+4. Install the shared extension into your test project.
+5. Run a pipeline that uses `PipelineTerraformTask@5` with `command: plan` and `publishPlanResults: true`.
+6. Open the build results page — the **Terraform Plan** tab appears alongside **Summary** / **Tests**. Iterate by rebuilding the `.vsix`, bumping the version in `configs/self.json`, and re-uploading.
+
+### Contribution points (manifest)
+
+The tab is declared in `azure-devops-extension.json` as a `ms.vss-build-web.build-results-tab` contribution and pulls its bundle from `tab/tabContent.js` (relative to the packaged extension root, which matches webpack's output layout).
+
+### When editing the tab
+
+- Run `npm run webpack` for fast iteration (skips re-running task compilation). Errors surface immediately in the webpack output.
+- The bundle currently pins **React 16.13.1** — if you upgrade to React 18, you must also switch from `ReactDOM.render` to `createRoot` in `tabContent.tsx`.
+- The tab uses `dangerouslySetInnerHTML` to render ANSI-converted HTML. Any change to `ansiToHtml` must keep opening/closing `<span>` tags balanced. See the roadmap item **P3.2 · plan tab hardening** for the planned state-machine rewrite.
+- There is no Jest harness in `src/tab/` yet (planned in roadmap item **P4.1**). Until then, end-to-end verification requires a private publish.
+
 ## Release Process
 
 Releases are triggered by pushing a semver tag to `main`. The automated workflow handles packaging and publishing.

--- a/README.md
+++ b/README.md
@@ -42,23 +42,26 @@ Installs a specific version of Terraform on the build agent.
 
 ### `PipelineTerraformTask@5` — Terraform
 
-Runs Terraform commands. Supports 13 commands:
+Runs Terraform commands. Supports 16 commands:
 
-| Command     | Description                                                                |
-| ----------- | -------------------------------------------------------------------------- |
-| `init`      | Initialize a working directory. Configure backend with `backendType`.      |
-| `validate`  | Validate configuration files.                                              |
-| `plan`      | Generate an execution plan. Use `replaceAddress` for `-replace=ADDRESS`.   |
-| `apply`     | Apply changes.                                                             |
-| `destroy`   | Destroy infrastructure.                                                    |
-| `show`      | Show the current state or a saved plan.                                    |
-| `output`    | Read output values from state.                                             |
-| `workspace` | Manage workspaces (`new`, `select`, `list`, `delete`, `show`).             |
-| `state`     | Advanced state management (`list`, `pull`, `push`, `mv`, `rm`, `show`).    |
-| `fmt`       | Reformat configuration files. Use `fmtCheck` to fail on unformatted files. |
-| `test`      | Run module tests (Terraform 1.6+).                                         |
-| `get`       | Download and install modules.                                              |
-| `custom`    | Run any Terraform command via `customCommand` input.                       |
+| Command       | Description                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| `init`        | Initialize a working directory. Configure backend with `backendType`.                          |
+| `validate`    | Validate configuration files.                                                                  |
+| `plan`        | Generate an execution plan. Use `replaceAddress` for `-replace=ADDRESS`.                       |
+| `apply`       | Apply changes.                                                                                 |
+| `destroy`     | Destroy infrastructure.                                                                        |
+| `show`        | Show the current state or a saved plan.                                                        |
+| `output`      | Read output values from state.                                                                 |
+| `workspace`   | Manage workspaces (`new`, `select`, `list`, `delete`, `show`).                                 |
+| `state`       | Advanced state management (`list`, `pull`, `push`, `mv`, `rm`, `show`).                        |
+| `fmt`         | Reformat configuration files. Use `fmtCheck` to fail on unformatted files.                     |
+| `test`        | Run module tests (Terraform 1.6+).                                                             |
+| `get`         | Download and install modules.                                                                  |
+| `import`      | Import existing infrastructure into state. Takes `importAddress` and `importId` inputs.        |
+| `forceunlock` | Forcibly release a stuck state lock. Takes a `lockId` input.                                   |
+| `refresh`     | Reconcile state with real-world resources. Supports `varFile`, `targetResources`, parallelism. |
+| `custom`      | Run any Terraform command via `customCommand` input.                                           |
 
 ---
 
@@ -69,7 +72,7 @@ Runs Terraform commands. Supports 13 commands:
 | Azure    | `azurerm`        | Azure Resource Manager (built-in)                            | Service Principal, Managed Identity, WIF         |
 | AWS      | `aws`            | Pipeline AWS for Terraform (`PTTAWSServiceEndpoint`)         | Static credentials, Workload Identity Federation |
 | GCP      | `gcp`            | Pipeline GCP for Terraform (`PTTGoogleCloudServiceEndpoint`) | Static credentials, Workload Identity Federation |
-| OCI      | `oci`            | Pipeline OCI for Terraform (`PTTOCIServiceEndpoint`)         | API key credentials                              |
+| OCI      | `oci`            | Pipeline OCI for Terraform (`PTTOCIServiceEndpoint`)         | API key credentials (WIF not yet supported)      |
 
 ---
 
@@ -153,7 +156,7 @@ AWS and GCP support Workload Identity Federation — no static credentials are s
 | Extension ID                                   | `custom-terraform-tasks`                                       | `pipeline-tasks-terraform`                                            |
 | Terraform task name                            | `TerraformTaskV4` (YAML)                                       | `PipelineTerraformTask@5`                                             |
 | Installer task name                            | `TerraformInstallerV0` (YAML)                                  | `PipelineTerraformInstaller@1`                                        |
-| Commands                                       | 8 (init, validate, plan, apply, destroy, show, output, custom) | 13 — adds workspace, state, fmt, test, get                            |
+| Commands                                       | 8 (init, validate, plan, apply, destroy, show, output, custom) | 16 — adds workspace, state, fmt, test, get, refresh, import, unlock   |
 | `-replace` flag                                | Not available                                                  | `replaceAddress` input on `plan`                                      |
 | Backend/provider coupling                      | Backend always matches provider                                | `backendType` input decouples them                                    |
 | HCP Terraform Cloud backend                    | Not supported                                                  | Supported via `backendType: hcp`                                      |
@@ -173,6 +176,12 @@ AWS and GCP support Workload Identity Federation — no static credentials are s
 ## Agent Compatibility
 
 Tasks run on Windows, macOS, and Linux build agents using Node 20.
+
+---
+
+## Migrating from Microsoft DevLabs
+
+See [docs/migration-from-ms-devlabs.md](docs/migration-from-ms-devlabs.md) for a step-by-step guide: task renames, service connection type changes, and side-by-side install instructions.
 
 ---
 

--- a/docs/migration-from-ms-devlabs.md
+++ b/docs/migration-from-ms-devlabs.md
@@ -1,0 +1,160 @@
+# Migrating from `ms-devlabs.custom-terraform-tasks`
+
+This guide walks through moving an existing pipeline from Microsoft DevLabs'
+`ms-devlabs.custom-terraform-tasks` extension to
+`sethbacon.pipeline-tasks-terraform`.
+
+The two extensions are designed to coexist — distinct extension IDs and
+distinct service connection type names — so you can install both and migrate
+pipelines incrementally without a big-bang cutover.
+
+---
+
+## Install side-by-side
+
+Keep the DevLabs extension installed while you migrate:
+
+1. Marketplace → install **Pipeline Tasks for Terraform** (`sethbacon.pipeline-tasks-terraform`).
+2. Both extensions will appear in the task picker. The tasks in this fork all
+   start with `Pipeline` (`PipelineTerraformInstaller`, `PipelineTerraformTask`)
+   so they're easy to tell apart in YAML and the classic editor.
+3. Migrate pipelines one at a time; uninstall DevLabs once nothing references it.
+
+---
+
+## YAML task renames
+
+Rename the task identifiers. Inputs are mostly compatible — a few renames are
+called out in the [Input renames](#input-renames) section below.
+
+| Old (DevLabs)         | New (this fork)                 |
+| --------------------- | ------------------------------- |
+| `TerraformInstaller@0` | `PipelineTerraformInstaller@1` |
+| `TerraformCLI@0`       | `PipelineTerraformTask@5`      |
+| `TerraformTaskV4@4`    | `PipelineTerraformTask@5`      |
+
+### Example — installer
+
+```yaml
+# Before
+- task: TerraformInstaller@0
+  inputs:
+    terraformVersion: "1.9.0"
+
+# After
+- task: PipelineTerraformInstaller@1
+  inputs:
+    terraformVersion: "1.9.0"
+```
+
+### Example — `plan` against Azure
+
+```yaml
+# Before
+- task: TerraformTaskV4@4
+  inputs:
+    provider: azurerm
+    command: plan
+    environmentServiceNameAzureRM: my-azure-connection
+
+# After
+- task: PipelineTerraformTask@5
+  inputs:
+    provider: azurerm
+    command: plan
+    environmentServiceNameAzureRM: my-azure-connection
+```
+
+---
+
+## Service connection type renames
+
+The DevLabs extension registered non-Azure service connection types with
+generic names. This fork uses `PTT`-prefixed names so both extensions can
+coexist without ID collisions.
+
+| Provider | DevLabs type                   | This fork type                    |
+| -------- | ------------------------------ | --------------------------------- |
+| AWS      | `AWSServiceEndpoint`           | `PTTAWSServiceEndpoint`           |
+| GCP      | `GoogleCloudServiceEndpoint`   | `PTTGoogleCloudServiceEndpoint`   |
+| OCI      | `OCIServiceEndpoint`           | `PTTOCIServiceEndpoint`           |
+
+Azure auth uses the built-in **Azure Resource Manager** service connection and
+is unchanged.
+
+**What this means for you:** existing AWS/GCP/OCI service connections created
+against the DevLabs extension cannot be reused by this fork. Create a new
+connection of the `PTT*` type. The credential material (access keys, WIF
+config, OCI private key) can be copy-pasted — only the type name changes.
+
+Steps in the Azure DevOps UI:
+
+1. Project Settings → **Service connections** → **New service connection**.
+2. Search for "Pipeline AWS for Terraform" (or GCP / OCI).
+3. Fill in the same credentials you used for the DevLabs connection.
+4. Reference the new connection by name in the `environmentServiceNameAWS` /
+   `environmentServiceNameGCP` / `environmentServiceNameOCI` input.
+
+---
+
+## Input renames
+
+Most inputs carry over verbatim. Known differences:
+
+| DevLabs input             | This fork                                | Notes                                                                                      |
+| ------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `allowTelemetryCollection` | _removed_                               | No telemetry is collected in this fork.                                                    |
+| `runAzLogin`              | _removed_                                | The AzureRM handler always authenticates via the service connection without `az login`.   |
+| `commandOptions`           | `commandOptions`                         | Unchanged.                                                                                 |
+| `secureVarsFile`           | `secureVarsFile`                         | Unchanged. Secure Files library reference.                                                 |
+
+### New inputs introduced by this fork
+
+- **`backendType`** on `init` — decouples the state backend from the provider.
+  Values: `azurerm`, `s3`, `gcs`, `oci`, `hcp`, `generic`, `local`. Defaults to
+  the value of `provider` if unset.
+- **`replaceAddress`** on `plan` / `apply` — passes `-replace=ADDRESS`.
+- **`downloadSource`** on the installer — `hashicorp` (default), `registry`
+  (private terraform-registry-backend), or `mirror` (custom HTTPS mirror).
+- **`environmentAuthSchemeAWS`** / **`environmentAuthSchemeGCP`** — `ServiceConnection`
+  (default) or `WorkloadIdentityFederation`. WIF avoids static credentials.
+- **Additional commands not in DevLabs:** `workspace`, `state`, `fmt`, `test`,
+  `get`, `refresh`, `import`, `forceunlock`.
+
+---
+
+## Terraform Plan attachment compatibility
+
+This fork's **Terraform Plan tab** reads pipeline attachments named
+`terraform-plan-results`, compatible with the
+[jason-johnson/azure-pipelines-tasks-terraform](https://github.com/jason-johnson/azure-pipelines-tasks-terraform)
+attachment convention. If you were using that extension's tab, this fork's tab
+will pick up the same attachments with no YAML change.
+
+The DevLabs extension did not publish plan attachments, so no migration step is
+needed for that case — enable `publishPlanResults: true` on the `plan` step to
+start surfacing plans in the tab.
+
+---
+
+## Validation checklist
+
+Before decommissioning the DevLabs extension:
+
+- [ ] All pipelines reference `Pipeline*` task names, no `TerraformInstaller@0`
+      or `TerraformTaskV4@4` left (grep the repo).
+- [ ] New `PTT*` service connections exist and pipelines reference them.
+- [ ] A test pipeline runs `init` + `plan` end-to-end against a non-production
+      workspace on each provider you use.
+- [ ] State backends are unchanged — this migration does not touch state files
+      or backend config.
+- [ ] Uninstall `ms-devlabs.custom-terraform-tasks` from the organization.
+
+---
+
+## Related docs
+
+- [README.md](../README.md) — extension overview, supported commands, providers
+- [AWS WIF Setup Guide](setup/aws-wif-setup.md)
+- [GCP WIF Setup Guide](setup/gcp-wif-setup.md)
+- [Troubleshooting Guide](troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,6 +33,37 @@ Common issues and their solutions when using Pipeline Tasks for Terraform.
 
 **Fix:** Verify the `issuer`, `audience`, and `subject` in the Workload Identity Provider match the Azure DevOps pipeline OIDC token. See [GCP WIF Setup Guide](setup/gcp-wif-setup.md).
 
+### "Unrecognized authorization scheme 'xxx'" (Azure)
+
+**Cause:** The Azure service connection's authorization scheme does not map to one of the three supported values after case-insensitive comparison: `WorkloadIdentityFederation`, `ManagedServiceIdentity`, `ServicePrincipal`.
+
+**Fix:**
+
+- The AzureRM handler lowercases the incoming scheme before matching, so `serviceprincipal`, `ServicePrincipal`, and `SERVICEPRINCIPAL` all resolve the same way.
+- If you see this error, the service connection was created with a scheme the task does not recognize (for example, a legacy certificate-based principal). Recreate the connection using one of the supported schemes from the Azure DevOps UI.
+- **AWS / GCP schemes are case-sensitive**, unlike Azure. The `environmentAuthSchemeAWS` and `environmentAuthSchemeGCP` inputs must be exactly `WorkloadIdentityFederation` or `ServiceConnection` — `workloadidentityfederation` will silently fall through to the static-credentials path.
+
+### AWS / GCP — WIF configured but task uses static credentials
+
+**Cause:** `environmentAuthSchemeAWS` / `environmentAuthSchemeGCP` is set to something other than the exact string `WorkloadIdentityFederation` (typos, case variation, or inadvertently blank).
+
+**Fix:**
+
+- Check the YAML or classic-editor input for the exact value `WorkloadIdentityFederation`. The string comparison is case-sensitive and no partial matching is performed.
+- Enable debug logging (`System.Debug: true`) and look for a `handleProvider` trace to confirm which code path executed.
+- If the input is unset, the default is `ServiceConnection` (static credentials). Explicitly set the auth scheme input — it is not inherited from the service connection.
+
+### OIDC federated-token acquisition — timeouts and retries
+
+**Cause:** The pipeline agent could not reach `SYSTEM_OIDCREQUESTURI` (the Azure DevOps token exchange endpoint) within 30 seconds, or the upstream service returned a non-2xx response.
+
+**Fix:**
+
+- Each token request has a 30-second timeout. The task retries up to **3 times** with exponential backoff (200 ms, then 400 ms between attempts), so worst-case total delay is around **90 seconds** before the task fails.
+- `Timed out acquiring federated token` indicates the HTTPS call itself did not return — check agent network connectivity to the Azure DevOps API, proxy configuration, and firewall rules.
+- `Failed to acquire federated token: HTTP 4xx/5xx` indicates a server-side response — check that the service connection ID is still valid and that the pipeline identity is allowed to use it.
+- `SYSTEM_OIDCREQUESTURI is not set` means the pipeline is running on an agent or in a context that does not expose the OIDC request endpoint. Only **yaml pipelines on Microsoft-hosted agents (and properly configured self-hosted agents)** receive this variable.
+
 ### OCI — "Error: Failed to parse private key"
 
 **Cause:** The OCI service connection private key is malformed or not in PEM format.
@@ -136,9 +167,19 @@ Common issues and their solutions when using Pipeline Tasks for Terraform.
 
 ### Multiple provider blocks warning
 
-**Cause:** The task detected multiple cloud provider blocks (e.g., both `aws` and `azurerm`) in your Terraform configuration.
+**Cause:** The task runs `terraform providers` after `handleProvider` and greps the output for names of _other_ cloud providers the extension supports. When a match is found, it emits a non-fatal warning so the pipeline author is aware that credentials for only the selected provider have been configured.
 
-**Fix:** This is a warning, not an error. If you intentionally use multiple providers, this warning is expected. If not, review your `.tf` files and remove unused provider blocks.
+**When to ignore:**
+
+- You are intentionally composing multiple providers (e.g. deploying to AWS while reading an AzureRM data source for cross-cloud references).
+- Only the selected provider's credentials are needed at runtime — Terraform will only authenticate against providers actually instantiated.
+
+**When to investigate:**
+
+- You did not expect to see a second provider — look for transitive module dependencies with stray provider blocks.
+- The warning names a provider whose binary has not been resolved — `terraform init` will fail.
+
+**Known false positive:** the current detection uses a substring match. Modules with names like `my-aws-helpers` or `terraform-azurerm-utils` can trip the warning even when no second cloud provider is actually configured. A stricter regex-anchored check is planned (roadmap item P3.7). Suppress by renaming the offending module or ignoring the warning.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 2 of the [April 2026 roadmap](../blob/development/docs/roadmap.md). Documentation-only — no runtime code change.

- **P2.1** — README command table now lists all 16 commands (added `import`, `forceunlock`, `refresh`). OCI providers row notes WIF is not yet supported. Differences-from-DevLabs table updated to `16 commands`.
- **P2.2** — New `docs/migration-from-ms-devlabs.md`: task renames (`TerraformInstaller@0` → `PipelineTerraformInstaller@1`, `TerraformCLI@0` / `TerraformTaskV4@4` → `PipelineTerraformTask@5`), service-connection type renames (`AWSServiceEndpoint` → `PTTAWSServiceEndpoint`, etc.), side-by-side install guidance. Linked from README.
- **P2.3** — New `Terraform Plan Tab` section in `CONTRIBUTING.md` covering `src/tab/` layout, `build:release` flow, webpack bundling, and how to iterate via `package:self` → private publish.
- **P2.4** — `docs/troubleshooting.md`: Azure auth-scheme case-insensitivity plus the AWS/GCP case-sensitivity gotcha; OIDC timeout (30s per attempt, 3 attempts, ~90s worst case); expanded multi-provider warning interpretation plus the known substring false-positive.

## Changelog

- docs: add 16-command table, OCI WIF caveat, and link to migration guide in README
- docs: add `docs/migration-from-ms-devlabs.md`
- docs: document Terraform Plan tab build + dev workflow in `CONTRIBUTING.md`
- docs: expand troubleshooting with auth-scheme case handling, OIDC retry behaviour, and multi-provider warning interpretation

## Test plan

- [x] `awk 'length>187'` on README tables — alignment preserved
- [x] Links resolve: README → `docs/migration-from-ms-devlabs.md`; migration guide → `setup/*.md`, `troubleshooting.md`
- [x] No source code modified; no build/test runs required

🤖 Generated with [Claude Code](https://claude.com/claude-code)