### PR TITLE
feat: fail-closed on unknown auth scheme for AWS/GCP

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -1611,6 +1611,34 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    /* aws/gcp invalid auth scheme tests */
+
+    it('aws plan should fail with invalid auth scheme', async () => {
+        let tp = path.join(__dirname, './PlanTests/AWS/AWSPlanInvalidAuthScheme.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 0, 'tool should not have been invoked. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 1, 'should have one error');
+        }, tr);
+    });
+
+    it('gcp plan should fail with invalid auth scheme', async () => {
+        let tp = path.join(__dirname, './PlanTests/GCP/GCPPlanInvalidAuthScheme.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 0, 'tool should not have been invoked. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 1, 'should have one error');
+        }, tr);
+    });
+
     /* terraform plan/apply -replace flag tests */
 
     it('azure plan should succeed with -replace flag', async () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanInvalidAuthScheme.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanInvalidAuthScheme.ts
@@ -1,0 +1,40 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AWSPlanInvalidAuthSchemeL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+tr.setInput('environmentAuthSchemeAWS', 'InvalidScheme');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'DummyUsername';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'DummyPassword';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'DummyRegion';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider aws"
+        },
+        "terraform plan -detailed-exitcode": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanInvalidAuthSchemeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanInvalidAuthSchemeL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../../src/aws-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'plan', 'AWSPlanInvalidAuthSchemeL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanInvalidAuthScheme.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanInvalidAuthScheme.ts
@@ -1,0 +1,42 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './GCPPlanInvalidAuthSchemeL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'gcp');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameGCP', 'GCP');
+tr.setInput('environmentAuthSchemeGCP', 'InvalidScheme');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
+process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider gcp"
+        },
+        "terraform plan -detailed-exitcode": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanInvalidAuthSchemeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanInvalidAuthSchemeL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerGCP } from './../../../src/gcp-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerGCP(), 'plan', 'GCPPlanInvalidAuthSchemeL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -9,10 +9,18 @@ import os = require('os');
 import fs = require('fs');
 import { v4 as uuidV4 } from 'uuid';
 
+const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
+
 export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
     constructor() {
         super();
         this.providerName = "aws";
+    }
+
+    private validateAuthScheme(scheme: string, inputName: string): void {
+        if (!(VALID_AUTH_SCHEMES as readonly string[]).includes(scheme)) {
+            throw new Error(`Unrecognized authorization scheme '${scheme}' for input '${inputName}'. Valid values: ${VALID_AUTH_SCHEMES.join(", ")}`);
+        }
     }
 
     private setupBackend(backendServiceName: string) {
@@ -51,6 +59,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
         const backendServiceName = tasks.getInput("backendServiceAWS", true)!;
         const authScheme = tasks.getInput("backendAuthSchemeAWS", false) || "ServiceConnection";
+        this.validateAuthScheme(authScheme, "backendAuthSchemeAWS");
 
         if (authScheme === "WorkloadIdentityFederation") {
             await this.setupBackendWIF(backendServiceName);
@@ -62,6 +71,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {
         const authScheme = tasks.getInput("environmentAuthSchemeAWS", false) || "ServiceConnection";
+        this.validateAuthScheme(authScheme, "environmentAuthSchemeAWS");
 
         if (authScheme === "WorkloadIdentityFederation") {
             await this.handleProviderWIF(command);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -9,10 +9,18 @@ import os = require('os');
 import fs = require('fs');
 import { v4 as uuidV4 } from 'uuid';
 
+const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
+
 export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
     constructor() {
         super();
         this.providerName = "gcp";
+    }
+
+    private validateAuthScheme(scheme: string, inputName: string): void {
+        if (!(VALID_AUTH_SCHEMES as readonly string[]).includes(scheme)) {
+            throw new Error(`Unrecognized authorization scheme '${scheme}' for input '${inputName}'. Valid values: ${VALID_AUTH_SCHEMES.join(", ")}`);
+        }
     }
 
     private getJsonKeyFilePath(serviceName: string) {
@@ -90,6 +98,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         tasks.debug('Setting up backend GCP.');
         const backendServiceName = tasks.getInput("backendServiceGCP", true)!;
         const authScheme = tasks.getInput("backendAuthSchemeGCP", false) || "ServiceConnection";
+        this.validateAuthScheme(authScheme, "backendAuthSchemeGCP");
 
         if (authScheme === "WorkloadIdentityFederation") {
             await this.setupBackendWIF(backendServiceName);
@@ -102,6 +111,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {
         const authScheme = tasks.getInput("environmentAuthSchemeGCP", false) || "ServiceConnection";
+        this.validateAuthScheme(authScheme, "environmentAuthSchemeGCP");
 
         if (authScheme === "WorkloadIdentityFederation") {
             await this.handleProviderWIF(command);


### PR DESCRIPTION
## Summary

- Validate `environmentAuthSchemeAWS`/`environmentAuthSchemeGCP` and `backendAuthSchemeAWS`/`backendAuthSchemeGCP` against known values (`ServiceConnection`, `WorkloadIdentityFederation`)
- Throw descriptive error on unrecognized auth scheme instead of silently falling through to static credentials
- New tests: `AWSPlanInvalidAuthScheme`, `GCPPlanInvalidAuthScheme`

Closes #105

## Changelog

- **Security:** AWS and GCP handlers now fail-closed on unrecognized authorization scheme values

## Test plan

- [x] `npm test` — 150 tests passing, 0 failures
- [x] New test: AWS plan with `InvalidScheme` → task fails, 0 tool invocations
- [x] New test: GCP plan with `InvalidScheme` → task fails, 0 tool invocations
- [x] Existing WIF and ServiceConnection tests continue to pass