### PR TITLE
feat: uncaughtException/unhandledRejection cleanup hooks

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
@@ -7,10 +7,20 @@ async function run() {
 
     const parentHandler = new ParentCommandHandler();
 
-    // Register process-level cleanup as defense-in-depth for SIGTERM
+    // Register process-level cleanup as defense-in-depth for unexpected termination
     const cleanup = () => parentHandler.emergencyCleanup();
     process.on('SIGTERM', cleanup);
     process.on('SIGINT', cleanup);
+    process.on('uncaughtException', (err) => {
+        cleanup();
+        tasks.setResult(tasks.TaskResult.Failed, `Uncaught exception: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+    });
+    process.on('unhandledRejection', (reason) => {
+        cleanup();
+        tasks.setResult(tasks.TaskResult.Failed, `Unhandled rejection: ${reason instanceof Error ? reason.message : String(reason)}`);
+        process.exit(1);
+    });
 
     try {
         await parentHandler.execute(tasks.getInput("provider", true)!, tasks.getInput("command", true)!);


### PR DESCRIPTION
## Summary

- Hook `uncaughtException` and `unhandledRejection` in `index.ts` to run `emergencyCleanup()` before failing
- Prevents credential env vars from persisting if the process crashes outside the try/catch

Closes #107

## Changelog

- **Security:** Emergency cleanup now runs on uncaught exceptions and unhandled rejections

## Test plan

- [x] `npm run compile` — clean build
- [x] `npm test` — all tests pass (existing tests exercise the normal code path)
- [ ] Manual: inject a throw after env vars are set → verify tracked vars are cleared