### PR TITLE
refactor: Set-based env var tracking

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/src/environment-variables.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/environment-variables.ts
@@ -1,7 +1,7 @@
 import tasks = require('azure-pipelines-task-lib/task');
 
 export class EnvironmentVariableHelper {
-    private static readonly trackedVariables: string[] = [];
+    private static readonly trackedVariables: Set<string> = new Set();
 
     public static setEnvironmentVariable(name: string, value: string, isSecret: boolean = false): void {
         if (!name) {
@@ -16,7 +16,7 @@ export class EnvironmentVariableHelper {
             tasks.setSecret(value);
         }
         process.env[name] = value;
-        this.trackedVariables.push(name);
+        this.trackedVariables.add(name);
         tasks.debug(`Set environment variable: ${name}${isSecret ? ' (secret)' : ''}`);
     }
 
@@ -25,6 +25,6 @@ export class EnvironmentVariableHelper {
             delete process.env[name];
             tasks.debug(`Cleared environment variable: ${name}`);
         }
-        this.trackedVariables.length = 0;
+        this.trackedVariables.clear();
     }
 }


### PR DESCRIPTION
## Summary

- Switch `trackedVariables` from `string[]` to `Set<string>` for idempotent re-registration
- `.push()` → `.add()`, `.length = 0` → `.clear()`

Closes #109

## Changelog

- **Refactor:** Environment variable tracking uses Set for idempotent registration

## Test plan

- [x] `npm test` — all tests pass
- [x] API-compatible: `setEnvironmentVariable` and `clearTrackedVariables` signatures unchanged