### PR TITLE
refactor: stricter provider detection regex

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/MultipleProviderTests/MultipleProviderWarning.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/MultipleProviderTests/MultipleProviderWarning.ts
@@ -20,7 +20,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "exec": {
         "terraform providers": {
             "code": 0,
-            "stdout": "provider azurerm\nprovider aws\nprovider gcp"
+            "stdout": "Providers required by configuration:\n├── provider[registry.terraform.io/hashicorp/azurerm]\n├── provider[registry.terraform.io/hashicorp/aws]\n└── provider[registry.terraform.io/hashicorp/google]"
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/MultipleProviderTests/SingleProviderNoWarning.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/MultipleProviderTests/SingleProviderNoWarning.ts
@@ -20,7 +20,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "exec": {
         "terraform providers": {
             "code": 0,
-            "stdout": "provider azurerm"
+            "stdout": "Providers required by configuration:\n└── provider[registry.terraform.io/hashicorp/azurerm]"
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -175,6 +175,17 @@ export abstract class BaseTerraformCommandHandler {
         }
     }
 
+    /**
+     * Regex patterns anchored to typical `terraform providers` output format.
+     * Matches lines like: `provider[registry.terraform.io/hashicorp/aws]`
+     */
+    private static readonly PROVIDER_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
+        ["aws",     /provider\[.*\/aws\s*\]/i],
+        ["azurerm", /provider\[.*\/azurerm\s*\]/i],
+        ["google",  /provider\[.*\/google\s*\]/i],
+        ["oracle",  /provider\[.*\/oci\s*\]/i],
+    ]);
+
     public async warnIfMultipleProviders(): Promise<void> {
         try {
             const binaryName = getBinaryName(tasks);
@@ -191,7 +202,8 @@ export abstract class BaseTerraformCommandHandler {
                 cwd: this.getWorkingDirectory()
             });
 
-            const countProviders = ["aws", "azurerm", "google", "oracle"].filter(provider => commandOutput.stdout.includes(provider)).length;
+            const countProviders = [...BaseTerraformCommandHandler.PROVIDER_PATTERNS.values()]
+                .filter(regex => regex.test(commandOutput.stdout)).length;
 
             tasks.debug(countProviders.toString());
             if (countProviders > 1) {


### PR DESCRIPTION
## Summary

- Replace `.includes(provider)` substring matching with anchored regex patterns in `warnIfMultipleProviders`
- Regex matches `provider[.../aws]` format from actual `terraform providers` output
- Eliminates false positives from module names containing provider keywords (e.g., `my-aws-helper`)
- Updated MultipleProvider test mock data to use realistic output format

Closes #111

## Changelog

- **Refactor:** Provider detection uses anchored regex to prevent false positive warnings

## Test plan

- [x] `npm test` — all tests pass
- [x] MultipleProviderWarning test passes with realistic mock data
- [x] SingleProviderNoWarning test passes with realistic mock data