### PR TITLE
feat: strict-by-default GPG signature verification

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissing.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissing.ts
@@ -2,12 +2,12 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-const tp = path.join(__dirname, 'GpgSignatureUnavailableL0.js');
+const tp = path.join(__dirname, 'GpgSignatureRequiredButMissingL0.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('terraformVersion', '1.9.8');
 tr.setInput('downloadSource', 'hashicorp');
-tr.setInput('requireGpgSignature', 'false');
+tr.setInput('requireGpgSignature', 'true');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
@@ -31,12 +31,12 @@ tr.registerMock('./http-client', {
 tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
-// gpg-verifier: mock .sig file unavailable — should warn but not fail
-let gpgWarningIssued = false;
+// gpg-verifier: mock required=true path — throws when .sig unavailable
 tr.registerMock('./gpg-verifier', {
-    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => {
-        // Simulate graceful degradation: no error thrown, just returns
-        // (the real implementation warns via tasks.warning when .sig fetch fails)
+    verifyGpgSignature: async (_sha256SumsContent: string, signatureUrl: string, required: boolean) => {
+        if (required) {
+            throw new Error(`GPG signature file unavailable (${signatureUrl}) and signature verification is required. Set 'requireGpgSignature' to false to skip.`);
+        }
     }
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissingL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissingL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('1.9.8');
+        tl.setResult(tl.TaskResult.Succeeded, 'GpgSignatureRequiredButMissingL0 should not have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'GpgSignatureRequiredButMissingL0 should have failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -157,4 +157,15 @@ describe('TerraformInstaller Test Suite', function () {
             assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
         }, tr);
     });
+
+    it('GPG signature required but missing: should fail when requireGpgSignature is true', async () => {
+        const tp = path.join(__dirname, 'GpgSignatureRequiredButMissing.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have an error issue');
+        }, tr);
+    });
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/gpg-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/gpg-verifier.ts
@@ -9,14 +9,18 @@ import { HASHICORP_GPG_PUBLIC_KEY } from './hashicorp-gpg-key';
  * Fetches the `.sig` file from the same base URL as the SHA256SUMS file.
  *
  * - If verification succeeds, returns the SHA256SUMS content (already fetched).
- * - If the `.sig` file is unavailable (e.g., air-gapped mirror), warns and returns the content unverified.
+ * - If the `.sig` file is unavailable and `required` is false, warns and returns unverified.
+ * - If the `.sig` file is unavailable and `required` is true, throws (hard fail).
  * - If the signature is invalid, throws (hard fail).
  */
-export async function verifyGpgSignature(sha256SumsContent: string, signatureUrl: string): Promise<void> {
+export async function verifyGpgSignature(sha256SumsContent: string, signatureUrl: string, required: boolean = false): Promise<void> {
     let signatureBytes: Uint8Array;
     try {
         signatureBytes = await fetchBuffer(signatureUrl);
     } catch {
+        if (required) {
+            throw new Error(`GPG signature file unavailable (${signatureUrl}) and signature verification is required. Set 'requireGpgSignature' to false to skip.`);
+        }
         tasks.warning(`GPG signature file unavailable (${signatureUrl}). SHA256SUMS will be trusted without signature verification.`);
         return;
     }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -133,7 +133,8 @@ async function downloadZipFromHashiCorp(version: string): Promise<string> {
     const sha256SumsSigUrl = `${sha256SumsUrl}.sig`;
 
     const sha256SumsContent = await fetchText(sha256SumsUrl);
-    await verifyGpgSignature(sha256SumsContent, sha256SumsSigUrl);
+    const requireGpg = tasks.getBoolInput("requireGpgSignature", false) !== false;
+    await verifyGpgSignature(sha256SumsContent, sha256SumsSigUrl, requireGpg);
 
     const expectedHash = parseSha256(sha256SumsContent, zipFileName);
     await verifySha256(zipPath, expectedHash);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -65,6 +65,15 @@
             "required": true,
             "visibleRule": "downloadSource = mirror",
             "helpMarkDown": "Base URL of your binary mirror. Must use HTTPS. Must serve files at the same path structure as releases.hashicorp.com/terraform. Example: https://artifacts.example.com/hashicorp/terraform"
+        },
+        {
+            "name": "requireGpgSignature",
+            "type": "boolean",
+            "label": "Require GPG signature verification",
+            "defaultValue": "true",
+            "required": false,
+            "visibleRule": "downloadSource = hashicorp || downloadSource = mirror",
+            "helpMarkDown": "When enabled, fail if the GPG signature file is unavailable. Defaults to true for HashiCorp downloads. Disable for mirrors that do not serve .sig files."
         }
     ],
     "execution": {


### PR DESCRIPTION
## Summary

- New `requireGpgSignature` boolean input on installer task (default `true`)
- `verifyGpgSignature()` now accepts `required` parameter — throws when `.sig` unavailable and required
- Visible for `hashicorp` and `mirror` download sources
- Updated `GpgSignatureUnavailable` test to explicitly set `requireGpgSignature: false`
- New test: `GpgSignatureRequiredButMissing` — verifies task fails when required and `.sig` missing

Closes #115

## Changelog

- **Security:** Installer now fails by default when GPG signature file is unavailable for HashiCorp downloads

## Test plan

- [x] `npm test` (installer) — 12 tests passing, 0 failures
- [x] New test: required + missing → task fails
- [x] Existing test: not required + missing → task succeeds with warning
- [x] GPG verification success/failure tests continue to pass