### PR TITLE
ci: add coverage reporting and extend lint to Tests/

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Audit production dependencies
         run: cd Tasks/TerraformTask/TerraformTaskV5 && npm audit --omit=dev --audit-level=high
       - name: Lint
-        run: cd Tasks/TerraformTask/TerraformTaskV5 && npx eslint src/
+        run: cd Tasks/TerraformTask/TerraformTaskV5 && npx eslint src/ Tests/
       - name: Compile TypeScript
         run: cd Tasks/TerraformTask/TerraformTaskV5 && npm run compile
-      - name: Run unit tests
-        run: cd Tasks/TerraformTask/TerraformTaskV5 && npm test
+      - name: Run unit tests with coverage
+        run: cd Tasks/TerraformTask/TerraformTaskV5 && npm run test:coverage
 
   build-and-test-installer-v1:
     name: Build and Test Installer V1

--- a/Tasks/TerraformTask/TerraformTaskV5/eslint.config.mjs
+++ b/Tasks/TerraformTask/TerraformTaskV5/eslint.config.mjs
@@ -21,6 +21,22 @@ export default tseslint.config(
         },
     },
     {
-        ignores: ['Tests/**', 'node_modules/**', '**/*.js', '**/*.mjs'],
+        files: ['Tests/**/*.ts'],
+        languageOptions: {
+            parserOptions: {
+                project: './tsconfig.tests.json',
+            },
+        },
+        rules: {
+            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-floating-promises': 'off',
+            '@typescript-eslint/return-await': 'off',
+            '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+            'prefer-const': 'off',
+            'no-var': 'off',
+        },
+    },
+    {
+        ignores: ['node_modules/**', '**/*.js', '**/*.mjs'],
     }
 );


### PR DESCRIPTION
## Summary
- Replace `npm test` with `npm run test:coverage` in V5 CI job for nyc coverage enforcement
- Extend ESLint to lint `Tests/` with relaxed rules: allow `any`, `no-var`, downgrade unused-vars to warning
- Current coverage: 82% statements, 70% branches, 77% functions, 84% lines (all above thresholds)

## Changelog
- **P4.7**: CI coverage reporting via nyc
- **P4.8**: ESLint extended to Tests/ with relaxed rules

## Test plan
- [x] `npx eslint src/ Tests/` passes with 0 errors (14 warnings for unused mock args)
- [x] `npm run test:coverage` passes with all thresholds met
- [x] 150 V5 tests pass

Closes #124