### PR TITLE
test: add emergency cleanup signal handling test

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/EmergencyCleanupTests/EmergencyCleanup.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/EmergencyCleanupTests/EmergencyCleanup.ts
@@ -1,0 +1,10 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, './EmergencyCleanupL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/EmergencyCleanupTests/EmergencyCleanupL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/EmergencyCleanupTests/EmergencyCleanupL0.ts
@@ -1,0 +1,22 @@
+import tl = require('azure-pipelines-task-lib');
+import { EnvironmentVariableHelper } from '../../src/environment-variables';
+
+// Simulate tracked env vars being set during command execution
+EnvironmentVariableHelper.setEnvironmentVariable('AWS_ACCESS_KEY_ID', 'test-key');
+EnvironmentVariableHelper.setEnvironmentVariable('AWS_SECRET_ACCESS_KEY', 'test-secret');
+
+// Verify vars are set
+if (!process.env['AWS_ACCESS_KEY_ID'] || !process.env['AWS_SECRET_ACCESS_KEY']) {
+    tl.setResult(tl.TaskResult.Failed, 'Environment variables should be set before cleanup');
+} else {
+    // Simulate emergency cleanup path — EnvironmentVariableHelper.clearTrackedVariables()
+    // is what the uncaughtException/unhandledRejection handlers ultimately call
+    EnvironmentVariableHelper.clearTrackedVariables();
+
+    // Verify vars are cleared
+    if (process.env['AWS_ACCESS_KEY_ID'] !== undefined || process.env['AWS_SECRET_ACCESS_KEY'] !== undefined) {
+        tl.setResult(tl.TaskResult.Failed, 'Emergency cleanup should have cleared tracked variables');
+    } else {
+        tl.setResult(tl.TaskResult.Succeeded, 'EmergencyCleanupL0 should have succeeded.');
+    }
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2251,4 +2251,16 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    /* emergency cleanup tests */
+
+    it('emergencyCleanup should clear tracked environment variables', async () => {
+        let tp = path.join(__dirname, './EmergencyCleanupTests/EmergencyCleanup.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
 });


### PR DESCRIPTION
## Summary
- New `EmergencyCleanupTests/` test directory
- Test sets tracked env vars, calls `clearTrackedVariables()`, and verifies they're removed from `process.env`

## Changelog
- **P4.5**: Emergency cleanup signal handling test

## Test plan
- [x] 154 V5 tests pass (153 existing + 1 new)

Closes #128