### PR TITLE
ci: add CodeQL workflow and changelog guard in release

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+---
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+      - development
+  schedule:
+    - cron: '17 4 * * 1'  # Monday 04:17 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          languages: javascript-typescript
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
             echo "::error::Tag version (${TAG_VERSION}) does not match azure-devops-extension.json version (${EXT_VERSION}). Update the extension manifest before tagging."
             exit 1
           fi
+      - name: Verify changelog has entry for release version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG_VERSION="${TAG#v}"
+          if ! grep -qE "^## \[?${TAG_VERSION}\]?" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no entry matching version ${TAG_VERSION}. Add a changelog section before releasing."
+            exit 1
+          fi
 
   ci:
     name: CI (build + test)


### PR DESCRIPTION
## Summary

- **P5.4**: Add `.github/workflows/codeql.yml` for TypeScript static analysis — runs on PRs to `main`/`development` and weekly on Mondays
- **P5.5**: Add changelog guard step in `release.yml` that verifies `CHANGELOG.md` has an entry matching the tag version before allowing a release

## Changelog

- ci: added CodeQL TypeScript scanning workflow (weekly + on PR)
- ci: added changelog version guard to release pipeline

Closes #132