### PR TITLE
ci: add cross-platform CI matrix for V5 and Installer V1

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,42 +26,56 @@ jobs:
         run: node scripts/check-versions.js
 
   build-and-test-v5:
-    name: Build and Test V5
-    runs-on: ubuntu-latest
+    name: Build and Test V5 (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        working-directory: Tasks/TerraformTask/TerraformTaskV5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "20"
       - name: Install dependencies
-        run: cd Tasks/TerraformTask/TerraformTaskV5 && npm install --include=dev
+        run: npm install --include=dev
       - name: Audit production dependencies
-        run: cd Tasks/TerraformTask/TerraformTaskV5 && npm audit --omit=dev --audit-level=moderate
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Lint
-        run: cd Tasks/TerraformTask/TerraformTaskV5 && npx eslint src/ Tests/
+        run: npx eslint src/ Tests/
       - name: Compile TypeScript
-        run: cd Tasks/TerraformTask/TerraformTaskV5 && npm run compile
+        run: npm run compile
       - name: Run unit tests with coverage
-        run: cd Tasks/TerraformTask/TerraformTaskV5 && npm run test:coverage
+        run: npm run test:coverage
 
   build-and-test-installer-v1:
-    name: Build and Test Installer V1
-    runs-on: ubuntu-latest
+    name: Build and Test Installer V1 (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        working-directory: Tasks/TerraformInstaller/TerraformInstallerV1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "20"
       - name: Install dependencies
-        run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npm install --include=dev
+        run: npm install --include=dev
       - name: Audit production dependencies
-        run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npm audit --omit=dev --audit-level=moderate
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Lint
-        run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npx eslint src/
+        run: npx eslint src/
       - name: Compile TypeScript
-        run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npm run compile
+        run: npm run compile
       - name: Run unit tests
-        run: cd Tasks/TerraformInstaller/TerraformInstallerV1 && npm test
+        run: npm test
 
   build-and-test-tab:
     name: Build and Test Tab


### PR DESCRIPTION
## Summary

**P5.1** — Convert `build-and-test-v5` and `build-and-test-installer-v1` to matrix jobs running on both `ubuntu-latest` and `windows-latest`.

### Changes

- Added `strategy.matrix.os: [ubuntu-latest, windows-latest]` with `fail-fast: false`
- Switched from `cd ... &&` to `defaults.run.working-directory` for cross-shell compatibility
- Job names now include the OS: `Build and Test V5 (ubuntu-latest)`, etc.

### Action required

Branch protection required status checks need updating:
- `Build and Test V5` → `Build and Test V5 (ubuntu-latest)` + `Build and Test V5 (windows-latest)`
- `Build and Test Installer V1` → `Build and Test Installer V1 (ubuntu-latest)` + `Build and Test Installer V1 (windows-latest)`

## Changelog

- ci: added Windows runner to V5 and Installer V1 test matrix

Closes #134