### PR TITLE
ci: restructure release to draft-first with marketplace gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
             echo "::error::Tag version (${TAG_VERSION}) does not match azure-devops-extension.json version (${EXT_VERSION}). Update the extension manifest before tagging."
             exit 1
           fi
+      - name: Verify changelog has entry for release version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG_VERSION="${TAG#v}"
+          if ! grep -qE "^## \[?${TAG_VERSION}\]?" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no entry matching version ${TAG_VERSION}. Add a changelog section before releasing."
+            exit 1
+          fi
 
   ci:
     name: CI (build + test)
@@ -90,10 +98,38 @@ jobs:
           path: '*.vsix'
           retention-days: 7
 
+  draft-release:
+    name: Create Draft GitHub Release
+    needs: package
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Download vsix artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: vsix
+      - name: Create draft GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        with:
+          files: '*.vsix'
+          generate_release_notes: true
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          draft: true
+
   publish-marketplace:
     name: Publish to VS Marketplace
-    needs: package
+    needs: draft-release
     runs-on: ubuntu-latest
+    environment: marketplace
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -110,25 +146,20 @@ jobs:
           VSIX_FILE=$(ls *.vsix | head -1)
           ./node_modules/.bin/tfx extension publish --vsix "$VSIX_FILE" --token "${{ secrets.TFX_PAT }}"
 
-  github-release:
-    name: Create GitHub Release
-    needs: publish-marketplace
+  undraft-release:
+    name: Undraft GitHub Release
+    needs: [draft-release, publish-marketplace]
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Undraft the release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
-          fetch-depth: 0
-      - name: Download vsix artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: vsix
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-        with:
-          files: '*.vsix'
-          generate_release_notes: true
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          script: |
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: ${{ needs.draft-release.outputs.release_id }},
+              draft: false
+            });


### PR DESCRIPTION
## Summary

**P5.6** — Restructure `release.yml` to eliminate half-published state on partial failure:

1. **Draft release** — creates a draft GitHub release with the `.vsix` before Marketplace publish
2. **Marketplace gate** — publish step uses `environment: marketplace` requiring manual approval
3. **Undraft** — on successful Marketplace publish, the GitHub release is undrafted automatically

Also includes **P5.5** changelog guard (verifies `CHANGELOG.md` has an entry matching the tag version).

### Action required

Create a `marketplace` environment in repo Settings → Environments with a required reviewer protection rule.

## Changelog

- ci: restructured release pipeline to draft-first with Marketplace approval gate
- ci: added changelog version guard to release pipeline

Closes #136