### PR TITLE
refactor: OCI PEM handling — proper normalizer with crypto validation

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIApplyFailEmptyWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIApplyFailInvalidWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApprove.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApprove.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIApplySuccessAdditionalArgsWithAutoApproveL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessNoAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIApplySuccessNoAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- DummyKey -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIDestroyFailEmptyWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroySuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroySuccessNoAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIDestroySuccessNoAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- DummyKey -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2275,4 +2275,16 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    /* PEM normalizer tests */
+
+    it('normalizePem should normalize valid keys and reject malformed input', async () => {
+        let tp = path.join(__dirname, './PemNormalizerTests/PemNormalizer.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/OCIOutputSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/OCIOutputSuccess.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIOutputSuccessL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- DummyKey -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 tr.registerMock('uuid', { v4: () => '123' });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PemNormalizerTests/PemNormalizer.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PemNormalizerTests/PemNormalizer.ts
@@ -1,0 +1,7 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './PemNormalizerL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PemNormalizerTests/PemNormalizerL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PemNormalizerTests/PemNormalizerL0.ts
@@ -1,0 +1,87 @@
+import tl = require('azure-pipelines-task-lib');
+import { normalizePem } from '../../src/pem-normalizer';
+import {
+    TEST_OCI_PRIVATE_KEY_SPACES,
+    TEST_OCI_PRIVATE_KEY_PEM,
+    TEST_OCI_PRIVATE_KEY_CRLF,
+} from '../test-oci-fixtures';
+
+let passed = true;
+
+function assertEqual(actual: string, expected: string, label: string): void {
+    if (actual !== expected) {
+        console.error(`FAIL [${label}]: expected\n${JSON.stringify(expected)}\nbut got\n${JSON.stringify(actual)}`);
+        passed = false;
+    } else {
+        console.log(`PASS [${label}]`);
+    }
+}
+
+function assertThrows(fn: () => void, expectedSubstring: string, label: string): void {
+    try {
+        fn();
+        console.error(`FAIL [${label}]: expected error containing "${expectedSubstring}" but no error was thrown`);
+        passed = false;
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes(expectedSubstring)) {
+            console.error(`FAIL [${label}]: expected error containing "${expectedSubstring}" but got: ${message}`);
+            passed = false;
+        } else {
+            console.log(`PASS [${label}]`);
+        }
+    }
+}
+
+// --- Test: key with proper LF newlines (standard PEM) ---
+const normalizedFromPem = normalizePem(TEST_OCI_PRIVATE_KEY_PEM);
+assertEqual(normalizedFromPem, TEST_OCI_PRIVATE_KEY_PEM, 'PEM with LF newlines normalizes correctly');
+
+// --- Test: key with spaces (ADO service connection format) ---
+const normalizedFromSpaces = normalizePem(TEST_OCI_PRIVATE_KEY_SPACES);
+assertEqual(normalizedFromSpaces, TEST_OCI_PRIVATE_KEY_PEM, 'PEM with spaces normalizes to standard PEM');
+
+// --- Test: key with CRLF line endings ---
+const normalizedFromCrlf = normalizePem(TEST_OCI_PRIVATE_KEY_CRLF);
+assertEqual(normalizedFromCrlf, TEST_OCI_PRIVATE_KEY_PEM, 'PEM with CRLF normalizes to standard PEM');
+
+// --- Test: missing header ---
+assertThrows(
+    () => normalizePem('MIGHAgEAMBMGByqG...'),
+    'missing header or footer',
+    'missing header/footer rejects'
+);
+
+// --- Test: empty body ---
+assertThrows(
+    () => normalizePem('-----BEGIN PRIVATE KEY----------END PRIVATE KEY-----'),
+    'empty key body',
+    'empty body rejects'
+);
+
+// --- Test: non-base64 characters ---
+assertThrows(
+    () => normalizePem('-----BEGIN PRIVATE KEY----- !!!invalid!!! -----END PRIVATE KEY-----'),
+    'non-base64 characters',
+    'non-base64 body rejects'
+);
+
+// --- Test: mismatched labels ---
+assertThrows(
+    () => normalizePem('-----BEGIN RSA PRIVATE KEY----- abc -----END PRIVATE KEY-----'),
+    'does not match footer label',
+    'mismatched labels rejects'
+);
+
+// --- Test: valid base64 but not a real key (crypto validation fails) ---
+assertThrows(
+    () => normalizePem('-----BEGIN PRIVATE KEY----- dGhpcyBpcyBub3QgYSBrZXk= -----END PRIVATE KEY-----'),
+    'crypto validation failed',
+    'invalid DER content rejects'
+);
+
+if (passed) {
+    tl.setResult(tl.TaskResult.Succeeded, 'All PEM normalizer tests passed.');
+} else {
+    tl.setResult(tl.TaskResult.Failed, 'One or more PEM normalizer tests failed.');
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIPlanFailEmptyWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- dummykeydata -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanSuccessNoAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIPlanSuccessNoAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- DummyKey -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/OCIShowConsoleSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/OCIShowConsoleSuccess.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCIShowConsoleSuccessL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -17,7 +18,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- DummyKey -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccess.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_OCI_PRIVATE_KEY_SPACES } from '../test-oci-fixtures';
 
 let tp = path.join(__dirname, './OCITestSuccessL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'DummyTenancy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'DummyUser';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'DummyFingerprint';
-process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = '-----BEGIN PRIVATE KEY----- DummyKey -----END PRIVATE KEY-----';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/test-oci-fixtures.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/test-oci-fixtures.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared OCI test fixtures.
+ *
+ * The EC P-256 key below is used ONLY in tests — it has zero access to any
+ * real infrastructure.  It is stored in "spaces" format (how Azure DevOps
+ * service connections deliver PEM keys) and in proper PEM format.
+ */
+
+/** PKCS#8 EC P-256 private key with spaces instead of newlines (ADO format). */
+export const TEST_OCI_PRIVATE_KEY_SPACES =
+    '-----BEGIN PRIVATE KEY----- MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgIwyERSFzQgCvXZNB OKG4XWPRXkZSEiTXPWIXcnbCciGhRANCAASwmlpLUCI6U52pVpbzAqXCbny9wTFc iKZ0WdIidDIdA3L8AHgObTZlkx28C42vNqt375Sm0ix77WI1ej2YUgwk -----END PRIVATE KEY-----';
+
+/** Same key in proper PEM format (LF line endings, 64-char wrapped). */
+export const TEST_OCI_PRIVATE_KEY_PEM =
+    '-----BEGIN PRIVATE KEY-----\n' +
+    'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgIwyERSFzQgCvXZNB\n' +
+    'OKG4XWPRXkZSEiTXPWIXcnbCciGhRANCAASwmlpLUCI6U52pVpbzAqXCbny9wTFc\n' +
+    'iKZ0WdIidDIdA3L8AHgObTZlkx28C42vNqt375Sm0ix77WI1ej2YUgwk\n' +
+    '-----END PRIVATE KEY-----\n';
+
+/** Same key with CRLF line endings. */
+export const TEST_OCI_PRIVATE_KEY_CRLF =
+    '-----BEGIN PRIVATE KEY-----\r\n' +
+    'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgIwyERSFzQgCvXZNB\r\n' +
+    'OKG4XWPRXkZSEiTXPWIXcnbCciGhRANCAASwmlpLUCI6U52pVpbzAqXCbny9wTFc\r\n' +
+    'iKZ0WdIidDIdA3L8AHgObTZlkx28C42vNqt375Sm0ix77WI1ej2YUgwk\r\n' +
+    '-----END PRIVATE KEY-----\r\n';

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -4,6 +4,7 @@ import { TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
 import { writeSecretFile } from './secure-temp';
+import { normalizePem } from './pem-normalizer';
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
@@ -17,15 +18,9 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
 
     private getPrivateKeyFilePath(privateKey: string) {
         tasks.setSecret(privateKey);
-        // Preserve PEM header/footer, convert spaces to newlines in the base64 body
-        privateKey = privateKey
-            .replace('-----BEGIN PRIVATE KEY-----', '_begin_')
-            .replace('-----END PRIVATE KEY-----', '_end_')
-            .replace(/ /g, '\n')
-            .replace('_begin_', '-----BEGIN PRIVATE KEY-----')
-            .replace('_end_', '-----END PRIVATE KEY-----');
+        const normalized = normalizePem(privateKey);
         const privateKeyFilePath = path.join(os.tmpdir(), `keyfile-${uuidV4()}.pem`);
-        writeSecretFile(privateKeyFilePath, privateKey);
+        writeSecretFile(privateKeyFilePath, normalized);
         this.tempFiles.push(privateKeyFilePath);
         return privateKeyFilePath;
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/pem-normalizer.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/pem-normalizer.ts
@@ -1,0 +1,64 @@
+import crypto = require('crypto');
+
+/**
+ * Normalize a PEM-encoded private key to standard format.
+ *
+ * Azure DevOps service connections often deliver PEM keys as a single line
+ * with spaces instead of newlines.  This function:
+ *   1. Extracts the PEM type label (e.g. "PRIVATE KEY", "RSA PRIVATE KEY").
+ *   2. Strips all whitespace from the base64 body.
+ *   3. Re-wraps at 64-character lines (RFC 7468 §2).
+ *   4. Reassembles header, body, and footer with LF line endings.
+ *   5. Validates the result with `crypto.createPrivateKey()`.
+ *
+ * Throws on malformed input (missing header/footer, invalid base64, or
+ * a key that Node's crypto cannot parse).
+ */
+export function normalizePem(pem: string): string {
+    const headerRe = /-----BEGIN ([A-Z0-9 ]+)-----/;
+    const footerRe = /-----END ([A-Z0-9 ]+)-----/;
+
+    const headerMatch = pem.match(headerRe);
+    const footerMatch = pem.match(footerRe);
+
+    if (!headerMatch || !footerMatch) {
+        throw new Error('Invalid PEM: missing header or footer');
+    }
+
+    const label = headerMatch[1];
+    if (headerMatch[1] !== footerMatch[1]) {
+        throw new Error(`Invalid PEM: header label "${headerMatch[1]}" does not match footer label "${footerMatch[1]}"`);
+    }
+
+    // Extract base64 body between header and footer, strip all whitespace
+    const afterHeader = pem.substring(pem.indexOf(headerMatch[0]) + headerMatch[0].length);
+    const body = afterHeader.substring(0, afterHeader.indexOf(footerMatch[0]));
+    const base64 = body.replace(/\s+/g, '');
+
+    if (base64.length === 0) {
+        throw new Error('Invalid PEM: empty key body');
+    }
+
+    // Validate base64 characters
+    if (!/^[A-Za-z0-9+/]+=*$/.test(base64)) {
+        throw new Error('Invalid PEM: key body contains non-base64 characters');
+    }
+
+    // Re-wrap at 64-character lines per RFC 7468
+    const lines: string[] = [];
+    for (let i = 0; i < base64.length; i += 64) {
+        lines.push(base64.substring(i, i + 64));
+    }
+
+    const normalized = `-----BEGIN ${label}-----\n${lines.join('\n')}\n-----END ${label}-----\n`;
+
+    // Validate the key can be parsed by Node's crypto
+    try {
+        crypto.createPrivateKey(normalized);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Invalid PEM: crypto validation failed — ${message}`);
+    }
+
+    return normalized;
+}


### PR DESCRIPTION
## Summary
- Extract `normalizePem()` in `src/pem-normalizer.ts` that strips whitespace from base64 body, re-wraps at 64-char lines (RFC 7468), and validates with `crypto.createPrivateKey()` before writing
- Replace the fragile 5-step string replace chain in `getPrivateKeyFilePath` with a single call to `normalizePem()`
- Update all 11 OCI test fixtures to use a real EC P-256 test key via shared `test-oci-fixtures.ts`
- Add PEM normalizer unit tests covering: LF, spaces (ADO format), CRLF, missing header, empty body, non-base64, mismatched labels, invalid DER

## Changelog
- `refactor`: Replace OCI private key string-replace chain with proper PEM normalizer
- `feat`: Validate OCI private keys with `crypto.createPrivateKey()` before writing to disk
- `test`: Add PEM normalizer tests and shared OCI test key fixture

Closes #146
Roadmap: P6.6