### PR TITLE
feat: add OpenTofu installer support

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissing.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissing.ts
@@ -40,6 +40,10 @@ tr.registerMock('./gpg-verifier', {
     }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
     readFileSync: (_path: string) => Buffer.from('fake-zip-content')

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
@@ -40,6 +40,10 @@ tr.registerMock('./gpg-verifier', {
     }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
     readFileSync: (_path: string) => Buffer.from('fake-zip-content')

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationFail.ts
@@ -37,6 +37,10 @@ tr.registerMock('./gpg-verifier', {
     }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
     readFileSync: (_path: string) => Buffer.from('fake-zip-content')

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccess.ts
@@ -35,6 +35,10 @@ tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
     readFileSync: (_path: string) => Buffer.from('fake-zip-content')

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
@@ -36,6 +36,10 @@ tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 // fs: readFileSync for verifySha256, chmodSync skipped on Windows
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlReject.ts
@@ -31,6 +31,10 @@ tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => null,
     downloadTool: async (_url: string, _fileName: string) => {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InvalidVersionFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InvalidVersionFail.ts
@@ -30,6 +30,10 @@ tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => null,
     downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -168,4 +168,39 @@ describe('TerraformInstaller Test Suite', function () {
             assert(tr.errorIssues.length > 0, 'should have an error issue');
         }, tr);
     });
+
+    // --- OpenTofu download ---
+
+    it('opentofu latest: should resolve version from GitHub API and download', async () => {
+        const tp = path.join(__dirname, 'OpenTofuLatestSuccess.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
+    it('opentofu specific version: should skip GitHub API and download directly', async () => {
+        const tp = path.join(__dirname, 'OpenTofuSpecificVersionSuccess.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
+    it('opentofu cached: should use cached tool and skip download', async () => {
+        const tp = path.join(__dirname, 'OpenTofuCachedSuccess.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
@@ -33,6 +33,10 @@ tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => null,
     downloadTool: async (url: string, _fileName: string) => {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccess.ts
@@ -2,33 +2,35 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-const tp = path.join(__dirname, 'CachedInstallSuccessL0.js');
+const tp = path.join(__dirname, 'OpenTofuCachedSuccessL0.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
-tr.setInput('terraformVersion', '1.9.8');
-tr.setInput('downloadSource', 'hashicorp');
+tr.setInput('binary', 'tofu');
+tr.setInput('terraformVersion', '1.11.6');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
     arch: () => 'x64'
 });
 
-// http-client should NOT be called when tool is cached (no download, no SHA256)
+// http-client should NOT be called when tool is cached
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => {
         throw new Error('fetchJson should not be called when tool is cached. Called with: ' + url);
     },
     fetchText: async (url: string) => {
         throw new Error('fetchText should not be called when tool is cached. Called with: ' + url);
+    },
+    fetchBuffer: async (url: string) => {
+        throw new Error('fetchBuffer should not be called when tool is cached. Called with: ' + url);
     }
 });
 
 tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
-// gpg-verifier: mock to prevent openpgp from loading
 tr.registerMock('./gpg-verifier', {
-    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
+    verifyGpgSignature: async () => { }
 });
 
 tr.registerMock('./cosign-verifier', {
@@ -36,8 +38,7 @@ tr.registerMock('./cosign-verifier', {
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
-    // findLocalTool returns a path, indicating the tool is already cached
-    findLocalTool: (_toolName: string, _version: string) => '/tmp/terraform-cached',
+    findLocalTool: (_toolName: string, _version: string) => '/tmp/tofu-cached',
     downloadTool: async (_url: string, _fileName: string) => {
         throw new Error('downloadTool should not be called when tool is cached');
     },
@@ -53,7 +54,7 @@ tr.registerMock('azure-pipelines-tool-lib/tool', {
 
 const a: ma.TaskLibAnswers = {
     'find': {
-        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+        '/tmp/tofu-cached': ['/tmp/tofu-cached/tofu.exe']
     }
 };
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccessL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        const result = await downloadTerraform('1.11.6');
+        tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuCachedSuccessL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'OpenTofuCachedSuccessL0 failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccess.ts
@@ -2,11 +2,11 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-const tp = path.join(__dirname, 'HashiCorpLatestSuccessL0.js');
+const tp = path.join(__dirname, 'OpenTofuLatestSuccessL0.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
+tr.setInput('binary', 'tofu');
 tr.setInput('terraformVersion', 'latest');
-tr.setInput('downloadSource', 'hashicorp');
 
 // Mock os: Windows_NT so chmodSync is skipped; arch x64 -> amd64
 tr.registerMock('os', {
@@ -16,30 +16,34 @@ tr.registerMock('os', {
 
 const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
 
-// Mock http-client: checkpoint API returns 1.9.8, SHA256SUMS returns matching hash
+// Mock http-client: GitHub API returns latest version, SHA256SUMS returns matching hash
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => {
-        if (url.includes('checkpoint-api.hashicorp.com')) {
-            return { current_version: '1.9.8' };
+        if (url.includes('api.github.com/repos/opentofu/opentofu/releases/latest')) {
+            return { tag_name: 'v1.11.6' };
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
     fetchText: async (url: string) => {
         if (url.includes('SHA256SUMS')) {
-            return `${EXPECTED_SHA256}  terraform_1.9.8_windows_amd64.zip\n`;
+            return `${EXPECTED_SHA256}  tofu_1.11.6_windows_amd64.zip\n`;
         }
         throw new Error('Unexpected fetchText URL: ' + url);
+    },
+    fetchBuffer: async (_url: string) => {
+        throw new Error('fetchBuffer should not be called in this test');
     }
 });
 
 tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
-// gpg-verifier: mock GPG verification as passing
+// gpg-verifier: mock to prevent openpgp from loading
 tr.registerMock('./gpg-verifier', {
-    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
+    verifyGpgSignature: async () => { }
 });
 
+// cosign-verifier: mock cosign as not required, skip verification
 tr.registerMock('./cosign-verifier', {
     verifyCosignSignature: async () => { }
 });
@@ -47,7 +51,9 @@ tr.registerMock('./cosign-verifier', {
 // fs: readFileSync for verifySha256, chmodSync skipped on Windows
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content'),
+    writeFileSync: (_path: string, _content: any) => { },
+    unlinkSync: (_path: string) => { }
 });
 
 // crypto: return the expected hash so SHA256 verification passes
@@ -61,16 +67,16 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => null,
-    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
-    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
-    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    downloadTool: async (_url: string, _fileName: string) => '/tmp/tofu.zip',
+    extractZip: async (_zipPath: string) => '/tmp/tofu-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/tofu-cached',
     cleanVersion: (version: string) => version,
     prependPath: (_toolPath: string) => { }
 });
 
 const a: ma.TaskLibAnswers = {
     'find': {
-        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+        '/tmp/tofu-cached': ['/tmp/tofu-cached/tofu.exe']
     }
 };
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccessL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        const result = await downloadTerraform('latest');
+        tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuLatestSuccessL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'OpenTofuLatestSuccessL0 failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccess.ts
@@ -2,13 +2,12 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-const tp = path.join(__dirname, 'HashiCorpLatestSuccessL0.js');
+const tp = path.join(__dirname, 'OpenTofuSpecificVersionSuccessL0.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
-tr.setInput('terraformVersion', 'latest');
-tr.setInput('downloadSource', 'hashicorp');
+tr.setInput('binary', 'tofu');
+tr.setInput('terraformVersion', '1.11.6');
 
-// Mock os: Windows_NT so chmodSync is skipped; arch x64 -> amd64
 tr.registerMock('os', {
     type: () => 'Windows_NT',
     arch: () => 'x64'
@@ -16,41 +15,40 @@ tr.registerMock('os', {
 
 const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
 
-// Mock http-client: checkpoint API returns 1.9.8, SHA256SUMS returns matching hash
+// Mock http-client: specific version skips GitHub API; only SHA256SUMS is fetched
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => {
-        if (url.includes('checkpoint-api.hashicorp.com')) {
-            return { current_version: '1.9.8' };
-        }
-        throw new Error('Unexpected fetchJson URL: ' + url);
+        throw new Error('fetchJson should not be called for specific version. Called with: ' + url);
     },
     fetchText: async (url: string) => {
         if (url.includes('SHA256SUMS')) {
-            return `${EXPECTED_SHA256}  terraform_1.9.8_windows_amd64.zip\n`;
+            return `${EXPECTED_SHA256}  tofu_1.11.6_windows_amd64.zip\n`;
         }
         throw new Error('Unexpected fetchText URL: ' + url);
+    },
+    fetchBuffer: async (_url: string) => {
+        throw new Error('fetchBuffer should not be called in this test');
     }
 });
 
 tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
-// gpg-verifier: mock GPG verification as passing
 tr.registerMock('./gpg-verifier', {
-    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
+    verifyGpgSignature: async () => { }
 });
 
 tr.registerMock('./cosign-verifier', {
     verifyCosignSignature: async () => { }
 });
 
-// fs: readFileSync for verifySha256, chmodSync skipped on Windows
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content'),
+    writeFileSync: (_path: string, _content: any) => { },
+    unlinkSync: (_path: string) => { }
 });
 
-// crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
@@ -61,16 +59,16 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => null,
-    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
-    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
-    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    downloadTool: async (_url: string, _fileName: string) => '/tmp/tofu.zip',
+    extractZip: async (_zipPath: string) => '/tmp/tofu-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/tofu-cached',
     cleanVersion: (version: string) => version,
     prependPath: (_toolPath: string) => { }
 });
 
 const a: ma.TaskLibAnswers = {
     'find': {
-        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+        '/tmp/tofu-cached': ['/tmp/tofu-cached/tofu.exe']
     }
 };
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccessL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        const result = await downloadTerraform('1.11.6');
+        tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuSpecificVersionSuccessL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'OpenTofuSpecificVersionSuccessL0 failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
@@ -43,6 +43,10 @@ tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 // fs: mock readFileSync (for verifySha256) and chmodSync (no-op, Windows mock)
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
@@ -42,6 +42,10 @@ tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
 });
 
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
 // fs: readFileSync returns some content
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
@@ -1,0 +1,80 @@
+import tasks = require('azure-pipelines-task-lib/task');
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+
+import { v4 as uuidV4 } from 'uuid';
+import { fetchBuffer } from './http-client';
+
+/**
+ * Verifies the cosign signature of a SHA256SUMS file against OpenTofu's Sigstore identity.
+ *
+ * - Downloads the `.sig` (signature) and `.pem` (certificate) files.
+ * - Shells out to the `cosign` binary to run `verify-blob`.
+ * - If cosign is not installed and `required` is false, warns and returns (unverified).
+ * - If cosign is not installed and `required` is true, throws (hard fail).
+ * - If signature verification fails, throws (hard fail).
+ */
+export async function verifyCosignSignature(
+    sha256SumsContent: string,
+    signatureUrl: string,
+    certificateUrl: string,
+    required: boolean = false
+): Promise<void> {
+    let cosignPath: string;
+    try {
+        cosignPath = tasks.which('cosign', true);
+    } catch {
+        if (required) {
+            throw new Error('cosign is required for OpenTofu signature verification but was not found on the agent. Install cosign or set requireCosignVerification to false.');
+        }
+        tasks.warning('cosign not found on agent. SHA256SUMS will be trusted without signature verification.');
+        return;
+    }
+
+    let signatureBytes: Uint8Array;
+    let certificateBytes: Uint8Array;
+    try {
+        signatureBytes = await fetchBuffer(signatureUrl);
+        certificateBytes = await fetchBuffer(certificateUrl);
+    } catch {
+        if (required) {
+            throw new Error(`Cosign signature or certificate file unavailable and verification is required. Signature: ${signatureUrl}, Certificate: ${certificateUrl}`);
+        }
+        tasks.warning('Cosign signature/certificate files unavailable. Skipping verification.');
+        return;
+    }
+
+    const tempDir = os.tmpdir();
+    const sha256SumsPath = path.join(tempDir, `sha256sums-${uuidV4()}`);
+    const signaturePath = path.join(tempDir, `sha256sums-${uuidV4()}.sig`);
+    const certificatePath = path.join(tempDir, `sha256sums-${uuidV4()}.pem`);
+
+    fs.writeFileSync(sha256SumsPath, sha256SumsContent);
+    fs.writeFileSync(signaturePath, signatureBytes);
+    fs.writeFileSync(certificatePath, certificateBytes);
+
+    try {
+        tasks.debug(`Verifying cosign signature: ${signatureUrl}`);
+        const toolRunner = tasks.tool(cosignPath);
+        toolRunner.arg('verify-blob');
+        toolRunner.arg(['--certificate', certificatePath]);
+        toolRunner.arg(['--signature', signaturePath]);
+        toolRunner.arg(['--certificate-identity-regexp', 'https://github.com/opentofu/opentofu']);
+        toolRunner.arg(['--certificate-oidc-issuer', 'https://token.actions.githubusercontent.com']);
+        toolRunner.arg(sha256SumsPath);
+
+        const result = await toolRunner.exec();
+        if (result !== 0) {
+            throw new Error('Cosign verification failed with non-zero exit code');
+        }
+        tasks.debug('Cosign signature verification passed');
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(`Cosign signature verification failed for SHA256SUMS: ${errorMessage}`);
+    } finally {
+        try { fs.unlinkSync(sha256SumsPath); } catch { /* ignore cleanup errors */ }
+        try { fs.unlinkSync(signaturePath); } catch { /* ignore cleanup errors */ }
+        try { fs.unlinkSync(certificatePath); } catch { /* ignore cleanup errors */ }
+    }
+}

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/index.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/index.ts
@@ -17,10 +17,11 @@ async function configureTerraform() {
 
 async function verifyTerraform() {
     console.log(tasks.loc("VerifyTerraformInstallation"));
-    const terraformPath = tasks.which("terraform", true);
-    const terraformTool: ToolRunner = tasks.tool(terraformPath);
-    terraformTool.arg("version");
-    return terraformTool.exec();
+    const binary = tasks.getInput("binary") || "terraform";
+    const binaryPath = tasks.which(binary, true);
+    const binaryTool: ToolRunner = tasks.tool(binaryPath);
+    binaryTool.arg("version");
+    return binaryTool.exec();
 }
 
 async function run() {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -8,14 +8,25 @@ import crypto = require('crypto');
 import { v4 as uuidV4 } from 'uuid';
 import { fetchJson, fetchText } from './http-client';
 import { verifyGpgSignature } from './gpg-verifier';
+import { verifyCosignSignature } from './cosign-verifier';
 
 const terraformToolName = "terraform";
+const tofuToolName = "tofu";
 const isWindows = os.type().match(/^Win/);
 
 /** Fallback version used when the HashiCorp checkpoint API is unreachable. Update periodically. */
 const FALLBACK_TERRAFORM_VERSION = '1.14.8';
 
+/** Fallback version used when the OpenTofu GitHub API is unreachable. Update periodically. */
+const FALLBACK_TOFU_VERSION = '1.11.6';
+
 export async function downloadTerraform(inputVersion: string): Promise<string> {
+    const binary = tasks.getInput("binary") || "terraform";
+
+    if (binary === "tofu") {
+        return downloadTofu(inputVersion);
+    }
+
     const downloadSource = tasks.getInput("downloadSource") || "hashicorp";
 
     // Step 1: Resolve version string (may require an API call for 'latest')
@@ -257,9 +268,13 @@ function getHashiCorpDownloadUrl(version: string): string {
 }
 
 function findTerraformExecutable(rootFolder: string): string {
-    const terraformPath = path.join(rootFolder, terraformToolName + getExecutableExtension());
+    return findExecutable(rootFolder, terraformToolName);
+}
+
+function findExecutable(rootFolder: string, toolName: string): string {
+    const execPath = path.join(rootFolder, toolName + getExecutableExtension());
     const allPaths = tasks.find(rootFolder);
-    const matchingResultFiles = tasks.match(allPaths, terraformPath, rootFolder);
+    const matchingResultFiles = tasks.match(allPaths, execPath, rootFolder);
     return matchingResultFiles[0];
 }
 
@@ -268,4 +283,85 @@ function getExecutableExtension(): string {
         return ".exe";
     }
     return "";
+}
+
+// --- OpenTofu ---
+
+async function downloadTofu(inputVersion: string): Promise<string> {
+    const resolvedVersion = await resolveVersionFromOpenTofu(inputVersion);
+    const version = tools.cleanVersion(resolvedVersion);
+    if (!version) {
+        throw new Error(tasks.loc("InputVersionNotValidSemanticVersion", resolvedVersion));
+    }
+
+    let cachedToolPath = tools.findLocalTool(tofuToolName, version);
+
+    if (!cachedToolPath) {
+        const zipPath = await downloadZipFromOpenTofu(version);
+        const unzippedPath = await tools.extractZip(zipPath);
+        cachedToolPath = await tools.cacheDir(unzippedPath, tofuToolName, version);
+        tasks.setVariable('terraformDownloadedFrom', 'opentofu');
+    } else {
+        tasks.setVariable('terraformDownloadedFrom', 'cache');
+    }
+
+    const tofuPath = findExecutable(cachedToolPath, tofuToolName);
+    if (!tofuPath) {
+        throw new Error(tasks.loc("TerraformNotFoundInFolder", cachedToolPath));
+    }
+
+    if (!isWindows) {
+        fs.chmodSync(tofuPath, "755");
+    }
+
+    tasks.setVariable('terraformLocation', tofuPath);
+    return tofuPath;
+}
+
+async function resolveVersionFromOpenTofu(inputVersion: string): Promise<string> {
+    if (inputVersion.toLowerCase() !== 'latest') {
+        return inputVersion;
+    }
+    console.log(tasks.loc("GettingLatestOpenTofuVersion"));
+    try {
+        const data = await fetchJson<{ tag_name: string }>('https://api.github.com/repos/opentofu/opentofu/releases/latest');
+        if (!data.tag_name) {
+            throw new Error("GitHub API returned invalid response: missing tag_name");
+        }
+        // tag_name is "v1.11.6" — strip the leading "v"
+        return data.tag_name.replace(/^v/, '');
+    } catch {
+        console.warn(tasks.loc("TerraformVersionNotFound"));
+        return FALLBACK_TOFU_VERSION;
+    }
+}
+
+async function downloadZipFromOpenTofu(version: string): Promise<string> {
+    const osPlatform = getPlatformString();
+    const arch = getArchString();
+    const zipFileName = `tofu_${version}_${osPlatform}_${arch}.zip`;
+    const downloadUrl = `https://github.com/opentofu/opentofu/releases/download/v${version}/${zipFileName}`;
+
+    const fileName = `${tofuToolName}-${version}-${uuidV4()}.zip`;
+    let zipPath: string;
+    try {
+        zipPath = await tools.downloadTool(downloadUrl, fileName);
+    } catch (exception) {
+        throw new Error(tasks.loc("TerraformDownloadFailed", downloadUrl, exception));
+    }
+
+    // SHA256 verification via SHA256SUMS file
+    const sha256SumsUrl = `https://github.com/opentofu/opentofu/releases/download/v${version}/tofu_${version}_SHA256SUMS`;
+    const sha256SumsContent = await fetchText(sha256SumsUrl);
+
+    // Cosign verification of SHA256SUMS
+    const requireCosign = tasks.getBoolInput("requireCosignVerification", false) === true;
+    const signatureUrl = `${sha256SumsUrl}.sig`;
+    const certificateUrl = `${sha256SumsUrl}.pem`;
+    await verifyCosignSignature(sha256SumsContent, signatureUrl, certificateUrl, requireCosign);
+
+    const expectedHash = parseSha256(sha256SumsContent, zipFileName);
+    await verifySha256(zipPath, expectedHash);
+
+    return zipPath;
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -16,15 +16,27 @@
         "Minor": "218",
         "Patch": "0"
     },
-    "instanceNameFormat": "Install Terraform $(terraformVersion)",
+    "instanceNameFormat": "Install $(binary) $(terraformVersion)",
     "inputs": [
+        {
+            "name": "binary",
+            "type": "pickList",
+            "label": "Binary",
+            "defaultValue": "terraform",
+            "required": true,
+            "helpMarkDown": "Which IaC binary to install: Terraform (HashiCorp) or OpenTofu.",
+            "options": {
+                "terraform": "Terraform (HashiCorp)",
+                "tofu": "OpenTofu"
+            }
+        },
         {
             "name": "terraformVersion",
             "type": "string",
             "label": "Version",
             "defaultValue": "latest",
             "required": true,
-            "helpMarkDown": "The version of Terraform to install. Use 'latest' to install the current latest release."
+            "helpMarkDown": "The version to install. Use 'latest' to install the current latest release. Applies to both Terraform and OpenTofu."
         },
         {
             "name": "downloadSource",
@@ -32,7 +44,8 @@
             "label": "Download source",
             "defaultValue": "hashicorp",
             "required": true,
-            "helpMarkDown": "Where to download the Terraform binary from.",
+            "visibleRule": "binary = terraform",
+            "helpMarkDown": "Where to download the Terraform binary from. OpenTofu always downloads from GitHub releases.",
             "options": {
                 "hashicorp": "HashiCorp official releases (releases.hashicorp.com)",
                 "registry": "Private registry (terraform-registry-backend)",
@@ -72,8 +85,17 @@
             "label": "Require GPG signature verification",
             "defaultValue": "true",
             "required": false,
-            "visibleRule": "downloadSource = hashicorp || downloadSource = mirror",
+            "visibleRule": "binary = terraform && downloadSource = hashicorp || binary = terraform && downloadSource = mirror",
             "helpMarkDown": "When enabled, fail if the GPG signature file is unavailable. Defaults to true for HashiCorp downloads. Disable for mirrors that do not serve .sig files."
+        },
+        {
+            "name": "requireCosignVerification",
+            "type": "boolean",
+            "label": "Require cosign signature verification",
+            "defaultValue": "false",
+            "required": false,
+            "visibleRule": "binary = tofu",
+            "helpMarkDown": "When enabled, fail if cosign is not available on the agent or the signature cannot be verified. When disabled (default), cosign verification is attempted but skipped if cosign is not installed."
         }
     ],
     "execution": {
@@ -92,14 +114,15 @@
         }
     ],
     "messages": {
-        "VerifyTerraformInstallation": "Verifying Terraform installation...",
+        "VerifyTerraformInstallation": "Verifying installation...",
         "InputVersionNotValidSemanticVersion": "Input version %s is not a valid semantic version",
-        "TerraformNotFoundInFolder": "Terraform executable not found in path %s",
+        "TerraformNotFoundInFolder": "Executable not found in path %s",
         "OperatingSystemNotSupported": "Operating system %s is not supported",
         "ArchitectureNotSupported": "Architecture %s is not supported",
-        "TerraformDownloadFailed": "Failed to download Terraform from url %s. Error: %s",
-        "TerraformVersionNotFound": "Unable to get latest version from source, defaulting to 1.9.8",
+        "TerraformDownloadFailed": "Failed to download binary from url %s. Error: %s",
+        "TerraformVersionNotFound": "Unable to get latest version from source, using fallback version",
         "GettingLatestTerraformVersion": "Getting latest Terraform version.",
+        "GettingLatestOpenTofuVersion": "Getting latest OpenTofu version from GitHub releases.",
         "InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed.",
         "RegistryRequestFailed": "Registry request failed for %s. HTTP status: %s",
         "Sha256VerificationFailed": "SHA256 verification failed. Expected: %s, Got: %s",


### PR DESCRIPTION
## Summary

- Add `binary: terraform | tofu` input to the installer task, enabling OpenTofu downloads from GitHub releases
- New `cosign-verifier.ts` module for optional Sigstore-based signature verification of SHA256SUMS
- Parameterize download URLs, tool cache names, and executable discovery for OpenTofu
- Resolve latest OpenTofu version via GitHub API (`/repos/opentofu/opentofu/releases/latest`) with fallback to `1.11.6`
- Update `index.ts` to run `tofu version` (not `terraform version`) when `binary=tofu`
- Add `requireCosignVerification` input (default `false`) — when enabled, fails if cosign is not installed or verification fails
- 3 new OpenTofu installer tests (latest, specific version, cached); cosign-verifier mock added to all 12 existing test fixtures

## Changelog

- feat: add `binary` input (`terraform` | `tofu`) to installer task for OpenTofu support
- feat: add cosign signature verification for OpenTofu downloads (optional, skipped if cosign not on agent)
- chore: add cosign-verifier mock to existing installer test fixtures

## Test plan

- [x] All 15 installer tests pass (12 existing + 3 new OpenTofu)
- [x] All 156 TerraformTaskV5 tests pass (no regressions)
- [ ] CI matrix (ubuntu + windows) passes

Closes #150