### PR TITLE
feat: add OCI Workload Identity Federation support

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
@@ -14,7 +14,8 @@
         "src/index.js",
         "src/parent-handler.js",
         "src/id-token-generator.js",
-        "src/secure-file-loader.js"
+        "src/secure-file-loader.js",
+        "src/oci-token-exchange.js"
     ],
     "check-coverage": true,
     "lines": 75,

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -1611,7 +1611,21 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
-    /* aws/gcp invalid auth scheme tests */
+    it('oci plan should succeed with workload identity federation', async () => {
+        let tp = path.join(__dirname, './PlanTests/OCI/OCIPlanWIFSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('OCIPlanWIFSuccessL0 should have succeeded.'), 'Should have printed: OCIPlanWIFSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    /* aws/gcp/oci invalid auth scheme tests */
 
     it('aws plan should fail with invalid auth scheme', async () => {
         let tp = path.join(__dirname, './PlanTests/AWS/AWSPlanInvalidAuthScheme.js');
@@ -1628,6 +1642,19 @@ describe('Terraform Test Suite', function () {
 
     it('gcp plan should fail with invalid auth scheme', async () => {
         let tp = path.join(__dirname, './PlanTests/GCP/GCPPlanInvalidAuthScheme.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 0, 'tool should not have been invoked. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 1, 'should have one error');
+        }, tr);
+    });
+
+    it('oci plan should fail with invalid auth scheme', async () => {
+        let tp = path.join(__dirname, './PlanTests/OCI/OCIPlanInvalidAuthScheme.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         await tr.runAsync();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanInvalidAuthScheme.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanInvalidAuthScheme.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIPlanInvalidAuthSchemeL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('environmentAuthSchemeOCI', 'InvalidScheme');
+tr.setInput('commandOptions', '');
+
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
+process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = 'dummy-key';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider oci"
+        },
+        "terraform plan -detailed-exitcode": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanInvalidAuthSchemeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanInvalidAuthSchemeL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'plan', 'OCIPlanInvalidAuthSchemeL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFSuccess.ts
@@ -1,0 +1,51 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIPlanWIFSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('environmentAuthSchemeOCI', 'WorkloadIdentityFederation');
+tr.setInput('ociWifTenancyOcid', 'ocid1.tenancy.oc1..dummy');
+tr.setInput('ociWifRegion', 'us-ashburn-1');
+tr.setInput('ociWifIdentityDomainUrl', 'https://idcs-dummy.identity.oraclecloud.com');
+tr.setInput('ociWifClientId', 'dummy-client-id');
+tr.setInput('commandOptions', '');
+
+tr.registerMock('./id-token-generator', {
+    generateIdToken: function(serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
+});
+
+tr.registerMock('./oci-token-exchange', {
+    exchangeOidcForUpst: function(oidcToken: string, identityDomainUrl: string, clientId: string, publicKeyPem: string) {
+        return Promise.resolve('mock-upst-token-67890');
+    }
+});
+
+tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider oci"
+        },
+        "terraform plan -detailed-exitcode": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'plan', 'OCIPlanWIFSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -3,17 +3,28 @@ import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
+import { generateIdToken } from './id-token-generator';
+import { exchangeOidcForUpst } from './oci-token-exchange';
 import { writeSecretFile } from './secure-temp';
 import { normalizePem } from './pem-normalizer';
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
+import crypto = require('crypto');
 import { v4 as uuidV4 } from 'uuid';
+
+const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
 
 export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     constructor() {
         super();
         this.providerName = "oci";
+    }
+
+    private validateAuthScheme(scheme: string, inputName: string): void {
+        if (!(VALID_AUTH_SCHEMES as readonly string[]).includes(scheme)) {
+            throw new Error(`Unrecognized authorization scheme '${scheme}' for input '${inputName}'. Valid values: ${VALID_AUTH_SCHEMES.join(", ")}`);
+        }
     }
 
     private getPrivateKeyFilePath(privateKey: string) {
@@ -86,13 +97,85 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     }
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {
-        if (command.serviceProviderName) {
-            const privateKeyFilePath = this.getPrivateKeyFilePath(tasks.getEndpointDataParameter(command.serviceProviderName, "privateKey", false)!);
-            EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_tenancy_ocid", tasks.getEndpointDataParameter(command.serviceProviderName, "tenancy", false) || '');
-            EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_user_ocid", tasks.getEndpointDataParameter(command.serviceProviderName, "user", false) || '');
-            EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_region", tasks.getEndpointDataParameter(command.serviceProviderName, "region", false) || '');
-            EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_fingerprint", tasks.getEndpointDataParameter(command.serviceProviderName, "fingerprint", false) || '');
-            EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_private_key_path", privateKeyFilePath);
+        const authScheme = tasks.getInput("environmentAuthSchemeOCI", false) || "ServiceConnection";
+        this.validateAuthScheme(authScheme, "environmentAuthSchemeOCI");
+
+        if (authScheme === "WorkloadIdentityFederation") {
+            await this.handleProviderWIF(command);
+        } else {
+            if (command.serviceProviderName) {
+                const privateKeyFilePath = this.getPrivateKeyFilePath(tasks.getEndpointDataParameter(command.serviceProviderName, "privateKey", false)!);
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_tenancy_ocid", tasks.getEndpointDataParameter(command.serviceProviderName, "tenancy", false) || '');
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_user_ocid", tasks.getEndpointDataParameter(command.serviceProviderName, "user", false) || '');
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_region", tasks.getEndpointDataParameter(command.serviceProviderName, "region", false) || '');
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_fingerprint", tasks.getEndpointDataParameter(command.serviceProviderName, "fingerprint", false) || '');
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_private_key_path", privateKeyFilePath);
+            }
         }
+    }
+
+    private async handleProviderWIF(command: TerraformAuthorizationCommandInitializer): Promise<void> {
+        // 1. Get OIDC JWT from Azure DevOps
+        const oidcToken = await generateIdToken(command.serviceProviderName);
+        tasks.setSecret(oidcToken);
+
+        // 2. Generate ephemeral RSA-2048 key pair
+        const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+            modulusLength: 2048,
+            publicKeyEncoding: { type: 'spki', format: 'pem' },
+            privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+        });
+        // Private key is multi-line PEM — not registered as a secret (which
+        // rejects newlines unless SYSTEM_UNSAFEALLOWMULTILINESECRET is set).
+        // Security relies on writeSecretFile (0o600) and temp-file cleanup.
+
+        // 3. Exchange OIDC JWT for OCI UPST
+        const identityDomainUrl = tasks.getInput("ociWifIdentityDomainUrl", true)!;
+        const clientId = tasks.getInput("ociWifClientId", true)!;
+        const upst = await exchangeOidcForUpst(oidcToken, identityDomainUrl, clientId, publicKey);
+        tasks.setSecret(upst);
+
+        // 4. Compute fingerprint of ephemeral public key
+        const keyObject = crypto.createPublicKey(publicKey);
+        const der = keyObject.export({ type: 'spki', format: 'der' });
+        const md5 = crypto.createHash('md5').update(der).digest('hex');
+        const fingerprint = md5.match(/.{2}/g)!.join(':');
+
+        // 5. Write ephemeral private key, UPST, and synthetic OCI config to temp files
+        const tempDir = os.tmpdir();
+        const sessionId = uuidV4();
+
+        const privateKeyPath = path.join(tempDir, `oci-wif-key-${sessionId}.pem`);
+        writeSecretFile(privateKeyPath, privateKey);
+        this.tempFiles.push(privateKeyPath);
+
+        const upstPath = path.join(tempDir, `oci-wif-upst-${sessionId}`);
+        writeSecretFile(upstPath, upst);
+        this.tempFiles.push(upstPath);
+
+        const tenancyOcid = tasks.getInput("ociWifTenancyOcid", true)!;
+        const region = tasks.getInput("ociWifRegion", true)!;
+
+        const configContent = [
+            '[DEFAULT]',
+            `tenancy=${tenancyOcid}`,
+            `region=${region}`,
+            `key_file=${privateKeyPath}`,
+            `fingerprint=${fingerprint}`,
+            `security_token_file=${upstPath}`,
+        ].join('\n') + '\n';
+
+        const configPath = path.join(tempDir, `oci-wif-config-${sessionId}`);
+        writeSecretFile(configPath, configContent);
+        this.tempFiles.push(configPath);
+
+        // 6. Set environment variables for the OCI Terraform provider
+        EnvironmentVariableHelper.setEnvironmentVariable("OCI_CLI_CONFIG_FILE", configPath);
+        EnvironmentVariableHelper.setEnvironmentVariable("OCI_CLI_PROFILE", "DEFAULT");
+        EnvironmentVariableHelper.setEnvironmentVariable("OCI_CLI_AUTH", "security_token");
+
+        // Also set TF_VAR_ env vars for users who reference these in their provider block
+        EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_tenancy_ocid", tenancyOcid);
+        EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_region", region);
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
@@ -1,0 +1,85 @@
+import tasks = require('azure-pipelines-task-lib/task');
+import crypto = require('crypto');
+
+/**
+ * Exchange an OIDC JWT for an OCI User Principal Session Token (UPST)
+ * using the OCI Identity Domains token exchange endpoint (RFC 8693).
+ *
+ * The endpoint is:
+ *   POST {identityDomainUrl}/oauth2/v1/token
+ *
+ * Requires an OCI Identity Domains application configured to accept
+ * external OIDC JWTs from Azure DevOps (vstoken.dev.azure.com).
+ *
+ * Returns the UPST string. The caller must write it to a file and
+ * reference it in an OCI config file with `security_token_file`.
+ */
+export async function exchangeOidcForUpst(
+    oidcToken: string,
+    identityDomainUrl: string,
+    clientId: string,
+    publicKeyPem: string
+): Promise<string> {
+    const tokenEndpoint = `${identityDomainUrl.replace(/\/+$/, '')}/oauth2/v1/token`;
+
+    // JWK thumbprint of the ephemeral public key for binding
+    const jwkThumbprint = computeJwkThumbprint(publicKeyPem);
+
+    const body = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        subject_token: oidcToken,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+        requested_token_type: 'urn:oci:token-type:oci-upst',
+        client_id: clientId,
+        public_key: jwkThumbprint,
+    });
+
+    tasks.debug(`Exchanging OIDC JWT for OCI UPST at ${tokenEndpoint}`);
+
+    let response: Response;
+    try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 30000);
+        response = await fetch(tokenEndpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: body.toString(),
+            signal: controller.signal,
+        });
+        clearTimeout(timeoutId);
+    } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+            throw new Error(`Timed out exchanging OIDC token for OCI UPST (30s timeout).`);
+        }
+        throw new Error(`Failed to exchange OIDC token for OCI UPST: ${error instanceof Error ? error.message : error}`);
+    }
+
+    if (!response.ok) {
+        const errorBody = await response.text().catch(() => '(unable to read response body)');
+        throw new Error(`OCI token exchange failed: HTTP ${response.status} ${response.statusText}. Body: ${errorBody}`);
+    }
+
+    const result = await response.json() as { access_token?: string; token?: string };
+    const upst = result.access_token || result.token;
+    if (!upst) {
+        throw new Error('OCI token exchange response missing access_token/token field.');
+    }
+
+    tasks.debug('Successfully exchanged OIDC JWT for OCI UPST.');
+    return upst;
+}
+
+/**
+ * Compute a JWK thumbprint (RFC 7638) of an RSA public key.
+ * OCI Identity Domains uses this to bind the UPST to the ephemeral key pair.
+ */
+function computeJwkThumbprint(publicKeyPem: string): string {
+    const keyObject = crypto.createPublicKey(publicKeyPem);
+    const jwk = keyObject.export({ format: 'jwk' }) as { e: string; kty: string; n: string };
+
+    // Canonical JWK for RSA: {"e":"...","kty":"RSA","n":"..."} (alphabetical order)
+    const canonical = JSON.stringify({ e: jwk.e, kty: jwk.kty, n: jwk.n });
+    return crypto.createHash('sha256').update(canonical).digest('base64url');
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -556,6 +556,54 @@
             "helpMarkDown": "Select a Oracle Cloud Platform connection for the deployment.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Oracle Cloud Platform service connection using the 'Add' or 'Manage' button."
         },
         {
+            "name": "environmentAuthSchemeOCI",
+            "type": "pickList",
+            "label": "Authentication scheme",
+            "defaultValue": "ServiceConnection",
+            "required": false,
+            "visibleRule": "provider = oci && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "helpMarkDown": "Select how to authenticate with OCI. 'Service connection' uses API key credentials. 'Workload Identity Federation' uses OIDC to obtain an OCI User Principal Session Token (UPST) without static credentials.",
+            "options": {
+                "ServiceConnection": "Service connection (API key)",
+                "WorkloadIdentityFederation": "Workload Identity Federation (OIDC)"
+            },
+            "properties": {
+                "EditableOptions": "False"
+            }
+        },
+        {
+            "name": "ociWifTenancyOcid",
+            "type": "string",
+            "label": "Tenancy OCID",
+            "required": true,
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "helpMarkDown": "OCID of the OCI tenancy. E.g. ocid1.tenancy.oc1..aaaa..."
+        },
+        {
+            "name": "ociWifRegion",
+            "type": "string",
+            "label": "OCI Region",
+            "required": true,
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "helpMarkDown": "OCI region identifier. E.g. us-ashburn-1"
+        },
+        {
+            "name": "ociWifIdentityDomainUrl",
+            "type": "string",
+            "label": "Identity Domain URL",
+            "required": true,
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "helpMarkDown": "URL of the OCI Identity Domain configured for OIDC federation. E.g. https://idcs-abc123.identity.oraclecloud.com"
+        },
+        {
+            "name": "ociWifClientId",
+            "type": "string",
+            "label": "Identity Domain Application Client ID",
+            "required": true,
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "helpMarkDown": "Client ID of the OCI Identity Domains application configured to accept OIDC tokens from Azure DevOps."
+        },
+        {
             "name": "backendAzureRmUseEntraIdForAuthentication",
             "type": "boolean",
             "defaultValue": "true",


### PR DESCRIPTION
## Summary
- Implement OIDC-based authentication for OCI provider using RFC 8693 token exchange with OCI Identity Domains
- Add `oci-token-exchange.ts` module for exchanging Azure DevOps OIDC JWTs for OCI User Principal Session Tokens (UPST)
- Rewrite `oci-terraform-command-handler.ts` with WIF flow: ephemeral RSA-2048 key pair generation, UPST exchange, synthetic OCI config file, and SecurityToken auth mode environment variables
- Add task.json inputs: `environmentAuthSchemeOCI`, `ociWifTenancyOcid`, `ociWifRegion`, `ociWifIdentityDomainUrl`, `ociWifClientId`
- Add OCI WIF plan success and invalid auth scheme tests

## Changelog
- **Added**: OCI Workload Identity Federation authentication (`environmentAuthSchemeOCI = WorkloadIdentityFederation`)
- **Added**: RFC 8693 token exchange module (`oci-token-exchange.ts`) with JWK thumbprint computation
- **Added**: task.json inputs for OCI WIF: tenancy OCID, region, identity domain URL, client ID
- **Added**: OCI WIF plan test and invalid auth scheme test (2 new tests, 158 total V5)
- **Changed**: Ephemeral RSA private key no longer registered via `setSecret()` (multi-line PEM incompatible with agent secret masking; security relies on temp file permissions and cleanup)

## Test plan
- [x] `npm run compile` — zero errors
- [x] `npm test` — 158 V5 tests passing (2 new: OCI WIF plan success, OCI invalid auth scheme)
- [x] Installer tests — 15 passing (unchanged)
- [ ] CI pipeline passes all checks