### PR TITLE
feat: surface fallback version warnings in pipeline panel

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -106,7 +106,7 @@ async function resolveVersionFromHashiCorp(inputVersion: string): Promise<string
         }
         return data.current_version;
     } catch {
-        console.warn(tasks.loc("TerraformVersionNotFound"));
+        tasks.warning(tasks.loc("TerraformVersionNotFound"));
         return FALLBACK_TERRAFORM_VERSION;
     }
 }
@@ -331,7 +331,7 @@ async function resolveVersionFromOpenTofu(inputVersion: string): Promise<string>
         // tag_name is "v1.11.6" — strip the leading "v"
         return data.tag_name.replace(/^v/, '');
     } catch {
-        console.warn(tasks.loc("TerraformVersionNotFound"));
+        tasks.warning(tasks.loc("TerraformVersionNotFound"));
         return FALLBACK_TOFU_VERSION;
     }
 }


### PR DESCRIPTION
## Summary
- Replace `console.warn` with `tasks.warning` for Terraform/OpenTofu fallback version triggers
- Warnings now appear in the Azure Pipelines Warnings panel instead of only in stdout

## Changelog
- **Changed**: Fallback version warnings (`TerraformVersionNotFound`) now use `tasks.warning()` instead of `console.warn()` for pipeline panel visibility

## Test plan
- [x] 15 installer tests passing (unchanged behavior — mock runner captures both)