### PR TITLE
fix: installer visibleRule mixes && and || operators

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -85,7 +85,7 @@
             "label": "Require GPG signature verification",
             "defaultValue": "true",
             "required": false,
-            "visibleRule": "binary = terraform && downloadSource = hashicorp || binary = terraform && downloadSource = mirror",
+            "visibleRule": "binary = terraform && downloadSource != registry",
             "helpMarkDown": "When enabled, fail if the GPG signature file is unavailable. Defaults to true for HashiCorp downloads. Disable for mirrors that do not serve .sig files."
         },
         {


### PR DESCRIPTION
## Summary
- VS Marketplace validation rejects `visibleRule` expressions that combine `&&` and `||` operators
- The `requireGpgSignature` input used `binary = terraform && downloadSource = hashicorp || binary = terraform && downloadSource = mirror`
- Replaced with equivalent `binary = terraform && downloadSource != registry`
- This caused the v1.0.0 release to fail at the publish step

## Changelog
- fix: replace mixed `&&`/`||` visibleRule in installer task.json with `!=` operator

Closes #160