### PR TITLE
docs: update stale references after roadmap completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ Three modes via service connection `authorizationScheme`:
 Source: `Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts`
 
 - Downloads Terraform from `https://releases.hashicorp.com/terraform/` for the requested version
-- Supports `latest` (queries HashiCorp checkpoint API, falls back to `1.9.8`)
+- Supports `latest` (queries HashiCorp checkpoint API, falls back to `1.14.8`)
 - Supports Windows, macOS, Linux on amd64, arm64, arm, 386
 - Verifies GPG signature of SHA256SUMS using HashiCorp's embedded public key (`gpg-verifier.ts`)
 - Sets `terraformLocation` pipeline variable after install
@@ -340,10 +340,13 @@ Node v25.7.0 is not LTS. The GitHub Actions workflow pins Node 18 LTS. Local dev
 - **Add a second collaborator/maintainer** to reduce bus factor (currently sole maintainer: @sethbacon)
 - **Consider adding a tag protection rule** to prevent deletion of release tags (`v*.*.*`)
 
-## Active Initiatives
+## Completed Initiatives
 
-See `docs/initiatives/` for detailed plans:
+All 7 roadmap phases are complete as of v1.0.0. See `docs/initiatives/` for detailed plans:
 
-- [Initiative 1: Flexible Terraform Installer](docs/initiatives/initiative-1-flexible-installer.md) — Support HashiCorp official releases, terraform-registry-backend, and custom mirror URLs
-- [Initiative 2: Complete CLI Coverage](docs/initiatives/initiative-2-complete-cli-coverage.md) — Add workspace, state, fmt, test, get commands; -replace flag on plan/apply
-- [Initiative 3: Workload Identity Federation for Non-AzureRM](docs/initiatives/initiative-3-workload-identity-federation.md) — AWS and GCP WIF support; backend/provider decoupling
+- [Initiative 1: Flexible Terraform Installer](docs/initiatives/initiative-1-flexible-installer.md) — Completed
+- [Initiative 2: Complete CLI Coverage](docs/initiatives/initiative-2-complete-cli-coverage.md) — Completed
+- [Initiative 3: Workload Identity Federation for Non-AzureRM](docs/initiatives/initiative-3-workload-identity-federation.md) — Completed
+- [Initiative 4: Workload Identity Federation for OCI](docs/initiatives/initiative-4-oci-wif.md) — Completed
+
+See [docs/roadmap.md](docs/roadmap.md) for the full 7-phase plan and [CHANGELOG.md](CHANGELOG.md) for the release history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ The tab is declared in `azure-devops-extension.json` as a `ms.vss-build-web.buil
 ### When editing the tab
 
 - Run `npm run webpack` for fast iteration (skips re-running task compilation). Errors surface immediately in the webpack output.
-- The bundle currently pins **React 16.13.1** — if you upgrade to React 18, you must also switch from `ReactDOM.render` to `createRoot` in `tabContent.tsx`.
+- The bundle uses **React 18** with the `createRoot` API in `tabContent.tsx`.
 - The tab uses `dangerouslySetInnerHTML` to render ANSI-converted HTML. Any change to `ansiToHtml` must keep opening/closing `<span>` tags balanced. See the roadmap item **P3.2 · plan tab hardening** for the planned state-machine rewrite.
 - There is no Jest harness in `src/tab/` yet (planned in roadmap item **P4.1**). Until then, end-to-end verification requires a private publish.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Runs Terraform commands. Supports 16 commands:
 | Azure    | `azurerm`        | Azure Resource Manager (built-in)                            | Service Principal, Managed Identity, WIF         |
 | AWS      | `aws`            | Pipeline AWS for Terraform (`PTTAWSServiceEndpoint`)         | Static credentials, Workload Identity Federation |
 | GCP      | `gcp`            | Pipeline GCP for Terraform (`PTTGoogleCloudServiceEndpoint`) | Static credentials, Workload Identity Federation |
-| OCI      | `oci`            | Pipeline OCI for Terraform (`PTTOCIServiceEndpoint`)         | API key credentials (WIF not yet supported)      |
+| OCI      | `oci`            | Pipeline OCI for Terraform (`PTTOCIServiceEndpoint`)         | API key credentials, Workload Identity Federation |
 
 ---
 

--- a/docs/initiatives/initiative-3-workload-identity-federation.md
+++ b/docs/initiatives/initiative-3-workload-identity-federation.md
@@ -6,7 +6,11 @@
 2. Add Workload Identity Federation (OIDC) support for AWS and GCP providers
 3. Support all Terraform backends: first-class for azurerm/s3/gcs/hcp, plus a generic passthrough for all others
 
-## Implementation Status (as of v0.1.2)
+## Implementation Status
+
+**Status: COMPLETED** — All features shipped in v0.8.0 (AWS/GCP WIF, backend/provider decoupling, HCP backend). This document is retained for reference.
+
+### Original tracking (as of v0.1.2)
 
 | Item | Status |
 |------|--------|

--- a/docs/initiatives/initiative-4-oci-wif.md
+++ b/docs/initiatives/initiative-4-oci-wif.md
@@ -6,7 +6,11 @@ Add Workload Identity Federation (OIDC) support to the OCI provider handler so t
 API key credentials are no longer required in pipeline service connections. This mirrors the
 WIF support added for AWS and GCP in Initiative 3.
 
-## Current State
+## Implementation Status
+
+**Status: COMPLETED** — OCI WIF support shipped in v1.0.0 (2026-04-17). This document is retained for reference.
+
+## Current State (historical)
 
 The `TerraformCommandHandlerOCI` handler currently authenticates using an API key stored in
 an `PTTOCIServiceEndpoint` service connection (user OCID + tenancy OCID + private key + fingerprint

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,8 @@
 
 Sequenced plan to close gaps identified in the April 2026 codebase review. Each item is sized for a single PR off `development`. Effort: **S** = <½ day, **M** = ½–2 days, **L** = 2–5 days.
 
+> **STATUS: COMPLETED** — All 7 phases delivered across v0.7.2 through v1.0.0. See [CHANGELOG.md](../CHANGELOG.md) for details by version.
+
 ---
 
 ## Phase 1 — Correctness bugs


### PR DESCRIPTION
## Summary
- README: OCI now supports WIF (shipped in v1.0.0)
- CLAUDE.md: fallback version 1.9.8 -> 1.14.8; Active -> Completed Initiatives; add Initiative 4
- initiative-3/4: add completion status markers
- CONTRIBUTING: React 16 -> 18 reference
- roadmap: add completion banner

## Changelog
- docs: update stale references after roadmap completion

Closes #163