### PR TITLE
release: v1.0.3 - fix task registration, replace uuid, bump fast-uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to **Pipeline Tasks for Terraform** (`sethbacon.pipeline-tas
 
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses [semantic versioning](https://semver.org/).
 
+## [1.0.3] — 2026-05-11
+
+### Fixed
+
+- Extension contribution `name` paths were missing versioned subdirectory (`TerraformInstallerV1`, `TerraformTaskV5`); ADO could not locate `task.json` to register task packages, causing `No task definition found` errors in pipelines
+- Replace `uuid` dependency with Node.js built-in `crypto.randomUUID()`; uuid v14 (ESM-only) broke CJS task runner; eliminates the dependency entirely from both tasks
+- Update `fast-uri` to 3.1.2 in TerraformTaskV5 (dev dep, GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc)
+
 ## [1.0.2] — 2026-05-11
 
 ### Fixed

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CachedInstallSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CachedInstallSuccess.ts
@@ -23,7 +23,7 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock to prevent openpgp from loading

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissing.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissing.ts
@@ -28,7 +28,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock required=true path — throws when .sig unavailable
@@ -50,6 +49,7 @@ tr.registerMock('fs', {
 });
 
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
@@ -28,7 +28,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock .sig file unavailable — should warn but not fail
@@ -50,6 +49,7 @@ tr.registerMock('fs', {
 });
 
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationFail.ts
@@ -27,7 +27,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock GPG verification as FAILING (invalid signature)
@@ -47,6 +46,7 @@ tr.registerMock('fs', {
 });
 
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccess.ts
@@ -27,7 +27,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock GPG verification as passing
@@ -45,6 +44,7 @@ tr.registerMock('fs', {
 });
 
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
@@ -32,7 +32,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock GPG verification as passing
@@ -52,6 +51,7 @@ tr.registerMock('fs', {
 
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
@@ -28,7 +28,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock GPG verification as passing
@@ -48,6 +47,7 @@ tr.registerMock('fs', {
 
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlReject.ts
@@ -23,7 +23,7 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock to prevent openpgp from loading

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InvalidVersionFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InvalidVersionFail.ts
@@ -22,7 +22,7 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock to prevent openpgp from loading

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
@@ -25,7 +25,7 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock to prevent openpgp from loading (not used in mirror path)

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccess.ts
@@ -26,7 +26,7 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('./gpg-verifier', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccess.ts
@@ -35,7 +35,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock to prevent openpgp from loading
@@ -58,6 +57,7 @@ tr.registerMock('fs', {
 
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccess.ts
@@ -31,7 +31,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('./gpg-verifier', {
@@ -50,6 +49,7 @@ tr.registerMock('fs', {
 });
 
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
@@ -35,7 +35,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock to prevent openpgp from loading (not used in registry path)
@@ -55,6 +54,7 @@ tr.registerMock('fs', {
 
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => EXPECTED_SHA256

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
@@ -34,7 +34,6 @@ tr.registerMock('./http-client', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock to prevent openpgp from loading (not used in registry path)
@@ -54,6 +53,7 @@ tr.registerMock('fs', {
 
 // crypto: returns a DIFFERENT hash than what the registry provided → mismatch
 tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => ({
         update: (_data: any) => ({
             digest: (_encoding: string) => 'wrong_hash_that_does_not_match_xyz789'

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -13,7 +13,7 @@
         "azure-pipelines-tool-lib": "^2.0.0-preview",
         "openpgp": "^6.0.1",
         "undici": "^6.21.0",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -3097,16 +3097,16 @@
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -12,8 +12,7 @@
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.0-preview",
         "openpgp": "^6.0.1",
-        "undici": "^6.21.0",
-        "uuid": "^14.0.0"
+        "undici": "^6.21.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -3095,19 +3094,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -21,7 +21,7 @@
     "azure-pipelines-tool-lib": "^2.0.0-preview",
     "openpgp": "^6.0.1",
     "undici": "^6.21.0",
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -20,8 +20,7 @@
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tool-lib": "^2.0.0-preview",
     "openpgp": "^6.0.1",
-    "undici": "^6.21.0",
-    "uuid": "^14.0.0"
+    "undici": "^6.21.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
@@ -3,7 +3,7 @@ import fs = require('fs');
 import os = require('os');
 import path = require('path');
 
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'crypto';
 import { fetchBuffer } from './http-client';
 
 /**

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -5,7 +5,7 @@ import os = require('os');
 import fs = require('fs');
 import crypto = require('crypto');
 
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchText } from './http-client';
 import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
@@ -21,7 +21,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
@@ -22,7 +22,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
@@ -21,7 +21,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
@@ -22,7 +22,7 @@ tr.registerMock('./id-token-generator', {
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "terraform": "terraform" },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/AWS/AWSInitWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/AWS/AWSInitWIFSuccess.ts
@@ -23,7 +23,7 @@ var mock = {
 };
 
 tr.registerMock('./id-token-generator', mock);
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
@@ -39,7 +39,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid', { v4: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
@@ -39,7 +39,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid', { v4: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
@@ -39,7 +39,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid', { v4: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
@@ -39,7 +39,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid', { v4: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123' });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitWIFSuccess.ts
@@ -27,7 +27,7 @@ var mock = {
 };
 
 tr.registerMock('./id-token-generator', mock);
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/OCIOutputSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/OCIOutputSuccess.ts
@@ -18,7 +18,7 @@ process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
 process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
-tr.registerMock('uuid', { v4: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/AWS/AWSPlanWIFSuccess.ts
@@ -20,7 +20,7 @@ var mock = {
 };
 
 tr.registerMock('./id-token-generator', mock);
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanWIFSuccess.ts
@@ -21,7 +21,7 @@ var mock = {
 };
 
 tr.registerMock('./id-token-generator', mock);
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFSuccess.ts
@@ -17,18 +17,16 @@ tr.setInput('ociWifClientId', 'dummy-client-id');
 tr.setInput('commandOptions', '');
 
 tr.registerMock('./id-token-generator', {
-    generateIdToken: function(serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
+    generateIdToken: function (serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
 });
 
 tr.registerMock('./oci-token-exchange', {
-    exchangeOidcForUpst: function(oidcToken: string, identityDomainUrl: string, clientId: string, publicKeyPem: string) {
+    exchangeOidcForUpst: function (oidcToken: string, identityDomainUrl: string, clientId: string, publicKeyPem: string) {
         return Promise.resolve('mock-upst-token-67890');
     }
 });
 
-tr.registerMock('uuid', { v4: () => 'test-uuid-1234' });
-
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },

--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -12,8 +12,7 @@
         "azure-devops-node-api": "^12.0.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-artifacts-common": "^2.225.0",
-        "azure-pipelines-tasks-securefiles-common": "^2.272.0",
-        "uuid": "^9.0.1"
+        "azure-pipelines-tasks-securefiles-common": "^2.272.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -2608,9 +2607,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5597,19 +5596,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -20,8 +20,7 @@
     "azure-devops-node-api": "^12.0.0",
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-artifacts-common": "^2.225.0",
-    "azure-pipelines-tasks-securefiles-common": "^2.272.0",
-    "uuid": "^9.0.1"
+    "azure-pipelines-tasks-securefiles-common": "^2.272.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -7,7 +7,7 @@ import { generateIdToken } from './id-token-generator';
 import { writeSecretFile } from './secure-temp';
 import path = require('path');
 import os = require('os');
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'crypto';
 
 const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -4,7 +4,7 @@ import { TerraformBaseCommandInitializer, TerraformAuthorizationCommandInitializ
 import { getSecureVarFileArgs, SecureFileLoader } from './secure-file-loader';
 import tasks = require('azure-pipelines-task-lib/task');
 import path = require('path');
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'crypto';
 import fs = require('fs');
 import os = require('os');
 
@@ -142,12 +142,12 @@ export abstract class BaseTerraformCommandHandler {
         secureVarFile?: boolean;
     }): Promise<string> {
         let args = base;
-        if (config.replaceFlag)      args = this.prependReplaceFlag(args);
-        if (config.refreshOnly)      args = this.prependRefreshOnly(args);
-        if (config.varFiles)         args = this.prependVarFiles(args);
-        if (config.targetResources)  args = this.prependTargetResources(args);
-        if (config.parallelism)      args = this.appendParallelism(args);
-        if (config.secureVarFile)    args = await this.appendSecureVarFile(args);
+        if (config.replaceFlag) args = this.prependReplaceFlag(args);
+        if (config.refreshOnly) args = this.prependRefreshOnly(args);
+        if (config.varFiles) args = this.prependVarFiles(args);
+        if (config.targetResources) args = this.prependTargetResources(args);
+        if (config.parallelism) args = this.appendParallelism(args);
+        if (config.secureVarFile) args = await this.appendSecureVarFile(args);
         return args;
     }
 
@@ -205,10 +205,10 @@ export abstract class BaseTerraformCommandHandler {
      * Matches lines like: `provider[registry.terraform.io/hashicorp/aws]`
      */
     private static readonly PROVIDER_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
-        ["aws",     /provider\[.*\/aws\s*\]/i],
+        ["aws", /provider\[.*\/aws\s*\]/i],
         ["azurerm", /provider\[.*\/azurerm\s*\]/i],
-        ["google",  /provider\[.*\/google\s*\]/i],
-        ["oracle",  /provider\[.*\/oci\s*\]/i],
+        ["google", /provider\[.*\/google\s*\]/i],
+        ["oracle", /provider\[.*\/oci\s*\]/i],
     ]);
 
     public async warnIfMultipleProviders(): Promise<void> {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -7,7 +7,7 @@ import { generateIdToken } from './id-token-generator';
 import { writeSecretFile } from './secure-temp';
 import path = require('path');
 import os = require('os');
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'crypto';
 
 const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -11,7 +11,7 @@ import path = require('path');
 import os = require('os');
 import fs = require('fs');
 import crypto = require('crypto');
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'crypto';
 
 const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
 

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "sethbacon",
     "targets": [
         {
@@ -140,7 +140,7 @@
                 "ms.vss-distributed-task.tasks"
             ],
             "properties": {
-                "name": "Tasks/TerraformInstaller"
+                "name": "Tasks/TerraformInstaller/TerraformInstallerV1"
             }
         },
         {
@@ -150,7 +150,7 @@
                 "ms.vss-distributed-task.tasks"
             ],
             "properties": {
-                "name": "Tasks/TerraformTask"
+                "name": "Tasks/TerraformTask/TerraformTaskV5"
             }
         },
         {


### PR DESCRIPTION
## Changelog

### Fixed

- Extension contribution name paths were missing versioned subdirectory (TerraformInstallerV1, TerraformTaskV5); ADO could not locate task.json to register task packages, causing No task definition found errors in pipelines
- Replace uuid dependency with Node.js built-in crypto.randomUUID(); uuid v14 (ESM-only) broke CJS task runner; eliminates the dependency entirely from both tasks
- Update fast-uri to 3.1.2 in TerraformTaskV5 (dev dep, GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc)