### PR TITLE
release: v1.0.4 - bump dev deps for CVEs, fix CodeQL alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to **Pipeline Tasks for Terraform** (`sethbacon.pipeline-tas
 
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses [semantic versioning](https://semver.org/).
 
+## [1.0.4] — 2026-05-11
+
+### Fixed
+
+- Bump `postcss` to 8.5.14 (CVE-2026-41305, medium, dev dep — XSS in CSS stringify output)
+- Bump `fast-uri` to 3.1.2 (CVE-2026-6322, high, dev dep — host confusion via percent-encoded authority)
+- Bump `uuid` to 13.0.2 via `overrides` (CVE-2026-41907, medium, nested in tfx-cli — missing buffer bounds check)
+- Resolve CodeQL `incomplete-url-substring-sanitization` warning in installer test by using exact hostname comparison
+
 ## [1.0.3] — 2026-05-11
 
 ### Fixed

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
@@ -19,7 +19,7 @@ const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccd
 // Mock http-client: checkpoint API returns 1.9.8, SHA256SUMS returns matching hash
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => {
-        if (url.includes('checkpoint-api.hashicorp.com')) {
+        if (new URL(url).hostname === 'checkpoint-api.hashicorp.com') {
             return { current_version: '1.9.8' };
         }
         throw new Error('Unexpected fetchJson URL: ' + url);

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "publisher": "sethbacon",
     "targets": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3931,9 +3931,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -6755,9 +6755,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -8528,20 +8528,6 @@
                 "node": ">= 16.0.0"
             }
         },
-        "node_modules/tfx-cli/node_modules/uuid": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-            "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist-node/bin/uuid"
-            }
-        },
         "node_modules/tinyglobby": {
             "version": "0.2.16",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -8976,13 +8962,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+            "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
             "bin": {
-                "uuid": "bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
@@ -11229,7 +11219,7 @@
                 "q": "^1.5.1",
                 "semver": "^5.7.2",
                 "shelljs": "^0.10.0",
-                "uuid": "^3.0.1"
+                "uuid": "13.0.2"
             }
         },
         "azure-pipelines-tool-lib": {
@@ -11244,7 +11234,7 @@
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
                 "typed-rest-client": "^1.8.6",
-                "uuid": "^3.3.2"
+                "uuid": "13.0.2"
             }
         },
         "b4a": {
@@ -12256,9 +12246,9 @@
             "dev": true
         },
         "fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true
         },
         "fastest-levenshtein": {
@@ -14192,9 +14182,9 @@
             }
         },
         "postcss": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.11",
@@ -15279,7 +15269,7 @@
                 "tmp": "^0.2.4",
                 "tracer": "0.7.4",
                 "util.promisify": "^1.0.0",
-                "uuid": "^13.0.0",
+                "uuid": "13.0.2",
                 "validator": "^13.15.23",
                 "winreg": "0.0.12",
                 "xml2js": "^0.5.0"
@@ -15376,12 +15366,6 @@
                         "tunnel": "0.0.6",
                         "underscore": "^1.12.1"
                     }
-                },
-                "uuid": {
-                    "version": "13.0.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-                    "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-                    "dev": true
                 }
             }
         },
@@ -15653,9 +15637,9 @@
             }
         },
         "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+            "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
             "dev": true
         },
         "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
         "typescript": "^5.0.0",
         "webpack": "^5.88.0",
         "webpack-cli": "^5.1.0"
+    },
+    "overrides": {
+        "uuid": "13.0.2"
     }
 }


### PR DESCRIPTION
## Changelog

### Fixed

- Bump postcss to 8.5.14 (CVE-2026-41305, medium, dev dep)
- Bump fast-uri to 3.1.2 (CVE-2026-6322, high, dev dep)
- Bump uuid to 13.0.2 via overrides (CVE-2026-41907, medium, nested in tfx-cli)
- Resolve CodeQL incomplete-url-substring-sanitization alert in installer test