### PR TITLE
fix: regenerate task IDs to bypass ADO catalog cache (v1.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to **Pipeline Tasks for Terraform** (`sethbacon.pipeline-tas
 
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses [semantic versioning](https://semver.org/).
 
+## [1.0.5] — 2026-05-11
+
+### Changed
+
+- Regenerated task IDs for both `PipelineTerraformInstaller` and `PipelineTerraformTask` to bypass an Azure DevOps task catalog cache that was pinning the previous task minor version (`1.217.0`) even after extension upgrades published newer task minors. New IDs force a fresh registration on extension install.
+  - `PipelineTerraformInstaller`: `310afe61-60d3-49bd-b4b8-7abb989a38fc` → `D935A3E4-0C05-4DB1-A7DF-18FE110C38C8`
+  - `PipelineTerraformTask`: `981E87CD-B686-4A9E-B09E-B4AFDEDF126B` → `51E85A73-2294-422A-B4D0-B780182923B5`
+- Updated the Terraform Plan tab `supportsTasks` contribution to the new V5 task ID so the tab continues to attach to plan results.
+
+### Notes
+
+- Existing pipeline YAML continues to work unchanged: tasks are still referenced as `PipelineTerraformInstaller@1` and `PipelineTerraformTask@5` (name-based lookup, not by ID).
+- After upgrading to v1.0.5, queue any failing pipelines once to refresh the task definition cache.
+
 ## [1.0.4] — 2026-05-11
 
 ### Fixed

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "310afe61-60d3-49bd-b4b8-7abb989a38fc",
+    "id": "D935A3E4-0C05-4DB1-A7DF-18FE110C38C8",
     "name": "PipelineTerraformInstaller",
     "friendlyName": "Pipeline Terraform tool installer",
     "description": "Find in cache or download a specific version of Terraform and prepend it to the PATH",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.loc.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.loc.json
@@ -1,5 +1,5 @@
 {
-  "id": "310afe61-60d3-49bd-b4b8-7abb989a38fc",
+  "id": "D935A3E4-0C05-4DB1-A7DF-18FE110C38C8",
   "name": "PipelineTerraformInstaller",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "981E87CD-B686-4A9E-B09E-B4AFDEDF126B",
+    "id": "51E85A73-2294-422A-B4D0-B780182923B5",
     "name": "PipelineTerraformTask",
     "friendlyName": "Pipeline Terraform",
     "description": "Execute terraform commands to manage resources on Microsoft Azure, Amazon Web Services(AWS), Google Cloud Platform(GCP) and Oracle Cloud Infrastructure(OCI).",

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "publisher": "sethbacon",
     "targets": [
         {
@@ -128,7 +128,7 @@
                 "name": "Terraform Plan",
                 "uri": "tab/index.html",
                 "supportsTasks": [
-                    "981E87CD-B686-4A9E-B09E-B4AFDEDF126B"
+                    "51E85A73-2294-422A-B4D0-B780182923B5"
                 ],
                 "dynamic": true
             }


### PR DESCRIPTION
## Changelog

### Changed

- Regenerated task IDs for both PipelineTerraformInstaller and PipelineTerraformTask to bypass an Azure DevOps task catalog cache that was pinning the previous task minor version (1.217.0) even after extension upgrades published newer task minors. New IDs force a fresh registration on extension install.
  - PipelineTerraformInstaller: 310afe61-... -> D935A3E4-0C05-4DB1-A7DF-18FE110C38C8
  - PipelineTerraformTask: 981E87CD-... -> 51E85A73-2294-422A-B4D0-B780182923B5
- Updated Terraform Plan tab supportsTasks contribution to the new V5 task ID.

### Notes

- Pipeline YAML continues to work unchanged (PipelineTerraformInstaller@1, PipelineTerraformTask@5).
- 158 V5 tests passing, installer compiles clean.