### PR TITLE
fix: make service connection optional for test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to **Pipeline Tasks for Terraform** (`sethbacon.pipeline-tas
 
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses [semantic versioning](https://semver.org/).
 
+## [1.0.8] — 2026-05-15
+
+### Fixed
+
+- **`test` command no longer requires a service connection**: previously, running `terraform test` with any provider would fail with `Input required: environmentServiceNameAWS` (or the equivalent for other providers) even when the tests didn't need cloud credentials. The service connection is now optional for the `test` command — unit/validation tests work without one, while integration tests that provision real resources can still provide a service connection and the task will configure provider auth automatically.
+
 ## [1.0.7] — 2026-05-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ To add a new provider: create a handler class implementing `handleBackend()` and
 - **`workspace`** - runs `terraform workspace` with `workspaceSubCommand` (select, new, list, show, delete)
 - **`state`** - runs `terraform state` with `stateSubCommand` (list, show, mv, rm, pull, push)
 - **`fmt`** - runs `terraform fmt -check` for formatting validation
-- **`test`** - runs `terraform test` with optional filter and verbose flags
+- **`test`** - runs `terraform test` with optional filter and verbose flags. Service connection is **optional**: omit for unit tests, provide for integration tests that need provider auth
 - **`get`** - runs `terraform get` to download modules
 - **`import`** - runs `terraform import` with `importAddress` and `importId` inputs
 - **`forceUnlock`** - runs `terraform force-unlock` with `lockId` input

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Runs Terraform commands. Supports 16 commands:
 | `workspace`   | Manage workspaces (`new`, `select`, `list`, `delete`, `show`).                                 |
 | `state`       | Advanced state management (`list`, `pull`, `push`, `mv`, `rm`, `show`).                        |
 | `fmt`         | Reformat configuration files. Use `fmtCheck` to fail on unformatted files.                     |
-| `test`        | Run module tests (Terraform 1.6+).                                                             |
+| `test`        | Run module tests (Terraform 1.6+). Service connection is optional (see below).                 |
 | `get`         | Download and install modules.                                                                  |
 | `import`      | Import existing infrastructure into state. Takes `importAddress` and `importId` inputs.        |
 | `forceunlock` | Forcibly release a stuck state lock. Takes a `lockId` input.                                   |
@@ -67,11 +67,11 @@ Runs Terraform commands. Supports 16 commands:
 
 ## Providers
 
-| Provider | `provider` value | Service Connection Type                                      | Auth Methods                                     |
-| -------- | ---------------- | ------------------------------------------------------------ | ------------------------------------------------ |
-| Azure    | `azurerm`        | Azure Resource Manager (built-in)                            | Service Principal, Managed Identity, WIF         |
-| AWS      | `aws`            | Pipeline AWS for Terraform (`PTTAWSServiceEndpoint`)         | Static credentials, Workload Identity Federation |
-| GCP      | `gcp`            | Pipeline GCP for Terraform (`PTTGoogleCloudServiceEndpoint`) | Static credentials, Workload Identity Federation |
+| Provider | `provider` value | Service Connection Type                                      | Auth Methods                                      |
+| -------- | ---------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| Azure    | `azurerm`        | Azure Resource Manager (built-in)                            | Service Principal, Managed Identity, WIF          |
+| AWS      | `aws`            | Pipeline AWS for Terraform (`PTTAWSServiceEndpoint`)         | Static credentials, Workload Identity Federation  |
+| GCP      | `gcp`            | Pipeline GCP for Terraform (`PTTGoogleCloudServiceEndpoint`) | Static credentials, Workload Identity Federation  |
 | OCI      | `oci`            | Pipeline OCI for Terraform (`PTTOCIServiceEndpoint`)         | API key credentials, Workload Identity Federation |
 
 ---
@@ -170,6 +170,48 @@ AWS and GCP support Workload Identity Federation — no static credentials are s
 | OCI service connection type                    | `OCIServiceEndpoint`                                           | `PTTOCIServiceEndpoint`                                               |
 | Azure backend resource group/storage dropdowns | Dynamic API lookups                                            | Free-text strings                                                     |
 | Side-by-side install                           | N/A                                                            | Yes — distinct extension ID and service connection types              |
+
+---
+
+## Service Connection Requirements by Command
+
+Most commands that interact with cloud resources require a provider service connection. The following commands **do not** require one:
+
+| Command       | Service Connection | Notes                                                                                                                                                                                                                   |
+| ------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `init`        | Backend only       | Uses the backend service connection (e.g. `backendServiceArm`), not the provider connection. `backendType: local` needs no connection at all.                                                                           |
+| `validate`    | Not required       | Validates configuration syntax and internal consistency.                                                                                                                                                                |
+| `fmt`         | Not required       | Checks or applies formatting.                                                                                                                                                                                           |
+| `get`         | Not required       | Downloads modules referenced in configuration.                                                                                                                                                                          |
+| `workspace`   | Not required       | Manages local workspace state.                                                                                                                                                                                          |
+| `state`       | Not required       | Local state operations.                                                                                                                                                                                                 |
+| `forceunlock` | Not required       | Releases a stuck state lock.                                                                                                                                                                                            |
+| `test`        | **Optional**       | Unit/validation tests run without auth. Integration tests that provision real resources (test files with `run` blocks using `command = apply`) need a service connection — provide it in YAML and the task will use it. |
+
+All other commands (`plan`, `apply`, `destroy`, `show`, `output`, `import`, `refresh`, `custom`) require a provider service connection.
+
+### Running `terraform test` without a service connection
+
+```yaml
+# Unit/validation tests — no service connection needed
+- task: PipelineTerraformTask@5
+  displayName: 'Terraform Test'
+  inputs:
+    provider: aws          # still required (selects handler)
+    command: test
+```
+
+### Running `terraform test` with a service connection
+
+```yaml
+# Integration tests that provision real resources
+- task: PipelineTerraformTask@5
+  displayName: 'Terraform Test (integration)'
+  inputs:
+    provider: aws
+    command: test
+    environmentServiceNameAWS: my-aws-connection
+```
 
 ---
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -1946,6 +1946,20 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    it('test command without service connection should succeed', async () => {
+        let tp = path.join(__dirname, './TestCommandTests/NoAuthTestSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('NoAuthTestSuccessL0 should have succeeded.'), 'Should have printed: NoAuthTestSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
     /* backend type decoupling tests */
 
     it('init with s3 backend and azurerm provider should succeed', async () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/NoAuthTestSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/NoAuthTestSuccess.ts
@@ -1,0 +1,30 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './NoAuthTestSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'test');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+// No environmentServiceNameAWS — service connection is optional for test
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+  "which": {
+    "terraform": "terraform"
+  },
+  "checkPath": {
+    "terraform": true
+  },
+  "exec": {
+    "terraform test": {
+      "code": 0,
+      "stdout": "Success! 0 passed, 0 failed."
+    }
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/NoAuthTestSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/NoAuthTestSuccessL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'test', 'NoAuthTestSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -559,9 +559,20 @@ export abstract class BaseTerraformCommandHandler {
             commandOptions = commandOptions ? `${commandOptions} -filter=${testFilter}` : `-filter=${testFilter}`;
         }
 
-        const testCommand = this.createAuthCommand("test", commandOptions);
+        // Service connection is optional for test. Unit/validation tests don't need
+        // provider auth, but integration tests (run blocks with command = apply) may.
+        const serviceName = tasks.getInput(this.getServiceName(), false);
+        if (serviceName) {
+            const testCommand = this.createAuthCommand("test", commandOptions);
+            const terraformTool = this.terraformToolHandler.createToolRunner(testCommand);
+            await this.handleProvider(testCommand);
+            return terraformTool.execAsync(<IExecOptions>{
+                cwd: testCommand.workingDirectory
+            });
+        }
+
+        const testCommand = this.createBaseCommand("test", commandOptions);
         const terraformTool = this.terraformToolHandler.createToolRunner(testCommand);
-        await this.handleProvider(testCommand);
         return terraformTool.execAsync(<IExecOptions>{
             cwd: testCommand.workingDirectory
         });

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -413,7 +413,7 @@
             "type": "connectedService:AzureRM",
             "label": "Azure Provider Service Connection",
             "required": true,
-            "visibleRule": "provider = azurerm && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = azurerm && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Select an Azure Resource Manager Service Connection for the Azure providers",
             "groupName": "providerAzureRm"
         },
@@ -422,7 +422,7 @@
             "type": "string",
             "label": "Subscription ID Override",
             "required": false,
-            "visibleRule": "provider = azurerm && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = azurerm && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Used to override the subscription ID that the provider will target by default. This is set to the ARM_SUBSCRIPTION_ID environment variable. It will use the service connection subscription ID by default.",
             "groupName": "providerAzureRm"
         },
@@ -447,7 +447,7 @@
             "type": "connectedService:PTTAWSServiceEndpoint",
             "label": "Amazon Web Services connection",
             "required": true,
-            "visibleRule": "provider = aws && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = aws && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Select an Amazon Web Services connection for the deployment.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup an Amazon Web Services service connection using the 'Add' or 'Manage' button."
         },
         {
@@ -456,7 +456,7 @@
             "label": "Authentication scheme",
             "defaultValue": "ServiceConnection",
             "required": false,
-            "visibleRule": "provider = aws && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = aws && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Select how to authenticate with AWS. 'Service connection' uses static credentials from the service connection. 'Workload Identity Federation' uses OIDC to assume an IAM role without static credentials.",
             "options": {
                 "ServiceConnection": "Service connection (static credentials)",
@@ -471,7 +471,7 @@
             "type": "string",
             "label": "IAM Role ARN",
             "required": true,
-            "visibleRule": "provider = aws && environmentAuthSchemeAWS = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = aws && environmentAuthSchemeAWS = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "ARN of the AWS IAM role to assume via OIDC. E.g. arn:aws:iam::123456789012:role/MyTerraformRole"
         },
         {
@@ -479,7 +479,7 @@
             "type": "string",
             "label": "AWS Region",
             "required": true,
-            "visibleRule": "provider = aws && environmentAuthSchemeAWS = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = aws && environmentAuthSchemeAWS = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "AWS region for the provider. E.g. us-east-1"
         },
         {
@@ -488,7 +488,7 @@
             "label": "Session name",
             "required": false,
             "defaultValue": "AzureDevOps-Terraform",
-            "visibleRule": "provider = aws && environmentAuthSchemeAWS = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = aws && environmentAuthSchemeAWS = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Name for the assumed role session. Defaults to 'AzureDevOps-Terraform'."
         },
         {
@@ -496,7 +496,7 @@
             "type": "connectedService:PTTGoogleCloudServiceEndpoint",
             "label": "Google Cloud Platform connection",
             "required": true,
-            "visibleRule": "provider = gcp && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = gcp && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Select a Google Cloud Platform connection for the deployment.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Google Cloud Platform service connection using the 'Add' or 'Manage' button."
         },
         {
@@ -505,7 +505,7 @@
             "label": "Authentication scheme",
             "defaultValue": "ServiceConnection",
             "required": false,
-            "visibleRule": "provider = gcp && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = gcp && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Select how to authenticate with GCP. 'Service connection' uses a service account key. 'Workload Identity Federation' uses OIDC without static credentials.",
             "options": {
                 "ServiceConnection": "Service connection (service account key)",
@@ -520,7 +520,7 @@
             "type": "string",
             "label": "GCP Project Number",
             "required": true,
-            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Numeric GCP project number where the Workload Identity Pool lives."
         },
         {
@@ -528,7 +528,7 @@
             "type": "string",
             "label": "Workload Identity Pool ID",
             "required": true,
-            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "ID of the Workload Identity Pool configured to trust Azure DevOps."
         },
         {
@@ -536,7 +536,7 @@
             "type": "string",
             "label": "Workload Identity Provider ID",
             "required": true,
-            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "ID of the OIDC provider within the Workload Identity Pool."
         },
         {
@@ -544,7 +544,7 @@
             "type": "string",
             "label": "Service Account Email",
             "required": true,
-            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = gcp && environmentAuthSchemeGCP = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Email of the GCP service account to impersonate. E.g. terraform@my-project.iam.gserviceaccount.com"
         },
         {
@@ -552,7 +552,7 @@
             "type": "connectedService:PTTOCIServiceEndpoint",
             "label": "Oracle Cloud Platform connection",
             "required": true,
-            "visibleRule": "provider = oci && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = oci && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Select a Oracle Cloud Platform connection for the deployment.<br><br>Note: If your connection is not listed or if you want to use an existing connection, you can setup a Oracle Cloud Platform service connection using the 'Add' or 'Manage' button."
         },
         {
@@ -561,7 +561,7 @@
             "label": "Authentication scheme",
             "defaultValue": "ServiceConnection",
             "required": false,
-            "visibleRule": "provider = oci && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = oci && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Select how to authenticate with OCI. 'Service connection' uses API key credentials. 'Workload Identity Federation' uses OIDC to obtain an OCI User Principal Session Token (UPST) without static credentials.",
             "options": {
                 "ServiceConnection": "Service connection (API key)",
@@ -576,7 +576,7 @@
             "type": "string",
             "label": "Tenancy OCID",
             "required": true,
-            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "OCID of the OCI tenancy. E.g. ocid1.tenancy.oc1..aaaa..."
         },
         {
@@ -584,7 +584,7 @@
             "type": "string",
             "label": "OCI Region",
             "required": true,
-            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "OCI region identifier. E.g. us-ashburn-1"
         },
         {
@@ -592,7 +592,7 @@
             "type": "string",
             "label": "Identity Domain URL",
             "required": true,
-            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "URL of the OCI Identity Domain configured for OIDC federation. E.g. https://idcs-abc123.identity.oraclecloud.com"
         },
         {
@@ -600,7 +600,7 @@
             "type": "string",
             "label": "Identity Domain Application Client ID",
             "required": true,
-            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock",
+            "visibleRule": "provider = oci && environmentAuthSchemeOCI = WorkloadIdentityFederation && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
             "helpMarkDown": "Client ID of the OCI Identity Domains application configured to accept OIDC tokens from Azure DevOps."
         },
         {

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "publisher": "sethbacon",
     "targets": [
         {

--- a/overview.md
+++ b/overview.md
@@ -19,6 +19,7 @@ Runs on **Windows**, **Linux**, and **macOS** agents.
 - **Flexible installer**: Download Terraform from HashiCorp releases, a private registry, or a custom mirror with SHA256 verification
 - **`-replace` flag** support on plan and apply (modern replacement for the deprecated `taint` command)
 - **Detailed exit code** on plan with `changesPresent` output variable for conditional apply
+- **Optional service connection for `test`**: run unit tests without provider auth, or provide a service connection for integration tests that provision real resources
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

The \	est\ command previously required a provider service connection (e.g. \nvironmentServiceNameAWS\) even for unit/validation tests that don't need cloud credentials. This caused \Input required: environmentServiceNameAWS\ errors in CI pipelines that only run \	erraform test\ for module validation.

## Changes

- **task.json**: Add \command != test\ to all 19 provider service connection \isibleRule\ entries — makes the input not required by ADO validation when command is \	est\
- **base-terraform-command-handler.ts**: \	est()\ now checks if a service connection is provided; if yes, configures provider auth (for integration tests); if no, runs without auth (for unit tests)
- **New test**: \NoAuthTestSuccess\ verifies \	erraform test\ succeeds without a service connection
- **README.md**: New *Service Connection Requirements by Command* section with table and YAML examples
- **overview.md**: Feature bullet for optional test auth
- **CHANGELOG.md**: v1.0.8 entry
- **azure-devops-extension.json**: Version bump to 1.0.8

## Changelog

### Fixed
- \	est\ command no longer requires a service connection — unit/validation tests work without one, integration tests can still provide one for provider auth

## Testing

\\\
159 passing (20s)
\\\

All existing test command tests (Azure, AWS, GCP, OCI) continue to pass with service connections. New \NoAuthTestSuccess\ test verifies the no-auth path.