### PR TITLE
chore: fix lint warnings and pin windows-2025 runner

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
     defaults:
       run:
         working-directory: Tasks/TerraformTask/TerraformTaskV5
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
     defaults:
       run:
         working-directory: Tasks/TerraformInstaller/TerraformInstallerV1

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/AWS/AWSApplyWIFSuccess.ts
@@ -16,7 +16,7 @@ tr.setInput('awsRegion', 'us-east-1');
 tr.setInput('awsSessionName', 'AzureDevOps-Terraform');
 
 tr.registerMock('./id-token-generator', {
-    generateIdToken: (serviceConnectionId: string) => {
+    generateIdToken: (_serviceConnectionId: string) => {
         return Promise.resolve('mock-oidc-token-12345');
     }
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyWIFSuccess.ts
@@ -17,7 +17,7 @@ tr.setInput('gcpWorkloadIdentityProviderId', 'my-oidc-provider');
 tr.setInput('gcpServiceAccountEmail', 'terraform@my-project.iam.gserviceaccount.com');
 
 tr.registerMock('./id-token-generator', {
-    generateIdToken: (serviceConnectionId: string) => {
+    generateIdToken: (_serviceConnectionId: string) => {
         return Promise.resolve('mock-oidc-token-12345');
     }
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/AWS/AWSDestroyWIFSuccess.ts
@@ -16,7 +16,7 @@ tr.setInput('awsRegion', 'us-east-1');
 tr.setInput('awsSessionName', 'AzureDevOps-Terraform');
 
 tr.registerMock('./id-token-generator', {
-    generateIdToken: (serviceConnectionId: string) => {
+    generateIdToken: (_serviceConnectionId: string) => {
         return Promise.resolve('mock-oidc-token-12345');
     }
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyWIFSuccess.ts
@@ -17,7 +17,7 @@ tr.setInput('gcpWorkloadIdentityProviderId', 'my-oidc-provider');
 tr.setInput('gcpServiceAccountEmail', 'terraform@my-project.iam.gserviceaccount.com');
 
 tr.registerMock('./id-token-generator', {
-    generateIdToken: (serviceConnectionId: string) => {
+    generateIdToken: (_serviceConnectionId: string) => {
         return Promise.resolve('mock-oidc-token-12345');
     }
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/AWS/AWSInitWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/AWS/AWSInitWIFSuccess.ts
@@ -19,13 +19,13 @@ tr.setInput('backendAWSRegion', 'us-east-1');
 tr.setInput('backendAWSSessionName', 'AzureDevOps-Terraform-Backend');
 
 var mock = {
-    "generateIdToken": function(serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
+    "generateIdToken": function (_serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
 };
 
 tr.registerMock('./id-token-generator', mock);
 tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentity.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentity.ts
@@ -20,7 +20,7 @@ process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ManagedServiceIdentity';
 process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -36,8 +36,8 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 }
 
 var mock = {
-    "generateIdToken" : function(command) { return Promise.resolve('12345'); }
- }
+    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+}
 
 tr.registerMock('./id-token-generator', mock);
 tr.setAnswers(a);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentityAndDefaultSettings.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentityAndDefaultSettings.ts
@@ -22,7 +22,7 @@ process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ManagedServiceIdentity';
 process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -38,8 +38,8 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 }
 
 var mock = {
-    "generateIdToken" : function(command) { return Promise.resolve('12345'); }
- }
+    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+}
 
 tr.registerMock('./id-token-generator', mock);
 tr.setAnswers(a);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederation.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederation.ts
@@ -22,7 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 process.env['ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN'] = 'DummyAccessToken';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -38,8 +38,8 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 }
 
 var mock = {
-    "generateIdToken" : function(command) { return Promise.resolve('12345'); }
- }
+    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+}
 
 tr.registerMock('./id-token-generator', mock);
 tr.setAnswers(a);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndCLIFlags.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndCLIFlags.ts
@@ -23,7 +23,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 process.env['ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN'] = 'DummyAccessToken';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -39,8 +39,8 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 }
 
 var mock = {
-    "generateIdToken" : function(command) { return Promise.resolve('12345'); }
- }
+    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+}
 
 tr.registerMock('./id-token-generator', mock);
 tr.setAnswers(a);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndDefaultSettings.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndDefaultSettings.ts
@@ -23,7 +23,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 process.env['ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN'] = 'DummyAccessToken';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -39,8 +39,8 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 }
 
 var mock = {
-    "generateIdToken" : function(command) { return Promise.resolve('12345'); }
- }
+    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+}
 
 tr.registerMock('./id-token-generator', mock);
 tr.setAnswers(a);


### PR DESCRIPTION
## Summary

Cleans up all 20 CI annotation warnings (10 unique, duplicated across ubuntu/windows matrix) and 2 runner deprecation notices.

### Changes

- **10 test files**: prefix unused mock params with \_\ to satisfy \@typescript-eslint/no-unused-vars\ (\command\ → \_command\, \serviceConnectionId\ → \_serviceConnectionId\)
- **unit-test.yml**: pin CI matrix to \windows-2025\ (suppresses GitHub's \windows-latest → windows-2025-vs2026\ redirect notice)

### Testing

159 passing (2m) — no functional changes.