### PR TITLE
fix: allow empty sha256 in registry binary download

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -159,11 +159,11 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     const infoUrl = `${registryUrl}/terraform/binaries/${mirrorName}/versions/${version}/${osPlatform}/${arch}`;
 
     const data = await fetchJson<{ download_url: string; sha256: string }>(infoUrl);
-    if (!data.download_url || !data.sha256) {
-        throw new Error(`Registry API returned invalid response: missing download_url or sha256 from ${infoUrl}`);
+    if (!data.download_url) {
+        throw new Error(`Registry API returned invalid response: missing download_url from ${infoUrl}`);
     }
     // data.download_url = pre-signed storage URL (15-minute TTL)
-    // data.sha256       = hex SHA256 of the zip
+    // data.sha256       = hex SHA256 of the zip (may be empty if registry verified server-side)
 
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
     let zipPath: string;
@@ -173,7 +173,11 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
         throw new Error(tasks.loc("TerraformDownloadFailed", data.download_url, exception));
     }
 
-    await verifySha256(zipPath, data.sha256);
+    if (data.sha256) {
+        await verifySha256(zipPath, data.sha256);
+    } else {
+        tasks.debug(`SHA256 not provided by registry for ${infoUrl}; skipping local verification (registry performed server-side verification)`);
+    }
     return zipPath;
 }
 

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pipeline-tasks-terraform",
     "name": "Pipeline Tasks for Terraform",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "publisher": "sethbacon",
     "targets": [
         {


### PR DESCRIPTION
## Summary

When `downloadSource: registry` is configured, the installer GETs the per-platform endpoint and requires both `download_url` and `sha256`. The `terraform-registry-backend` returns an empty string for `sha256` when the binary has already been verified server-side (`sha256_verified: true`). An empty string is falsy in JS, causing the installer to throw a fetch-failed error even though the download URL is valid.

## Changes

- Remove `sha256` from the required-fields guard (only `download_url` is required)
- If `sha256` is present and non-empty, verify locally as before
- If `sha256` is empty, log a debug message and skip local verification
- Bump extension version to `1.0.10`

## Changelog

- fix: TerraformInstallerV1 registry download no longer fails when registry returns empty sha256

Closes #185