### PR TITLE
fix: unique provider mirror task id and command arg quoting

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -144,7 +144,7 @@ async function downloadZipFromHashiCorp(version: string): Promise<string> {
     const sha256SumsSigUrl = `${sha256SumsUrl}.sig`;
 
     const sha256SumsContent = await fetchText(sha256SumsUrl);
-    const requireGpg = tasks.getBoolInput("requireGpgSignature", false) !== false;
+    const requireGpg = tasks.getBoolInput("requireGpgSignature", false);
     await verifyGpgSignature(sha256SumsContent, sha256SumsSigUrl, requireGpg);
 
     const expectedHash = parseSha256(sha256SumsContent, zipFileName);
@@ -201,14 +201,19 @@ async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Pr
     // Attempt SHA256 verification from mirror — fail if SHA256SUMS is available but hash doesn't match
     const zipFileName = `terraform_${version}_${osPlatform}_${arch}.zip`;
     const sha256SumsUrl = `${mirrorBaseUrl}/${version}/terraform_${version}_SHA256SUMS`;
+    const requireChecksum = tasks.getBoolInput("requireChecksum", false);
     try {
         const expectedHash = await fetchExpectedSha256(sha256SumsUrl, zipFileName);
         await verifySha256(zipPath, expectedHash);
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        // Only warn if SHA256SUMS file is unavailable; fail if hash mismatch
-        if (errorMessage.includes('SHA256 checksum not found') || errorMessage.includes('Failed to fetch')) {
+        const checksumUnavailable = errorMessage.includes('SHA256 checksum not found') || errorMessage.includes('Failed to fetch');
+        // A genuine hash mismatch is always fatal. An unavailable SHA256SUMS file is
+        // fatal only when the user requires checksum verification; otherwise warn.
+        if (checksumUnavailable && !requireChecksum) {
             tasks.warning(`SHA256 verification skipped for mirror download: ${errorMessage}`);
+        } else if (checksumUnavailable) {
+            throw new Error(`Checksum verification is required but the mirror did not provide a usable SHA256SUMS file (${sha256SumsUrl}): ${errorMessage}`);
         } else {
             throw error;
         }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "221",
+        "Minor": "222",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",
@@ -96,6 +96,15 @@
             "required": false,
             "visibleRule": "binary = tofu",
             "helpMarkDown": "When enabled, fail if cosign is not available on the agent or the signature cannot be verified. When disabled (default), cosign verification is attempted but skipped if cosign is not installed."
+        },
+        {
+            "name": "requireChecksum",
+            "type": "boolean",
+            "label": "Require checksum verification",
+            "defaultValue": "false",
+            "required": false,
+            "visibleRule": "binary = terraform && downloadSource = mirror",
+            "helpMarkDown": "When enabled, fail if the mirror does not serve a SHA256SUMS file for the requested version. When disabled (default), checksum verification is attempted but skipped if the mirror does not publish a SHA256SUMS file."
         }
     ],
     "execution": {

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "id": "1c36ffb0-b3b3-4716-90c7-d7d02884acd0",
     "name": "PipelineTerraformProviderMirror",
     "friendlyName": "Pipeline Terraform provider mirror",
     "description": "Configure Terraform to download providers from a network mirror instead of the public registry",
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "1",
+        "Minor": "2",
         "Patch": "0"
     },
     "instanceNameFormat": "Configure provider mirror: $(mirrorUrl)",

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CommandArgsTests/CommandArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CommandArgsTests/CommandArgs.ts
@@ -1,0 +1,10 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, './CommandArgsL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CommandArgsTests/CommandArgsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CommandArgsTests/CommandArgsL0.ts
@@ -1,0 +1,62 @@
+import tl = require('azure-pipelines-task-lib');
+import { parseVarFileTokens, parseTargetTokens } from '../../src/base-terraform-command-handler';
+
+let failed = false;
+
+function check(actual: string[], expected: string[], label: string): void {
+    const ok = actual.length === expected.length && actual.every((v, i) => v === expected[i]);
+    if (!ok) {
+        tl.error(`${label}: expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+        failed = true;
+    }
+}
+
+// Empty / undefined input yields no tokens.
+check(parseVarFileTokens(undefined), [], 'varFile undefined');
+check(parseVarFileTokens(''), [], 'varFile empty');
+check(parseTargetTokens(undefined), [], 'target undefined');
+
+// A simple path stays a single token.
+check(parseVarFileTokens('prod.tfvars'), ['-var-file=prod.tfvars'], 'varFile simple');
+
+// A path containing spaces must remain ONE token (the bug being fixed: it used to
+// be concatenated into a string and re-split on whitespace by ToolRunner.line()).
+check(
+    parseVarFileTokens('C:\\My Folder\\prod.tfvars'),
+    ['-var-file=C:\\My Folder\\prod.tfvars'],
+    'varFile with spaces',
+);
+
+// Multiple lines produce one token each, trimming blanks.
+check(
+    parseVarFileTokens('a.tfvars\n  b.tfvars  \n\nc d.tfvars'),
+    ['-var-file=a.tfvars', '-var-file=b.tfvars', '-var-file=c d.tfvars'],
+    'varFile multiline',
+);
+
+// Target addresses, including a quoted index key that contains a space, stay whole.
+check(
+    parseTargetTokens('aws_instance.foo'),
+    ['-target=aws_instance.foo'],
+    'target simple',
+);
+check(
+    parseTargetTokens('module.x["a b"]'),
+    ['-target=module.x["a b"]'],
+    'target with quoted space key',
+);
+
+// Invalid target addresses are rejected.
+try {
+    parseTargetTokens('has spaces');
+    tl.error('target invalid: expected parseTargetTokens to throw on "has spaces"');
+    failed = true;
+} catch {
+    // expected
+}
+
+if (failed) {
+    tl.setResult(tl.TaskResult.Failed, 'Command arg token parsing failed');
+} else {
+    tl.setResult(tl.TaskResult.Succeeded, 'CommandArgsL0 should have succeeded.');
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2316,6 +2316,18 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    /* command arg token tests */
+
+    it('parseVarFileTokens/parseTargetTokens keep space-containing values as single tokens', async () => {
+        let tp = path.join(__dirname, './CommandArgsTests/CommandArgs.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
     /* PEM normalizer tests */
 
     it('normalizePem should normalize valid keys and reject malformed input', async () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -37,23 +37,43 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_SECRET_ACCESS_KEY", secretKey, true);
     }
 
+    /**
+     * Generates the OIDC token, writes it to a cleanup-tracked temp file, and sets
+     * the AWS web-identity environment variables used by both the backend and the
+     * provider. The token-file prefix is passed in so each call site keeps its own
+     * stable temp-file name.
+     */
+    private async applyWifEnvironment(params: {
+        serviceConnection: string;
+        roleArn: string;
+        region: string;
+        sessionName: string;
+        tokenFilePrefix: string;
+    }): Promise<void> {
+        const oidcToken = await generateIdToken(params.serviceConnection);
+        tasks.setSecret(oidcToken);
+
+        const tokenFilePath = path.join(os.tmpdir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
+        writeSecretFile(tokenFilePath, oidcToken);
+        this.tempFiles.push(tokenFilePath);
+
+        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_ARN", params.roleArn);
+        EnvironmentVariableHelper.setEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFilePath);
+        EnvironmentVariableHelper.setEnvironmentVariable("AWS_REGION", params.region);
+        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_SESSION_NAME", params.sessionName);
+    }
+
     private async setupBackendWIF(backendServiceName: string): Promise<void> {
         this.backendConfig.set('bucket', tasks.getInput("backendAWSBucketName", true)!);
         this.backendConfig.set('key', tasks.getInput("backendAWSKey", true)!);
 
-        const oidcToken = await generateIdToken(backendServiceName);
-        tasks.setSecret(oidcToken);
-
-        const tokenFilePath = path.join(os.tmpdir(), `aws-backend-oidc-token-${uuidV4()}.jwt`);
-        writeSecretFile(tokenFilePath, oidcToken);
-        this.tempFiles.push(tokenFilePath);
-
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_ARN", tasks.getInput("backendAWSRoleArn", true)!);
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFilePath);
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_REGION", tasks.getInput("backendAWSRegion", true)!);
-
-        const sessionName = tasks.getInput("backendAWSSessionName", false) || "AzureDevOps-Terraform-Backend";
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_SESSION_NAME", sessionName);
+        await this.applyWifEnvironment({
+            serviceConnection: backendServiceName,
+            roleArn: tasks.getInput("backendAWSRoleArn", true)!,
+            region: tasks.getInput("backendAWSRegion", true)!,
+            sessionName: tasks.getInput("backendAWSSessionName", false) || "AzureDevOps-Terraform-Backend",
+            tokenFilePrefix: "aws-backend-oidc-token",
+        });
     }
 
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
@@ -87,18 +107,12 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
     }
 
     private async handleProviderWIF(command: TerraformAuthorizationCommandInitializer): Promise<void> {
-        const oidcToken = await generateIdToken(command.serviceProviderName);
-        tasks.setSecret(oidcToken);
-
-        const tokenFilePath = path.join(os.tmpdir(), `aws-oidc-token-${uuidV4()}.jwt`);
-        writeSecretFile(tokenFilePath, oidcToken);
-        this.tempFiles.push(tokenFilePath);
-
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_ARN", tasks.getInput("awsRoleArn", true)!);
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFilePath);
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_REGION", tasks.getInput("awsRegion", true)!);
-
-        const sessionName = tasks.getInput("awsSessionName", false) || "AzureDevOps-Terraform";
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_SESSION_NAME", sessionName);
+        await this.applyWifEnvironment({
+            serviceConnection: command.serviceProviderName,
+            roleArn: tasks.getInput("awsRoleArn", true)!,
+            region: tasks.getInput("awsRegion", true)!,
+            sessionName: tasks.getInput("awsSessionName", false) || "AzureDevOps-Terraform",
+            tokenFilePrefix: "aws-oidc-token",
+        });
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -11,6 +11,32 @@ import os = require('os');
 /** Validates Terraform resource addresses (e.g. `aws_instance.foo`, `module.bar["key"]`). */
 export const RESOURCE_ADDRESS_RE = /^[a-zA-Z_][\w\-]*(\[[^\]]+\])?(\.[a-zA-Z_][\w\-]*(\[[^\]]+\])?)*$/;
 
+/**
+ * Splits a multi-line `varFile` input into `-var-file=<path>` tokens, one per
+ * non-empty line. Each path is kept whole so it can be passed as a single argv
+ * entry — paths containing spaces (common on Windows agents) must not be split.
+ */
+export function parseVarFileTokens(varFile: string | undefined): string[] {
+    if (!varFile) return [];
+    return varFile.split('\n').map(l => l.trim()).filter(l => l).map(f => `-var-file=${f}`);
+}
+
+/**
+ * Splits a multi-line `targetResources` input into validated `-target=<address>`
+ * tokens. Addresses may legitimately contain spaces inside quoted index keys
+ * (e.g. `module.x["a b"]`), so each is kept as a single argv entry.
+ */
+export function parseTargetTokens(targetResources: string | undefined): string[] {
+    if (!targetResources) return [];
+    const lines = targetResources.split('\n').map(l => l.trim()).filter(l => l);
+    for (const address of lines) {
+        if (!RESOURCE_ADDRESS_RE.test(address)) {
+            throw new Error(`Invalid target address '${address}': must be a valid Terraform resource address`);
+        }
+    }
+    return lines.map(a => `-target=${a}`);
+}
+
 export abstract class BaseTerraformCommandHandler {
     providerName: string;
     terraformToolHandler: ITerraformToolHandler;
@@ -59,96 +85,65 @@ export abstract class BaseTerraformCommandHandler {
         );
     }
 
-    protected ensureAutoApprove(args: string | undefined): string {
-        const autoApprove = '-auto-approve';
-        let result = args || autoApprove;
-        if (!result.includes(autoApprove)) {
-            result = `${autoApprove} ${result}`;
-        }
-        return result;
-    }
-
-    protected prependReplaceFlag(args: string): string {
+    protected replaceTokens(): string[] {
         const replaceAddress = tasks.getInput("replaceAddress", false);
-        if (replaceAddress) {
-            if (!RESOURCE_ADDRESS_RE.test(replaceAddress)) {
-                throw new Error(`Invalid replace address '${replaceAddress}': must be a valid Terraform resource address`);
-            }
-            return `-replace=${replaceAddress} ${args}`;
+        if (!replaceAddress) return [];
+        if (!RESOURCE_ADDRESS_RE.test(replaceAddress)) {
+            throw new Error(`Invalid replace address '${replaceAddress}': must be a valid Terraform resource address`);
         }
-        return args;
+        return [`-replace=${replaceAddress}`];
     }
 
-    protected prependRefreshOnly(args: string): string {
-        if (tasks.getBoolInput("refreshOnly", false)) {
-            return `-refresh-only ${args}`;
-        }
-        return args;
-    }
-
-    protected appendParallelism(args: string): string {
+    /** Returns the `-parallelism=N` token, or [] if not set. Validates the value. */
+    protected parallelismTokens(): string[] {
         const parallelism = tasks.getInput("parallelism", false);
-        if (parallelism) {
-            const n = parseInt(parallelism, 10);
-            if (isNaN(n) || n < 1) {
-                throw new Error(`Invalid parallelism value '${parallelism}': must be a positive integer`);
-            }
-            return `${args} -parallelism=${n}`;
+        if (!parallelism) return [];
+        const n = parseInt(parallelism, 10);
+        if (isNaN(n) || n < 1) {
+            throw new Error(`Invalid parallelism value '${parallelism}': must be a positive integer`);
         }
-        return args;
+        return [`-parallelism=${n}`];
     }
 
-    protected async appendSecureVarFile(args: string): Promise<string> {
+    /** Downloads the secure var file (if configured) and returns its `-var-file=<path>` token. */
+    protected async secureVarFileTokens(): Promise<string[]> {
         const result = await getSecureVarFileArgs();
-        if (result) {
-            this.secureFileId = result.secureFileId;
-            return `${result.varFileArg} ${args}`;
-        }
-        return args;
-    }
-
-    protected prependVarFiles(args: string): string {
-        const varFile = tasks.getInput("varFile", false);
-        if (!varFile) return args;
-        const lines = varFile.split('\n').map(l => l.trim()).filter(l => l);
-        const flags = lines.map(f => `-var-file=${f}`).join(' ');
-        return flags ? `${flags} ${args}` : args;
-    }
-
-    protected prependTargetResources(args: string): string {
-        const targetResources = tasks.getInput("targetResources", false);
-        if (!targetResources) return args;
-        const lines = targetResources.split('\n').map(l => l.trim()).filter(l => l);
-        for (const address of lines) {
-            if (!RESOURCE_ADDRESS_RE.test(address)) {
-                throw new Error(`Invalid target address '${address}': must be a valid Terraform resource address`);
-            }
-        }
-        const flags = lines.map(a => `-target=${a}`).join(' ');
-        return flags ? `${flags} ${args}` : args;
+        if (!result) return [];
+        this.secureFileId = result.secureFileId;
+        return [result.varFileArg];
     }
 
     /**
-     * Declarative command-args pipeline.  Ordering is fixed here so every
-     * command that opts-in gets flags in a consistent position:
-     *   [secureVarFile] [varFiles] [targetResources] [replace] [refreshOnly] <base> [parallelism]
+     * Builds the structured leading flags that precede the base command. Each flag
+     * is returned as a single argv token (applied later via {@link applyTokens})
+     * so values containing spaces — a var-file path on a Windows agent, or a
+     * target/replace address with a quoted index key — are never split.
+     *
+     * Token order (left to right): secureVarFile, targetResources, varFiles,
+     * refreshOnly, replace. Flag order is irrelevant to Terraform; it is fixed
+     * here only for predictability and stable test assertions.
      */
-    protected async buildCommandArgs(base: string, config: {
+    protected async buildLeadingArgs(config: {
         replaceFlag?: boolean;
         refreshOnly?: boolean;
         varFiles?: boolean;
         targetResources?: boolean;
-        parallelism?: boolean;
         secureVarFile?: boolean;
-    }): Promise<string> {
-        let args = base;
-        if (config.replaceFlag) args = this.prependReplaceFlag(args);
-        if (config.refreshOnly) args = this.prependRefreshOnly(args);
-        if (config.varFiles) args = this.prependVarFiles(args);
-        if (config.targetResources) args = this.prependTargetResources(args);
-        if (config.parallelism) args = this.appendParallelism(args);
-        if (config.secureVarFile) args = await this.appendSecureVarFile(args);
-        return args;
+    }): Promise<string[]> {
+        const tokens: string[] = [];
+        if (config.secureVarFile) tokens.push(...await this.secureVarFileTokens());
+        if (config.targetResources) tokens.push(...parseTargetTokens(tasks.getInput("targetResources", false)));
+        if (config.varFiles) tokens.push(...parseVarFileTokens(tasks.getInput("varFile", false)));
+        if (config.refreshOnly && tasks.getBoolInput("refreshOnly", false)) tokens.push('-refresh-only');
+        if (config.replaceFlag) tokens.push(...this.replaceTokens());
+        return tokens;
+    }
+
+    /** Applies tokens to a tool runner as individual argv entries (no re-splitting). */
+    protected applyTokens(tool: ToolRunner, tokens: string[]): void {
+        for (const token of tokens) {
+            tool.arg(token);
+        }
     }
 
     protected appendTerraformVariables(terraformTool: ToolRunner): void {
@@ -367,15 +362,19 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async plan(): Promise<number> {
-        const base = tasks.getInput("commandOptions") ? `${tasks.getInput("commandOptions")} -detailed-exitcode` : `-detailed-exitcode`;
-        const commandOptions = await this.buildCommandArgs(base, {
-            replaceFlag: true, refreshOnly: true, varFiles: true,
-            targetResources: true, parallelism: true, secureVarFile: true,
-        });
-
-        const planCommand = this.createAuthCommand("plan", commandOptions);
+        const planCommand = this.createAuthCommand("plan");
         const terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
+
+        this.applyTokens(terraformTool, await this.buildLeadingArgs({
+            replaceFlag: true, refreshOnly: true, varFiles: true,
+            targetResources: true, secureVarFile: true,
+        }));
+        const commandOptions = tasks.getInput("commandOptions");
+        if (commandOptions) terraformTool.line(commandOptions);
+        terraformTool.arg("-detailed-exitcode");
+        this.applyTokens(terraformTool, this.parallelismTokens());
         this.appendTerraformVariables(terraformTool);
+
         await this.handleProvider(planCommand);
         await this.warnIfMultipleProviders();
 
@@ -435,15 +434,17 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async apply(): Promise<number> {
-        const additionalArgs = await this.buildCommandArgs(
-            this.ensureAutoApprove(tasks.getInput("commandOptions")), {
-            replaceFlag: true, refreshOnly: true, varFiles: true,
-            targetResources: true, parallelism: true, secureVarFile: true,
-        });
-
-        const applyCommand = this.createAuthCommand("apply", additionalArgs);
+        const applyCommand = this.createAuthCommand("apply");
         const terraformTool = this.terraformToolHandler.createToolRunner(applyCommand);
+
+        this.applyTokens(terraformTool, await this.buildLeadingArgs({
+            replaceFlag: true, refreshOnly: true, varFiles: true,
+            targetResources: true, secureVarFile: true,
+        }));
+        this.applyAutoApprove(terraformTool);
+        this.applyTokens(terraformTool, this.parallelismTokens());
         this.appendTerraformVariables(terraformTool);
+
         await this.handleProvider(applyCommand);
         await this.warnIfMultipleProviders();
 
@@ -453,21 +454,35 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async destroy(): Promise<number> {
-        const additionalArgs = await this.buildCommandArgs(
-            this.ensureAutoApprove(tasks.getInput("commandOptions")), {
-            varFiles: true, targetResources: true,
-            parallelism: true, secureVarFile: true,
-        });
-
-        const destroyCommand = this.createAuthCommand("destroy", additionalArgs);
+        const destroyCommand = this.createAuthCommand("destroy");
         const terraformTool = this.terraformToolHandler.createToolRunner(destroyCommand);
+
+        this.applyTokens(terraformTool, await this.buildLeadingArgs({
+            varFiles: true, targetResources: true, secureVarFile: true,
+        }));
+        this.applyAutoApprove(terraformTool);
+        this.applyTokens(terraformTool, this.parallelismTokens());
         this.appendTerraformVariables(terraformTool);
+
         await this.handleProvider(destroyCommand);
         await this.warnIfMultipleProviders();
 
         return terraformTool.execAsync(<IExecOptions>{
             cwd: destroyCommand.workingDirectory
         });
+    }
+
+    /**
+     * Forces `-auto-approve` on the tool runner (apply/destroy), then applies any
+     * free-form `commandOptions`. If the user already supplied `-auto-approve` in
+     * `commandOptions`, it is not added a second time.
+     */
+    private applyAutoApprove(terraformTool: ToolRunner): void {
+        const commandOptions = tasks.getInput("commandOptions");
+        if (!commandOptions || !commandOptions.includes('-auto-approve')) {
+            terraformTool.arg('-auto-approve');
+        }
+        if (commandOptions) terraformTool.line(commandOptions);
     }
 
     public async validate(): Promise<number> {
@@ -593,18 +608,21 @@ export abstract class BaseTerraformCommandHandler {
     public async import(): Promise<number> {
         const resourceAddress = tasks.getInput("importAddress", true)!;
         const resourceId = tasks.getInput("importId", true)!;
-        const commandOptions = tasks.getInput("commandOptions");
 
-        let args = commandOptions
-            ? `${commandOptions} ${resourceAddress} ${resourceId}`
-            : `${resourceAddress} ${resourceId}`;
-        args = await this.buildCommandArgs(args, {
-            varFiles: true, secureVarFile: true,
-        });
-
-        const importCommand = this.createAuthCommand("import", args);
+        const importCommand = this.createAuthCommand("import");
         const terraformTool = this.terraformToolHandler.createToolRunner(importCommand);
+
+        this.applyTokens(terraformTool, await this.buildLeadingArgs({
+            varFiles: true, secureVarFile: true,
+        }));
+        const commandOptions = tasks.getInput("commandOptions");
+        if (commandOptions) terraformTool.line(commandOptions);
+        // Address and id are passed as discrete argv entries so an id containing
+        // spaces is not split.
+        terraformTool.arg(resourceAddress);
+        terraformTool.arg(resourceId);
         this.appendTerraformVariables(terraformTool);
+
         await this.handleProvider(importCommand);
 
         return terraformTool.execAsync(<IExecOptions>{
@@ -630,15 +648,17 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async refresh(): Promise<number> {
-        const commandOptions = await this.buildCommandArgs(
-            this.getCommandOptions() || '', {
-            varFiles: true, targetResources: true,
-            parallelism: true, secureVarFile: true,
-        });
-
-        const refreshCommand = this.createAuthCommand("refresh", commandOptions.trim() || undefined);
+        const refreshCommand = this.createAuthCommand("refresh");
         const terraformTool = this.terraformToolHandler.createToolRunner(refreshCommand);
+
+        this.applyTokens(terraformTool, await this.buildLeadingArgs({
+            varFiles: true, targetResources: true, secureVarFile: true,
+        }));
+        const commandOptions = this.getCommandOptions();
+        if (commandOptions) terraformTool.line(commandOptions);
+        this.applyTokens(terraformTool, this.parallelismTokens());
         this.appendTerraformVariables(terraformTool);
+
         await this.handleProvider(refreshCommand);
 
         return terraformTool.execAsync(<IExecOptions>{

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -63,26 +63,29 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         this.backendConfig.set('credentials', jsonKeyFilePath);
     }
 
-    private async setupBackendWIF(backendServiceName: string): Promise<void> {
-        this.backendConfig.set('bucket', tasks.getInput("backendGCPBucketName", true)!);
-        const prefix = tasks.getInput("backendGCPPrefix", false);
-        if (prefix) {
-            this.backendConfig.set('prefix', prefix);
-        }
-
-        const oidcToken = await generateIdToken(backendServiceName);
+    /**
+     * Writes the OIDC token file and a GCP external_account credentials file for
+     * Workload Identity Federation, registering both for cleanup. Returns the path
+     * to the credentials file. The file-name prefixes are passed in so the backend
+     * and provider call sites keep their distinct, stable temp-file names.
+     */
+    private async writeWifCredentials(params: {
+        serviceConnection: string;
+        projectNumber: string;
+        poolId: string;
+        providerId: string;
+        serviceAccountEmail: string;
+        tokenFilePrefix: string;
+        credentialsFilePrefix: string;
+    }): Promise<string> {
+        const oidcToken = await generateIdToken(params.serviceConnection);
         tasks.setSecret(oidcToken);
 
-        const tokenFilePath = path.join(os.tmpdir(), `gcp-backend-oidc-token-${uuidV4()}.jwt`);
+        const tokenFilePath = path.join(os.tmpdir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
         writeSecretFile(tokenFilePath, oidcToken);
         this.tempFiles.push(tokenFilePath);
 
-        const projectNumber = tasks.getInput("backendGCPProjectNumber", true)!;
-        const poolId = tasks.getInput("backendGCPWorkloadIdentityPoolId", true)!;
-        const providerId = tasks.getInput("backendGCPWorkloadIdentityProviderId", true)!;
-        const serviceAccountEmail = tasks.getInput("backendGCPServiceAccountEmail", true)!;
-
-        const audience = `//iam.googleapis.com/projects/${projectNumber}/locations/global/workloadIdentityPools/${poolId}/providers/${providerId}`;
+        const audience = `//iam.googleapis.com/projects/${params.projectNumber}/locations/global/workloadIdentityPools/${params.poolId}/providers/${params.providerId}`;
 
         const credentials = {
             type: "external_account",
@@ -90,12 +93,32 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
             token_url: "https://sts.googleapis.com/v1/token",
             credential_source: { file: tokenFilePath },
-            service_account_impersonation_url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${serviceAccountEmail}:generateAccessToken`
+            service_account_impersonation_url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${params.serviceAccountEmail}:generateAccessToken`
         };
 
-        const credentialsFilePath = path.join(os.tmpdir(), `gcp-backend-wif-credentials-${uuidV4()}.json`);
+        const credentialsFilePath = path.join(os.tmpdir(), `${params.credentialsFilePrefix}-${uuidV4()}.json`);
         writeSecretFile(credentialsFilePath, JSON.stringify(credentials));
         this.tempFiles.push(credentialsFilePath);
+
+        return credentialsFilePath;
+    }
+
+    private async setupBackendWIF(backendServiceName: string): Promise<void> {
+        this.backendConfig.set('bucket', tasks.getInput("backendGCPBucketName", true)!);
+        const prefix = tasks.getInput("backendGCPPrefix", false);
+        if (prefix) {
+            this.backendConfig.set('prefix', prefix);
+        }
+
+        const credentialsFilePath = await this.writeWifCredentials({
+            serviceConnection: backendServiceName,
+            projectNumber: tasks.getInput("backendGCPProjectNumber", true)!,
+            poolId: tasks.getInput("backendGCPWorkloadIdentityPoolId", true)!,
+            providerId: tasks.getInput("backendGCPWorkloadIdentityProviderId", true)!,
+            serviceAccountEmail: tasks.getInput("backendGCPServiceAccountEmail", true)!,
+            tokenFilePrefix: "gcp-backend-oidc-token",
+            credentialsFilePrefix: "gcp-backend-wif-credentials",
+        });
 
         this.backendConfig.set('credentials', credentialsFilePath);
     }
@@ -132,32 +155,17 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
     }
 
     private async handleProviderWIF(command: TerraformAuthorizationCommandInitializer): Promise<void> {
-        const oidcToken = await generateIdToken(command.serviceProviderName);
-        tasks.setSecret(oidcToken);
-
-        const tokenFilePath = path.join(os.tmpdir(), `gcp-oidc-token-${uuidV4()}.jwt`);
-        writeSecretFile(tokenFilePath, oidcToken);
-        this.tempFiles.push(tokenFilePath);
-
         const projectNumber = tasks.getInput("gcpProjectNumber", true)!;
-        const poolId = tasks.getInput("gcpWorkloadIdentityPoolId", true)!;
-        const providerId = tasks.getInput("gcpWorkloadIdentityProviderId", true)!;
-        const serviceAccountEmail = tasks.getInput("gcpServiceAccountEmail", true)!;
 
-        const audience = `//iam.googleapis.com/projects/${projectNumber}/locations/global/workloadIdentityPools/${poolId}/providers/${providerId}`;
-
-        const credentials = {
-            type: "external_account",
-            audience: audience,
-            subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
-            token_url: "https://sts.googleapis.com/v1/token",
-            credential_source: { file: tokenFilePath },
-            service_account_impersonation_url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${serviceAccountEmail}:generateAccessToken`
-        };
-
-        const credentialsFilePath = path.join(os.tmpdir(), `gcp-wif-credentials-${uuidV4()}.json`);
-        writeSecretFile(credentialsFilePath, JSON.stringify(credentials));
-        this.tempFiles.push(credentialsFilePath);
+        const credentialsFilePath = await this.writeWifCredentials({
+            serviceConnection: command.serviceProviderName,
+            projectNumber,
+            poolId: tasks.getInput("gcpWorkloadIdentityPoolId", true)!,
+            providerId: tasks.getInput("gcpWorkloadIdentityProviderId", true)!,
+            serviceAccountEmail: tasks.getInput("gcpServiceAccountEmail", true)!,
+            tokenFilePrefix: "gcp-oidc-token",
+            credentialsFilePrefix: "gcp-wif-credentials",
+        });
 
         EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_CREDENTIALS", credentialsFilePath);
         EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_PROJECT", projectNumber);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
@@ -22,8 +22,11 @@ export async function exchangeOidcForUpst(
 ): Promise<string> {
     const tokenEndpoint = `${identityDomainUrl.replace(/\/+$/, '')}/oauth2/v1/token`;
 
-    // JWK thumbprint of the ephemeral public key for binding
-    const jwkThumbprint = computeJwkThumbprint(publicKeyPem);
+    // The ephemeral public key is sent so OCI can bind the issued UPST to it; the
+    // caller signs subsequent API requests with the matching private key. OCI
+    // expects the base64-encoded SubjectPublicKeyInfo (DER), i.e. the PEM body
+    // with armor and line breaks removed.
+    const publicKeyDerBase64 = publicKeyToBase64Der(publicKeyPem);
 
     const body = new URLSearchParams({
         grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
@@ -31,7 +34,7 @@ export async function exchangeOidcForUpst(
         subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
         requested_token_type: 'urn:oci:token-type:oci-upst',
         client_id: clientId,
-        public_key: jwkThumbprint,
+        public_key: publicKeyDerBase64,
     });
 
     tasks.debug(`Exchanging OIDC JWT for OCI UPST at ${tokenEndpoint}`);
@@ -72,14 +75,12 @@ export async function exchangeOidcForUpst(
 }
 
 /**
- * Compute a JWK thumbprint (RFC 7638) of an RSA public key.
- * OCI Identity Domains uses this to bind the UPST to the ephemeral key pair.
+ * Export an RSA public key as base64-encoded SubjectPublicKeyInfo (DER).
+ * This is the form OCI Identity Domains expects in the token-exchange
+ * `public_key` parameter so it can bind the issued UPST to the ephemeral key.
  */
-function computeJwkThumbprint(publicKeyPem: string): string {
+function publicKeyToBase64Der(publicKeyPem: string): string {
     const keyObject = crypto.createPublicKey(publicKeyPem);
-    const jwk = keyObject.export({ format: 'jwk' }) as { e: string; kty: string; n: string };
-
-    // Canonical JWK for RSA: {"e":"...","kty":"RSA","n":"..."} (alphabetical order)
-    const canonical = JSON.stringify({ e: jwk.e, kty: jwk.kty, n: jwk.n });
-    return crypto.createHash('sha256').update(canonical).digest('base64url');
+    const der = keyObject.export({ type: 'spki', format: 'der' });
+    return der.toString('base64');
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "262",
+        "Minor": "263",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",
@@ -190,7 +190,7 @@
             "label": "Terraform variables (key=value)",
             "required": false,
             "visibleRule": "command = plan || command = apply || command = destroy || command = import || command = refresh",
-            "helpMarkDown": "Define Terraform input variables, one per line, as key=value pairs. Each line is passed as a separate -var flag. Lines starting with # are ignored.<br><br>Example:<br>region=us-east-1<br>environment=prod<br>instance_count=3",
+            "helpMarkDown": "Define Terraform input variables, one per line, as key=value pairs. Each line is passed as a separate -var flag. Lines starting with # are ignored.<br><br>Do not use this for secrets: -var values are passed on the command line and may be visible in process listings and logs. For sensitive values use a secure variables file (Secure variables file input) or TF_VAR_ pipeline secret variables instead.<br><br>Example:<br>region=us-east-1<br>environment=prod<br>instance_count=3",
             "properties": {
                 "rows": "5",
                 "resizable": "true"


### PR DESCRIPTION
## Summary

Fixes the failed **1.1.0** Marketplace publish (the Provider Mirror task shipped with a placeholder GUID that collides with an existing Marketplace task) and addresses the code-review findings.

The `v1.1.0` tag points at the bad-GUID commit and its GitHub Release is stuck in Draft, so this cuts a fresh patch release with a unique task id.

## Changes

- **Provider Mirror unique task id** — replace placeholder `a1b2c3d4-…` GUID with a unique one so `tfx extension publish` validation passes.
- **Argument quoting** — build var-file / target / replace / secure-var-file and import address+id as discrete argv tokens (via `.arg()`), so var-file paths containing spaces (common on Windows agents) and target/replace addresses with quoted index keys are no longer split by `ToolRunner.line()`. New unit test covers the token parsing.
- **OCI WIF token exchange** — send the ephemeral public key (base64 SPKI DER) instead of a SHA-256 thumbprint in the `public_key` field. ⚠️ No integration test exists for this path; verify against a live OCI exchange.
- **Installer** — add `requireChecksum` option for mirror downloads; simplify a redundant boolean.
- **Docs** — note that `terraformVariables` values are visible in process listings and should not be used for secrets.
- **Refactor** — deduplicate AWS/GCP WIF credential setup (temp-file name patterns preserved).
- **Versions** — bump task `Minor` for TerraformTaskV5 (→5.263.0), TerraformInstallerV1 (→1.222.0), TerraformProviderMirrorV1 (→1.2.0).

## Testing

- V5: 160 passing · Installer: 15 passing · Provider Mirror: 12 passing
- eslint clean, version check passes