### PR TITLE
ci: upgrade Node 20 actions to Node 24 versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
 
       - name: Run release-please
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.token.outputs.token }}
           config-file: .release-please-config.json

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create issue on new vulnerabilities
         if: steps.osv.outcome == 'failure'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = `OSV-Scanner: vulnerabilities found — ${new Date().toISOString().slice(0,10)}`;
@@ -109,7 +109,7 @@ jobs:
       issues: write
     steps:
       - name: Create failure issue
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = `Scheduled build failed — ${new Date().toISOString().slice(0,10)}`;


### PR DESCRIPTION
Bumps the two actions still running on the deprecated Node 20 runtime:

- `release-please-action` v4 → **v5.0.0** (Node 24). The only breaking change in v5 is the Node upgrade; `config-file`/`manifest-file`/`token` inputs are unchanged.
- `actions/github-script` v7 → **v9.0.0** in weekly-security.yml, matching the v9 already used in release.yml.

Clears the 'Node.js 20 actions are deprecated' warnings (Node 20 forced off on 2026-06-16).