### PR TITLE
chore: bump TerraformInstallerV1 task version to 1.223.0

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "222",
+        "Minor": "223",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",


### PR DESCRIPTION
## Summary

`Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts` changed since the v1.2.0 release (removal of the dead `case "x32"` arch mapping) without a task version bump — `task.json` was still `1.222.0`, identical to what shipped in v1.2.0.

Azure DevOps caches tasks by `Major.Minor`, so agents holding a cached `1.222.x` would never download the rebuilt task. This bumps Minor to `223`.

The release workflow does not handle this: release-please only updates `azure-devops-extension.json` (per `.release-please-config.json` extra-files), so task versions are manual.

**Merge this before release PR #209** — merging #209 creates the v1.3.0 tag immediately, and the bump must be on main before then.

## Verification

- `node scripts/check-versions.js` passes locally (all six manifests OK, installer now `1.223.0`).