### PR TITLE
ci: consolidate CodeQL scanning into codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,10 @@ name: CodeQL
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1" # Every Monday 08:00 UTC
 
 permissions:
   contents: read

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -12,29 +12,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/unit-test.yml
 
-  # ── CodeQL Analysis ───────────────────────────────────
-  codeql:
-    name: CodeQL Analysis (TypeScript)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          languages: javascript-typescript
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          category: /language:javascript-typescript
-
   # ── OSV Vulnerability Scan ────────────────────────────
   osv-scan:
     name: OSV Vulnerability Scan
@@ -103,7 +80,7 @@ jobs:
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
-    needs: [ci, codeql, osv-scan, stale-dependabot]
+    needs: [ci, osv-scan, stale-dependabot]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

Every PR shows this code scanning warning:

> Code scanning cannot determine the alerts introduced by this pull request, because 1 configuration present on refs/heads/main was not found: Actions workflow (weekly-security.yml) `/language:javascript-typescript`

**Cause**: code scanning identifies configurations by workflow file + category. The `main` baseline was uploaded by `weekly-security.yml` (with an explicit category), while PRs analyze via `codeql.yml` (no category) — two different configurations, so PRs can never match the baseline.

## Changes

- `codeql.yml` now also triggers on `push: main` (fresh baseline on every merge) and the Monday 08:00 UTC schedule (rescans with updated query packs), so a single configuration covers PRs and the baseline.
- Removed the duplicate CodeQL job from `weekly-security.yml`; `notify-on-failure` needs updated.

The stale `weekly-security.yml` configuration on main stops uploading after this merges; once its analyses are deleted (or age out), the PR warning disappears.

## Verification

- `actionlint` passes locally.