### PR TITLE
security: bump undici to ^6.27.0 (patches 4 high/moderate advisories)

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -12,7 +12,7 @@
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
         "openpgp": "^6.0.1",
-        "undici": "^6.21.0"
+        "undici": "^6.27.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -3044,9 +3044,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -20,7 +20,7 @@
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",
     "openpgp": "^6.0.1",
-    "undici": "^6.21.0"
+    "undici": "^6.27.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",


### PR DESCRIPTION
TerraformInstallerV1 depends on `undici` directly (proxy support via `ProxyAgent` in http-client.ts). The installed 6.24.1 is covered by `undici <=6.26.0` advisories — including the **high** GHSA-p88m-4jfj-68fv (Set-Cookie percent-decoding) plus GHSA-vxpw-j846-p89q, GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m — so the `npm audit --omit=dev --audit-level=high` gate in the Installer V1 CI job started failing on every PR.

Fix: bump the range to `^6.27.0` (6.27.0 is the patched 6.x; `ProxyAgent` API unchanged). Stays on the 6.x line — minimal blast radius.

Verified locally: `npm audit --omit=dev --audit-level=high` exits 0, `npm run compile` clean, all 15 Installer V1 tests pass.