### PR TITLE
fix(deps): bump @babel/core and js-yaml, scope dev uuid override

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -31,13 +31,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -56,21 +56,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -104,14 +104,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -132,14 +132,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -179,29 +179,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -241,27 +241,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -271,33 +271,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -305,14 +305,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1638,6 +1638,16 @@
         "semver": "^5.7.2",
         "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
+      }
+    },
+    "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/azure-pipelines-tasks-artifacts-common": {
@@ -3315,16 +3325,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -3471,10 +3471,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5588,13 +5598,17 @@
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -24,7 +24,15 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "@babel/core": "^7.29.7",
+    "js-yaml": "^4.2.0",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.13.1"
+    },
+    "istanbul-lib-processinfo": {
+      "uuid": "^11.1.1"
+    }
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,13 +34,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -49,9 +49,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -59,21 +59,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -100,14 +100,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -117,14 +117,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -161,9 +161,9 @@
             "license": "ISC"
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -171,29 +171,29 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -213,9 +213,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -223,9 +223,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -233,9 +233,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -243,27 +243,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -512,33 +512,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -546,14 +546,14 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -9549,37 +9549,37 @@
     },
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             }
         },
         "@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -9597,26 +9597,26 @@
             }
         },
         "@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -9646,30 +9646,30 @@
             }
         },
         "@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true
         },
         "@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -9679,40 +9679,40 @@
             "dev": true
         },
         "@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true
         },
         "@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             }
         },
         "@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -9869,39 +9869,39 @@
             }
         },
         "@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             }
         },
         "@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             }
         },
         "@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             }
         },
         "@bcoe/v8-coverage": {
@@ -10239,7 +10239,7 @@
             "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.27.4",
+                "@babel/core": "^7.29.7",
                 "@jest/types": "30.3.0",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "babel-plugin-istanbul": "^7.0.1",
@@ -12901,7 +12901,7 @@
             "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.23.9",
+                "@babel/core": "^7.29.7",
                 "@babel/parser": "^7.23.9",
                 "@istanbuljs/schema": "^0.1.3",
                 "istanbul-lib-coverage": "^3.2.0",
@@ -13100,7 +13100,7 @@
             "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.27.4",
+                "@babel/core": "^7.29.7",
                 "@jest/get-type": "30.1.0",
                 "@jest/pattern": "30.0.1",
                 "@jest/test-sequencer": "30.3.0",
@@ -13426,7 +13426,7 @@
             "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.27.4",
+                "@babel/core": "^7.29.7",
                 "@babel/generator": "^7.27.5",
                 "@babel/plugin-syntax-jsx": "^7.27.1",
                 "@babel/plugin-syntax-typescript": "^7.27.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "webpack-cli": "^5.1.0"
     },
     "overrides": {
-        "uuid": "13.0.2"
+        "uuid": "13.0.2",
+        "@babel/core": "^7.29.7"
     }
 }


### PR DESCRIPTION
## Summary

Remediates medium/low Dependabot advisories spread across the root and `TerraformTaskV5` manifests using npm `overrides`. Overrides were added only to the manifests where a vulnerable version actually resolves, then `npm install` was re-run and each lockfile re-verified.

## Packages / CVEs addressed

- **@babel/core** (CVE-2026-49356, fixed >= 7.29.6) — overridden to `^7.29.7` in **root** and **TerraformTaskV5** (was 7.29.0 in both lockfiles).
- **js-yaml** (CVE-2026-53550, fixed >= 4.2.0) — top-level overridden to `^4.2.0` in **TerraformTaskV5** (was 4.1.1, pulled by `@eslint/eslintrc` and `mocha`). The override is **scoped** so `@istanbuljs/load-nyc-config` keeps js-yaml 3.x — nyc/istanbul calls the removed `safeLoad()` API and forcing 4.x there breaks coverage tooling.
- **uuid** (CVE-2026-41907, fixed >= 11.1.1) — scoped a `^11.1.1` override to the dev-only `istanbul-lib-processinfo` (it uses the named `v4` export, which v11 supports), clearing the dev uuid 8.x advisory.

## Intentionally not fixed

- **uuid 3.4.0** under `azure-pipelines-task-lib` (TerraformTaskV5, TerraformInstallerV1, TerraformDriftReportV1). This is a **runtime** pin from the Microsoft task SDK, which uses the removed `uuid/v4` deep import. Forcing v11 throws `ERR_PACKAGE_PATH_NOT_EXPORTED` at runtime (verified), so no safe in-repo override exists. Left in place to avoid shipping a broken ADO task.
- **js-yaml 3.x** under istanbul (root + TerraformTaskV5 coverage path) — preserved deliberately as above.
- **TerraformInstallerV1 / TerraformDriftReportV1** — js-yaml already resolves to 4.2.0; the only remaining alert is the task-lib uuid 3.4.0 pin above, so no manifest change was needed.

## Verification

- Root `npm run test:tab` (jest): 20/20 pass with @babel/core 7.29.7.
- TerraformTaskV5 `npm test` (mocha): 160/160 pass.
- TerraformTaskV5 `npm run test:coverage` (nyc/istanbul): full coverage report generated, no break.
- Re-read both touched lockfiles: top-level js-yaml 4.1.1 and @babel/core 7.29.0 are gone.