### PR TITLE
fix: bump task versions to refresh ADO task cache

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "0",
+        "Minor": "1",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(policyAgent) $(version)",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "0",
+    "Minor": "1",
     "Patch": "0"
   },
   "instanceNameFormat": "Drift report",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "223",
+        "Minor": "224",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "0",
+        "Minor": "1",
         "Patch": "0"
     },
     "instanceNameFormat": "Publish module $(name) to $(registryType)",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "0",
+        "Minor": "1",
         "Patch": "0"
     },
     "instanceNameFormat": "Policy check ($(engine))",

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "263",
+        "Minor": "264",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",


### PR DESCRIPTION
## What

Bump the `Minor` version of every task by one:

| Task | Was | Now |
| --- | --- | --- |
| PipelineTerraformTask (V5) | 5.263.0 | 5.264.0 |
| PipelineTerraformInstaller (V1) | 1.223.0 | 1.224.0 |
| PipelineTerraformModulePublish (V1) | 1.0.0 | 1.1.0 |
| PipelinePolicyAgentInstaller (V1) | 1.0.0 | 1.1.0 |
| PipelineTerraformPolicyCheck (V1) | 1.0.0 | 1.1.0 |
| PipelineTerraformDriftReport (V1) | 1.0.0 | 1.1.0 |

## Why

The `PipelineTerraformDriftReport` task shipped in 1.4.0/1.4.1 does **not**
register in organizations that already had the extension installed — the new
task never appears in the org task catalog (a drift dispatch fails with
"task not found"). Azure DevOps caches tasks by `Major.Minor` and will not
re-scan an extension's task manifest until a task version changes. Bumping
every task forces a full re-register on the next republish.

Release-please will cut **1.4.2** from this `fix:` commit; the tag-triggered
release republishes to the Marketplace, which clears the cache and registers
the drift report task.

No code changes — version metadata only. `check-versions.js` passes.