### PR TITLE
fix: track ProviderMirror in version check and bump it

### DIFF
--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "2",
+        "Minor": "3",
         "Patch": "0"
     },
     "instanceNameFormat": "Configure provider mirror: $(mirrorUrl)",

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -8,6 +8,7 @@ const files = [
     { path: 'azure-devops-extension.json', type: 'extension' },
     { path: 'Tasks/TerraformTask/TerraformTaskV5/task.json', type: 'task' },
     { path: 'Tasks/TerraformInstaller/TerraformInstallerV1/task.json', type: 'task' },
+    { path: 'Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json', type: 'task' },
     { path: 'Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json', type: 'task' },
     { path: 'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json', type: 'task' },
     { path: 'Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json', type: 'task' },


### PR DESCRIPTION
## What
- Bump `TerraformProviderMirrorV1` `Minor` (`1.2.0 → 1.3.0`).
- Add `TerraformProviderMirror/TerraformProviderMirrorV1/task.json` to `scripts/check-versions.js`.

## Why
The 1.4.2 cache-bust (#221) bumped every task **listed in `check-versions.js`** — but `TerraformProviderMirrorV1` was **never in that list**, so it was silently skipped. Version Lab / health pipelines (and the drift templates) use `PipelineTerraformProviderMirror@1`, so it should re-cache on the agents alongside the others.

This bumps its version so a **1.4.3** republish refreshes its ADO agent cache, and adds it to the checker so the task can't be omitted from future version sweeps. Release-please will cut **1.4.3** from this `fix:` commit.

Metadata only; `check-versions.js` passes locally.