### PR TITLE
feat: require Node 24 agent runtime, bump deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
           name: sbom-and-signatures
       - name: Create draft GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: |
             *.vsix

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24",
     "@types/uuid": "^9.0.8",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "1",
+        "Minor": "2",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(policyAgent) $(version)",
@@ -98,9 +98,6 @@
         }
     ],
     "execution": {
-        "Node20_1": {
-            "target": "src/index.js"
-        },
         "Node24": {
             "target": "src/index.js"
         }

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",
     "ts-node": "^10.9.1",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "1",
+    "Minor": "2",
     "Patch": "0"
   },
   "instanceNameFormat": "Drift report",
@@ -85,9 +85,6 @@
     { "name": "summaryFilePath", "description": "Path to the JSON report written to the agent temp directory (the exact callback body)." }
   ],
   "execution": {
-    "Node20_1": {
-      "target": "src/index.js"
-    },
     "Node24": {
       "target": "src/index.js"
     }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.11.0",
+        "@types/node": "^24",
         "@types/uuid": "^9.0.8",
         "eslint": "^9.0.0",
         "mocha": "^11.2.0",
@@ -379,13 +379,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/semver": {
@@ -3063,9 +3063,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24",
     "@types/uuid": "^9.0.8",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "224",
+        "Minor": "225",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",
@@ -108,9 +108,6 @@
         }
     ],
     "execution": {
-        "Node20_1": {
-            "target": "src/index.js"
-        },
         "Node24": {
             "target": "src/index.js"
         }

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",
     "ts-node": "^10.9.1",

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "1",
+        "Minor": "2",
         "Patch": "0"
     },
     "instanceNameFormat": "Publish module $(name) to $(registryType)",
@@ -182,9 +182,6 @@
         }
     ],
     "execution": {
-        "Node20_1": {
-            "target": "src/index.js"
-        },
         "Node24": {
             "target": "src/index.js"
         }

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",
     "ts-node": "^10.9.1",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "1",
+        "Minor": "2",
         "Patch": "0"
     },
     "instanceNameFormat": "Policy check ($(engine))",
@@ -216,9 +216,6 @@
         }
     ],
     "execution": {
-        "Node20_1": {
-            "target": "src/index.js"
-        },
         "Node24": {
             "target": "src/index.js"
         }

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",
     "ts-node": "^10.9.1",

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "4",
         "Patch": "0"
     },
     "instanceNameFormat": "Configure provider mirror: $(mirrorUrl)",
@@ -62,9 +62,6 @@
         }
     ],
     "execution": {
-        "Node20_1": {
-            "target": "src/index.js"
-        },
         "Node24": {
             "target": "src/index.js"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.11.0",
+        "@types/node": "^24",
         "@types/uuid": "^9.0.8",
         "eslint": "^9.0.0",
         "mocha": "^11.2.0",
@@ -897,12 +897,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/q": {
@@ -5536,9 +5536,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24",
     "@types/uuid": "^9.0.8",
     "eslint": "^9.0.0",
     "mocha": "^11.2.0",

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,14 +14,11 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "264",
+        "Minor": "265",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",
     "execution": {
-        "Node20_1": {
-            "target": "src/index.js"
-        },
         "Node24": {
             "target": "src/index.js"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "react-dom": "^18.3.1",
                 "rimraf": "^5.0.0",
                 "style-loader": "^3.3.2",
-                "tfx-cli": "0.23.1",
+                "tfx-cli": "0.23.3",
                 "ts-jest": "^29.4.9",
                 "ts-loader": "^9.5.0",
                 "tslib": "^2.6.0",
@@ -8318,9 +8318,9 @@
             }
         },
         "node_modules/tfx-cli": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.23.1.tgz",
-            "integrity": "sha512-TNOY4D0ntRER09nf5egmZQWXdCpPyGgaou3BZjwH909B2O52W9x2AVFNuvyEDOIbVCq1qlW1hPpGi0x02l/jxQ==",
+            "version": "0.23.3",
+            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.23.3.tgz",
+            "integrity": "sha512-4M+2vbMqho3uZIZA4qM1DU6wIIcRRhNbhSfAg9P9C13EUN4YH8R3x8Lkmg6cpSuutEALSTojFAVCW01W4BuOww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8333,7 +8333,7 @@
                 "jju": "^1.4.0",
                 "json-in-place": "^1.0.1",
                 "jszip": "^3.10.1",
-                "lodash": "^4.17.21",
+                "lodash": "~4.17.23",
                 "minimist": "^1.2.6",
                 "mkdirp": "^1.0.4",
                 "onecolor": "^2.5.0",
@@ -8341,7 +8341,7 @@
                 "prompt": "^1.3.0",
                 "read": "^1.0.6",
                 "shelljs": "^0.10.0",
-                "tmp": "^0.2.4",
+                "tmp": "^0.2.6",
                 "tracer": "0.7.4",
                 "util.promisify": "^1.0.0",
                 "uuid": "^13.0.0",
@@ -8443,6 +8443,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/tfx-cli/node_modules/lodash": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tfx-cli/node_modules/lru-cache": {
             "version": "11.3.1",
@@ -15219,9 +15226,9 @@
             }
         },
         "tfx-cli": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.23.1.tgz",
-            "integrity": "sha512-TNOY4D0ntRER09nf5egmZQWXdCpPyGgaou3BZjwH909B2O52W9x2AVFNuvyEDOIbVCq1qlW1hPpGi0x02l/jxQ==",
+            "version": "0.23.3",
+            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.23.3.tgz",
+            "integrity": "sha512-4M+2vbMqho3uZIZA4qM1DU6wIIcRRhNbhSfAg9P9C13EUN4YH8R3x8Lkmg6cpSuutEALSTojFAVCW01W4BuOww==",
             "dev": true,
             "requires": {
                 "app-root-path": "1.0.0",
@@ -15233,7 +15240,7 @@
                 "jju": "^1.4.0",
                 "json-in-place": "^1.0.1",
                 "jszip": "^3.10.1",
-                "lodash": "^4.17.21",
+                "lodash": "~4.17.23",
                 "minimist": "^1.2.6",
                 "mkdirp": "^1.0.4",
                 "onecolor": "^2.5.0",
@@ -15241,7 +15248,7 @@
                 "prompt": "^1.3.0",
                 "read": "^1.0.6",
                 "shelljs": "^0.10.0",
-                "tmp": "^0.2.4",
+                "tmp": "^0.2.6",
                 "tracer": "0.7.4",
                 "util.promisify": "^1.0.0",
                 "uuid": "13.0.2",
@@ -15303,6 +15310,12 @@
                     "requires": {
                         "@isaacs/cliui": "^9.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.23",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+                    "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+                    "dev": true
                 },
                 "lru-cache": {
                     "version": "11.3.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "react-dom": "^18.3.1",
         "rimraf": "^5.0.0",
         "style-loader": "^3.3.2",
-        "tfx-cli": "0.23.1",
+        "tfx-cli": "0.23.3",
         "ts-jest": "^29.4.9",
         "ts-loader": "^9.5.0",
         "tslib": "^2.6.0",


### PR DESCRIPTION
Drops the Node20_1 execution handler from all seven tasks, leaving Node24 as the sole runtime (ADO end-of-support for Node20_1 is April 2026). Each task's version.Minor is bumped so agents pick up the new task.json (tasks are cached by Major.Minor).

Also:
- @types/node ^20.11 -> ^24 in all seven task packages (match the runtime)
- tfx-cli 0.23.1 -> 0.23.3 (build tooling)
- action-gh-release v3.0.0 -> v3.0.1 in release.yml

Agents that only support Node20_1 (older self-hosted / legacy OS) will no longer run these tasks.