### PR TITLE
security: add task.json restrictions to all tasks

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -97,6 +97,17 @@
             "helpMarkDown": "When enabled, fail if a SHA256 checksum is not available for the requested version/platform."
         }
     ],
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": [
+                "policyAgentLocation",
+                "policyAgentDownloadedFrom"
+            ]
+        }
+    },
     "execution": {
         "Node24": {
             "target": "src/index.js"

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -84,6 +84,21 @@
     { "name": "destroyedCount", "description": "Count of resources whose plan contains a delete." },
     { "name": "summaryFilePath", "description": "Path to the JSON report written to the agent temp directory (the exact callback body)." }
   ],
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": [
+        "driftDetected",
+        "addedCount",
+        "changedCount",
+        "destroyedCount",
+        "summaryFilePath",
+        "sarifFilePath"
+      ]
+    }
+  },
   "execution": {
     "Node24": {
       "target": "src/index.js"

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -107,6 +107,17 @@
             "helpMarkDown": "When enabled, fail if the mirror does not serve a SHA256SUMS file for the requested version. When disabled (default), checksum verification is attempted but skipped if the mirror does not publish a SHA256SUMS file."
         }
     ],
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": [
+                "terraformLocation",
+                "terraformDownloadedFrom"
+            ]
+        }
+    },
     "execution": {
         "Node24": {
             "target": "src/index.js"

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
@@ -181,6 +181,14 @@
             "helpMarkDown": "Maximum time to wait for the version to become available."
         }
     ],
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": []
+        }
+    },
     "execution": {
         "Node24": {
             "target": "src/index.js"

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -215,6 +215,16 @@
             "helpMarkDown": "Publish a JUnit report so policy outcomes appear in the pipeline Tests tab."
         }
     ],
+    "restrictions": {
+        "settableVariables": {
+            "allowed": [
+                "policyResult",
+                "violationCount",
+                "resultsFilePath",
+                "sarifFilePath"
+            ]
+        }
+    },
     "execution": {
         "Node24": {
             "target": "src/index.js"

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
@@ -61,6 +61,17 @@
             }
         }
     ],
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": [
+                "TF_CLI_CONFIG_FILE",
+                "configFilePath"
+            ]
+        }
+    },
     "execution": {
         "Node24": {
             "target": "src/index.js"

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -18,6 +18,19 @@
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",
+    "restrictions": {
+        "settableVariables": {
+            "allowed": [
+                "TF_OUT_*",
+                "jsonPlanFilePath",
+                "jsonOutputVariablesPath",
+                "changesPresent",
+                "destroyChangesPresent",
+                "showFilePath",
+                "customFilePath"
+            ]
+        }
+    },
     "execution": {
         "Node24": {
             "target": "src/index.js"


### PR DESCRIPTION
## Summary
Adds a `restrictions` block to all 7 task.json files to blunt log-command injection from captured external-tool stdout (`##vso[...]` smuggling). Requires ADO agent 2.182.1+.

| Task | `commands.mode` | `settableVariables.allowed` |
|---|---|---|
| TerraformTaskV5 | — (uses `addAttachment`) | `TF_OUT_*`, plan/output/show/custom paths, change flags |
| TerraformInstallerV1 | `restricted` | `terraformLocation`, `terraformDownloadedFrom` |
| TerraformProviderMirrorV1 | `restricted` | `TF_CLI_CONFIG_FILE`, `configFilePath` |
| TerraformModulePublishV1 | `restricted` | `[]` (sets none) |
| PolicyAgentInstallerV1 | `restricted` | `policyAgentLocation`, `policyAgentDownloadedFrom` |
| TerraformPolicyCheckV1 | — (uses `results.publish`) | `policyResult`, `violationCount`, `resultsFilePath`, `sarifFilePath` |
| TerraformDriftReportV1 | `restricted` | drift counts, `summaryFilePath`, `sarifFilePath` |

V5 and PolicyCheck deliberately omit `commands.mode: restricted` — they emit `addAttachment` / `results.publish`, which restricted mode would block. Every allow-list was built from a source-truth `setVariable` audit.

## Verification
- All 7 task.json parse; `node scripts/check-versions.js` passes.
- No version bumps (release-time `Minor` bump per CONTRIBUTING).

Closes #235