### PR TITLE
security: validate OCI WIF identity domain URL before token exchange

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
@@ -14,8 +14,7 @@
         "src/index.js",
         "src/parent-handler.js",
         "src/id-token-generator.js",
-        "src/secure-file-loader.js",
-        "src/oci-token-exchange.js"
+        "src/secure-file-loader.js"
     ],
     "check-coverage": true,
     "lines": 75,

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2,6 +2,9 @@ import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
 
+// Direct unit tests for OCI WIF token-exchange URL validation & transport.
+import './OciTokenExchangeL0';
+
 describe('Terraform Test Suite', function () {
 
     before(() => {
@@ -1622,6 +1625,19 @@ describe('Terraform Test Suite', function () {
             assert(tr.invokedToolCount === 2, 'tool should have been invoked two times. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.stdOutContained('OCIPlanWIFSuccessL0 should have succeeded.'), 'Should have printed: OCIPlanWIFSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('oci plan should fail with an invalid WIF identity domain url', async () => {
+        let tp = path.join(__dirname, './PlanTests/OCI/OCIPlanWIFFailInvalidDomainUrl.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have errors');
+            assert(tr.stdOutContained('OCIPlanWIFFailInvalidDomainUrlL0 should have failed.'), 'Should have printed: OCIPlanWIFFailInvalidDomainUrlL0 should have failed.');
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciTokenExchangeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciTokenExchangeL0.ts
@@ -1,0 +1,128 @@
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+import { exchangeOidcForUpst, validateIdentityDomainUrl } from '../src/oci-token-exchange';
+
+/**
+ * Direct unit tests for the OCI WIF token-exchange transport hardening.
+ * The federated OIDC bearer JWT is POSTed to an operator-supplied identity
+ * domain URL, so the destination is validated and redirects are refused
+ * before the token leaves the agent. fetch is stubbed so no network is hit.
+ */
+describe('OCI token exchange — URL validation & transport', function () {
+    // A real RSA public key so publicKeyToBase64Der succeeds on the happy path.
+    const { publicKey } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const VALID_DOMAIN = 'https://idcs-abc123.identity.oraclecloud.com';
+
+    let originalFetch: typeof globalThis.fetch;
+    beforeEach(() => { originalFetch = globalThis.fetch; });
+    afterEach(() => { globalThis.fetch = originalFetch; });
+
+    /* validateIdentityDomainUrl (pure) */
+
+    it('accepts a genuine OCI Identity Domains HTTPS URL', () => {
+        const u = validateIdentityDomainUrl(VALID_DOMAIN);
+        assert.strictEqual(u.hostname, 'idcs-abc123.identity.oraclecloud.com');
+    });
+
+    it('accepts OCI government-realm identity hosts', () => {
+        assert.doesNotThrow(() => validateIdentityDomainUrl('https://idcs-x.identity.oraclegovcloud.com'));
+    });
+
+    it('rejects a non-HTTPS scheme', () => {
+        assert.throws(() => validateIdentityDomainUrl('http://idcs-x.identity.oraclecloud.com'), /HTTPS/);
+    });
+
+    it('rejects a host outside the OCI Identity Domains realms', () => {
+        assert.throws(() => validateIdentityDomainUrl('https://evil.example.com'), /not an OCI Identity Domains endpoint/);
+    });
+
+    it('rejects a look-alike suffix host', () => {
+        assert.throws(
+            () => validateIdentityDomainUrl('https://identity.oraclecloud.com.evil.example'),
+            /not an OCI Identity Domains endpoint/
+        );
+    });
+
+    it('rejects a malformed URL', () => {
+        assert.throws(() => validateIdentityDomainUrl('not a url'), /not a valid URL/);
+    });
+
+    /* exchangeOidcForUpst (fetch stubbed) */
+
+    it('rejects before any network call when the domain is invalid', async () => {
+        let called = false;
+        globalThis.fetch = (async () => { called = true; return new Response('{}'); }) as typeof globalThis.fetch;
+        await assert.rejects(
+            exchangeOidcForUpst('jwt', 'http://evil.example.com', 'client', publicKey),
+            /HTTPS/
+        );
+        assert.strictEqual(called, false, 'fetch must not be called for an invalid domain');
+    });
+
+    it('posts to the identity domain token endpoint with manual redirect and returns the UPST', async () => {
+        let seenUrl = '';
+        let seenRedirect: RequestRedirect | undefined;
+        globalThis.fetch = (async (url: string, init: RequestInit) => {
+            seenUrl = url;
+            seenRedirect = init.redirect;
+            return new Response(JSON.stringify({ access_token: 'the-upst' }), { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        const upst = await exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey);
+        assert.strictEqual(upst, 'the-upst');
+        assert.strictEqual(seenUrl, `${VALID_DOMAIN}/oauth2/v1/token`);
+        assert.strictEqual(seenRedirect, 'manual');
+    });
+
+    it('falls back to the token field when access_token is absent', async () => {
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ token: 'alt-upst' }), { status: 200 })) as unknown as typeof globalThis.fetch;
+        const upst = await exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey);
+        assert.strictEqual(upst, 'alt-upst');
+    });
+
+    it('throws when the response omits a token', async () => {
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ nope: true }), { status: 200 })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey), /missing access_token/);
+    });
+
+    it('throws on a non-OK response', async () => {
+        globalThis.fetch = (async () =>
+            new Response('bad request', { status: 400, statusText: 'Bad Request' })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey), /HTTP 400/);
+    });
+
+    it('refuses an opaque redirect from the token endpoint', async () => {
+        globalThis.fetch = (async () => {
+            const r = new Response(null, { status: 200 });
+            Object.defineProperty(r, 'type', { value: 'opaqueredirect' });
+            return r;
+        }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey), /redirect/);
+    });
+
+    it('refuses a raw 3xx redirect from the token endpoint', async () => {
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302 })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey), /redirect/);
+    });
+
+    it('maps an abort/timeout to a clear error', async () => {
+        globalThis.fetch = (async () => {
+            const e = new Error('aborted');
+            e.name = 'AbortError';
+            throw e;
+        }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey), /Timed out/);
+    });
+
+    it('wraps a generic network error', async () => {
+        globalThis.fetch = (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey), /Failed to exchange/);
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFFailInvalidDomainUrl.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFFailInvalidDomainUrl.ts
@@ -1,0 +1,47 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './OCIPlanWIFFailInvalidDomainUrlL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'oci');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameOCI', 'OCI');
+tr.setInput('environmentAuthSchemeOCI', 'WorkloadIdentityFederation');
+tr.setInput('ociWifTenancyOcid', 'ocid1.tenancy.oc1..dummy');
+tr.setInput('ociWifRegion', 'us-ashburn-1');
+// Non-HTTPS, non-OCI host: the real token exchange must reject this before
+// the federated OIDC JWT is sent anywhere.
+tr.setInput('ociWifIdentityDomainUrl', 'http://insecure-url.example.com');
+tr.setInput('ociWifClientId', 'dummy-client-id');
+tr.setInput('commandOptions', '');
+
+// Mock only the OIDC token source so the flow reaches the REAL token exchange,
+// where the identity-domain URL validation lives.
+tr.registerMock('./id-token-generator', {
+    generateIdToken: function (_serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
+});
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider oci"
+        },
+        "terraform plan -detailed-exitcode": {
+            "code": 0,
+            "stdout": "Executed successfully"
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFFailInvalidDomainUrlL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanWIFFailInvalidDomainUrlL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerOCI } from './../../../src/oci-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerOCI(), 'plan', 'OCIPlanWIFFailInvalidDomainUrlL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
@@ -2,6 +2,48 @@ import tasks = require('azure-pipelines-task-lib/task');
 import crypto = require('crypto');
 
 /**
+ * Hostname suffixes that identify a genuine OCI Identity Domains endpoint.
+ * The federated OIDC bearer JWT is POSTed to this host, so it is constrained
+ * to Oracle-owned realms to prevent the token from being exfiltrated to an
+ * operator-supplied or mistyped third-party origin.
+ */
+const OCI_IDENTITY_DOMAIN_SUFFIXES = [
+    '.identity.oraclecloud.com',   // OC1 commercial
+    '.identity.oraclegovcloud.com', // OC2/OC3 US government
+    '.identity.oraclegovcloud.uk',  // OC4 UK government
+    '.identity.oraclecloud.eu',     // OC5/EU sovereign
+];
+
+/**
+ * Validate an operator-supplied OCI Identity Domains base URL before any token
+ * is sent to it. Rejects non-HTTPS schemes and hosts outside the OCI Identity
+ * Domains realms. Returns the parsed URL so the caller can build the endpoint
+ * from a value that has actually been verified.
+ */
+export function validateIdentityDomainUrl(identityDomainUrl: string): URL {
+    let parsed: URL;
+    try {
+        parsed = new URL(identityDomainUrl);
+    } catch {
+        throw new Error(`OCI identity domain URL is not a valid URL: ${identityDomainUrl}`);
+    }
+    if (parsed.protocol !== 'https:') {
+        throw new Error('OCI identity domain URL must use HTTPS scheme.');
+    }
+    const host = parsed.hostname.toLowerCase();
+    const allowed = OCI_IDENTITY_DOMAIN_SUFFIXES.some(
+        (suffix) => host.endsWith(suffix) && host.length > suffix.length
+    );
+    if (!allowed) {
+        throw new Error(
+            `OCI identity domain URL host '${parsed.hostname}' is not an OCI Identity Domains endpoint ` +
+            `(expected a host under ${OCI_IDENTITY_DOMAIN_SUFFIXES.join(', ')}).`
+        );
+    }
+    return parsed;
+}
+
+/**
  * Exchange an OIDC JWT for an OCI User Principal Session Token (UPST)
  * using the OCI Identity Domains token exchange endpoint (RFC 8693).
  *
@@ -20,7 +62,10 @@ export async function exchangeOidcForUpst(
     clientId: string,
     publicKeyPem: string
 ): Promise<string> {
-    const tokenEndpoint = `${identityDomainUrl.replace(/\/+$/, '')}/oauth2/v1/token`;
+    // Validate the destination BEFORE the federated JWT is sent anywhere.
+    const validated = validateIdentityDomainUrl(identityDomainUrl);
+    const base = `${validated.origin}${validated.pathname.replace(/\/+$/, '')}`;
+    const tokenEndpoint = `${base}/oauth2/v1/token`;
 
     // The ephemeral public key is sent so OCI can bind the issued UPST to it; the
     // caller signs subsequent API requests with the matching private key. OCI
@@ -50,6 +95,9 @@ export async function exchangeOidcForUpst(
             },
             body: body.toString(),
             signal: controller.signal,
+            // Never follow a redirect: a 3xx could forward the OIDC bearer JWT
+            // (preserved with the POST body) to a different, unvalidated origin.
+            redirect: 'manual',
         });
         clearTimeout(timeoutId);
     } catch (error) {
@@ -57,6 +105,16 @@ export async function exchangeOidcForUpst(
             throw new Error(`Timed out exchanging OIDC token for OCI UPST (30s timeout).`);
         }
         throw new Error(`Failed to exchange OIDC token for OCI UPST: ${error instanceof Error ? error.message : error}`);
+    }
+
+    // With redirect:'manual', fetch surfaces a redirect as an opaque response
+    // (type 'opaqueredirect', status 0) or, on some runtimes, the raw 3xx.
+    // Treat either as a refusal — do not chase it with the token in hand.
+    if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+        throw new Error(
+            `OCI token exchange endpoint returned a redirect (status ${response.status}); ` +
+            `refusing to forward the OIDC token to another origin.`
+        );
     }
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
Closes the one HIGH finding from the workflow review: `exchangeOidcForUpst()` built the OCI token-exchange endpoint directly from the operator-supplied `ociWifIdentityDomainUrl` and POSTed the **federated OIDC bearer JWT** to it with no validation — a concrete **SSRF + token-exfiltration** primitive. Node `fetch` also follows 3xx redirects by default (preserving method + body), so a redirect could forward the token to a different origin. The sibling PAR backend URL in the same task was already fully validated, so this was an omission rather than a design choice.

## Changes
- **`validateIdentityDomainUrl()`** — parse with `new URL()`, reject non-`https:`, constrain the host to the OCI Identity Domains realms (`*.identity.oraclecloud.com` + gov/EU realms).
- Build the token endpoint from the **validated** URL (origin + normalized path), not the raw string.
- `redirect: 'manual'` on the fetch, and refuse an opaque-redirect or raw 3xx response before trusting the body.
- Remove `src/oci-token-exchange.js` from the nyc exclude list — it shipped unverified and excluded from coverage.

## Tests
- New direct unit tests (`Tests/OciTokenExchangeL0.ts`): validation accept/reject cases + transport paths (success, token fallback, missing token, non-OK, opaque redirect, raw 3xx, timeout, generic error) with `fetch` stubbed.
- New integration negative test (`OCIPlanWIFFailInvalidDomainUrl`) mirroring `OCIInitFailInvalidParUrl` — proves validation fires through the full task flow.

## Verification
- eslint clean; **177 passing** (was 161).
- `oci-token-exchange.js` now **100% line / 94% branch** covered; overall branch coverage rises 72.14% → 74.28% (all thresholds 75/75/70 cleared).

Closes #231