### PR TITLE
security: restore secret masking + transport discipline in ModulePublish and DriftReport

### DIFF
--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -1,6 +1,25 @@
 import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
+import { postJson, truncateBody } from '../src/callback';
+
+describe('TerraformDriftReport callback transport', function () {
+    it('refuses to POST the callback token over a non-HTTPS URL', async () => {
+        await assert.rejects(
+            postJson('http://insecure.example.com/drift', { 'X-TSM-Callback-Token': 't' }, '{}'),
+            /non-HTTPS/,
+        );
+    });
+
+    it('truncates a long response body and passes a short one through', () => {
+        assert.strictEqual(truncateBody(''), '');
+        assert.strictEqual(truncateBody('short body'), 'short body');
+        const long = 'x'.repeat(600);
+        const out = truncateBody(long);
+        assert.ok(out.length < long.length, 'long body should be truncated');
+        assert.ok(out.endsWith('… (truncated)'), 'should mark truncation');
+    });
+});
 
 describe('TerraformDriftReport Test Suite', function () {
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
@@ -19,6 +19,13 @@ export function postJson(
 ): Promise<HttpResponse> {
     return new Promise<HttpResponse>((resolve, reject) => {
         const parsed = new URL(url);
+        // Never send the callback token over a non-HTTPS connection.
+        if (parsed.protocol !== 'https:') {
+            reject(new Error(
+                `Refusing to send the callback token over a non-HTTPS URL (scheme '${parsed.protocol}//' on host '${parsed.host}'). Use an https:// callback URL.`,
+            ));
+            return;
+        }
         const options: https.RequestOptions = {
             method: 'POST',
             hostname: parsed.hostname,
@@ -41,4 +48,17 @@ export function postJson(
         req.write(body);
         req.end();
     });
+}
+
+/**
+ * Bounds a remote response body before it is interpolated into a thrown error
+ * or log line, so a large — or token-reflecting — body cannot be dumped
+ * wholesale. The token is also registered with setSecret() for masking; this is
+ * defense-in-depth against verbose error bodies.
+ */
+export function truncateBody(body: string, max = 500): string {
+    if (!body) {
+        return '';
+    }
+    return body.length > max ? `${body.slice(0, max)}… (truncated)` : body;
 }

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -3,7 +3,7 @@ import path = require('path');
 import fs = require('fs');
 import os = require('os');
 import { summarize, moduleCallsPlan, Plan } from 'terraform-drift-contract';
-import { postJson } from './callback';
+import { postJson, truncateBody } from './callback';
 
 // Reads `.terraform/modules/modules.json` verbatim for the callback's
 // module_locks field; null when absent/unreadable (the backend then records
@@ -67,8 +67,20 @@ async function run(): Promise<void> {
 
         const callbackUrl = tasks.getInput('callbackUrl', false);
         const callbackToken = tasks.getInput('callbackToken', false);
+        // Mask the one-shot callback token as soon as it is read, regardless of
+        // whether the callback ends up being made.
+        if (callbackToken) {
+            tasks.setSecret(callbackToken);
+        }
         if (callbackUrl && callbackToken) {
             const rejectUnauthorized = tasks.getBoolInput('rejectUnauthorized', false);
+            if (!rejectUnauthorized) {
+                tasks.warning(
+                    'rejectUnauthorized is disabled: TLS certificate validation is OFF for the drift callback, ' +
+                    'so the callback token is sent over an unverified TLS channel. Use only for an internal TSM ' +
+                    'endpoint fronted by a private CA the agent does not trust.',
+                );
+            }
             const resp = await postJson(
                 callbackUrl,
                 { 'X-TSM-Callback-Token': callbackToken },
@@ -76,7 +88,7 @@ async function run(): Promise<void> {
                 rejectUnauthorized,
             );
             if (resp.status < 200 || resp.status >= 300) {
-                throw new Error(`Drift callback failed (HTTP ${resp.status}): ${resp.body}`);
+                throw new Error(`Drift callback failed (HTTP ${resp.status}): ${truncateBody(resp.body)}`);
             }
             console.log(`Drift result posted to TSM (HTTP ${resp.status}).`);
         } else if (callbackUrl || callbackToken) {

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
-import { HttpClient, HttpResponse } from '../src/http';
+import { HttpClient, HttpResponse, createHttpsClient, truncateBody } from '../src/http';
 import * as priv from '../src/private-publisher';
 import * as hcp from '../src/hcp-publisher';
 
@@ -26,6 +26,25 @@ function fakeClient(responses: HttpResponse[]): { client: HttpClient; calls: Cal
     };
     return { client, calls };
 }
+
+describe('http client transport', () => {
+    it('refuses to send credentials over a non-HTTPS URL', async () => {
+        const client = createHttpsClient(true);
+        await assert.rejects(
+            client('GET', 'http://insecure.example.com/api', { Authorization: 'Bearer k' }),
+            /non-HTTPS/,
+        );
+    });
+
+    it('truncates a long response body and passes a short one through', () => {
+        assert.strictEqual(truncateBody(''), '');
+        assert.strictEqual(truncateBody('short body'), 'short body');
+        const long = 'x'.repeat(600);
+        const out = truncateBody(long);
+        assert.ok(out.length < long.length, 'long body should be truncated');
+        assert.ok(out.endsWith('… (truncated)'), 'should mark truncation');
+    });
+});
 
 describe('private-publisher', () => {
     describe('url builders', () => {

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/hcp-publisher.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/hcp-publisher.ts
@@ -1,4 +1,4 @@
-import { HttpClient, parseJson, delay } from './http';
+import { HttpClient, parseJson, delay, truncateBody } from './http';
 import { ModuleCoordinates, PublishResult, RegistryPublisher } from './types';
 
 /** Inputs for publishing to HCP Terraform / Terraform Enterprise. */
@@ -108,7 +108,7 @@ export class HcpPublisher implements RegistryPublisher {
             this.log(`Module not found; creating VCS-connected module ${o.namespace}/${o.name}/${o.provider}.`);
             const created = await this.http('POST', vcsUrl(o.address, o.namespace), headers, vcsModuleBody(o));
             if (created.status < 200 || created.status >= 300) {
-                throw new Error(`Failed to create HCP module (HTTP ${created.status}): ${created.body}`);
+                throw new Error(`Failed to create HCP module (HTTP ${created.status}): ${truncateBody(created.body)}`);
             }
         } else {
             this.log(`Could not check existing module (HTTP ${check.status}); attempting to publish version.`);
@@ -118,7 +118,7 @@ export class HcpPublisher implements RegistryPublisher {
         if (versionResp.status === 422) {
             this.log(`Version ${o.version} already exists.`);
         } else if (versionResp.status < 200 || versionResp.status >= 300) {
-            throw new Error(`Failed to create version (HTTP ${versionResp.status}): ${versionResp.body}`);
+            throw new Error(`Failed to create version (HTTP ${versionResp.status}): ${truncateBody(versionResp.body)}`);
         } else {
             this.log(`Version ${o.version} created.`);
         }

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/http.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/http.ts
@@ -22,6 +22,13 @@ export function createHttpsClient(rejectUnauthorized = true): HttpClient {
     return (method, url, headers, body) =>
         new Promise<HttpResponse>((resolve, reject) => {
             const parsed = new URL(url);
+            // Never send the registry credential over a non-HTTPS connection.
+            if (parsed.protocol !== 'https:') {
+                reject(new Error(
+                    `Refusing to send credentials over a non-HTTPS URL (scheme '${parsed.protocol}//' on host '${parsed.host}'). Use an https:// registry URL.`,
+                ));
+                return;
+            }
             const payload = body ?? '';
             const options: https.RequestOptions = {
                 method,
@@ -52,6 +59,19 @@ export function createHttpsClient(rejectUnauthorized = true): HttpClient {
 /** Parses a JSON response body into the requested shape. */
 export function parseJson<T>(body: string): T {
     return JSON.parse(body) as T;
+}
+
+/**
+ * Bounds a remote response body before it is interpolated into a thrown error
+ * or log line, so a large — or credential-reflecting — body cannot be dumped
+ * wholesale. The credential itself is also registered with setSecret(), so the
+ * agent masks it; this is defense-in-depth against verbose error bodies.
+ */
+export function truncateBody(body: string, max = 500): string {
+    if (!body) {
+        return '';
+    }
+    return body.length > max ? `${body.slice(0, max)}… (truncated)` : body;
 }
 
 /** Resolves after the given number of milliseconds. */

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
@@ -30,20 +30,31 @@ function buildPublisher(): RegistryPublisher {
 
     if (registryType === 'private') {
         const skipTlsVerify = tasks.getBoolInput('skipTlsVerify', false);
+        if (skipTlsVerify) {
+            tasks.warning(
+                'skipTlsVerify is enabled: TLS certificate validation is DISABLED for the private registry connection, ' +
+                'so the API key is sent over an unverified TLS channel. Use only for an internal registry fronted by a ' +
+                'private CA the agent does not trust.',
+            );
+        }
+        const apiKey = requireInput('apiKey');
+        tasks.setSecret(apiKey);
         return new PrivateRegistryPublisher(createHttpsClient(!skipTlsVerify), {
             ...coordinates,
             registryUrl: requireInput('registryUrl'),
-            apiKey: requireInput('apiKey'),
+            apiKey,
             waitForPublish,
             timeoutSeconds,
         });
     }
 
     if (registryType === 'hcp') {
+        const token = requireInput('hcpToken');
+        tasks.setSecret(token);
         return new HcpPublisher(createHttpsClient(true), {
             ...coordinates,
             address: tasks.getInput('hcpAddress', false) || 'https://app.terraform.io',
-            token: requireInput('hcpToken'),
+            token,
             vcsRepoIdentifier: tasks.getInput('vcsRepoIdentifier', false) || '',
             vcsBranch: tasks.getInput('vcsBranch', false) || 'main',
             vcsOauthTokenId: tasks.getInput('vcsOauthTokenId', false) || '',

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/private-publisher.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/private-publisher.ts
@@ -1,4 +1,4 @@
-import { HttpClient, parseJson, delay } from './http';
+import { HttpClient, parseJson, delay, truncateBody } from './http';
 import { ModuleCoordinates, PublishResult, RegistryPublisher } from './types';
 
 /** Inputs for publishing to a private registry (terraform-registry-backend). */
@@ -62,7 +62,7 @@ export class PrivateRegistryPublisher implements RegistryPublisher {
             );
         }
         if (moduleResp.status < 200 || moduleResp.status >= 300) {
-            throw new Error(`Failed to resolve module (HTTP ${moduleResp.status}): ${moduleResp.body}`);
+            throw new Error(`Failed to resolve module (HTTP ${moduleResp.status}): ${truncateBody(moduleResp.body)}`);
         }
         const moduleId = parseJson<ModuleResponse>(moduleResp.body).id;
         if (!moduleId) {
@@ -71,7 +71,7 @@ export class PrivateRegistryPublisher implements RegistryPublisher {
 
         const syncResp = await this.http('POST', syncUrl(registryUrl, moduleId), authHeader);
         if (syncResp.status !== 202) {
-            throw new Error(`Failed to trigger sync (HTTP ${syncResp.status}): ${syncResp.body}`);
+            throw new Error(`Failed to trigger sync (HTTP ${syncResp.status}): ${truncateBody(syncResp.body)}`);
         }
         this.log(`Sync triggered for ${namespace}/${name}/${provider}.`);
 


### PR DESCRIPTION
## Summary
The two newest network-calling tasks did not inherit the masking/transport discipline used elsewhere in the codebase. This is one consistency pass closing the surviving medium cluster from the workflow review.

## Changes
**Secret masking** — `setSecret()` immediately after reading:
- `apiKey` and `hcpToken` (ModulePublish `index.ts`)
- `callbackToken` (DriftReport `index.ts`), masked as soon as it is read regardless of whether the callback runs.

**Transport** — refuse to send a credential over plaintext:
- `createHttpsClient` (ModulePublish) and `postJson` (DriftReport) now reject any non-`https:` URL before constructing the request.

**Loud TLS-off warning** — never silently pair TLS-off with a credential:
- `tasks.warning()` when `skipTlsVerify` (ModulePublish) or `rejectUnauthorized=false` (DriftReport) is set.

**Error-body hygiene** — `truncateBody()` bounds remote `resp.body` interpolated into thrown errors (token-reflection-into-logs path) in `hcp-publisher.ts`, `private-publisher.ts`, and DriftReport `index.ts`.

## Tests
- ModulePublish: new `http client transport` block — non-HTTPS refusal + body truncation. **19 passing.**
- DriftReport: new `callback transport` block — non-HTTPS refusal + body truncation. **6 passing.**
- eslint clean in both tasks.

## Note
The earlier-rated claim that DriftReport's `rejectUnauthorized` "fails open by default" was **refuted** during review verification — the ADO agent materializes `defaultValue:"true"`, so TLS verification is on by default. This PR implements only the surviving `setSecret` + transport + error-body items.

Closes #232