### PR TITLE
security: anchor OpenTofu cosign certificate identity and fail closed

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
@@ -1,0 +1,138 @@
+import { describe, it, afterEach } from 'mocha';
+import assert = require('assert');
+import tasks = require('azure-pipelines-task-lib/task');
+import { OPENTOFU_CERT_IDENTITY_REGEXP, verifyCosignSignature } from '../src/cosign-verifier';
+import * as httpClient from '../src/http-client';
+
+// Direct (non-MockTestRunner) unit tests for the cosign verifier. These run in
+// the mocha parent process and stub the shared task-lib / http-client singletons
+// in place; the MockTestRunner integration tests in L0.ts run in child processes
+// and are unaffected. afterEach restores every stub.
+
+const identityRe = new RegExp(OPENTOFU_CERT_IDENTITY_REGEXP);
+
+describe('cosign-verifier: OpenTofu certificate identity regexp', () => {
+    // The canonical SAN OpenTofu's keyless release signing produces.
+    const accepted = [
+        'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.11.6',
+        'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.6.0',
+        'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.7.0-alpha1',
+    ];
+
+    // Each of these satisfied the previous unanchored `https://github.com/opentofu/opentofu`
+    // pattern (or could, via substring / dot-wildcard) but is a different identity.
+    const rejected = [
+        'https://github.com/opentofu/opentofu',
+        'https://github.com/opentofu/opentofu-malicious/.github/workflows/release.yml@refs/tags/v1.0.0',
+        'https://github.com/evil/opentofu/.github/workflows/release.yml@refs/tags/v1.0.0',
+        'https://evil.com/?u=https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.0.0',
+        'xhttps://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.0.0',
+        'http://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.0.0',
+        'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/main',
+        'https://githubXcom/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.0.0',
+    ];
+
+    accepted.forEach((id) => {
+        it(`accepts the canonical identity ${id}`, () => {
+            assert.ok(identityRe.test(id), `expected the regexp to accept ${id}`);
+        });
+    });
+
+    rejected.forEach((id) => {
+        it(`rejects the look-alike identity ${id}`, () => {
+            assert.ok(!identityRe.test(id), `expected the regexp to reject ${id}`);
+        });
+    });
+});
+
+describe('cosign-verifier: verifyCosignSignature behavior', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const t = tasks as any;
+    const hc = httpClient as any;
+    const original = {
+        which: t.which, warning: t.warning, debug: t.debug, tool: t.tool,
+        fetchBuffer: hc.fetchBuffer,
+    };
+    let warnings: string[] = [];
+
+    afterEach(() => {
+        t.which = original.which;
+        t.warning = original.warning;
+        t.debug = original.debug;
+        t.tool = original.tool;
+        hc.fetchBuffer = original.fetchBuffer;
+        warnings = [];
+    });
+
+    function stubLogging(): void {
+        t.warning = (m: string) => { warnings.push(m); };
+        t.debug = (_m: string) => { /* silence */ };
+    }
+
+    it('throws when cosign is missing and verification is required', async () => {
+        stubLogging();
+        t.which = () => { throw new Error('cosign not found'); };
+        await assert.rejects(
+            verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', true),
+            /cosign is required/,
+        );
+    });
+
+    it('warns and returns when cosign is missing and verification is not required', async () => {
+        stubLogging();
+        t.which = () => { throw new Error('cosign not found'); };
+        await verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', false);
+        assert.ok(
+            warnings.some((w) => /without signature verification/.test(w)),
+            'expected a downgrade warning',
+        );
+    });
+
+    it('throws when signature/certificate are unavailable and verification is required', async () => {
+        stubLogging();
+        t.which = () => '/usr/bin/cosign';
+        hc.fetchBuffer = async () => { throw new Error('404'); };
+        await assert.rejects(
+            verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', true),
+            /unavailable and verification is required/,
+        );
+    });
+
+    it('passes the anchored identity regexp and pinned OIDC issuer to cosign', async () => {
+        stubLogging();
+        t.which = () => '/usr/bin/cosign';
+        hc.fetchBuffer = async () => new Uint8Array([1, 2, 3]);
+        const args: string[] = [];
+        t.tool = (_path: string) => ({
+            arg(a: string | string[]) {
+                if (Array.isArray(a)) { args.push(...a); } else { args.push(a); }
+                return this;
+            },
+            exec: async () => 0,
+        });
+
+        await verifyCosignSignature('sums-content', 'https://x.example/sig', 'https://x.example/pem', true);
+
+        const idIdx = args.indexOf('--certificate-identity-regexp');
+        assert.ok(idIdx >= 0, 'the --certificate-identity-regexp flag should be passed');
+        assert.strictEqual(args[idIdx + 1], OPENTOFU_CERT_IDENTITY_REGEXP);
+        const issIdx = args.indexOf('--certificate-oidc-issuer');
+        assert.ok(issIdx >= 0, 'the --certificate-oidc-issuer flag should be passed');
+        assert.strictEqual(args[issIdx + 1], 'https://token.actions.githubusercontent.com');
+    });
+
+    it('throws when cosign exits non-zero', async () => {
+        stubLogging();
+        t.which = () => '/usr/bin/cosign';
+        hc.fetchBuffer = async () => new Uint8Array([1]);
+        t.tool = (_path: string) => ({
+            arg() { return this; },
+            exec: async () => 1,
+        });
+        await assert.rejects(
+            verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', true),
+            /verification failed/i,
+        );
+    });
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+});

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -2,6 +2,10 @@ import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
 
+// Direct unit tests for the cosign verifier (certificate-identity anchoring +
+// fail-closed behavior). Registered alongside the integration suite below.
+import './CosignVerifierL0';
+
 describe('TerraformInstaller Test Suite', function () {
 
     before(() => {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
@@ -7,10 +7,25 @@ import { randomUUID as uuidV4 } from 'crypto';
 import { fetchBuffer } from './http-client';
 
 /**
+ * Anchored, escaped regular expression for the Fulcio certificate identity (SAN)
+ * that OpenTofu's keyless release signing produces. OpenTofu signs each release's
+ * SHA256SUMS from its `release.yml` workflow on a tag ref, yielding a SAN of the
+ * form `https://github.com/opentofu/opentofu/.github/workflows/<wf>@refs/tags/v<n>`.
+ *
+ * cosign matches `--certificate-identity-regexp` unanchored (Go `regexp.MatchString`),
+ * so the pattern is anchored with `^`/`$` and its dots are escaped. This prevents a
+ * look-alike certificate whose SAN merely *contains* the OpenTofu identity (or sits
+ * on a different host/org/repo, a branch ref, or http) from satisfying the match.
+ */
+export const OPENTOFU_CERT_IDENTITY_REGEXP =
+    '^https://github\\.com/opentofu/opentofu/\\.github/workflows/.+@refs/tags/v[0-9].*$';
+
+/**
  * Verifies the cosign signature of a SHA256SUMS file against OpenTofu's Sigstore identity.
  *
  * - Downloads the `.sig` (signature) and `.pem` (certificate) files.
- * - Shells out to the `cosign` binary to run `verify-blob`.
+ * - Shells out to the `cosign` binary to run `verify-blob`, pinning both the OIDC
+ *   issuer (exact) and the certificate identity (anchored regexp, see above).
  * - If cosign is not installed and `required` is false, warns and returns (unverified).
  * - If cosign is not installed and `required` is true, throws (hard fail).
  * - If signature verification fails, throws (hard fail).
@@ -60,7 +75,7 @@ export async function verifyCosignSignature(
         toolRunner.arg('verify-blob');
         toolRunner.arg(['--certificate', certificatePath]);
         toolRunner.arg(['--signature', signaturePath]);
-        toolRunner.arg(['--certificate-identity-regexp', 'https://github.com/opentofu/opentofu']);
+        toolRunner.arg(['--certificate-identity-regexp', OPENTOFU_CERT_IDENTITY_REGEXP]);
         toolRunner.arg(['--certificate-oidc-issuer', 'https://token.actions.githubusercontent.com']);
         toolRunner.arg(sha256SumsPath);
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -362,8 +362,14 @@ async function downloadZipFromOpenTofu(version: string): Promise<string> {
     const sha256SumsUrl = `https://github.com/opentofu/opentofu/releases/download/v${version}/tofu_${version}_SHA256SUMS`;
     const sha256SumsContent = await fetchText(sha256SumsUrl);
 
-    // Cosign verification of SHA256SUMS
-    const requireCosign = tasks.getBoolInput("requireCosignVerification", false) === true;
+    // Cosign verification of SHA256SUMS. Fail closed: require a verified signature
+    // unless the operator has explicitly opted out (requireCosignVerification=false).
+    // The task.json default is "true"; reading the raw input keeps the default fail-
+    // closed even on an agent that does not materialize task input defaults.
+    const requireCosignInput = tasks.getInput("requireCosignVerification", false);
+    const requireCosign = requireCosignInput === undefined || requireCosignInput.trim() === ''
+        ? true
+        : requireCosignInput.trim().toLowerCase() !== 'false';
     const signatureUrl = `${sha256SumsUrl}.sig`;
     const certificateUrl = `${sha256SumsUrl}.pem`;
     await verifyCosignSignature(sha256SumsContent, signatureUrl, certificateUrl, requireCosign);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -92,10 +92,10 @@
             "name": "requireCosignVerification",
             "type": "boolean",
             "label": "Require cosign signature verification",
-            "defaultValue": "false",
+            "defaultValue": "true",
             "required": false,
             "visibleRule": "binary = tofu",
-            "helpMarkDown": "When enabled, fail if cosign is not available on the agent or the signature cannot be verified. When disabled (default), cosign verification is attempted but skipped if cosign is not installed."
+            "helpMarkDown": "When enabled (default), fail the install if cosign is not available on the agent or the OpenTofu SHA256SUMS signature cannot be verified against OpenTofu's pinned Sigstore identity. Install cosign on the agent (e.g. sigstore/cosign-installer) to satisfy this. Set to false only to fall back to checksum-only verification on agents without cosign."
         },
         {
             "name": "requireChecksum",


### PR DESCRIPTION
## Summary

Tightens OpenTofu release-signature verification in **TerraformInstallerV1** (`cosign-verifier.ts`).

`cosign verify-blob` matches `--certificate-identity-regexp` **unanchored** (Go `regexp.MatchString`). The previous value `https://github.com/opentofu/opentofu` was unanchored and treated `.` as a wildcard, so a look-alike Fulcio certificate SAN that merely *contained* that substring — a different host/org/repo, a branch ref, or `http` — could satisfy the match. The OIDC issuer was already pinned exactly.

## Changes

- **Anchor + escape the identity regexp** into an exported constant `OPENTOFU_CERT_IDENTITY_REGEXP`:

  ```
  ^https://github\.com/opentofu/opentofu/\.github/workflows/.+@refs/tags/v[0-9].*$
  ```

  This pins OpenTofu's keyless release identity (the `release.yml` workflow on a version tag) and rejects substring/prefix injection, look-alike orgs/repos, branch refs, and `http`.
- **Fail closed:** `requireCosignVerification` now defaults to **true** (`task.json` default + a raw-input read in `terraform-installer.ts` that defaults true even on agents that don't materialize input defaults), so the warn-and-continue downgrade branch is never silently hit on the OpenTofu path. Operators can still set it to `false` to fall back to checksum-only on agents without cosign; the help text documents installing cosign (e.g. `sigstore/cosign-installer`).

## Verification

OpenTofu signing mechanism re-verified online: keyless cosign (Fulcio cert identity `https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/<tag>`, issuer `https://token.actions.githubusercontent.com`), plus a published GPG key — so the cosign approach is valid; only the identity match needed tightening.

## Tests

New `Tests/CosignVerifierL0.ts` (16 cases, wired into `L0.ts`):
- Identity regexp **accepts** canonical OpenTofu SANs (multiple tags incl. a prerelease) and **rejects** look-alikes: bare substring, `opentofu/opentofu-malicious`, `evil/opentofu`, prefix injection, leading-char, `http`, `@refs/heads/main`, dot-as-wildcard `githubXcom`.
- `verifyCosignSignature` fail-closed/transport paths: throws when cosign missing + required; warns+returns when missing + not required; throws when sig/cert unavailable + required; **passes the anchored regexp and pinned issuer to cosign**; throws on non-zero exit.

Full installer suite: **31 passing** (16 new + 15 existing). `npm run compile:all` clean; `eslint src/` clean.

Closes #233