### PR TITLE
security: harden registry download path

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -53,8 +53,21 @@ describe('PolicyAgentInstaller Test Suite', function () {
     expectSuccess('OpaLatestSuccess');
     expectSuccess('OpaRegistrySuccess');
 
+    it('OpaRegistryEmptySha256Warns', async () => {
+        const tp = path.join(__dirname, 'OpaRegistryEmptySha256Warns.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+            assert(tr.stdout.includes('skipping local verification'), 'should warn that local verification was skipped');
+        }, tr);
+    });
+
     // --- Failure cases ---
     expectFailure('InsecureUrlReject');
     expectFailure('Sha256Fail');
     expectFailure('InvalidVersionFail');
+    expectFailure('OpaRegistryInsecureUrl');
+    expectFailure('OpaRegistryEmptySha256RequireChecksum');
 });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256RequireChecksum.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256RequireChecksum.ts
@@ -1,0 +1,58 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Registry returns an empty sha256 and requireChecksum=true. With no local
+// integrity check possible, the task must fail closed instead of trusting the
+// binary on the registry's server-side verification.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'opa');
+tr.setInput('requireChecksum', 'true');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/opa/versions/1.17.1/linux/amd64')) {
+            return { download_url: 'https://storage.example.com/signed/opa?sig=abc', sha256: '' };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('fs', {
+    chmodSync: () => { },
+    readFileSync: () => Buffer.from('fake-binary'),
+    mkdirSync: () => undefined,
+    copyFileSync: () => { }
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid',
+    createHash: () => ({ update: () => ({ digest: () => 'unused' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: () => null,
+    downloadTool: async () => '/tmp/opa-download',
+    extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
+    cacheDir: async () => '/tmp/opa-cached',
+    cleanVersion: (v: string) => v,
+    prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256Warns.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256Warns.ts
@@ -1,0 +1,56 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Registry returns an empty sha256 and requireChecksum is not set (default false).
+// The install proceeds but must emit a warning that local verification was skipped.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'opa');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/opa/versions/1.17.1/linux/amd64')) {
+            return { download_url: 'https://storage.example.com/signed/opa?sig=abc', sha256: '' };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('fs', {
+    chmodSync: () => { },
+    readFileSync: () => Buffer.from('fake-binary'),
+    mkdirSync: () => undefined,
+    copyFileSync: () => { }
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid',
+    createHash: () => ({ update: () => ({ digest: () => 'unused-no-local-verification' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: () => null,
+    downloadTool: async () => '/tmp/opa-download',
+    extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
+    cacheDir: async () => '/tmp/opa-cached',
+    cleanVersion: (v: string) => v,
+    prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryInsecureUrl.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryInsecureUrl.ts
@@ -1,0 +1,59 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Registry returns a non-HTTPS pre-signed download_url. The download succeeds in
+// the mock, so without the HTTPS guard the task would install the binary and
+// succeed — the guard must reject the URL first and fail the task.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'opa');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/opa/versions/1.17.1/linux/amd64')) {
+            return { download_url: 'http://storage.example.com/signed/opa?sig=abc', sha256: EXPECTED_SHA256 };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('fs', {
+    chmodSync: () => { },
+    readFileSync: () => Buffer.from('fake-binary'),
+    mkdirSync: () => undefined,
+    copyFileSync: () => { }
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid',
+    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: () => null,
+    downloadTool: async () => '/tmp/opa-download',
+    extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
+    cacheDir: async () => '/tmp/opa-cached',
+    cleanVersion: (v: string) => v,
+    prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -202,14 +202,23 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
     if (!data.download_url) {
         throw new Error(`Registry API returned invalid response: missing download_url from ${infoUrl}`);
     }
+    // The download URL is registry-controlled and fetched outside fetchJson's HTTPS
+    // guard, so pin it to HTTPS before downloading — as the mirror path already does.
+    if (!data.download_url.startsWith('https://')) {
+        throw new Error(tasks.loc("InsecureUrlRejected", data.download_url));
+    }
 
     const ext = agent === "sentinel" ? ".zip" : (isWindows ? ".exe" : "");
     const filePath = await downloadTo(data.download_url, `${agent}-${version}-${uuidV4()}${ext}`);
 
     if (data.sha256) {
         await verifySha256(filePath, data.sha256);
+    } else if (tasks.getBoolInput("requireChecksum", false)) {
+        // Empty sha256 means no local integrity check is possible. Fail closed when
+        // the operator requires checksum verification rather than trusting the binary.
+        throw new Error(`Checksum verification is required but the registry did not provide a sha256 for ${infoUrl}.`);
     } else {
-        tasks.debug(`SHA256 not provided by registry for ${infoUrl}; skipping local verification (registry performed server-side verification)`);
+        tasks.warning(`SHA256 not provided by registry for ${infoUrl}; skipping local verification (trusting the registry's server-side verification only). Set requireChecksum to enforce a local check.`);
     }
     return filePath;
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -92,6 +92,40 @@ describe('TerraformInstaller Test Suite', function () {
         }, tr);
     });
 
+    it('registry insecure download_url: should reject a non-https pre-signed URL', async () => {
+        const tp = path.join(__dirname, 'RegistryInsecureUrlReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have an error issue');
+        }, tr);
+    });
+
+    it('registry empty sha256 + requireChecksum: should fail closed', async () => {
+        const tp = path.join(__dirname, 'RegistryEmptySha256RequireChecksum.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have an error issue');
+        }, tr);
+    });
+
+    it('registry empty sha256 (not required): should succeed with a skip warning', async () => {
+        const tp = path.join(__dirname, 'RegistryEmptySha256Warns.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+            assert(tr.stdout.includes('skipping local verification'), 'should warn that local verification was skipped');
+        }, tr);
+    });
+
     // --- Failure cases ---
 
     it('insecure URL: should reject http:// mirror URL', async () => {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksum.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksum.ts
@@ -1,0 +1,79 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Registry returns an empty sha256 and the operator set requireChecksum=true.
+// With no local integrity check possible, the task must fail closed.
+const tp = path.join(__dirname, 'RegistryEmptySha256RequireChecksumL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform');
+tr.setInput('requireChecksum', 'true');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/terraform/versions/1.9.8/windows/amd64')) {
+            return {
+                os: 'windows',
+                arch: 'amd64',
+                version: '1.9.8',
+                sha256: '',
+                download_url: 'https://storage.example.com/signed/terraform_1.9.8_windows_amd64.zip'
+            };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => {
+        throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async () => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+    chmodSync: (_path: string, _mode: string) => { },
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => 'should-not-be-reached'
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksumL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksumL0.ts
@@ -1,0 +1,18 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('1.9.8');
+        // Reaching here means an empty sha256 was accepted despite requireChecksum —
+        // surface as success so the integration test's `tr.failed` assertion catches it.
+        tl.setResult(tl.TaskResult.Succeeded, 'RegistryEmptySha256RequireChecksumL0 should have failed closed.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256Warns.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256Warns.ts
@@ -1,0 +1,78 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Registry returns an empty sha256 and requireChecksum is not set (default false).
+// The install proceeds but must emit a warning that local verification was skipped.
+const tp = path.join(__dirname, 'RegistryEmptySha256WarnsL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/terraform/versions/1.9.8/windows/amd64')) {
+            return {
+                os: 'windows',
+                arch: 'amd64',
+                version: '1.9.8',
+                sha256: '',
+                download_url: 'https://storage.example.com/signed/terraform_1.9.8_windows_amd64.zip'
+            };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => {
+        throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async () => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+    chmodSync: (_path: string, _mode: string) => { },
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => 'unused-no-local-verification'
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256WarnsL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256WarnsL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('1.9.8');
+        tl.setResult(tl.TaskResult.Succeeded, 'RegistryEmptySha256WarnsL0 succeeded with a skipped-verification warning.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'RegistryEmptySha256WarnsL0 should have succeeded: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryInsecureUrlReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryInsecureUrlReject.ts
@@ -1,0 +1,81 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Registry returns a non-HTTPS pre-signed download_url. The task must reject it
+// before downloading (the URL is registry-controlled and bypasses fetchJson's
+// HTTPS guard).
+const tp = path.join(__dirname, 'RegistryInsecureUrlRejectL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/terraform/versions/1.9.8/windows/amd64')) {
+            return {
+                os: 'windows',
+                arch: 'amd64',
+                version: '1.9.8',
+                sha256: 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+                download_url: 'http://storage.example.com/signed/terraform_1.9.8_windows_amd64.zip'
+            };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => {
+        throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async () => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+    chmodSync: (_path: string, _mode: string) => { },
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => 'should-not-be-reached'
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => {
+        throw new Error('downloadTool should not be reached for an insecure download_url');
+    },
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryInsecureUrlRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryInsecureUrlRejectL0.ts
@@ -1,0 +1,18 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('1.9.8');
+        // Reaching here means the insecure URL was not rejected — surface as success
+        // so the integration test's `tr.failed` assertion catches the regression.
+        tl.setResult(tl.TaskResult.Succeeded, 'RegistryInsecureUrlRejectL0 should have rejected the http download_url.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -164,6 +164,11 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     }
     // data.download_url = pre-signed storage URL (15-minute TTL)
     // data.sha256       = hex SHA256 of the zip (may be empty if registry verified server-side)
+    // The download URL is registry-controlled and fetched outside fetchJson's HTTPS
+    // guard, so pin it to HTTPS before downloading — as the mirror path already does.
+    if (!data.download_url.startsWith('https://')) {
+        throw new Error(tasks.loc("InsecureUrlRejected", data.download_url));
+    }
 
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
     let zipPath: string;
@@ -175,8 +180,12 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
 
     if (data.sha256) {
         await verifySha256(zipPath, data.sha256);
+    } else if (tasks.getBoolInput("requireChecksum", false)) {
+        // Empty sha256 means no local integrity check is possible. Fail closed when
+        // the operator requires checksum verification rather than trusting the binary.
+        throw new Error(`Checksum verification is required but the registry did not provide a sha256 for ${infoUrl}.`);
     } else {
-        tasks.debug(`SHA256 not provided by registry for ${infoUrl}; skipping local verification (registry performed server-side verification)`);
+        tasks.warning(`SHA256 not provided by registry for ${infoUrl}; skipping local verification (trusting the registry's server-side verification only). Set requireChecksum to enforce a local check.`);
     }
     return zipPath;
 }


### PR DESCRIPTION
## Summary

Hardens the private-registry download path in both **TerraformInstaller** and **PolicyAgentInstaller**, closing the gap where the registry-provided `download_url` is fetched via `tools.downloadTool` — which bypasses the `http-client` HTTPS guard that protects metadata URLs.

## Changes

- **Enforce HTTPS** on `download_url` before fetching, in `downloadZipFromRegistry` (Terraform) and `downloadFromRegistry` (PolicyAgent). A non-`https://` URL is rejected via the existing `InsecureUrlRejected` loc string.
- **Fail closed on a missing/empty `sha256`:** when `requireChecksum` is enabled, error instead of trusting the registry's server-side verification only; otherwise emit a warning rather than silently skipping local verification.

## Notes

- The baseline hardening (HTTPS enforcement + the skip-warning) is **unconditional**. `requireChecksum` only escalates the empty-`sha256` case to a hard failure.
- `requireChecksum` is settable from YAML for the registry source regardless of its classic-editor `visibleRule`, which stays mirror-scoped (UX-only; not a functional gap for YAML pipelines).

## Tests

- TerraformInstaller (18 passing): registry insecure `download_url` rejected; empty `sha256` + `requireChecksum` fails closed; empty `sha256` without `requireChecksum` succeeds with a skip warning.
- PolicyAgentInstaller (10 passing): same three registry cases for the OPA registry path.
- `eslint src/` clean for both tasks.

Closes #234