### PR TITLE
docs: fix documentation drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,14 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 
 **Required secrets/variables:**
 
-| Name                       | Type     | Purpose                                               |
-| -------------------------- | -------- | ----------------------------------------------------- |
-| `TFX_PAT`                  | Secret   | VS Marketplace PAT with `Marketplace (publish)` scope |
-| `RELEASE_DISPATCH_APP_ID`  | Variable | GitHub App client ID for release-please               |
-| `RELEASE_DISPATCH_APP_KEY` | Secret   | GitHub App private key for release-please             |
+| Name                       | Type     | Purpose                                                                            |
+| -------------------------- | -------- | --------------------------------------------------------------------------------- |
+| `AZDO_PUBLISH_CLIENT_ID`   | Variable | Client ID of the Entra app federated to GitHub for the Marketplace publish login  |
+| `AZDO_PUBLISH_TENANT_ID`   | Variable | Entra tenant ID for the publish login                                             |
+| `RELEASE_DISPATCH_APP_ID`  | Variable | GitHub App client ID for release-please                                           |
+| `RELEASE_DISPATCH_APP_KEY` | Secret   | GitHub App private key for release-please                                          |
+
+As of PR #218, `release.yml` publishes via **GitHub OIDC federated to Microsoft Entra** — there is no stored `TFX_PAT`. The publish job (under the `marketplace` environment, `id-token: write`) signs in with `azure/login` using the two `AZDO_PUBLISH_*` variables, exchanges the OIDC token for a short-lived Entra access token, and passes it to `tfx extension publish`. The Entra app needs a federated credential with subject `repo:sethbacon/azure-pipelines-terraform:environment:marketplace`.
 
 The `marketplace` environment (Settings → Environments) must have at least one required reviewer so every VS Marketplace publish gets human approval.
 
@@ -101,7 +104,7 @@ To publish to the VS Marketplace:
 2. Sign in with a Microsoft account
 3. Publisher ID: `sethbacon`
 4. Accept the Marketplace Publisher Agreement
-5. The `TFX_PAT` secret must have `Marketplace (publish)` scope to enable automated publishing
+5. Automated publishing uses the GitHub OIDC → Entra federated credential (no PAT). A Marketplace PAT is only needed for manual CLI publishing of private dev builds (see `docs/setup/private-testing.md`).
 
 ## Extension Naming — HashiCorp Trademark
 
@@ -115,11 +118,19 @@ HashiCorp's trademark policy prohibits using "Terraform" as a standalone product
 azure-pipelines-terraform/
 ├── Tasks/
 │   ├── TerraformInstaller/
-│   │   └── TerraformInstallerV1/      # Current installer task
+│   │   └── TerraformInstallerV1/        # Terraform / OpenTofu installer
 │   ├── TerraformProviderMirror/
-│   │   └── TerraformProviderMirrorV1/ # Provider mirror configuration task
-│   └── TerraformTask/
-│       └── TerraformTaskV5/           # Current development target
+│   │   └── TerraformProviderMirrorV1/   # Provider mirror configuration task
+│   ├── TerraformTask/
+│   │   └── TerraformTaskV5/             # Current development target
+│   ├── PolicyAgentInstaller/
+│   │   └── PolicyAgentInstallerV1/      # OPA / Sentinel installer
+│   ├── TerraformPolicyCheck/
+│   │   └── TerraformPolicyCheckV1/      # OPA / Sentinel policy evaluation
+│   ├── TerraformDriftReport/
+│   │   └── TerraformDriftReportV1/      # Plan-JSON drift summary + TSM callback
+│   └── TerraformModulePublish/
+│       └── TerraformModulePublishV1/    # Module publish to HCP / private registry
 ├── src/
 │   └── tab/                           # Terraform Plan tab UI (React + ADO Extension SDK)
 │       ├── tabContent.tsx             # Tab component with ANSI rendering

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,10 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
    - `Tasks/TerraformTask/TerraformTaskV5/task.json` — if TerraformTaskV5 changed
    - `Tasks/TerraformInstaller/TerraformInstallerV1/task.json` — if TerraformInstallerV1 changed
    - `Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json` — if TerraformProviderMirrorV1 changed
+   - `Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json` — if PolicyAgentInstallerV1 changed
+   - `Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json` — if TerraformPolicyCheckV1 changed
+   - `Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json` — if TerraformDriftReportV1 changed
+   - `Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json` — if TerraformModulePublishV1 changed
 
    Increment `Minor` by 1, leave `Patch` at 0.
 
@@ -219,11 +223,14 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 
 **Required secrets/variables:**
 
-| Name                       | Type     | Purpose                                               |
-| -------------------------- | -------- | ----------------------------------------------------- |
-| `TFX_PAT`                  | Secret   | VS Marketplace PAT with `Marketplace (publish)` scope |
-| `RELEASE_DISPATCH_APP_ID`  | Variable | GitHub App client ID for release-please               |
-| `RELEASE_DISPATCH_APP_KEY` | Secret   | GitHub App private key for release-please             |
+| Name                       | Type     | Purpose                                                                         |
+| -------------------------- | -------- | ------------------------------------------------------------------------------- |
+| `AZDO_PUBLISH_CLIENT_ID`   | Variable | Client ID of the Entra app whose federated credential publishes to the Marketplace |
+| `AZDO_PUBLISH_TENANT_ID`   | Variable | Entra tenant ID for the publish login                                           |
+| `RELEASE_DISPATCH_APP_ID`  | Variable | GitHub App client ID for release-please                                         |
+| `RELEASE_DISPATCH_APP_KEY` | Secret   | GitHub App private key for release-please                                        |
+
+The Marketplace publish uses **GitHub OIDC federated to Microsoft Entra** — there is no stored Marketplace PAT. The `release.yml` publish job runs under the `marketplace` environment with `id-token: write`, signs in via `azure/login` using `AZDO_PUBLISH_CLIENT_ID`/`AZDO_PUBLISH_TENANT_ID`, exchanges the OIDC token for a short-lived Entra access token, and passes it to `tfx extension publish`. The Entra app must have a federated credential whose subject is `repo:sethbacon/azure-pipelines-terraform:environment:marketplace`.
 
 The `marketplace` environment (Settings → Environments) must have at least one required reviewer so every VS Marketplace publish gets human approval.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,80 @@ Runs Terraform commands. Supports 16 commands:
 
 ---
 
+### `PipelineTerraformModulePublish@1` — Module Publisher
+
+Publishes a module version to HCP Terraform / Terraform Enterprise or a private Terraform registry (`terraform-registry-backend`) from a release pipeline.
+
+| Input              | Default                  | Description                                                                                  |
+| ------------------ | ------------------------ | -------------------------------------------------------------------------------------------- |
+| `registryType`     | `private`                | `private` (terraform-registry-backend) or `hcp` (HCP Terraform / TFE).                       |
+| `namespace`        | —                        | Module namespace.                                                                            |
+| `name`             | —                        | Module name.                                                                                 |
+| `provider`         | —                        | Provider / target system the module is for.                                                  |
+| `version`          | —                        | Semantic version to publish.                                                                 |
+| `registryUrl`      | —                        | Base HTTPS URL of the private registry. Required when `registryType=private`.                |
+| `apiKey`           | —                        | Private-registry API key. Treat as a secret variable.                                        |
+| `hcpAddress`       | `https://app.terraform.io` | HCP Terraform / TFE address. Used when `registryType=hcp`.                                  |
+| `hcpToken`         | —                        | HCP API token. Treat as a secret variable. Used when `registryType=hcp`.                      |
+| `waitForPublish`   | `true`                   | Poll until the version is available before completing.                                        |
+| `timeoutSeconds`   | `180`                    | Wall-clock bound for `waitForPublish`.                                                        |
+
+HCP VCS-backed publishing also accepts `vcsRepoIdentifier`, `vcsBranch`, `vcsOauthTokenId`, and `commitSha`.
+
+---
+
+### `PipelinePolicyAgentInstaller@1` — Policy Agent Installer
+
+Installs a policy engine — **OPA** (sha256-verified binary from the `open-policy-agent/opa` GitHub releases) or **Sentinel** (GPG-signed zip from `releases.hashicorp.com`) — and prepends it to the `PATH`.
+
+| Input                 | Default    | Description                                                                                      |
+| --------------------- | ---------- | ------------------------------------------------------------------------------------------------ |
+| `policyAgent`         | `opa`      | `opa` or `sentinel`.                                                                              |
+| `version`             | `latest`   | Version to install. `latest` resolves via the GitHub releases (OPA) or checkpoint (Sentinel) API. |
+| `downloadSource`      | `official` | `official`, `registry` (terraform-registry-backend), or `mirror` (custom HTTPS mirror).          |
+| `requireGpgSignature` | `true`     | Fail if a Sentinel GPG signature is unavailable.                                                  |
+| `requireChecksum`     | `true`     | Fail if a SHA256 checksum is unavailable.                                                         |
+
+**Output variables:** `policyAgentLocation`, `policyAgentDownloadedFrom`. OPA ships `amd64`/`arm64` only.
+
+---
+
+### `PipelineTerraformPolicyCheck@1` — Policy Check
+
+Evaluates **OPA** or **Sentinel** policies against Terraform plan JSON (`terraform show -json` output) and gates the pipeline on the result.
+
+| Input                     | Default          | Description                                                                                   |
+| ------------------------- | ---------------- | --------------------------------------------------------------------------------------------- |
+| `engine`                  | `opa`            | `opa` or `sentinel`.                                                                           |
+| `inputFile`               | —                | Path to the plan JSON to evaluate.                                                             |
+| `policySource`            | `path`           | `path` (local directory) or `git` (HTTPS shallow clone / ref checkout).                        |
+| `policyPath`              | —                | Policy directory when `policySource=path`.                                                     |
+| `policyRepoUrl`           | —                | Policy repo URL when `policySource=git`. Pairs with `policyRepoRef`/`policyRepoSubdir`/`policyRepoToken`. |
+| `decisionPath`            | `terraform/deny` | OPA decision path to query.                                                                    |
+| `failMode`                | `nonEmpty`       | OPA gate: fail when the decision is `nonEmpty` or `defined`.                                    |
+| `defaultEnforcementLevel` | `soft-mandatory` | Sentinel enforcement level (`advisory`/`soft-mandatory`/`hard-mandatory`).                     |
+| `publishTestResults`      | `true`           | Publish a JUnit results file to the pipeline **Tests** tab.                                     |
+
+**Output variables:** `policyResult`, `violationCount`, `resultsFilePath`.
+
+---
+
+### `PipelineTerraformDriftReport@1` — Drift Report
+
+Parses a Terraform/OpenTofu plan JSON into drift counts plus a changed-resource summary, and optionally POSTs the summary to a [Terraform State Manager](https://github.com/sethbacon/terraform-state-manager) (TSM) drift callback.
+
+| Input                | Default                              | Description                                                                  |
+| -------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| `planJsonFile`       | —                                    | Path to the plan JSON to analyse.                                            |
+| `includeModuleProvenance` | `true`                          | Include module source provenance from the module manifest.                  |
+| `moduleManifest`     | `.terraform/modules/modules.json`    | Module manifest path used for provenance.                                    |
+| `failOnDrift`        | `false`                              | Fail the task when drift is detected.                                        |
+| `callbackUrl`        | —                                    | TSM drift-callback URL. Must be HTTPS.                                       |
+| `callbackToken`      | —                                    | TSM callback bearer token. Treat as a secret variable.                       |
+| `rejectUnauthorized` | `true`                               | Verify the callback endpoint's TLS certificate (leave enabled in production). |
+
+---
+
 ## Providers
 
 | Provider | `provider` value | Service Connection Type                                      | Auth Methods                                      |
@@ -264,6 +338,12 @@ See [docs/troubleshooting.md](docs/troubleshooting.md) for solutions to common i
 See [CONTRIBUTING.md](CONTRIBUTING.md) for branch strategy, commit conventions, local development setup, and the release process.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full history of changes since the fork.
+
+---
+
+## Trademarks
+
+Terraform is a registered trademark of HashiCorp. OpenTofu is a trademark of the Linux Foundation. This extension is an independent, community-maintained fork and is **not** affiliated with, endorsed by, or sponsored by HashiCorp or the Linux Foundation. Product names are used under nominative fair use solely to describe compatibility.
 
 ---
 

--- a/docs/migration-from-ms-devlabs.md
+++ b/docs/migration-from-ms-devlabs.md
@@ -104,9 +104,19 @@ Most inputs carry over verbatim. Known differences:
 | DevLabs input             | This fork                                | Notes                                                                                      |
 | ------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `allowTelemetryCollection` | _removed_                               | No telemetry is collected in this fork.                                                    |
-| `runAzLogin`              | _removed_                                | The AzureRM handler always authenticates via the service connection without `az login`.   |
+| `runAzLogin`              | `runAzLogin` (opt-in)                    | Still a live boolean input, default `false`. See the security note below.                  |
 | `commandOptions`           | `commandOptions`                         | Unchanged.                                                                                 |
 | `secureVarsFile`           | `secureVarsFile`                         | Unchanged. Secure Files library reference.                                                 |
+
+> **Security note on `runAzLogin`.** Set this to `true` only when a `local-exec`
+> provisioner or an external data source genuinely needs Azure CLI
+> authentication. When enabled, the task runs `az login --service-principal`,
+> which passes the federated OIDC token (Workload Identity Federation) or the
+> service principal secret (Service Principal scheme) as `az` command-line
+> arguments. The task masks those values in the logs (`setSecret`) and runs the
+> login silently, but command-line arguments are briefly visible in the agent's
+> process table (e.g. `/proc/<pid>/cmdline`). On ephemeral hosted agents this is
+> low risk; on shared self-hosted agents, leave it `false` unless required.
 
 ### New inputs introduced by this fork
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -26,7 +26,7 @@ npm run package:release   # or package:self for a private test extension
 
 - [ ] Upload the `.vsix` to a test ADO org via **Organization Settings → Extensions → Browse local extensions → Upload**
 - [ ] Extension installs without errors
-- [ ] Both tasks appear: `PipelineTerraformInstaller@1`, `PipelineTerraformProviderMirror@1`, and `PipelineTerraformTask@5`
+- [ ] All seven tasks appear: `PipelineTerraformInstaller@1`, `PipelineTerraformProviderMirror@1`, `PipelineTerraformTask@5`, `PipelineTerraformModulePublish@1`, `PipelinePolicyAgentInstaller@1`, `PipelineTerraformPolicyCheck@1`, and `PipelineTerraformDriftReport@1`
 
 ## 4. Installer task smoke test
 
@@ -39,6 +39,30 @@ npm run package:release   # or package:self for a private test extension
 - [ ] `PipelineTerraformProviderMirror@1` with a valid mirror URL — generates `.terraformrc` and sets `TF_CLI_CONFIG_FILE`
 - [ ] `PipelineTerraformProviderMirror@1` with `allowDirectFallback: false` — config contains only `network_mirror` block
 - [ ] Subsequent `terraform init` downloads providers from the configured mirror
+
+## 4c. Policy agent installer smoke test
+
+- [ ] `PipelinePolicyAgentInstaller@1` with `policyAgent: opa`, `version: latest` — installs and reports version
+- [ ] `PipelinePolicyAgentInstaller@1` with `policyAgent: sentinel`, `version: latest` — installs and reports version
+- [ ] Output variables `policyAgentLocation` and `policyAgentDownloadedFrom` are set
+
+## 4d. Policy check smoke test
+
+- [ ] `PipelineTerraformPolicyCheck@1` with `engine: opa` against a plan JSON and a local policy directory — sets `policyResult`/`violationCount` and publishes JUnit results
+- [ ] `PipelineTerraformPolicyCheck@1` with `engine: sentinel` — exit-code-driven enforcement maps correctly
+- [ ] `policySource: git` clones the policy repo at the requested ref
+
+## 4e. Drift report smoke test
+
+- [ ] `PipelineTerraformDriftReport@1` with a plan JSON — reports drift counts and a changed-resource summary
+- [ ] `failOnDrift: true` fails the task when drift is present
+- [ ] With `callbackUrl` set (HTTPS), the summary POSTs to the TSM drift callback
+
+## 4f. Module publish smoke test
+
+- [ ] `PipelineTerraformModulePublish@1` with `registryType: private` — publishes a version to a terraform-registry-backend instance
+- [ ] `PipelineTerraformModulePublish@1` with `registryType: hcp` — publishes a version to HCP Terraform / TFE
+- [ ] `waitForPublish: true` blocks until the version is available (bounded by `timeoutSeconds`)
 
 ## 5. Core commands smoke test (AzureRM)
 

--- a/docs/setup/private-testing.md
+++ b/docs/setup/private-testing.md
@@ -12,9 +12,9 @@ This guide covers how to build, publish, and test the extension privately in you
 4. Accept the Marketplace Publisher Agreement
 5. Click **Create**
 
-## Get a Marketplace PAT (one-time)
+## Get a Marketplace PAT (for manual CLI publishing)
 
-This PAT is used both for the automated release workflow and for manual publishing via CLI.
+You only need a PAT for **manual** publishing of a private dev build from your own machine (Option B below). The automated release workflow does **not** use a PAT — it authenticates to the Marketplace via GitHub OIDC federated to Microsoft Entra (see [CONTRIBUTING.md](../../CONTRIBUTING.md#release-process)).
 
 1. Go to `https://marketplace.visualstudio.com` and sign in
 2. Click your profile icon → **Security**
@@ -23,7 +23,7 @@ This PAT is used both for the automated release workflow and for manual publishi
 5. Set **Scopes** → select **Marketplace** → check **Publish**
 6. Copy the token — you will not see it again
 
-This is the same token stored as the `TFX_PAT` GitHub Actions secret.
+Keep this token local to your machine; it is not stored as a GitHub Actions secret.
 
 ## Build and Package (each dev cycle)
 

--- a/docs/yaml-examples.md
+++ b/docs/yaml-examples.md
@@ -6,6 +6,9 @@
 - [`PipelineTerraformProviderMirror@1`](#pipelineterraformprovidermirror1) — Configure provider network mirror
 - [`PipelineTerraformTask@5`](#pipelineterraformtask5) — Run Terraform commands (init, plan, apply, destroy, etc.)
 - [Cross-cloud examples](#cross-cloud-examples) — AzureRM state with AWS/GCP resources; HCP Terraform with AzureRM resources
+- [Policy as code](#policy-as-code) — Install OPA/Sentinel and evaluate policies against plan JSON
+- [`PipelineTerraformDriftReport@1`](#pipelineterraformdriftreport1) — Summarise plan drift, optional SARIF report + TSM callback
+- [`PipelineTerraformModulePublish@1`](#pipelineterraformmodulepublish1) — Publish a module version to HCP Terraform or a private registry
 
 ---
 
@@ -784,3 +787,186 @@ Bring your own config with `sentinelConfigPath` to manage imports yourself.
 The check task sets output variables `policyResult` (`passed`/`failed`),
 `violationCount`, and `resultsFilePath`, and (by default) publishes a JUnit
 report so outcomes appear in the pipeline **Tests** tab.
+
+---
+
+## PipelineTerraformDriftReport@1
+
+Parse a Terraform/OpenTofu plan JSON into drift counts and a changed-resource
+summary, and optionally POST it to a Terraform State Manager (TSM) drift
+callback. Like the policy check, it consumes the `terraform show -json` document,
+so the natural chain is plan → show -json → drift report.
+
+### Report drift from a plan
+
+```yaml
+- task: PipelineTerraformTask@5
+  inputs:
+    command: 'plan'
+    provider: 'azurerm'
+    environmentServiceNameAzureRM: 'my-azure-connection'
+    commandOptions: '-out=tfplan'
+
+- task: PipelineTerraformTask@5
+  name: tfshow
+  inputs:
+    command: 'show'
+    provider: 'azurerm'
+    environmentServiceNameAzureRM: 'my-azure-connection'
+    outputTo: 'file'
+    outputFormat: 'json'
+    filename: 'plan.json'
+    commandOptions: 'tfplan'
+
+- task: PipelineTerraformDriftReport@1
+  name: drift
+  inputs:
+    planJsonFile: '$(tfshow.showFilePath)'
+```
+
+The task sets output variables `driftDetected` (`true`/`false`), `addedCount`,
+`changedCount`, `destroyedCount`, and `summaryFilePath` (the JSON report, which
+is also the exact callback body). Reference them by the task `name`, e.g.
+`$(drift.driftDetected)`.
+
+### Fail the build on drift
+
+```yaml
+- task: PipelineTerraformDriftReport@1
+  inputs:
+    planJsonFile: '$(tfshow.showFilePath)'
+    failOnDrift: true               # default false
+```
+
+### Report to Terraform State Manager
+
+```yaml
+- task: PipelineTerraformDriftReport@1
+  inputs:
+    planJsonFile: '$(tfshow.showFilePath)'
+    detail: '$(Build.BuildId)'                 # free-text run label, forwarded as the callback detail
+    callbackUrl: 'https://tsm.example.com/api/v1/drift/ingest'
+    callbackToken: '$(tsm-callback-token)'     # per-run one-shot secret; sent as X-TSM-Callback-Token
+    rejectUnauthorized: true                   # default; set false only for an untrusted private-CA endpoint
+```
+
+The result is POSTed **only when both `callbackUrl` and `callbackToken` are
+set**. `callbackToken` is a per-run one-shot token sent as the
+`X-TSM-Callback-Token` header — pass it as a secret variable. `rejectUnauthorized`
+(default `true`) verifies the callback's TLS certificate; set it `false` only for
+a private-CA endpoint the agent does not trust.
+
+### Emit a SARIF report
+
+```yaml
+- task: PipelineTerraformDriftReport@1
+  name: drift
+  inputs:
+    planJsonFile: '$(tfshow.showFilePath)'
+    sarifOutput: true               # default false
+    # sarifPath: '$(Build.ArtifactStagingDirectory)/drift.sarif'  # optional; defaults to the agent temp dir
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(drift.sarifFilePath)'
+    ArtifactName: 'CodeAnalysisLogs'           # picked up by SARIF-aware viewers
+```
+
+With `sarifOutput: true` the task writes a SARIF 2.1.0 report of the drifted
+resources and exposes its path via the `sarifFilePath` output variable. When
+`sarifPath` is empty a file is written to the agent temp directory; either way
+the path is exposed via `sarifFilePath`. Publish it as a build artifact to
+surface drift in SARIF-aware tooling.
+
+Module provenance: `includeModuleProvenance` (default `true`) adds the
+configuration's `module_calls` and locked module versions — read from
+`moduleManifest` (default `.terraform/modules/modules.json`) — to the report and
+callback body. Set it `false` to omit them.
+
+---
+
+## PipelineTerraformModulePublish@1
+
+Publish a module version to HCP Terraform / Terraform Enterprise or a private
+`terraform-registry-backend`. Typically the last step of a module's release
+pipeline.
+
+### Publish to a private registry
+
+```yaml
+- task: PipelineTerraformModulePublish@1
+  displayName: 'Publish module to private registry'
+  inputs:
+    registryType: 'private'
+    registryUrl: 'https://registry.example.com'
+    namespace: 'platform'
+    name: 'networking-vpc'          # module name without the terraform-<provider>- prefix
+    provider: 'aws'
+    version: '1.2.3'
+    apiKey: '$(tfregistry-api-key)' # secret variable; needs the modules:write scope
+```
+
+`apiKey` must be a **secret** pipeline variable with the `modules:write` scope —
+never inline the literal. For an internal registry fronted by a private CA the
+agent does not trust, prefer installing the CA via `NODE_EXTRA_CA_CERTS`;
+`skipTlsVerify: true` is a last resort.
+
+### Publish to HCP Terraform
+
+```yaml
+- task: PipelineTerraformModulePublish@1
+  displayName: 'Publish module to HCP Terraform'
+  inputs:
+    registryType: 'hcp'
+    namespace: 'my-org'             # HCP organization name
+    name: 'networking-vpc'
+    provider: 'aws'
+    version: '1.2.3'
+    hcpToken: '$(hcp-team-token)'   # secret variable
+    # hcpAddress defaults to https://app.terraform.io; point it at your TFE host for Terraform Enterprise
+```
+
+For HCP Terraform / TFE the `namespace` is the organization name. `hcpToken` is a
+team or user API token and must be a secret variable.
+
+### Create a VCS-connected module on first publish
+
+```yaml
+- task: PipelineTerraformModulePublish@1
+  displayName: 'Publish (create VCS-connected module if missing)'
+  inputs:
+    registryType: 'hcp'
+    namespace: 'my-org'
+    name: 'networking-vpc'
+    provider: 'aws'
+    version: '1.2.3'
+    hcpToken: '$(hcp-team-token)'
+    vcsRepoIdentifier: 'my-org/my-project/_git/terraform-aws-networking-vpc'
+    vcsOauthTokenId: 'ot-xxxxxxxxxxxxxxxx'
+    vcsBranch: 'main'               # defaults to main
+```
+
+`vcsRepoIdentifier` and `vcsOauthTokenId` apply **only when the module does not
+yet exist** and HCP should create a VCS-connected module for it; for modules that
+already exist they are ignored. `commitSha` defaults to `$(Build.SourceVersion)`.
+
+### Wait behaviour
+
+```yaml
+- task: PipelineTerraformModulePublish@1
+  inputs:
+    registryType: 'private'
+    registryUrl: 'https://registry.example.com'
+    namespace: 'platform'
+    name: 'networking-vpc'
+    provider: 'aws'
+    version: '1.2.3'
+    apiKey: '$(tfregistry-api-key)'
+    waitForPublish: true            # default; poll until the version is queryable
+    timeoutSeconds: '300'           # default 180
+```
+
+With `waitForPublish: true` (the default) the task polls the registry until the
+published version is available, failing if it is not ready within
+`timeoutSeconds`. Set `waitForPublish: false` to return as soon as the publish
+request is accepted.

--- a/overview.md
+++ b/overview.md
@@ -10,6 +10,7 @@ This extension provides:
 - **PipelineTerraformModulePublish** -- Publish a module version to HCP Terraform or a private Terraform registry
 - **PipelinePolicyAgentInstaller** -- Install a policy engine (OPA or Sentinel) on the pipeline agent
 - **PipelineTerraformPolicyCheck** -- Evaluate OPA or Sentinel policies against Terraform plan JSON
+- **PipelineTerraformDriftReport** -- Summarise plan-detected drift and optionally report it to Terraform State Manager
 - Service connections for AWS, GCP, and OCI accounts
 
 Runs on **Windows**, **Linux**, and **macOS** agents.
@@ -111,7 +112,7 @@ The `backendType` input on `init` selects the state backend independently of the
 | `generic`    | Any backend via `-backend-config` file or key=value arguments |
 | `local`      | Local state file (no remote backend)                          |
 
-If `backendType` is not specified, it defaults to `azurerm`. For backward compatibility, if `backendType` is not set in a pre-existing pipeline, it falls back to the value of `provider`.
+If `backendType` is not set, it defaults to the value of the `provider` input, preserving the original behaviour where the state backend matched the deployment provider.
 
 ## Output Variables
 
@@ -130,3 +131,7 @@ Reference output variables using the task `name` prefix: `$(taskName.changesPres
 - **Examples**: See [docs/yaml-examples.md](https://github.com/sethbacon/azure-pipelines-terraform/blob/main/docs/yaml-examples.md)
 - **Contributing**: See [CONTRIBUTING.md](https://github.com/sethbacon/azure-pipelines-terraform/blob/main/CONTRIBUTING.md)
 - **Changelog**: See [CHANGELOG.md](https://github.com/sethbacon/azure-pipelines-terraform/blob/main/CHANGELOG.md)
+
+## Trademarks
+
+Terraform is a registered trademark of HashiCorp. OpenTofu is a trademark of the Linux Foundation. This extension is an independent, community-maintained fork and is **not** affiliated with, endorsed by, or sponsored by HashiCorp or the Linux Foundation. Product names are used under nominative fair use solely to describe compatibility.


### PR DESCRIPTION
Fixes documentation drift surfaced in the security review (#240). Docs-only; no code or workflow files touched, so this is conflict-free with the in-flight CI/security PRs.

## What changed
- **README**: documented the four previously undocumented tasks — `PipelineTerraformModulePublish@1`, `PipelinePolicyAgentInstaller@1`, `PipelineTerraformPolicyCheck@1`, `PipelineTerraformDriftReport@1` (key inputs + outputs, verified against each `task.json`).
- **README + overview.md**: added a HashiCorp / OpenTofu nominative-fair-use trademark notice.
- **overview.md**: added DriftReport to the task list; fixed the self-contradictory `backendType` default — it falls back to the value of `provider` (confirmed in `parent-handler.ts:24`: `getInput("backendType", false) || providerName`), not `azurerm`.
- **CONTRIBUTING.md + CLAUDE.md**: replaced the deprecated `TFX_PAT` secret with the `AZDO_PUBLISH_CLIENT_ID` / `AZDO_PUBLISH_TENANT_ID` variables and documented the GitHub OIDC → Entra federated publish (verified against `release.yml`: `azure/login` + `az account get-access-token` → `tfx extension publish`, no stored PAT).
- **CONTRIBUTING.md**: added the four newer tasks to the release Minor-bump list. **CLAUDE.md**: added them to the repository-structure tree.
- **private-testing.md**: reframed the Marketplace PAT as manual-CLI-publish-only and removed the false "same token stored as `TFX_PAT` secret" / "automated release workflow" claims (a PAT is still needed for the documented Option B CLI publish, so the section was kept, not deleted).
- **migration-from-ms-devlabs.md**: `runAzLogin` is a live opt-in input (default `false`), not "removed" (confirmed in `azure-terraform-command-handler.ts:74`). Added a measured security note: WIF passes `--federated-token` and ServicePrincipal passes `--password` on the `az login` argv; `setSecret` + `silent` prevent log leakage but the values are briefly visible in the process table.
- **release-checklist.md**: install check now lists all seven tasks; added smoke-test subsections (4c–4f) for the four newer tasks.

## Deviations from the issue spec (intentional)
- **SARIF docs deferred**: #246 (SARIF output) is not yet merged and doesn't touch README, so documenting SARIF here would couple this PR to unmerged work. Deferred to a follow-up once #246 lands.
- **Skipped the redundant CLAUDE.md "Azure WIF" subsection** (spec item 12): the runtime `ARM_USE_OIDC` / `ARM_OIDC_TOKEN` vars are already documented under "Azure auth schemes".
- **Kept the PAT section** in private-testing.md rather than removing it (manual CLI publish still needs it) — fixed the inaccurate claims instead.

## Verification
Grep checks: no stale `TFX_PAT` required-secret rows remain; all four new README sections present; `backendType` wording corrected; trademark notices present; `runAzLogin` security note present; new relative link `../../CONTRIBUTING.md#release-process` resolves.

Closes #240
