### PR TITLE
ci: extend SBOM coverage to all 7 tasks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,31 @@ jobs:
           cd Tasks/TerraformInstaller/TerraformInstallerV1
           npm ci --omit=dev
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-installer-v1.cdx.json --omit dev
+      - name: Generate SBOM for TerraformProviderMirrorV1
+        run: |
+          cd Tasks/TerraformProviderMirror/TerraformProviderMirrorV1
+          npm ci --omit=dev
+          npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-provider-mirror-v1.cdx.json --omit dev
+      - name: Generate SBOM for PolicyAgentInstallerV1
+        run: |
+          cd Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1
+          npm ci --omit=dev
+          npx --no-install cyclonedx-npm --output-file ../../../sbom-policy-agent-installer-v1.cdx.json --omit dev
+      - name: Generate SBOM for TerraformPolicyCheckV1
+        run: |
+          cd Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1
+          npm ci --omit=dev
+          npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-policy-check-v1.cdx.json --omit dev
+      - name: Generate SBOM for TerraformDriftReportV1
+        run: |
+          cd Tasks/TerraformDriftReport/TerraformDriftReportV1
+          npm ci --omit=dev
+          npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-drift-report-v1.cdx.json --omit dev
+      - name: Generate SBOM for TerraformModulePublishV1
+        run: |
+          cd Tasks/TerraformModulePublish/TerraformModulePublishV1
+          npm ci --omit=dev
+          npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-module-publish-v1.cdx.json --omit dev
       - name: Download vsix artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -141,6 +166,31 @@ jobs:
         with:
           subject-path: '*.vsix'
           sbom-path: 'sbom-terraform-installer-v1.cdx.json'
+      - name: Attest SBOM (TerraformProviderMirrorV1) for VSIX
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: '*.vsix'
+          sbom-path: 'sbom-terraform-provider-mirror-v1.cdx.json'
+      - name: Attest SBOM (PolicyAgentInstallerV1) for VSIX
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: '*.vsix'
+          sbom-path: 'sbom-policy-agent-installer-v1.cdx.json'
+      - name: Attest SBOM (TerraformPolicyCheckV1) for VSIX
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: '*.vsix'
+          sbom-path: 'sbom-terraform-policy-check-v1.cdx.json'
+      - name: Attest SBOM (TerraformDriftReportV1) for VSIX
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: '*.vsix'
+          sbom-path: 'sbom-terraform-drift-report-v1.cdx.json'
+      - name: Attest SBOM (TerraformModulePublishV1) for VSIX
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: '*.vsix'
+          sbom-path: 'sbom-terraform-module-publish-v1.cdx.json'
       - name: Upload SBOM and signature artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
Extends CycloneDX SBOM coverage in `release.yml` from 2 of 7 tasks to **all 7**, so the published `.vsix` dependency graph is fully attested (#241).

## What changed
The `sbom-and-sign` job previously generated and attested SBOMs only for **TerraformTaskV5** and **TerraformInstallerV1**. This adds the remaining five tasks, each following the exact existing pattern:

| Task | SBOM file |
| --- | --- |
| TerraformProviderMirrorV1 | `sbom-terraform-provider-mirror-v1.cdx.json` |
| PolicyAgentInstallerV1 | `sbom-policy-agent-installer-v1.cdx.json` |
| TerraformPolicyCheckV1 | `sbom-terraform-policy-check-v1.cdx.json` |
| TerraformDriftReportV1 | `sbom-terraform-drift-report-v1.cdx.json` |
| TerraformModulePublishV1 | `sbom-terraform-module-publish-v1.cdx.json` |

For each: a `Generate SBOM for <task>` step (`npm ci --omit=dev` in the task dir → `cyclonedx-npm --omit dev`) and a matching `Attest SBOM (<task>) for VSIX` step (`actions/attest-sbom`, pinned to the same `c604332985…` # v4.1.0 SHA already in use).

## No glob changes needed
The existing `Upload SBOM and signature artifacts` (`sbom-*.cdx.json`) and `Create draft GitHub Release` (`sbom-*.cdx.json`) globs already capture every new file, so all seven SBOMs ship with the GitHub Release and each is attested against the published `.vsix`.

## Verification
- `release.yml` parses as valid YAML; `actionlint` clean.
- 7 `Generate SBOM` steps + 7 `Attest SBOM` steps; 7 distinct `sbom-*.cdx.json` filenames.
- All five new task directories have `package.json` + `package-lock.json` (so `npm ci --omit=dev` resolves — the lockfiles landed via #248).
- `@cyclonedx/cyclonedx-npm` remains a root devDependency, so `npx --no-install cyclonedx-npm` resolves from each task dir.

Docs-only path: no task source, no extension behavior changed; only the release pipeline emits more attestations.

Closes #241
