### PR TITLE
fix: add network timeouts and bounded poll loops

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/HttpClientL0.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import * as net from 'net';
+import { fetchWithTimeout } from '../src/http-client';
+
+// Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
+// These run in the mocha parent process; the MockTestRunner integration tests in
+// L0.ts run in child processes and are unaffected.
+
+describe('http-client: fetchWithTimeout', () => {
+    it('rejects a non-https URL before opening a connection', async () => {
+        await assert.rejects(
+            fetchWithTimeout('http://insecure.example.com/x', 1000, async (r) => r.text()),
+            /InsecureUrlRejected|insecure/i,
+        );
+    });
+
+    it('aborts a hung connection and reports the timeout', async () => {
+        // A bare TCP server that accepts the socket but never completes the TLS
+        // handshake — the AbortController must fire and surface a timeout error.
+        const server = net.createServer(() => { /* accept and stall */ });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        try {
+            await assert.rejects(
+                fetchWithTimeout(`https://127.0.0.1:${port}/x`, 150, async (r) => r.text()),
+                /timed out after 150ms/,
+            );
+        } finally {
+            server.close();
+        }
+    });
+});

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -2,6 +2,9 @@ import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
 
+// Direct unit tests for the http-client timeout guard.
+import './HttpClientL0';
+
 describe('PolicyAgentInstaller Test Suite', function () {
 
     before(() => {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
@@ -1,6 +1,14 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 
+/**
+ * Per-request timeouts (ms). Without an AbortController a hung TCP connection
+ * stalls the install until the agent job timeout. Metadata lookups are quick;
+ * binary downloads need a far larger ceiling.
+ */
+export const METADATA_TIMEOUT_MS = 60_000;
+export const DOWNLOAD_TIMEOUT_MS = 600_000;
+
 function buildFetchOptions(): RequestInit {
     const proxy = tasks.getHttpProxyConfiguration();
     if (!proxy) return {};
@@ -19,41 +27,61 @@ function buildFetchOptions(): RequestInit {
     };
 }
 
-export async function fetchJson<T>(url: string): Promise<T> {
+/**
+ * Fetches an https:// URL under a wall-clock timeout that covers the connection,
+ * the response headers, AND body consumption — the consume callback runs inside
+ * the timeout guard, so a stalled body stream is bounded too. On timeout the
+ * request is aborted and a clear error is thrown rather than hanging the job.
+ */
+export async function fetchWithTimeout<T>(
+    url: string,
+    timeoutMs: number,
+    consume: (response: Response) => Promise<T>,
+): Promise<T> {
     if (!url.startsWith('https://')) {
         throw new Error(tasks.loc("InsecureUrlRejected", url));
     }
 
-    const options = buildFetchOptions();
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        throw new Error(tasks.loc("RegistryRequestFailed", url, response.status));
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetch(url, { ...buildFetchOptions(), signal: controller.signal });
+        return await consume(response);
+    } catch (err) {
+        if (controller.signal.aborted) {
+            throw new Error(`Request to ${url} timed out after ${timeoutMs}ms.`);
+        }
+        throw err;
+    } finally {
+        clearTimeout(timer);
     }
-    return response.json() as Promise<T>;
 }
 
-export async function fetchText(url: string): Promise<string> {
-    if (!url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", url));
-    }
-
-    const options = buildFetchOptions();
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
-    }
-    return response.text();
+export function fetchJson<T>(url: string): Promise<T> {
+    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+        if (!response.ok) {
+            throw new Error(tasks.loc("RegistryRequestFailed", url, response.status));
+        }
+        return (await response.json()) as T;
+    });
 }
 
-export async function fetchBuffer(url: string): Promise<Uint8Array> {
-    if (!url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", url));
-    }
+export function fetchText(url: string): Promise<string> {
+    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+        }
+        // The returned promise is awaited inside fetchWithTimeout's guard, so the
+        // body read stays bounded by the timeout without a redundant await here.
+        return response.text();
+    });
+}
 
-    const options = buildFetchOptions();
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
-    }
-    return new Uint8Array(await response.arrayBuffer());
+export function fetchBuffer(url: string): Promise<Uint8Array> {
+    return fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+        }
+        return new Uint8Array(await response.arrayBuffer());
+    });
 }

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -3,6 +3,7 @@ import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as net from 'net';
 import { postJson, truncateBody } from '../src/callback';
 
 describe('TerraformDriftReport callback transport', function () {
@@ -11,6 +12,22 @@ describe('TerraformDriftReport callback transport', function () {
             postJson('http://insecure.example.com/drift', { 'X-TSM-Callback-Token': 't' }, '{}'),
             /non-HTTPS/,
         );
+    });
+
+    it('times out a hung callback connection instead of hanging', async () => {
+        // A bare TCP server that accepts the socket but never completes the TLS
+        // handshake — req.setTimeout must fire and reject.
+        const server = net.createServer(() => { /* accept and stall */ });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        try {
+            await assert.rejects(
+                postJson(`https://127.0.0.1:${port}/drift`, { 'X-TSM-Callback-Token': 't' }, '{}', true, 150),
+                /timed out after 150ms/,
+            );
+        } finally {
+            server.close();
+        }
     });
 
     it('truncates a long response body and passes a short one through', () => {

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
@@ -1,6 +1,12 @@
 import * as https from 'https';
 import { URL } from 'url';
 
+/**
+ * Per-request socket timeout (ms). Without it a hung TCP connection leaves the
+ * callback POST waiting until the agent job timeout.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 100_000;
+
 export interface HttpResponse {
     status: number;
     body: string;
@@ -16,6 +22,7 @@ export function postJson(
     headers: Record<string, string>,
     body: string,
     rejectUnauthorized = true,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
 ): Promise<HttpResponse> {
     return new Promise<HttpResponse>((resolve, reject) => {
         const parsed = new URL(url);
@@ -43,6 +50,9 @@ export function postJson(
             res.setEncoding('utf8');
             res.on('data', (chunk) => { chunks += chunk; });
             res.on('end', () => resolve({ status: res.statusCode ?? 0, body: chunks }));
+        });
+        req.setTimeout(timeoutMs, () => {
+            req.destroy(new Error(`Callback request to ${parsed.host} timed out after ${timeoutMs}ms.`));
         });
         req.on('error', reject);
         req.write(body);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import * as net from 'net';
+import { fetchWithTimeout } from '../src/http-client';
+
+// Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
+// These run in the mocha parent process; the MockTestRunner integration tests in
+// L0.ts run in child processes and are unaffected.
+
+describe('http-client: fetchWithTimeout', () => {
+    it('rejects a non-https URL before opening a connection', async () => {
+        await assert.rejects(
+            fetchWithTimeout('http://insecure.example.com/x', 1000, async (r) => r.text()),
+            /InsecureUrlRejected|insecure/i,
+        );
+    });
+
+    it('aborts a hung connection and reports the timeout', async () => {
+        // A bare TCP server that accepts the socket but never completes the TLS
+        // handshake — the AbortController must fire and surface a timeout error.
+        const server = net.createServer(() => { /* accept and stall */ });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        try {
+            await assert.rejects(
+                fetchWithTimeout(`https://127.0.0.1:${port}/x`, 150, async (r) => r.text()),
+                /timed out after 150ms/,
+            );
+        } finally {
+            server.close();
+        }
+    });
+});

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 // Direct unit tests for the cosign verifier (certificate-identity anchoring +
 // fail-closed behavior). Registered alongside the integration suite below.
 import './CosignVerifierL0';
+// Direct unit tests for the http-client timeout guard.
+import './HttpClientL0';
 
 describe('TerraformInstaller Test Suite', function () {
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
@@ -1,6 +1,14 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 
+/**
+ * Per-request timeouts (ms). Without an AbortController a hung TCP connection
+ * stalls the install until the agent job timeout. Metadata lookups are quick;
+ * binary downloads need a far larger ceiling.
+ */
+export const METADATA_TIMEOUT_MS = 60_000;
+export const DOWNLOAD_TIMEOUT_MS = 600_000;
+
 function buildFetchOptions(): RequestInit {
     const proxy = tasks.getHttpProxyConfiguration();
     if (!proxy) return {};
@@ -19,41 +27,61 @@ function buildFetchOptions(): RequestInit {
     };
 }
 
-export async function fetchJson<T>(url: string): Promise<T> {
+/**
+ * Fetches an https:// URL under a wall-clock timeout that covers the connection,
+ * the response headers, AND body consumption — the consume callback runs inside
+ * the timeout guard, so a stalled body stream is bounded too. On timeout the
+ * request is aborted and a clear error is thrown rather than hanging the job.
+ */
+export async function fetchWithTimeout<T>(
+    url: string,
+    timeoutMs: number,
+    consume: (response: Response) => Promise<T>,
+): Promise<T> {
     if (!url.startsWith('https://')) {
         throw new Error(tasks.loc("InsecureUrlRejected", url));
     }
 
-    const options = buildFetchOptions();
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        throw new Error(tasks.loc("RegistryRequestFailed", url, response.status));
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetch(url, { ...buildFetchOptions(), signal: controller.signal });
+        return await consume(response);
+    } catch (err) {
+        if (controller.signal.aborted) {
+            throw new Error(`Request to ${url} timed out after ${timeoutMs}ms.`);
+        }
+        throw err;
+    } finally {
+        clearTimeout(timer);
     }
-    return response.json() as Promise<T>;
 }
 
-export async function fetchText(url: string): Promise<string> {
-    if (!url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", url));
-    }
-
-    const options = buildFetchOptions();
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
-    }
-    return response.text();
+export function fetchJson<T>(url: string): Promise<T> {
+    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+        if (!response.ok) {
+            throw new Error(tasks.loc("RegistryRequestFailed", url, response.status));
+        }
+        return (await response.json()) as T;
+    });
 }
 
-export async function fetchBuffer(url: string): Promise<Uint8Array> {
-    if (!url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", url));
-    }
+export function fetchText(url: string): Promise<string> {
+    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+        }
+        // The returned promise is awaited inside fetchWithTimeout's guard, so the
+        // body read stays bounded by the timeout without a redundant await here.
+        return response.text();
+    });
+}
 
-    const options = buildFetchOptions();
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
-    }
-    return new Uint8Array(await response.arrayBuffer());
+export function fetchBuffer(url: string): Promise<Uint8Array> {
+    return fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+        }
+        return new Uint8Array(await response.arrayBuffer());
+    });
 }

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
+import * as net from 'net';
 import { HttpClient, HttpResponse, createHttpsClient, truncateBody } from '../src/http';
 import * as priv from '../src/private-publisher';
 import * as hcp from '../src/hcp-publisher';
@@ -34,6 +35,23 @@ describe('http client transport', () => {
             client('GET', 'http://insecure.example.com/api', { Authorization: 'Bearer k' }),
             /non-HTTPS/,
         );
+    });
+
+    it('times out a hung connection instead of hanging', async () => {
+        // A bare TCP server that accepts the socket but never completes the TLS
+        // handshake — req.setTimeout must fire and reject.
+        const server = net.createServer(() => { /* accept and stall */ });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        try {
+            const client = createHttpsClient(true, 150);
+            await assert.rejects(
+                client('GET', `https://127.0.0.1:${port}/api`, {}),
+                /timed out after 150ms/,
+            );
+        } finally {
+            server.close();
+        }
     });
 
     it('truncates a long response body and passes a short one through', () => {
@@ -122,6 +140,32 @@ describe('private-publisher', () => {
             assert.strictEqual(calls.length, 3);
             assert.match(result.message, /available/);
         });
+
+        it('bounds the wait by the deadline and throws on timeout', async () => {
+            const { client } = fakeClient([
+                { status: 200, body: '{"id":"mod-1","versions":[]}' }, // resolve module
+                { status: 202, body: '' },                              // trigger sync
+                { status: 200, body: '{"id":"mod-1","versions":[]}' },  // poll: still absent
+            ]);
+            await assert.rejects(
+                () => new priv.PrivateRegistryPublisher(client, { ...opts, waitForPublish: true, timeoutSeconds: 0 }, noop).publish(),
+                /Timed out after 0s/,
+            );
+        });
+
+        it('swallows a failing poll and still bounds by the deadline', async () => {
+            let n = 0;
+            const client: HttpClient = () => {
+                n += 1;
+                if (n === 1) return Promise.resolve({ status: 200, body: '{"id":"mod-1","versions":[]}' });
+                if (n === 2) return Promise.resolve({ status: 202, body: '' });
+                return Promise.reject(new Error('ECONNRESET')); // poll fails, must not propagate
+            };
+            await assert.rejects(
+                () => new priv.PrivateRegistryPublisher(client, { ...opts, waitForPublish: true, timeoutSeconds: 0 }, noop).publish(),
+                (err: Error) => /Timed out after 0s/.test(err.message) && !/ECONNRESET/.test(err.message),
+            );
+        });
     });
 });
 
@@ -204,6 +248,20 @@ describe('hcp-publisher', () => {
             ]);
             const result = await new hcp.HcpPublisher(client, base, noop).publish();
             assert.strictEqual(result.published, true);
+        });
+
+        it('swallows a failing status poll and bounds by the deadline', async () => {
+            let n = 0;
+            const client: HttpClient = () => {
+                n += 1;
+                if (n === 1) return Promise.resolve({ status: 200, body: '{"data":{"attributes":{"version-statuses":[]}}}' });
+                if (n === 2) return Promise.resolve({ status: 201, body: '{}' });
+                return Promise.reject(new Error('ETIMEDOUT')); // poll fails, must not propagate
+            };
+            await assert.rejects(
+                () => new hcp.HcpPublisher(client, { ...base, waitForPublish: true, timeoutSeconds: 0 }, noop).publish(),
+                (err: Error) => /Timed out after 0s/.test(err.message) && !/ETIMEDOUT/.test(err.message),
+            );
         });
     });
 });

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/hcp-publisher.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/hcp-publisher.ts
@@ -132,13 +132,19 @@ export class HcpPublisher implements RegistryPublisher {
     private async waitForOk(headers: Record<string, string>): Promise<boolean> {
         const deadline = Date.now() + this.options.timeoutSeconds * 1000;
         for (;;) {
-            const resp = await this.http('GET', moduleUrl(this.options), headers);
-            if (
-                resp.status >= 200 &&
-                resp.status < 300 &&
-                versionStatus(resp.body, this.options.version) === 'ok'
-            ) {
-                return true;
+            // A single poll failing (e.g. a per-request timeout or transient 5xx)
+            // must not abort the wait; keep polling until the wall-clock deadline.
+            try {
+                const resp = await this.http('GET', moduleUrl(this.options), headers);
+                if (
+                    resp.status >= 200 &&
+                    resp.status < 300 &&
+                    versionStatus(resp.body, this.options.version) === 'ok'
+                ) {
+                    return true;
+                }
+            } catch (err) {
+                this.log(`Polling version status failed, will retry: ${err instanceof Error ? err.message : String(err)}`);
             }
             if (Date.now() >= deadline) {
                 return false;

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/http.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/http.ts
@@ -1,6 +1,12 @@
 import * as https from 'https';
 import { URL } from 'url';
 
+/**
+ * Per-request socket timeout (ms). Without it a hung TCP connection makes the
+ * task's own timeoutSeconds silently ineffective until the agent job timeout.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 100_000;
+
 export interface HttpResponse {
     status: number;
     body: string;
@@ -17,8 +23,10 @@ export type HttpClient = (
  * Creates an HTTPS client backed by Node's built-in https module.
  * @param rejectUnauthorized when false, TLS certificate validation is disabled
  *        (only appropriate for internal registries fronted by a private CA the agent does not trust).
+ * @param timeoutMs per-request socket timeout; a stalled connection is destroyed
+ *        and rejected rather than hanging until the agent job timeout.
  */
-export function createHttpsClient(rejectUnauthorized = true): HttpClient {
+export function createHttpsClient(rejectUnauthorized = true, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): HttpClient {
     return (method, url, headers, body) =>
         new Promise<HttpResponse>((resolve, reject) => {
             const parsed = new URL(url);
@@ -47,6 +55,9 @@ export function createHttpsClient(rejectUnauthorized = true): HttpClient {
                     chunks += chunk;
                 });
                 res.on('end', () => resolve({ status: res.statusCode ?? 0, body: chunks }));
+            });
+            req.setTimeout(timeoutMs, () => {
+                req.destroy(new Error(`Request to ${parsed.host} timed out after ${timeoutMs}ms.`));
             });
             req.on('error', reject);
             if (body) {

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
@@ -39,7 +39,7 @@ function buildPublisher(): RegistryPublisher {
         }
         const apiKey = requireInput('apiKey');
         tasks.setSecret(apiKey);
-        return new PrivateRegistryPublisher(createHttpsClient(!skipTlsVerify), {
+        return new PrivateRegistryPublisher(createHttpsClient(!skipTlsVerify, timeoutSeconds * 1000), {
             ...coordinates,
             registryUrl: requireInput('registryUrl'),
             apiKey,
@@ -51,7 +51,7 @@ function buildPublisher(): RegistryPublisher {
     if (registryType === 'hcp') {
         const token = requireInput('hcpToken');
         tasks.setSecret(token);
-        return new HcpPublisher(createHttpsClient(true), {
+        return new HcpPublisher(createHttpsClient(true, timeoutSeconds * 1000), {
             ...coordinates,
             address: tasks.getInput('hcpAddress', false) || 'https://app.terraform.io',
             token,

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/private-publisher.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/private-publisher.ts
@@ -90,9 +90,15 @@ export class PrivateRegistryPublisher implements RegistryPublisher {
     private async waitForVersion(modUrl: string, authHeader: Record<string, string>): Promise<boolean> {
         const deadline = Date.now() + this.options.timeoutSeconds * 1000;
         for (;;) {
-            const resp = await this.http('GET', modUrl, authHeader);
-            if (resp.status >= 200 && resp.status < 300 && hasVersion(resp.body, this.options.version)) {
-                return true;
+            // A single poll failing (e.g. a per-request timeout or transient 5xx)
+            // must not abort the wait; keep polling until the wall-clock deadline.
+            try {
+                const resp = await this.http('GET', modUrl, authHeader);
+                if (resp.status >= 200 && resp.status < 300 && hasVersion(resp.body, this.options.version)) {
+                    return true;
+                }
+            } catch (err) {
+                this.log(`Polling registry failed, will retry: ${err instanceof Error ? err.message : String(err)}`);
             }
             if (Date.now() >= deadline) {
                 return false;

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -54,6 +54,17 @@ describe('TerraformPolicyCheck Test Suite', function () {
     expectFailure('OpaFailPath');
     expectFailure('OpaFailDefined');
 
+    it('OpaExecError — non-zero opa exit surfaces stderr and the exit code', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'OpaExecError.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            const output = tr.errorIssues.join('\n') + '\n' + tr.stdout;
+            assert(/'opa exec' failed \(exit code 1\)/.test(output), `error should name the exit code; got: ${output}`);
+            assert(/rego_parse_error/.test(output), 'error should include the stderr diagnostic');
+        }, tr);
+    });
+
     // --- Sentinel engine (enforcement levels) ---
     expectSuccess('SentinelPassPath');
     expectFailure('SentinelHardFail');

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/OpaExecError.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/OpaExecError.ts
@@ -1,0 +1,39 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+import fs = require('fs');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const testDir = path.join(os.tmpdir(), 'tpc-opa-execerror');
+fs.rmSync(testDir, { recursive: true, force: true });
+fs.mkdirSync(path.join(testDir, 'policies'), { recursive: true });
+const planFile = path.join(testDir, 'plan.json');
+fs.writeFileSync(planFile, '{}');
+const policyDir = path.join(testDir, 'policies');
+
+tr.setInput('engine', 'opa');
+tr.setInput('inputFile', planFile);
+tr.setInput('policySource', 'path');
+tr.setInput('policyPath', policyDir);
+tr.setInput('publishTestResults', 'false');
+
+const opaPath = '/usr/bin/opa';
+const a: ma.TaskLibAnswers = {
+    which: { opa: opaPath },
+    checkPath: { [opaPath]: true },
+    exec: {
+        // opa fails to load the bundle: non-zero exit with diagnostics on stderr
+        // and no JSON on stdout. The task must surface this, not fail later on
+        // empty-output JSON parsing.
+        [`${opaPath} exec --decision terraform/deny --bundle ${policyDir} ${planFile}`]: {
+            code: 1,
+            stdout: '',
+            stderr: 'opa: error loading bundle: failed to parse module policies/deny.rego: rego_parse_error'
+        }
+    }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/opa-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/opa-engine.ts
@@ -22,11 +22,20 @@ export async function runOpa(opaPath: string, policyDir: string, inputFile: stri
     tool.arg(inputFile);
 
     let stdout = '';
+    let stderr = '';
     tool.on('stdout', (data: string | Buffer) => { stdout += data.toString(); });
+    tool.on('stderr', (data: string | Buffer) => { stderr += data.toString(); });
 
     // opa exec returns 0 even when the decision contains violations; we gate on the
     // parsed result, not the exit code.
     const code = await tool.execAsync(<IExecOptions>{ ignoreReturnCode: true });
+
+    // A non-zero exit is a real failure (bad bundle, malformed input, opa crash),
+    // not a policy violation — surface stderr instead of failing later on empty JSON.
+    if (code !== 0) {
+        const detail = stderr.trim() || stdout.trim() || '(no output)';
+        throw new Error(`'opa exec' failed (exit code ${code}): ${detail.slice(0, 500)}`);
+    }
 
     let parsed: { result?: Array<{ path?: string; result?: unknown; error?: unknown }> };
     try {


### PR DESCRIPTION
## Summary

Closes #236. Hardens the network-facing tasks against two failure modes the audit flagged:

1. **No request timeout** — a hung TCP connection left the HTTP clients waiting until the agent job timeout, making each task's own `timeoutSeconds` silently ineffective.
2. **Fragile poll loops** — the ModulePublish wait loops aborted the entire publish on a single transient poll failure.
3. **OPA exit code ignored** — a non-zero `opa exec` (bad bundle, malformed input) surfaced only as an opaque "empty output" JSON parse error.

## Changes

- **ModulePublish `http.ts` / DriftReport `callback.ts`** (`https.request`): add a per-request socket timeout (`req.setTimeout`) that destroys and rejects a stalled connection. Threaded through from the task's `timeoutSeconds` input for ModulePublish; default 100s for the drift callback.
- **TerraformInstaller / PolicyAgentInstaller `http-client.ts`** (`fetch`): centralize the helpers behind an `AbortController`-backed `fetchWithTimeout` that bounds connect, headers **and** body consumption (metadata 60s, downloads 600s). Each helper keeps its existing non-OK error message.
- **ModulePublish `waitForOk` / `waitForVersion`**: tolerate a single failing poll (per-request timeout or transient 5xx) and keep polling until the wall-clock deadline instead of throwing early.
- **PolicyCheck `opa-engine.ts`**: subscribe to stderr and check the exit code before `JSON.parse`, surfacing the diagnostic.

## Tests

- ModulePublish: hung-connection `createHttpsClient` timeout; `waitForOk`/`waitForVersion` deadline-bound + failing-poll-tolerance.
- DriftReport: hung-connection `postJson` timeout.
- Installers: direct `fetchWithTimeout` unit tests (non-https reject + hung-connection abort) via a new `HttpClientL0`.
- PolicyCheck: new `OpaExecError` mock asserting a non-zero opa exit surfaces stderr + exit code.

All five affected task suites pass; `eslint src/` clean; `tsc` clean.