### PR TITLE
refactor: enforce installer shared-module parity

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Validate version fields
         run: node scripts/check-versions.js
 
+  check-shared-modules:
+    name: Check Shared Module Parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Validate shared installer modules are identical
+        run: node scripts/check-shared-modules.js
+
   build-and-test-v5:
     name: Build and Test V5 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -236,8 +236,9 @@ async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Pr
 function parseSha256(sha256SumsContent: string, zipFileName: string): string {
     const lines = sha256SumsContent.split('\n');
     for (const line of lines) {
-        // Format: "<hex-hash>  <filename>" (two spaces between hash and filename)
-        const match = line.match(/^([a-fA-F0-9]{64})\s+(.+)$/);
+        // Format: "<hex-hash>  <filename>"; the optional leading "*" marks
+        // binary mode (canonical regex shared with PolicyAgentInstaller).
+        const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
         if (match && match[2].trim() === zipFileName) {
             tasks.debug(`Found SHA256 for ${zipFileName}: ${match[1]}`);
             return match[1];

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Enforces a single effective source of truth for the security-critical modules
+// that are intentionally duplicated between the two installer tasks. The embedded
+// HashiCorp GPG public key, the signature verifier, and the HTTP client must stay
+// byte-identical across tasks so a fix (e.g. the 2030 GPG key rotation) can never be
+// applied to one copy and silently missed in the other. CI fails on any divergence.
+
+const fs = require('fs');
+const path = require('path');
+
+// Tasks that carry the shared modules. The first entry is the canonical source;
+// every other task's copy must match it exactly.
+const TASK_SRC_DIRS = [
+    'Tasks/TerraformInstaller/TerraformInstallerV1/src',
+    'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src',
+];
+
+// Modules that must remain identical across all of the dirs above.
+const SHARED_MODULES = [
+    'hashicorp-gpg-key.ts',
+    'gpg-verifier.ts',
+    'http-client.ts',
+];
+
+// Normalize line endings so a CRLF checkout never reads as drift; the bytes that
+// matter (the key material, the verification logic) are still compared exactly.
+function read(relDir, file) {
+    const full = path.resolve(relDir, file);
+    if (!fs.existsSync(full)) {
+        return { ok: false, full };
+    }
+    return { ok: true, full, content: fs.readFileSync(full, 'utf8').replace(/\r\n/g, '\n') };
+}
+
+let hasError = false;
+const [canonicalDir, ...otherDirs] = TASK_SRC_DIRS;
+
+for (const file of SHARED_MODULES) {
+    const base = read(canonicalDir, file);
+    if (!base.ok) {
+        console.error(`FAIL: canonical copy missing: ${path.join(canonicalDir, file)}`);
+        hasError = true;
+        continue;
+    }
+    for (const dir of otherDirs) {
+        const other = read(dir, file);
+        if (!other.ok) {
+            console.error(`FAIL: copy missing: ${path.join(dir, file)}`);
+            hasError = true;
+            continue;
+        }
+        if (other.content !== base.content) {
+            console.error(`FAIL: ${file} diverged between ${canonicalDir} and ${dir}`);
+            console.error(`      reconcile both copies (canonical: ${base.full})`);
+            hasError = true;
+        } else {
+            console.log(`OK: ${file} identical (${canonicalDir} == ${dir})`);
+        }
+    }
+}
+
+if (hasError) {
+    process.exit(1);
+}
+console.log('All shared-module parity checks passed.');


### PR DESCRIPTION
## Summary

`gpg-verifier.ts`, `hashicorp-gpg-key.ts`, and `http-client.ts` are byte-duplicated between **TerraformInstallerV1** and **PolicyAgentInstallerV1**. The embedded HashiCorp GPG public key in particular must have a single effective source of truth before the 2030 key rotation — otherwise a rotation could be applied to one copy and silently missed in the other, leaving a task trusting the wrong key.

This enforces that invariant without destabilizing the per-task build/packaging model:

- **CI parity gate** — new `scripts/check-shared-modules.js` (run by a `Check Shared Module Parity` job) fails the build if any of the three modules diverge between the two tasks. Editing one copy without the other now makes the branch un-mergeable, which is functionally equivalent to a single physical source for the drift threat, with zero release-pipeline risk and no test churn.
- **`parseSha256` reconciliation** — the Installer's regex now matches PolicyAgentInstaller's binary-aware canonical form (`\s+\*?`), so the optional `*` binary-mode marker is stripped consistently in both tasks. Backward-compatible for HashiCorp's two-space text-mode `SHA256SUMS`.

### Why a CI gate rather than hoisting into a shared package

The mock-runner tests mock these modules **by relative path** (`registerMock('./http-client', …)` / `'./gpg-verifier'`) across ~33 test files. Hoisting to a bare-specifier npm package would break every one of those mocks and add build-order + `.vsix` packaging machinery that only fails at marketplace-publish time. The parity gate delivers the same single-source-of-truth guarantee for the actual threat while keeping the diff small and the release pipeline untouched.

> Note: the three self-contained modules are parity-guarded. `parseSha256` itself remains a task-local function (distinct call signatures per task); only its regex is reconciled to one canonical form.

## Test plan

- `node scripts/check-shared-modules.js` passes (all three identical); verified it exits non-zero on an injected diff and recovers cleanly.
- Installer suite green (`npm test`, 36 passing) after the regex change; `npx eslint src/` clean.
- Binary-mode `*` marker is covered by PolicyAgentInstaller's existing `InstallerHelpersL0` test; the regexes are now identical across both tasks.

Closes #238
