### PR TITLE
ci: add zizmor workflow security scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,13 +10,16 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+
 jobs:
   conventional-title:
     name: Conventional PR Title
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title follows Conventional Commits
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v5.5.3
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -48,9 +51,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_DISPATCH_APP_ID }}
           private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
+          # Scope the installation token to exactly what release-please needs
+          # (open/update the release PR + push the version-bump commit/tag)
+          # instead of inheriting the app's blanket installation permissions.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Run release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,20 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check tag reachable from main
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           git fetch origin main
           if ! git merge-base --is-ancestor "refs/tags/${TAG}" origin/main 2>/dev/null; then
             echo "Tag ${TAG} is not reachable from origin/main. Releases must be tagged on main." >&2
             exit 1
           fi
       - name: Verify extension version matches tag
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           TAG_VERSION="${TAG#v}"
           EXT_VERSION=$(node -p "require('./azure-devops-extension.json').version")
           if [ "$TAG_VERSION" != "$EXT_VERSION" ]; then
@@ -51,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
@@ -71,6 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
@@ -100,6 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
@@ -212,6 +221,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Download vsix artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -242,6 +252,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
@@ -265,12 +277,14 @@ jobs:
           VSIX_FILE=$(find . -maxdepth 1 -name "*.vsix" -print -quit)
           # 499b84ac-1321-427f-aa17-267ca6975798 is the Azure DevOps resource app.
           ENTRA_TOKEN=$(az account get-access-token \
-            --tenant "${{ vars.AZDO_PUBLISH_TENANT_ID }}" \
+            --tenant "${VARS_AZDO_PUBLISH_TENANT_ID}" \
             --resource 499b84ac-1321-427f-aa17-267ca6975798 \
             --query accessToken -o tsv)
           # Mask the runtime-minted token so it is redacted from any log output.
           echo "::add-mask::$ENTRA_TOKEN"
           ./node_modules/.bin/tfx extension publish --vsix "$VSIX_FILE" --auth-type pat --token "$ENTRA_TOKEN"
+        env:
+          VARS_AZDO_PUBLISH_TENANT_ID: ${{ vars.AZDO_PUBLISH_TENANT_ID }}
 
   undraft-release:
     name: Undraft GitHub Release
@@ -281,11 +295,13 @@ jobs:
     steps:
       - name: Undraft the release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_ID: ${{ needs.draft-release.outputs.release_id }}
         with:
           script: |
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              release_id: ${{ needs.draft-release.outputs.release_id }},
+              release_id: Number(process.env.RELEASE_ID),
               draft: false
             });

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Validate version fields
         run: node scripts/check-versions.js
 
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Validate shared installer modules are identical
         run: node scripts/check-shared-modules.js
 
@@ -41,6 +45,8 @@ jobs:
         working-directory: Tasks/TerraformTask/TerraformTaskV5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -67,6 +73,8 @@ jobs:
         working-directory: Tasks/TerraformInstaller/TerraformInstallerV1
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -93,6 +101,8 @@ jobs:
         working-directory: Tasks/TerraformProviderMirror/TerraformProviderMirrorV1
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -119,6 +129,8 @@ jobs:
         working-directory: Tasks/TerraformModulePublish/TerraformModulePublishV1
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -145,6 +157,8 @@ jobs:
         working-directory: Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -171,6 +185,8 @@ jobs:
         working-directory: Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -197,6 +213,8 @@ jobs:
         working-directory: Tasks/TerraformDriftReport/TerraformDriftReportV1
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -216,6 +234,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
@@ -231,8 +251,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Install actionlint
         shell: bash
         run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
       - name: Run actionlint
         run: ./actionlint -color
+
+  zizmor:
+    name: Scan Workflows (zizmor)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      # Online audits (ref-version-mismatch, impostor-commit, known-vulnerable
+      # actions) use GITHUB_TOKEN; the rest (unpinned-uses, template-injection,
+      # excessive-permissions) run regardless. Pinned for a deterministic gate.
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pipx run --spec zizmor==1.26.1 zizmor .github/workflows/

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -6,10 +6,12 @@ on:
     - cron: "0 8 * * 1" # Every Monday 08:00 UTC
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI
-    secrets: inherit
     uses: ./.github/workflows/unit-test.yml
 
   # ── OSV Vulnerability Scan ────────────────────────────
@@ -22,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Run OSV-Scanner
         id: osv

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+# Documented, intentional exceptions. Every other finding fails CI.
+rules:
+  cache-poisoning:
+    ignore:
+      # The release pipeline's setup-node steps do not enable dependency
+      # caching (no `cache:` input), so there is no cached artifact to poison.
+      # zizmor flags setup-node defensively in any artifact-publishing workflow.
+      - release.yml
+  superfluous-actions:
+    ignore:
+      # softprops/action-gh-release is used deliberately for its multi-file
+      # glob upload + release-notes generation; `gh release` is not equivalent.
+      - release.yml


### PR DESCRIPTION
Adds [zizmor](https://docs.zizmor.sh/) (GitHub Actions static analysis) as a CI job so future unpinned-action, over-broad-permission, and template-injection regressions in the workflows fail the build. Remediates the existing baseline so the gate starts green.

### CI job
- New `Scan Workflows (zizmor)` job in `unit-test.yml` (so it also runs via the release pipeline and weekly scan that reuse this workflow).
- Pinned to `zizmor==1.26.1` via `pipx run` (no `curl | bash`), deterministic gate.
- Runs **online** (`GITHUB_TOKEN`) so the ref-version-mismatch / impostor-commit / known-vulnerable-action audits run alongside the offline ones.

### Baseline remediations
| Audit | Sev | Fix |
| --- | --- | --- |
| `template-injection` | high | Hoist `github.event.inputs.tag`/`github.ref_name`, `vars.AZDO_PUBLISH_TENANT_ID`, `needs.*.outputs.release_id` into `env:` (and `Number(process.env.*)` in github-script) instead of inlining into `run`/`script` blocks |
| `github-app` | high | Scope the release-please app token to `contents` + `pull-requests` write instead of blanket installation permissions |
| `excessive-permissions` | med | Add top-level `permissions: contents: read` to `pr-checks.yml` and `weekly-security.yml` |
| `secrets-inherit` | med | Drop the unused `secrets: inherit` on the weekly CI call (`unit-test.yml` consumes no user secrets; `GITHUB_TOKEN` is automatic) |
| `artipacked` | low | `persist-credentials: false` on every checkout (no job pushes via git) |
| `ref-version-mismatch` | — | Correct two stale SHA-pin comments — `action-semantic-pull-request` `v5.5.3`→`v6.1.1`, `dependency-review` `v4`→`v4.7.1` (verified against the GitHub API; the pinned SHAs are unchanged) |

The two residual low-confidence findings are ignored with rationale in `.github/zizmor.yml`: `cache-poisoning` (the release `setup-node` steps set no `cache:`, so there is no cache to poison) and `superfluous-actions` (`softprops/action-gh-release` is used deliberately for its multi-file glob upload + release notes).

### Verification
- `zizmor --gh-token … .github/workflows/` → **No findings to report** (5 ignored, 19 suppressed).
- `actionlint` (Docker image) → clean.
- All six workflows + the config parse as YAML.
- All SHA pins unchanged; every `${{ … }}` value preserved (moved into `env:`, not altered).

Closes #242