### PR TITLE
fix: grant release-please issues:write for labels

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:
@@ -22,10 +23,12 @@ jobs:
           client-id: ${{ vars.RELEASE_DISPATCH_APP_ID }}
           private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
           # Scope the installation token to exactly what release-please needs
-          # (open/update the release PR + push the version-bump commit/tag)
-          # instead of inheriting the app's blanket installation permissions.
+          # (open/update the release PR + push the version-bump commit/tag,
+          # and manage the autorelease:* labels) instead of inheriting the
+          # app's blanket installation permissions.
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
 
       - name: Run release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
Follow-up from the adversarial verification of #259.

#259 scoped the release-please `create-github-app-token` installation token to least privilege (`contents:write` + `pull-requests:write`). That dropped `issues:write`, which `release-please-action` lists in its documented permission set because it **creates/manages the `autorelease:pending` / `autorelease:tagged` labels**.

### Why CI is still green today
Both labels already exist on the repo, and applying an existing label to a PR is covered by `pull-requests:write`. **Creating** a label (`POST /repos/.../labels`) is not. So the gap is latent and release-time-only: it would 403 if either label is deleted/renamed, the repo is mirrored to a fresh repo without the labels pre-seeded, or a future release-please version upserts a renamed/recolored label.

### Fix
Restore `issues: write` at the workflow level and add `permission-issues: write` to the scoped app-token step — back to parity with the action's documented permissions, without re-broadening to the app's blanket installation grant.

No code paths or other workflows touched.