### PR TITLE
fix: drop release-please issues:write request

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   release-please:
@@ -23,12 +22,13 @@ jobs:
           client-id: ${{ vars.RELEASE_DISPATCH_APP_ID }}
           private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
           # Scope the installation token to exactly what release-please needs
-          # (open/update the release PR + push the version-bump commit/tag,
-          # and manage the autorelease:* labels) instead of inheriting the
-          # app's blanket installation permissions.
+          # (open/update the release PR + push the version-bump commit/tag)
+          # instead of inheriting the app's blanket installation permissions.
+          # NOTE: the app installation is NOT granted the `issues` permission,
+          # so requesting permission-issues here 422s the token step (#261);
+          # release-please runs fine without it (labels already exist).
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - name: Run release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
Reverts the workflow change from #261, which is breaking `release-please` on every push to `main`.

### What happened
#261 added `permission-issues: write` (and `issues: write`) to the `create-github-app-token` step, following the adversarial-verification recommendation that release-please needs `issues:write` to create its `autorelease:*` labels.

That recommendation doesn't hold for this setup: **the release-please GitHub App installation is not granted the `issues` permission**, and `create-github-app-token`'s `permission-*` inputs can only request a *subset* of the app's installation permissions. So requesting `issues` now hard-fails the token step:

```
POST /app/installations/126825299/access_tokens -> 422
"The level of access for permissions requested are not granted to this installation."
```

### Evidence
- Run on the **#260** merge (`contents` + `pull-requests` only, from #259): **success**
- Run on the **#261** merge (adds `issues`): **422 failure** on *Get GitHub App token*

release-please has run this repo's entire history without `issues` permission — the `autorelease:*` labels already exist, and label *application* on PRs is covered by `pull-requests:write`.

### Fix
Revert to the working #259 scoping (`contents:write` + `pull-requests:write`), and add a NOTE comment so this isn't reintroduced. If app-side label *creation* is ever wanted, grant the GitHub App the `issues` permission in its settings first, then re-add `permission-issues` alongside it.