### PR TITLE
security: harden PolicyCheck git policy source

### DIFF
--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Strings/resources.resjson/en-US/resources.resjson
@@ -3,5 +3,8 @@
   "loc.helpMarkDown": "[Learn more about this task](https://github.com/sethbacon/azure-pipelines-terraform)",
   "loc.description": "Evaluate OPA or Sentinel policies from a directory or git repo against Terraform plan JSON",
   "loc.instanceNameFormat": "Policy check ($(engine))",
-  "loc.messages.InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed."
+  "loc.messages.InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed.",
+  "loc.messages.InvalidPolicyRepoRef": "Invalid policy repo ref rejected: %s. Refs must not start with '-' and may contain only letters, digits, '.', '_', '/', and '-'.",
+  "loc.messages.PolicySubdirOutsideRepo": "Policy subdirectory escapes the cloned repository: %s",
+  "loc.messages.PolicyRepoCloneTimedOut": "Cloning the policy repository timed out after %s ms."
 }

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitCloneFailure.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitCloneFailure.ts
@@ -7,39 +7,33 @@ import fs = require('fs');
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
-const FIXED_UUID = 'fixed-clone-uuid';
+const FIXED_UUID = 'fixed-clonefail-uuid';
 const cloneDir = path.join(os.tmpdir(), `policy-repo-${FIXED_UUID}`);
 
-const testDir = path.join(os.tmpdir(), 'tpc-git');
+const testDir = path.join(os.tmpdir(), 'tpc-clonefail');
 fs.rmSync(testDir, { recursive: true, force: true });
 fs.rmSync(cloneDir, { recursive: true, force: true });
 fs.mkdirSync(testDir, { recursive: true });
-// Pre-create the clone target so the post-clone existence check passes (clone is mocked).
-fs.mkdirSync(cloneDir, { recursive: true });
 const planFile = path.join(testDir, 'plan.json');
 fs.writeFileSync(planFile, '{}');
 
-// Deterministic uuid so the clone path (and thus the mocked git command) is predictable.
 tr.registerMock('crypto', { randomUUID: () => FIXED_UUID });
 
 tr.setInput('engine', 'opa');
 tr.setInput('inputFile', planFile);
+tr.setInput('policyAgentPath', '/usr/bin/opa');
 tr.setInput('policySource', 'gitUrl');
 tr.setInput('policyRepoUrl', 'https://github.com/example/policies');
 tr.setInput('policyRepoRef', 'main');
 tr.setInput('publishTestResults', 'false');
 
 const gitPath = '/usr/bin/git';
-const opaPath = '/usr/bin/opa';
 const a: ma.TaskLibAnswers = {
-    which: { git: gitPath, opa: opaPath },
-    checkPath: { [gitPath]: true, [opaPath]: true },
+    which: { git: gitPath },
+    checkPath: { [gitPath]: true, '/usr/bin/opa': true },
     exec: {
         [`${gitPath} clone --depth 1 --branch main -- https://github.com/example/policies ${cloneDir}`]: {
-            code: 0, stdout: 'Cloning...'
-        },
-        [`${opaPath} exec --decision terraform/deny --bundle ${cloneDir} ${planFile}`]: {
-            code: 0, stdout: JSON.stringify({ result: [{ path: planFile, result: [] }] })
+            code: 128, stdout: '', stderr: "fatal: could not read from remote repository"
         }
     }
 };

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitRefInjectionReject.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitRefInjectionReject.ts
@@ -1,0 +1,30 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+import fs = require('fs');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const testDir = path.join(os.tmpdir(), 'tpc-refinject');
+fs.rmSync(testDir, { recursive: true, force: true });
+fs.mkdirSync(testDir, { recursive: true });
+const planFile = path.join(testDir, 'plan.json');
+fs.writeFileSync(planFile, '{}');
+
+tr.setInput('engine', 'opa');
+tr.setInput('inputFile', planFile);
+tr.setInput('policyAgentPath', '/usr/bin/opa');
+tr.setInput('policySource', 'gitUrl');
+tr.setInput('policyRepoUrl', 'https://github.com/example/policies');
+// Leading-dash ref is an argument-injection vector (e.g. git's --upload-pack);
+// it must be rejected before any git invocation.
+tr.setInput('policyRepoRef', '--upload-pack=touch /tmp/pwned');
+tr.setInput('publishTestResults', 'false');
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { '/usr/bin/opa': true }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitShaCheckout.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitShaCheckout.ts
@@ -7,26 +7,32 @@ import fs = require('fs');
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
-const FIXED_UUID = 'fixed-clone-uuid';
+const FIXED_UUID = 'fixed-sha-uuid';
 const cloneDir = path.join(os.tmpdir(), `policy-repo-${FIXED_UUID}`);
 
-const testDir = path.join(os.tmpdir(), 'tpc-git');
+const testDir = path.join(os.tmpdir(), 'tpc-sha');
 fs.rmSync(testDir, { recursive: true, force: true });
 fs.rmSync(cloneDir, { recursive: true, force: true });
 fs.mkdirSync(testDir, { recursive: true });
-// Pre-create the clone target so the post-clone existence check passes (clone is mocked).
 fs.mkdirSync(cloneDir, { recursive: true });
 const planFile = path.join(testDir, 'plan.json');
 fs.writeFileSync(planFile, '{}');
 
-// Deterministic uuid so the clone path (and thus the mocked git command) is predictable.
 tr.registerMock('crypto', { randomUUID: () => FIXED_UUID });
+
+const sha = '0123456789abcdef0123456789abcdef01234567';
+const token = 'secrettoken';
+const header = `Authorization: Basic ${Buffer.from(`:${token}`).toString('base64')}`;
+const url = 'https://github.com/example/private';
 
 tr.setInput('engine', 'opa');
 tr.setInput('inputFile', planFile);
 tr.setInput('policySource', 'gitUrl');
-tr.setInput('policyRepoUrl', 'https://github.com/example/policies');
-tr.setInput('policyRepoRef', 'main');
+tr.setInput('policyRepoUrl', url);
+// A full 40-char SHA takes the clone --no-checkout + checkout path; a token
+// exercises the http.extraheader auth branch.
+tr.setInput('policyRepoRef', sha);
+tr.setInput('policyRepoToken', token);
 tr.setInput('publishTestResults', 'false');
 
 const gitPath = '/usr/bin/git';
@@ -35,8 +41,11 @@ const a: ma.TaskLibAnswers = {
     which: { git: gitPath, opa: opaPath },
     checkPath: { [gitPath]: true, [opaPath]: true },
     exec: {
-        [`${gitPath} clone --depth 1 --branch main -- https://github.com/example/policies ${cloneDir}`]: {
+        [`${gitPath} -c http.extraheader=${header} clone --no-checkout -- ${url} ${cloneDir}`]: {
             code: 0, stdout: 'Cloning...'
+        },
+        [`${gitPath} -C ${cloneDir} checkout ${sha}`]: {
+            code: 0, stdout: `HEAD is now at ${sha.slice(0, 7)}`
         },
         [`${opaPath} exec --decision terraform/deny --bundle ${cloneDir} ${planFile}`]: {
             code: 0, stdout: JSON.stringify({ result: [{ path: planFile, result: [] }] })

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -76,7 +76,47 @@ describe('TerraformPolicyCheck Test Suite', function () {
 
     // --- Policy source ---
     expectSuccess('GitSourceClone');
+    expectSuccess('GitShaCheckout');
     expectFailure('InsecureGitUrlReject');
+
+    it('GitRefInjectionReject — a leading-dash ref is rejected before git runs', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'GitRefInjectionReject.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            const output = tr.errorIssues.join('\n') + '\n' + tr.stdout;
+            assert(/loc_mock_InvalidPolicyRepoRef/.test(output), `ref should be rejected; got: ${output}`);
+        }, tr);
+    });
+
+    it('SubdirTraversalReject — a `../` subdir escaping the clone dir is rejected', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'SubdirTraversalReject.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            const output = tr.errorIssues.join('\n') + '\n' + tr.stdout;
+            assert(/loc_mock_PolicySubdirOutsideRepo/.test(output), `subdir should be rejected; got: ${output}`);
+        }, tr);
+    });
+
+    it('GitCloneFailure — a non-zero git clone surfaces as a task failure', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'GitCloneFailure.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have an error issue');
+        }, tr);
+    });
+
+    it('MissingSubdir — an absent subdir in the clone surfaces a clear error', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'MissingSubdir.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            const output = tr.errorIssues.join('\n') + '\n' + tr.stdout;
+            assert(/Policy subdirectory does not exist in the cloned repo/.test(output), `should report missing subdir; got: ${output}`);
+        }, tr);
+    });
 
     // --- Results publishing ---
     expectSuccess('PublishResults');

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/MissingSubdir.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/MissingSubdir.ts
@@ -7,39 +7,36 @@ import fs = require('fs');
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
-const FIXED_UUID = 'fixed-clone-uuid';
+const FIXED_UUID = 'fixed-missingsubdir-uuid';
 const cloneDir = path.join(os.tmpdir(), `policy-repo-${FIXED_UUID}`);
 
-const testDir = path.join(os.tmpdir(), 'tpc-git');
+const testDir = path.join(os.tmpdir(), 'tpc-missingsubdir');
 fs.rmSync(testDir, { recursive: true, force: true });
 fs.rmSync(cloneDir, { recursive: true, force: true });
 fs.mkdirSync(testDir, { recursive: true });
-// Pre-create the clone target so the post-clone existence check passes (clone is mocked).
+// Clone target exists, but the requested subdir within it does not.
 fs.mkdirSync(cloneDir, { recursive: true });
 const planFile = path.join(testDir, 'plan.json');
 fs.writeFileSync(planFile, '{}');
 
-// Deterministic uuid so the clone path (and thus the mocked git command) is predictable.
 tr.registerMock('crypto', { randomUUID: () => FIXED_UUID });
 
 tr.setInput('engine', 'opa');
 tr.setInput('inputFile', planFile);
+tr.setInput('policyAgentPath', '/usr/bin/opa');
 tr.setInput('policySource', 'gitUrl');
 tr.setInput('policyRepoUrl', 'https://github.com/example/policies');
 tr.setInput('policyRepoRef', 'main');
+tr.setInput('policyRepoSubdir', 'policies');
 tr.setInput('publishTestResults', 'false');
 
 const gitPath = '/usr/bin/git';
-const opaPath = '/usr/bin/opa';
 const a: ma.TaskLibAnswers = {
-    which: { git: gitPath, opa: opaPath },
-    checkPath: { [gitPath]: true, [opaPath]: true },
+    which: { git: gitPath },
+    checkPath: { [gitPath]: true, '/usr/bin/opa': true },
     exec: {
         [`${gitPath} clone --depth 1 --branch main -- https://github.com/example/policies ${cloneDir}`]: {
             code: 0, stdout: 'Cloning...'
-        },
-        [`${opaPath} exec --decision terraform/deny --bundle ${cloneDir} ${planFile}`]: {
-            code: 0, stdout: JSON.stringify({ result: [{ path: planFile, result: [] }] })
         }
     }
 };

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SubdirTraversalReject.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SubdirTraversalReject.ts
@@ -7,39 +7,36 @@ import fs = require('fs');
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
-const FIXED_UUID = 'fixed-clone-uuid';
+const FIXED_UUID = 'fixed-traversal-uuid';
 const cloneDir = path.join(os.tmpdir(), `policy-repo-${FIXED_UUID}`);
 
-const testDir = path.join(os.tmpdir(), 'tpc-git');
+const testDir = path.join(os.tmpdir(), 'tpc-traversal');
 fs.rmSync(testDir, { recursive: true, force: true });
 fs.rmSync(cloneDir, { recursive: true, force: true });
 fs.mkdirSync(testDir, { recursive: true });
-// Pre-create the clone target so the post-clone existence check passes (clone is mocked).
 fs.mkdirSync(cloneDir, { recursive: true });
 const planFile = path.join(testDir, 'plan.json');
 fs.writeFileSync(planFile, '{}');
 
-// Deterministic uuid so the clone path (and thus the mocked git command) is predictable.
 tr.registerMock('crypto', { randomUUID: () => FIXED_UUID });
 
 tr.setInput('engine', 'opa');
 tr.setInput('inputFile', planFile);
+tr.setInput('policyAgentPath', '/usr/bin/opa');
 tr.setInput('policySource', 'gitUrl');
 tr.setInput('policyRepoUrl', 'https://github.com/example/policies');
 tr.setInput('policyRepoRef', 'main');
+// `../../` escapes the clone dir — must be rejected after the clone.
+tr.setInput('policyRepoSubdir', '../../etc');
 tr.setInput('publishTestResults', 'false');
 
 const gitPath = '/usr/bin/git';
-const opaPath = '/usr/bin/opa';
 const a: ma.TaskLibAnswers = {
-    which: { git: gitPath, opa: opaPath },
-    checkPath: { [gitPath]: true, [opaPath]: true },
+    which: { git: gitPath },
+    checkPath: { [gitPath]: true, '/usr/bin/opa': true },
     exec: {
         [`${gitPath} clone --depth 1 --branch main -- https://github.com/example/policies ${cloneDir}`]: {
             code: 0, stdout: 'Cloning...'
-        },
-        [`${opaPath} exec --decision terraform/deny --bundle ${cloneDir} ${planFile}`]: {
-            code: 0, stdout: JSON.stringify({ result: [{ path: planFile, result: [] }] })
         }
     }
 };

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
@@ -1,9 +1,19 @@
 import tasks = require('azure-pipelines-task-lib/task');
-import { IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
+import { IExecOptions, ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
 import { randomUUID as uuidV4 } from 'crypto';
+
+// Wall-clock bound for each git invocation. git's HTTP transport has no built-in
+// connect/idle timeout, so an unreachable, slow, or credential-prompting host
+// would otherwise hang until the ADO job timeout.
+const GIT_TIMEOUT_MS = 300_000;
+
+// A git ref we are willing to hand to `git clone --branch` / `git checkout`.
+// Rejects leading-dash refs (e.g. `--upload-pack=<cmd>`) and anything outside a
+// conservative branch/tag/SHA charset, closing the argument-injection vector.
+const SAFE_REF = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
 
 /**
  * Resolves the directory containing the policies to evaluate.
@@ -32,6 +42,9 @@ export async function resolvePolicyDir(tempDirs: string[]): Promise<string> {
         throw new Error(tasks.loc('InsecureUrlRejected', url));
     }
     const ref = tasks.getInput('policyRepoRef') || 'main';
+    if (!SAFE_REF.test(ref)) {
+        throw new Error(tasks.loc('InvalidPolicyRepoRef', ref));
+    }
     const subdir = tasks.getInput('policyRepoSubdir');
     const token = tasks.getInput('policyRepoToken');
 
@@ -39,7 +52,13 @@ export async function resolvePolicyDir(tempDirs: string[]): Promise<string> {
     await cloneRepo(url, ref, token, cloneDir);
     tempDirs.push(cloneDir);
 
-    const policyDir = subdir ? path.join(cloneDir, subdir) : cloneDir;
+    // Resolve the subdir against the clone root and assert containment, so a
+    // `../../x` (or absolute) subdir cannot point the policy bundle at an
+    // arbitrary readable directory on the agent.
+    const policyDir = subdir ? path.resolve(cloneDir, subdir) : cloneDir;
+    if (policyDir !== cloneDir && !policyDir.startsWith(cloneDir + path.sep)) {
+        throw new Error(tasks.loc('PolicySubdirOutsideRepo', subdir));
+    }
     if (!fs.existsSync(policyDir)) {
         throw new Error(`Policy subdirectory does not exist in the cloned repo: ${policyDir}`);
     }
@@ -59,19 +78,52 @@ async function cloneRepo(url: string, ref: string, token: string | undefined, cl
     }
 
     if (isSha) {
-        // Full clone (no checkout), then check out the exact commit.
+        // Full clone (no checkout), then check out the exact commit. `--` stops
+        // git option-parsing before the url/dir positionals; `ref` is a
+        // validated 40-char SHA here, so the checkout positional is safe.
         const clone = tasks.tool(gitPath);
         clone.arg(authArgs);
-        clone.arg(['clone', '--no-checkout', url, cloneDir]);
-        await clone.execAsync(<IExecOptions>{});
+        clone.arg(['clone', '--no-checkout', '--', url, cloneDir]);
+        await execGit(clone);
 
         const checkout = tasks.tool(gitPath);
         checkout.arg(['-C', cloneDir, 'checkout', ref]);
-        await checkout.execAsync(<IExecOptions>{});
+        await execGit(checkout);
     } else {
+        // `--` stops option-parsing before url/dir; `ref` is the `--branch`
+        // value and is constrained by SAFE_REF (no leading dash).
         const clone = tasks.tool(gitPath);
         clone.arg(authArgs);
-        clone.arg(['clone', '--depth', '1', '--branch', ref, url, cloneDir]);
-        await clone.execAsync(<IExecOptions>{});
+        clone.arg(['clone', '--depth', '1', '--branch', ref, '--', url, cloneDir]);
+        await execGit(clone);
+    }
+}
+
+/**
+ * Runs a git ToolRunner with a hard wall-clock timeout and a fail-fast
+ * environment (never prompt for credentials; abort a stalled HTTP transfer).
+ */
+async function execGit(tool: ToolRunner): Promise<void> {
+    const options = <IExecOptions>{
+        env: {
+            ...process.env,
+            GIT_TERMINAL_PROMPT: '0',
+            GIT_HTTP_LOW_SPEED_LIMIT: '1000',
+            GIT_HTTP_LOW_SPEED_TIME: '60'
+        }
+    };
+    let timer: NodeJS.Timeout | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+            tool.killChildProcess();
+            reject(new Error(tasks.loc('PolicyRepoCloneTimedOut', GIT_TIMEOUT_MS)));
+        }, GIT_TIMEOUT_MS);
+    });
+    try {
+        await Promise.race([tool.execAsync(options), deadline]);
+    } finally {
+        if (timer) {
+            clearTimeout(timer);
+        }
     }
 }

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "2",
+        "Minor": "3",
         "Patch": "0"
     },
     "instanceNameFormat": "Policy check ($(engine))",
@@ -268,6 +268,9 @@
         }
     ],
     "messages": {
-        "InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed."
+        "InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed.",
+        "InvalidPolicyRepoRef": "Invalid policy repo ref rejected: %s. Refs must not start with '-' and may contain only letters, digits, '.', '_', '/', and '-'.",
+        "PolicySubdirOutsideRepo": "Policy subdirectory escapes the cloned repository: %s",
+        "PolicyRepoCloneTimedOut": "Cloning the policy repository timed out after %s ms."
     }
 }


### PR DESCRIPTION
Hardens the `gitUrl` policy source in `TerraformPolicyCheckV1/src/policy-source.ts`, surfaced by the post-audit residual sweep (follow-up to the wv9ih3klz review #231–#244).

## Changes
- **Git ref argument injection (#263)** — validate `policyRepoRef` against a conservative branch/tag/SHA charset (rejects leading-dash refs like `--upload-pack=<cmd>`) and add a `--` end-of-options separator before the `url`/`dir` positionals in both clone commands. The checkout path only runs for a validated 40-char SHA, so its positional is safe.
- **Subdir path traversal (#264)** — resolve `policyRepoSubdir` against the clone root with `path.resolve` and assert containment; `../` or absolute subdirs are rejected with a localized error.
- **Unbounded clone (#265)** — bound every git invocation with a 5-minute wall-clock timeout (races `execAsync`, kills the child on expiry) plus a fail-fast env: `GIT_TERMINAL_PROMPT=0`, `GIT_HTTP_LOW_SPEED_LIMIT`/`_TIME`.
- **Failure-path coverage (#266)** — new L0 tests for ref rejection, subdir traversal rejection, a non-zero `git clone`, a missing subdir, and the SHA + token (`http.extraheader`) clone path. `policy-source.js` coverage rises to 94.7% stmts / 86.5% branch; the existing happy-path test updated for the new `--`.

New localized messages: `InvalidPolicyRepoRef`, `PolicySubdirOutsideRepo`, `PolicyRepoCloneTimedOut` (task.json + resjson). Bumps `TerraformPolicyCheckV1` task.json `Minor` (1.2 → 1.3) so agents re-fetch the handler.

## Verification
- `npm run compile` — clean
- `npm run test:coverage` — 22 passing; gate (75/75/70) met at 90.5/77.8/85.2/93.0
- `npm run lint` — clean

Closes #263
Closes #264
Closes #265
Closes #266