### PR TITLE
fix: show requireChecksum for the registry source

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "225",
+        "Minor": "226",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",
@@ -103,8 +103,8 @@
             "label": "Require checksum verification",
             "defaultValue": "false",
             "required": false,
-            "visibleRule": "binary = terraform && downloadSource = mirror",
-            "helpMarkDown": "When enabled, fail if the mirror does not serve a SHA256SUMS file for the requested version. When disabled (default), checksum verification is attempted but skipped if the mirror does not publish a SHA256SUMS file."
+            "visibleRule": "binary = terraform && downloadSource != hashicorp",
+            "helpMarkDown": "When enabled, fail if the mirror or registry does not serve a SHA256SUMS file for the requested version. When disabled (default), checksum verification is attempted but skipped if no SHA256SUMS file is published."
         }
     ],
     "restrictions": {


### PR DESCRIPTION
## Summary

The `requireChecksum` input governs fail-closed checksum verification on **both** the mirror and registry download paths:

- `terraform-installer.ts:183` — `downloadZipFromRegistry` reads it to fail when the registry returns an empty SHA256.
- `terraform-installer.ts:213` — `downloadZipFromMirror` reads it to fail when the mirror serves no SHA256SUMS.

…but its `visibleRule` was scoped to `downloadSource = mirror` only, so a classic-editor user on `downloadSource = registry` could not see or set the control that governs their fail-closed behavior — it silently defaulted to `false` (#274).

This repo's `visibleRule` expressions never mix `&&`/`||` or use parentheses, so "terraform AND (mirror OR registry)" can't be written directly. Since `downloadSource` has exactly three options (`hashicorp`, `registry`, `mirror`), the union of mirror+registry is the complement of `hashicorp`, expressed with the `!=` idiom already used for `requireGpgSignature` (`downloadSource != registry`):

```
"binary = terraform && downloadSource != hashicorp"
```

The input is now reachable on every path that consults it, and stays hidden on the HashiCorp path (which always verifies) and the OpenTofu path (`downloadZipFromOpenTofu` always calls `verifySha256` unconditionally, and `binary = tofu` hides `downloadSource` entirely).

`helpMarkDown` updated to say "mirror or registry". Installer `task.json` Minor bumped 225 → 226 so ADO registers the updated manifest.

## Test

No automated test asserts `visibleRule` strings (UX-only manifest change). Validated: `task.json` parses, version-consistency check passes, and the 36 installer unit tests (which load the manifest via MockTestRunner) still pass.

Closes #274