### PR TITLE
chore: bump two task minors for 1.6.0 release

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "2",
+        "Minor": "3",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(policyAgent) $(version)",

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "4",
+        "Minor": "5",
         "Patch": "0"
     },
     "instanceNameFormat": "Configure provider mirror: $(mirrorUrl)",


### PR DESCRIPTION
## Summary

Pre-release housekeeping for **1.6.0** (release-please PR #252): bump the `Minor` of the two tasks whose runtime-relevant content changed since **v1.5.1** but which were **not** bumped in a feature PR this cycle. ADO agents cache tasks by `Major.Minor` and will not re-download until `Minor` increments, so without these the changes never take effect on agents holding the cached versions.

| Task | Minor | Why |
|------|-------|-----|
| **TerraformProviderMirrorV1** | 4 → 5 | Gained an agent-enforced `restrictions` block (`commands.mode=restricted`, `settableVariables.allowed=[TF_CLI_CONFIG_FILE, configFilePath]`) via #245. No `src/` change, but the security restriction is enforced from the cached task definition — it won't apply without the bump. |
| **PolicyAgentInstallerV1** | 2 → 3 | Runtime `src/` changes (`http-client.ts` network timeouts #256, `policy-agent-installer.ts` registry-download hardening) **and** the #245 `restrictions` block; `Minor` never moved. |

The other five tasks were already correctly `Minor`-bumped (+1 since v1.5.1) in their feature PRs this cycle and are **not** touched here:

| Task | Minor@v1.5.1 → HEAD |
|------|------|
| TerraformTaskV5 | 266 → 267 |
| TerraformInstallerV1 | 225 → 226 |
| TerraformPolicyCheckV1 | 2 → 3 |
| TerraformDriftReportV1 | 2 → 3 |
| TerraformModulePublishV1 | 2 → 3 |

Determined by a per-task audit of `v1.5.1..HEAD` (independent verification of each task's runtime diff + `Minor` delta; no double-bumps, no missed bumps beyond these two).

## Test

Config-only (`task.json` version fields). Validated: both files parse, and the version-consistency check passes (ProviderMirror 1.5.0, PolicyAgentInstaller 1.3.0).