### PR TITLE
security: validate sentinel import name

### DIFF
--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -6,6 +6,8 @@ import * as os from 'os';
 
 // Direct unit tests for the reporting helpers (SARIF/JUnit branch coverage).
 import './ResultsL0';
+// Direct unit tests for sentinel import-name validation (HCL injection guard).
+import './SentinelImportNameL0';
 
 describe('TerraformPolicyCheck Test Suite', function () {
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SentinelImportNameL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SentinelImportNameL0.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import { validateSentinelImportName } from '../src/sentinel-engine';
+
+// Direct unit tests for sentinel import-name validation. The import name is user
+// input (sentinelImportName) embedded verbatim into the generated sentinel.hcl as
+// an HCL identifier — import "static" "<name>" { ... }. Unlike the source paths it
+// is not string-escaped, so without validation a crafted value could close the
+// import block and inject arbitrary config. It must be constrained to a valid
+// identifier, which is the only thing Sentinel itself accepts there anyway.
+describe('sentinel import-name validation', () => {
+    it('accepts valid HCL identifiers (including the tfplan default)', () => {
+        assert.strictEqual(validateSentinelImportName('tfplan'), 'tfplan');
+        assert.strictEqual(validateSentinelImportName('_plan2'), '_plan2');
+        assert.strictEqual(validateSentinelImportName('TF_Plan_v2'), 'TF_Plan_v2');
+    });
+
+    it('rejects names that could break out of the HCL import block', () => {
+        const rejected = [
+            'tfplan" {}\npolicy "evil" { source = "x" }\nimport "static" "x', // injection
+            'tfplan-1',  // dash is not an identifier character
+            'tf plan',   // whitespace
+            '2plan',     // leading digit
+            '',          // empty
+            'tf$plan',   // shell/HCL metacharacter
+        ];
+        for (const bad of rejected) {
+            assert.throws(
+                () => validateSentinelImportName(bad),
+                /Invalid sentinelImportName/,
+                `expected rejection for: ${JSON.stringify(bad)}`,
+            );
+        }
+    });
+});

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
@@ -99,9 +99,28 @@ function applyEnforcement(
     }
 }
 
+const SENTINEL_IMPORT_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * The Sentinel import name is embedded verbatim into the generated sentinel.hcl as
+ * an HCL identifier — `import "static" "<name>" { ... }`. Unlike the source paths,
+ * which `hcl()` escapes, the identifier is not escapable; an unconstrained value
+ * could close the import block and inject arbitrary HCL. Constrain it to a valid
+ * identifier (the only thing Sentinel accepts in that position anyway).
+ */
+export function validateSentinelImportName(name: string): string {
+    if (!SENTINEL_IMPORT_NAME_RE.test(name)) {
+        throw new Error(
+            `Invalid sentinelImportName '${name}': must be a valid identifier ` +
+            `(letters, digits, and underscores; not starting with a digit).`
+        );
+    }
+    return name;
+}
+
 /** Generates a sentinel.hcl in a temp dir; returns that dir. */
 function generateConfig(policyDir: string, inputFile: string, level: string, tempFiles: string[]): string {
-    const importName = tasks.getInput('sentinelImportName') || 'tfplan';
+    const importName = validateSentinelImportName(tasks.getInput('sentinelImportName') || 'tfplan');
     const policies = findSentinelPolicies(policyDir);
     if (policies.length === 0) {
         throw new Error(`No .sentinel policy files found in ${policyDir}.`);

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "4",
         "Patch": "0"
     },
     "instanceNameFormat": "Policy check ($(engine))",


### PR DESCRIPTION
The `sentinelImportName` input was embedded verbatim into the generated `sentinel.hcl` as an HCL identifier:

```hcl
import "static" "<name>" {
  source = "..."
}
```

Unlike the source paths (which `hcl()` escapes), the identifier position is not escapable, so a crafted value could close the import block and inject arbitrary HCL config into the generated policy harness.

## Fix

Constrain the import name to a valid identifier — `/^[A-Za-z_][A-Za-z0-9_]*$/`, which is the only form Sentinel itself accepts in that position anyway — via an exported `validateSentinelImportName()` helper. Anything else (whitespace, quotes, metacharacters, leading digit, empty) is rejected with a clear error before the config is written.

## Tests (TDD, tests-first)

`Tests/SentinelImportNameL0.ts` (direct-unit, wired into `L0.ts`):
- accepts valid identifiers including the `tfplan` default;
- rejects an HCL-breakout injection plus dash/whitespace/leading-digit/empty/metachar cases.

Full PolicyCheck suite: 24 passing (incl. the 2 new tests). `npm ci` was run locally to match CI's pinned deps; with the stale local `@types/node` refreshed, `compile:all` is clean.

## Versioning

TerraformPolicyCheckV1 `Minor` bumped 3 → 4 (runtime `src/` changed; ADO agents cache by Major.Minor).

Closes #295, #303