### PR TITLE
security: fail-secure drift callback TLS verify

### DIFF
--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackFails.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackFails.ts
@@ -2,6 +2,7 @@ import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
+import { resolveRejectUnauthorized } from '../src/callback';
 
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -30,6 +31,7 @@ tr.setInput('rejectUnauthorized', 'true');
 tr.registerMock('./callback', {
     postJson: async () => ({ status: 500, body: 'internal error' }),
     truncateBody: (body: string) => body,
+    resolveRejectUnauthorized,
 });
 
 tr.run();

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackSuccess.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackSuccess.ts
@@ -2,6 +2,7 @@ import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
+import { resolveRejectUnauthorized } from '../src/callback';
 
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -30,6 +31,7 @@ tr.setInput('rejectUnauthorized', 'true');
 tr.registerMock('./callback', {
     postJson: async () => ({ status: 200, body: '{}' }),
     truncateBody: (body: string) => body,
+    resolveRejectUnauthorized,
 });
 
 tr.run();

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackTlsOff.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackTlsOff.ts
@@ -2,6 +2,7 @@ import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
+import { resolveRejectUnauthorized } from '../src/callback';
 
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -30,6 +31,7 @@ tr.setInput('rejectUnauthorized', 'false');
 tr.registerMock('./callback', {
     postJson: async () => ({ status: 200, body: '{}' }),
     truncateBody: (body: string) => body,
+    resolveRejectUnauthorized,
 });
 
 tr.run();

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -9,6 +9,9 @@ import { postJson, truncateBody } from '../src/callback';
 import { createHttpsClient } from '../src/https-client';
 import { TLS_CERT, TLS_KEY } from './loopback-tls';
 
+// Direct unit tests for the fail-secure rejectUnauthorized default.
+import './RejectUnauthorizedDefaultL0';
+
 describe('TerraformDriftReport callback transport', function () {
     it('refuses to POST the callback token over a non-HTTPS URL', async () => {
         await assert.rejects(

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/RejectUnauthorizedDefaultL0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/RejectUnauthorizedDefaultL0.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import { resolveRejectUnauthorized } from '../src/callback';
+
+// Direct unit tests for the fail-secure resolution of the callback TLS-verify
+// flag. tasks.getBoolInput would return false for an absent or blank input — a
+// YAML pipeline that omits rejectUnauthorized, since the task.json defaultValue
+// only applies in the classic editor — silently turning TLS verification OFF.
+// The raw value is read instead and a missing/blank input defaults to secure
+// (verify); only an explicit "false" (case-insensitive) disables verification.
+describe('drift callback: rejectUnauthorized fail-secure default', () => {
+    it('defaults a missing or blank input to true (verify TLS)', () => {
+        assert.strictEqual(resolveRejectUnauthorized(undefined), true);
+        assert.strictEqual(resolveRejectUnauthorized(''), true);
+        assert.strictEqual(resolveRejectUnauthorized('   '), true);
+    });
+
+    it('honours an explicit true', () => {
+        assert.strictEqual(resolveRejectUnauthorized('true'), true);
+        assert.strictEqual(resolveRejectUnauthorized('TRUE'), true);
+    });
+
+    it('disables verification only on an explicit false', () => {
+        assert.strictEqual(resolveRejectUnauthorized('false'), false);
+        assert.strictEqual(resolveRejectUnauthorized('False'), false);
+        assert.strictEqual(resolveRejectUnauthorized(' false '), false);
+    });
+
+    it('treats any unrecognized value as secure (verify), not as disabled', () => {
+        assert.strictEqual(resolveRejectUnauthorized('yes'), true);
+        assert.strictEqual(resolveRejectUnauthorized('1'), true);
+    });
+});

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
@@ -6,6 +6,18 @@ import { createHttpsClient, HttpResponse, DEFAULT_REQUEST_TIMEOUT_MS } from './h
 export { truncateBody } from './https-client';
 
 /**
+ * Resolves the callback TLS-verification flag, fail-secure. The task input is a
+ * boolean with a task.json defaultValue of "true", but that default only applies
+ * in the classic editor — tasks.getBoolInput returns false for an absent or blank
+ * runtime value (e.g. a YAML pipeline that omits rejectUnauthorized), which would
+ * silently turn TLS verification OFF. Read the raw value and default a missing or
+ * blank input to verify; only an explicit "false" (case-insensitive) disables it.
+ */
+export function resolveRejectUnauthorized(raw: string | undefined): boolean {
+    return (raw || 'true').trim().toUpperCase() !== 'FALSE';
+}
+
+/**
  * Minimal HTTPS POST backed by the shared https client. rejectUnauthorized
  * = false disables TLS verification — only for an internal TSM callback fronted
  * by a private CA the agent does not trust.

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -3,7 +3,7 @@ import path = require('path');
 import fs = require('fs');
 import os = require('os');
 import { summarize, moduleCallsPlan, Plan } from 'terraform-drift-contract';
-import { postJson, truncateBody } from './callback';
+import { postJson, truncateBody, resolveRejectUnauthorized } from './callback';
 import { writeSarif } from './sarif';
 
 // Reads `.terraform/modules/modules.json` verbatim for the callback's
@@ -79,7 +79,9 @@ async function run(): Promise<void> {
             tasks.setSecret(callbackToken);
         }
         if (callbackUrl && callbackToken) {
-            const rejectUnauthorized = tasks.getBoolInput('rejectUnauthorized', false);
+            // Fail-secure: an absent/blank rejectUnauthorized verifies TLS (see
+            // resolveRejectUnauthorized); only an explicit "false" disables it.
+            const rejectUnauthorized = resolveRejectUnauthorized(tasks.getInput('rejectUnauthorized', false));
             if (!rejectUnauthorized) {
                 tasks.warning(
                     'rejectUnauthorized is disabled: TLS certificate validation is OFF for the drift callback, ' +

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "3",
+    "Minor": "4",
     "Patch": "0"
   },
   "instanceNameFormat": "Drift report",


### PR DESCRIPTION
The drift callback read its TLS-verification flag with `tasks.getBoolInput('rejectUnauthorized', false)`, which returns `false` for an **absent or blank** runtime input. The `task.json` `defaultValue` of `"true"` only applies in the classic editor, so a YAML pipeline that omitted `rejectUnauthorized` silently POSTed the callback token over an **unverified TLS channel** — a fail-open default for a security-sensitive flag.

## Fix

Resolve the flag fail-secure via an exported `resolveRejectUnauthorized()` helper in `callback.ts`:

- absent / blank input → **verify** (`true`);
- explicit `"true"` → verify;
- explicit `"false"` (case-insensitive, trimmed) → disable verification;
- any unrecognized value → verify (secure), not disabled.

`index.ts` now reads the raw input and routes it through the helper.

## Tests (TDD, tests-first)

- `Tests/RejectUnauthorizedDefaultL0.ts` (direct-unit, wired into `L0.ts`) — covers the default/true/false/unrecognized cases including blank and whitespace.
- The three callback mock scenarios (`...CallbackSuccess`, `...CallbackFails`, `...CallbackTlsOff`) now inject the **real** `resolveRejectUnauthorized` into the `./callback` mock (stubbing only the network), so the `index.ts` integration path — including the TLS-off warning branch — is genuinely exercised rather than bypassed.

Full DriftReport suite: 17 passing. `npm ci` was run locally to align with CI's pinned deps.

## Versioning

TerraformDriftReportV1 `Minor` bumped 3 → 4 (runtime `src/` changed; ADO agents cache by Major.Minor). Only `callback.ts` (DriftReport-specific) changed — the parity-guarded `https-client.ts` shared module is untouched.

Closes #307