### PR TITLE
fix: prefer installer terraformLocation over PATH

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -12,6 +12,8 @@ import './SecureFileLoaderL0';
 import './OciWifTempDirL0';
 // Direct unit test for emergency cleanup before a handler is assigned.
 import './EmergencyCleanupNoHandlerL0';
+// Direct unit tests for tool-path resolution (terraformLocation vs PATH).
+import './ResolveToolPathL0';
 
 describe('Terraform Test Suite', function () {
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ResolveToolPathL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ResolveToolPathL0.ts
@@ -1,0 +1,63 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import tasks = require('azure-pipelines-task-lib/task');
+import { resolveToolPath } from '../src/terraform';
+
+/**
+ * Direct unit tests for tool-path resolution. PipelineTerraformInstaller records
+ * the binary it installed in the terraformLocation variable (and PATH, via
+ * tools.prependPath — see TerraformInstallerV1 issue #319). Both are job-scoped
+ * the same way, so terraformLocation is same-job defense-in-depth for cases where
+ * a PATH lookup would otherwise fail, not a cross-job handoff. The recorded path
+ * is only trusted when its filename matches the requested binary, so installing
+ * tofu in one step can't make a `terraform` command silently run the tofu binary.
+ */
+describe('resolveToolPath — installer terraformLocation vs PATH lookup', function () {
+    const originalGetVariable = tasks.getVariable;
+    const originalWhich = tasks.which;
+    const originalExistsSync = fs.existsSync;
+
+    afterEach(() => {
+        (tasks as any).getVariable = originalGetVariable;
+        (tasks as any).which = originalWhich;
+        (fs as any).existsSync = originalExistsSync;
+    });
+
+    it('prefers terraformLocation when it exists on disk and matches the requested binary', () => {
+        (tasks as any).getVariable = (name: string) =>
+            name === 'terraformLocation' ? '/tmp/terraform-cached/terraform' : undefined;
+        (fs as any).existsSync = (p: string) => p === '/tmp/terraform-cached/terraform';
+        (tasks as any).which = () => {
+            throw new Error('tasks.which should not be called when terraformLocation is valid');
+        };
+        assert.strictEqual(resolveToolPath(tasks, 'terraform'), '/tmp/terraform-cached/terraform');
+    });
+
+    it('falls back to PATH lookup when terraformLocation points at a different binary', () => {
+        (tasks as any).getVariable = (name: string) =>
+            name === 'terraformLocation' ? '/tmp/tofu-cached/tofu' : undefined;
+        (fs as any).existsSync = () => true;
+        (tasks as any).which = (name: string) => '/usr/local/bin/' + name;
+        assert.strictEqual(resolveToolPath(tasks, 'terraform'), '/usr/local/bin/terraform');
+    });
+
+    it('falls back to PATH lookup when terraformLocation no longer exists on disk', () => {
+        (tasks as any).getVariable = (name: string) =>
+            name === 'terraformLocation' ? '/tmp/terraform-cached/terraform' : undefined;
+        (fs as any).existsSync = () => false;
+        (tasks as any).which = (name: string) => '/usr/local/bin/' + name;
+        assert.strictEqual(resolveToolPath(tasks, 'terraform'), '/usr/local/bin/terraform');
+    });
+
+    it('falls back to PATH lookup when terraformLocation is unset', () => {
+        (tasks as any).getVariable = () => undefined;
+        (tasks as any).which = (name: string) => '/usr/local/bin/' + name;
+        assert.strictEqual(resolveToolPath(tasks, 'terraform'), '/usr/local/bin/terraform');
+    });
+
+    it('throws when neither terraformLocation nor PATH resolve the binary', () => {
+        (tasks as any).getVariable = () => undefined;
+        (tasks as any).which = () => { throw new Error('not found'); };
+        assert.throws(() => resolveToolPath(tasks, 'terraform'));
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -1,4 +1,4 @@
-import { TerraformToolHandler, ITerraformToolHandler, getBinaryName } from './terraform';
+import { TerraformToolHandler, ITerraformToolHandler, getBinaryName, resolveToolPath } from './terraform';
 import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformBaseCommandInitializer, TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import { getSecureVarFileArgs, SecureFileLoader } from './secure-file-loader';
@@ -220,12 +220,7 @@ export abstract class BaseTerraformCommandHandler {
     public async warnIfMultipleProviders(): Promise<void> {
         try {
             const binaryName = getBinaryName(tasks);
-            let toolPath;
-            try {
-                toolPath = tasks.which(binaryName, true);
-            } catch {
-                throw new Error(tasks.loc("TerraformToolNotFound"));
-            }
+            const toolPath = resolveToolPath(tasks, binaryName);
 
             const terraformToolRunner: ToolRunner = tasks.tool(toolPath);
             terraformToolRunner.arg("providers");

--- a/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
@@ -1,3 +1,5 @@
+import fs = require('fs');
+import path = require('path');
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner'
 import { TerraformBaseCommandInitializer } from './terraform-commands'
 
@@ -9,6 +11,31 @@ export function getBinaryName(tasks: typeof import('azure-pipelines-task-lib/tas
         throw new Error(`Invalid binaryName '${name}'. Allowed values: ${ALLOWED_BINARY_NAMES.join(', ')}`);
     }
     return name;
+}
+
+/**
+ * Resolves the binary to invoke, preferring the path PipelineTerraformInstaller
+ * recorded in terraformLocation over a bare PATH lookup. terraformLocation is
+ * job-scoped the same way PATH itself is (set via tasks.setVariable, not an
+ * output variable), so this is same-job defense-in-depth — it helps when a PATH
+ * lookup would otherwise fail (e.g. tools.prependPath not honored on some
+ * agent/container configuration) while the installer's own variable is still
+ * intact, not a cross-job handoff. The recorded path is only trusted when its
+ * filename matches the requested binary, so installing tofu in one step can't
+ * make a `terraform` command silently run the tofu binary.
+ */
+export function resolveToolPath(tasks: typeof import('azure-pipelines-task-lib/task'), binaryName: string): string {
+    const installerLocation = tasks.getVariable('terraformLocation');
+    if (installerLocation
+        && fs.existsSync(installerLocation)
+        && path.basename(installerLocation).toLowerCase().startsWith(binaryName.toLowerCase())) {
+        return installerLocation;
+    }
+    try {
+        return tasks.which(binaryName, true);
+    } catch {
+        throw new Error(tasks.loc("TerraformToolNotFound"));
+    }
 }
 
 export interface ITerraformToolHandler {
@@ -24,12 +51,7 @@ export class TerraformToolHandler implements ITerraformToolHandler {
 
     public createToolRunner(command?: TerraformBaseCommandInitializer): ToolRunner {
         const binaryName = getBinaryName(this.tasks);
-        let toolPath;
-        try {
-            toolPath = this.tasks.which(binaryName, true);
-        } catch {
-            throw new Error(this.tasks.loc("TerraformToolNotFound"));
-        }
+        const toolPath = resolveToolPath(this.tasks, binaryName);
 
         const toolRunner: ToolRunner = this.tasks.tool(toolPath);
         if (command) {

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "268",
+        "Minor": "269",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",


### PR DESCRIPTION
Follow-up to #319 / #320. #320 fixes the root cause (the installer never put the binary on PATH), and is sufficient on its own. This adds same-job defense-in-depth on the consuming side: `PipelineTerraformTask` resolved the binary only via `tasks.which()` (a PATH lookup) and never consulted the `terraformLocation` variable the installer already sets.

`terraformLocation` is job-scoped the same way PATH itself is (plain `tasks.setVariable`, not an output variable), so this is **not** a cross-job handoff — it only helps when a PATH lookup would otherwise fail within the same job (e.g. `prependPath` not honored on some agent/container configuration) while the installer's own variable is still intact.

`resolveToolPath()` only trusts `terraformLocation` when the file still exists on disk *and* its filename matches the requested `binaryName` — so installing `tofu` in one step can't make a later `terraform` command silently run the tofu binary. Falls back to the existing `tasks.which()` lookup otherwise (matches every existing test's behavior, since none of them set `terraformLocation`). Also de-duplicates the previously-copy-pasted `tasks.which()`/`TerraformToolNotFound` pattern across `terraform.ts` and `base-terraform-command-handler.ts`.

5 new direct-unit tests cover: prefer-when-valid, fall back on binary mismatch, fall back when the file no longer exists on disk, fall back when unset, and the not-found error path. 200/200 passing (195 prior + 5 new).

Bumped TerraformTaskV5 Minor 268->269 (runtime src changed).