### PR TITLE
security: opt-in host allowlist for registry download_url

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -7,6 +7,8 @@ import * as path from 'path';
 import './CosignVerifierL0';
 // Direct unit tests for the http-client timeout guard.
 import './HttpClientL0';
+// Direct unit tests for the optional registry download_url host allowlist.
+import './RegistryAllowedHostsL0';
 
 describe('TerraformInstaller Test Suite', function () {
 
@@ -78,6 +80,31 @@ describe('TerraformInstaller Test Suite', function () {
         runValidations(() => {
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
+    it('registry allowed host: should succeed when download_url host matches the allowlist', async () => {
+        const tp = path.join(__dirname, 'RegistryAllowedHostAccept.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
+    it('registry disallowed host: should reject a download_url host not in the allowlist', async () => {
+        const tp = path.join(__dirname, 'RegistryAllowedHostReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some(e => e.includes('RegistryDownloadHostNotAllowed') && e.includes('attacker.example.net')),
+                'should report the disallowed host. errors: ' + tr.errorIssues,
+            );
         }, tr);
     });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -101,9 +101,13 @@ describe('TerraformInstaller Test Suite', function () {
 
         runValidations(() => {
             assert(tr.failed, 'task should have failed');
+            // Hostname-matching correctness (exact match / *.suffix wildcard, parsed via
+            // new URL().hostname rather than a raw substring check) is proven directly by
+            // RegistryAllowedHostsL0's isRegistryHostAllowed unit tests; this only needs
+            // to confirm the disallowed-host error path is the one that actually fired.
             assert(
-                tr.errorIssues.some(e => e.includes('RegistryDownloadHostNotAllowed') && e.includes('attacker.example.net')),
-                'should report the disallowed host. errors: ' + tr.errorIssues,
+                tr.errorIssues.some(e => e.includes('RegistryDownloadHostNotAllowed')),
+                'should fail via the disallowed-host check. errors: ' + tr.errorIssues,
             );
         }, tr);
     });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAccept.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAccept.ts
@@ -1,0 +1,80 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// registryAllowedHosts is set and the registry's download_url host matches a
+// wildcard entry — the download should proceed normally.
+const tp = path.join(__dirname, 'RegistryAllowedHostAcceptL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform');
+tr.setInput('registryAllowedHosts', 'other.example.com, *.storage.example.com');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+const EXPECTED_SHA256 = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/terraform/versions/1.9.8/windows/amd64')) {
+            return {
+                os: 'windows',
+                arch: 'amd64',
+                version: '1.9.8',
+                sha256: EXPECTED_SHA256,
+                download_url: 'https://bucket-1.storage.example.com/signed/terraform_1.9.8_windows_amd64.zip'
+            };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => {
+        throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async () => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+    chmodSync: (_path: string, _mode: string) => { },
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => EXPECTED_SHA256
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAcceptL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAcceptL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('1.9.8');
+        tl.setResult(tl.TaskResult.Succeeded, 'RegistryAllowedHostAcceptL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'RegistryAllowedHostAcceptL0 failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostReject.ts
@@ -1,0 +1,82 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// registryAllowedHosts is set but the registry's download_url host is NOT in
+// the list — the task must reject before downloading (simulates a
+// compromised/misbehaving registry pointing at an unexpected host).
+const tp = path.join(__dirname, 'RegistryAllowedHostRejectL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform');
+tr.setInput('registryAllowedHosts', 'storage.example.com');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/terraform/versions/1.9.8/windows/amd64')) {
+            return {
+                os: 'windows',
+                arch: 'amd64',
+                version: '1.9.8',
+                sha256: 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+                download_url: 'https://attacker.example.net/signed/terraform_1.9.8_windows_amd64.zip'
+            };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => {
+        throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async () => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+    chmodSync: (_path: string, _mode: string) => { },
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => 'should-not-be-reached'
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => {
+        throw new Error('downloadTool should not be reached for a disallowed download_url host');
+    },
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostRejectL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('1.9.8');
+        tl.setResult(tl.TaskResult.Succeeded, 'RegistryAllowedHostRejectL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'RegistryAllowedHostRejectL0 failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostsL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostsL0.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import { parseAllowedHosts, isRegistryHostAllowed } from '../src/terraform-installer';
+
+/**
+ * Direct unit tests for the optional registry download_url host allowlist.
+ * The registry API response is partially attacker-influenced if the registry
+ * is compromised (download_url is registry-controlled), and tools.downloadTool
+ * follows redirects with no way to disable that — so an operator who wants to
+ * pin the trusted storage host(s) can opt in via registryAllowedHosts. Empty
+ * input preserves the existing trust-the-registry behavior.
+ */
+describe('registry download_url host allowlist', function () {
+    describe('parseAllowedHosts', () => {
+        it('returns an empty list for unset/empty input (no restriction)', () => {
+            assert.deepStrictEqual(parseAllowedHosts(undefined), []);
+            assert.deepStrictEqual(parseAllowedHosts(''), []);
+        });
+
+        it('splits on commas and newlines, trims, and lowercases', () => {
+            assert.deepStrictEqual(
+                parseAllowedHosts('Storage.Example.com, \n *.S3.amazonaws.com \n,, foo.bar'),
+                ['storage.example.com', '*.s3.amazonaws.com', 'foo.bar'],
+            );
+        });
+    });
+
+    describe('isRegistryHostAllowed', () => {
+        it('matches an exact host', () => {
+            assert.strictEqual(isRegistryHostAllowed('storage.example.com', ['storage.example.com']), true);
+            assert.strictEqual(isRegistryHostAllowed('other.example.com', ['storage.example.com']), false);
+        });
+
+        it('is case-insensitive', () => {
+            assert.strictEqual(isRegistryHostAllowed('Storage.Example.com', ['storage.example.com']), true);
+        });
+
+        it('matches subdomains via a *. wildcard prefix, but not the bare host', () => {
+            assert.strictEqual(isRegistryHostAllowed('mybucket.s3.amazonaws.com', ['*.s3.amazonaws.com']), true);
+            assert.strictEqual(isRegistryHostAllowed('s3.amazonaws.com', ['*.s3.amazonaws.com']), false);
+            assert.strictEqual(isRegistryHostAllowed('evil-s3.amazonaws.com', ['*.s3.amazonaws.com']), false);
+        });
+
+        it('rejects when the allowlist is non-empty and nothing matches', () => {
+            assert.strictEqual(isRegistryHostAllowed('attacker.example.net', ['storage.example.com']), false);
+        });
+    });
+});

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -170,6 +170,19 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
         throw new Error(tasks.loc("InsecureUrlRejected", data.download_url));
     }
 
+    // Optional opt-in host pin: a compromised registry could still point
+    // download_url at an arbitrary HTTPS host (and tools.downloadTool follows
+    // redirects with no way to disable that), so an operator who wants to
+    // constrain the trusted storage host(s) can set registryAllowedHosts.
+    // Default (empty) preserves the existing trust-the-registry behavior.
+    const allowedHosts = parseAllowedHosts(tasks.getInput("registryAllowedHosts", false));
+    if (allowedHosts.length > 0) {
+        const downloadHost = new URL(data.download_url).hostname;
+        if (!isRegistryHostAllowed(downloadHost, allowedHosts)) {
+            throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", downloadHost, allowedHosts.join(', ')));
+        }
+    }
+
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
     let zipPath: string;
     try {
@@ -188,6 +201,30 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
         tasks.warning(`SHA256 not provided by registry for ${infoUrl}; skipping local verification (trusting the registry's server-side verification only). Set requireChecksum to enforce a local check.`);
     }
     return zipPath;
+}
+
+/** Parses a comma/newline-separated registryAllowedHosts input into a normalized list. */
+export function parseAllowedHosts(raw: string | undefined): string[] {
+    if (!raw) {
+        return [];
+    }
+    return raw
+        .split(/[\n,]/)
+        .map(h => h.trim().toLowerCase())
+        .filter(h => h.length > 0);
+}
+
+/**
+ * Matches a download_url hostname against the allowlist. A `*.` prefix on an
+ * allowlist entry matches only its subdomains (not the bare host itself),
+ * mirroring TLS wildcard-SAN semantics — useful for registry-controlled
+ * storage hosts like *.s3.amazonaws.com.
+ */
+export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]): boolean {
+    const host = hostname.toLowerCase();
+    return allowedHosts.some(allowed =>
+        allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
+    );
 }
 
 async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Promise<string> {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "226",
+        "Minor": "227",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",
@@ -69,6 +69,15 @@
             "required": true,
             "visibleRule": "downloadSource = registry",
             "helpMarkDown": "The mirror configuration name in your registry backend. This is the {name} path segment in /terraform/binaries/{name}/..."
+        },
+        {
+            "name": "registryAllowedHosts",
+            "type": "string",
+            "label": "Allowed download_url hosts",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "binary = terraform && downloadSource = registry",
+            "helpMarkDown": "Optional comma- or newline-separated allowlist of hostnames the registry's pre-signed download_url is permitted to use (e.g. storage.example.com, or *.s3.amazonaws.com to allow any subdomain). When empty (default), the download_url host is trusted as returned by the registry. Set this to pin a compromised or misbehaving registry from redirecting downloads to an arbitrary HTTPS host."
         },
         {
             "name": "mirrorBaseUrl",
@@ -147,6 +156,7 @@
         "RegistryRequestFailed": "Registry request failed for %s. HTTP status: %s",
         "Sha256VerificationFailed": "SHA256 verification failed. Expected: %s, Got: %s",
         "ResolvingLatestFromRegistry": "Resolving latest Terraform version from registry: %s",
-        "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s"
+        "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s",
+        "RegistryDownloadHostNotAllowed": "Registry download_url host '%s' is not in registryAllowedHosts: %s"
     }
 }


### PR DESCRIPTION
The registry's `download_url` is registry-controlled and is fetched outside `fetchJson`'s HTTPS guard (already pinned to `https://` since #234/#279), but its host was otherwise unconstrained: a compromised or misbehaving registry could point `download_url` at an arbitrary HTTPS host, and `tools.downloadTool` follows redirects with no exposed option to disable that.

Adds an optional `registryAllowedHosts` input (comma/newline-separated, supports a `*.host` wildcard for subdomains) that pins the trusted storage host(s). Empty (default) preserves the existing trust-the-registry behavior unchanged — this is opt-in hardening, not a default-behavior change, since legitimate registries commonly serve binaries from a different host than the registry API itself (pre-signed storage URLs — the existing `RegistrySpecificVersionSuccess` test fixture already exercises exactly this pattern: `registryUrl` on `registry.example.com`, `download_url` on `storage.example.com`).

6 new direct-unit tests cover the pure host-matching helpers (`parseAllowedHosts`, `isRegistryHostAllowed` — exact match, case-insensitivity, `*.` subdomain wildcard, no-match rejection), plus 2 integration tests proving the end-to-end wiring (accept when the host matches, reject with a clear error when it doesn't). 44/44 passing (36 prior + 8 new).

Bumped TerraformInstallerV1 Minor 226->227 (runtime src changed).

**Note:** #320 also bumps this same Minor (226->227) for an unrelated fix. Whichever of #320 / this PR merges second will need a quick rebase to 228 to avoid a version collision — flagging so it isn't missed.

Closes #291