### PR TITLE
docs: document why the HTTP client families stay separate

### DIFF
--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -39,6 +39,16 @@ const FAMILIES = [
     },
 ];
 
+// These two families are deliberately NOT merged into one shared client, even
+// though both enforce an https-only guard: they sit on different transport
+// primitives (fetch+AbortController vs raw https.request+req.setTimeout) and
+// different trust models (the installer family downloads public release
+// artifacts and sends no credential; the second family attaches a bearer
+// token/API key to every request). Each family is independently guarded
+// end-to-end by this script, which is the property that actually matters;
+// collapsing them into a single abstraction would be a large, risky rewrite
+// of working transport code for no behavior change.
+
 // Normalize line endings so a CRLF checkout never reads as drift; the bytes that
 // matter (the key material, the verification logic) are still compared exactly.
 function read(relDir, file) {


### PR DESCRIPTION
The installer download-trust-chain family (`fetch`+`AbortController`, no credential) and the credential-bearing transport family (raw `https.request`+`req.setTimeout`, bearer token/API key on every request) both already enforce an https-only guard independently — the security-relevant fix from the original finding (#239/#9fcef2b) already landed.

What remained open was a code-quality suggestion to collapse all three clients into one shared abstraction. Documents why that wasn't done: the two families differ in transport primitive and trust model, and each is already independently parity-guarded end-to-end by `scripts/check-shared-modules.js` — which is the property that actually prevents drift, not how many distinct client implementations exist. Recording the rationale so a future read of this script doesn't re-raise the same question as an oversight rather than a considered decision.

Comment-only change to `scripts/check-shared-modules.js`; no task `src/` touched, no `task.json` Minor bump needed. Both guard scripts verified still passing.

Closes #301