### PR TITLE
security: validate OCI WIF tenancy OCID and region

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -14,6 +14,8 @@ import './OciWifTempDirL0';
 import './EmergencyCleanupNoHandlerL0';
 // Direct unit tests for tool-path resolution (terraformLocation vs PATH).
 import './ResolveToolPathL0';
+// Direct unit tests for OCI WIF synthetic-config field validation.
+import './OciWifConfigValidationL0';
 
 describe('Terraform Test Suite', function () {
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciWifConfigValidationL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciWifConfigValidationL0.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import { validateOciTenancyOcid, validateOciRegion } from '../src/oci-terraform-command-handler';
+
+/**
+ * Direct unit tests for the OCI WIF synthetic-config field validation.
+ * tenancyOcid and region are interpolated raw into an INI file consumed via
+ * OCI_CLI_CONFIG_FILE — an embedded newline could inject or override config
+ * keys (e.g. a crafted tenancy value introducing its own key_file= line).
+ * Both inputs are author-controlled pipeline YAML, so this is defense in
+ * depth matching the same OCID/region character set HashiCorp's own OCI
+ * provider accepts, not a privilege-boundary fix.
+ */
+describe('OCI WIF synthetic-config field validation', function () {
+    describe('validateOciTenancyOcid', () => {
+        it('accepts a well-formed tenancy OCID', () => {
+            const ocid = 'ocid1.tenancy.oc1..aaaaaaaaba3pv6wkcr4jqae5f44n2b2m2yt2j6rx32uzr4h25vqstifsfdsq';
+            assert.strictEqual(validateOciTenancyOcid(ocid), ocid);
+        });
+
+        it('rejects a value with an embedded newline (INI key injection)', () => {
+            assert.throws(() => validateOciTenancyOcid('ocid1.tenancy.oc1..abc\nkey_file=/etc/passwd'));
+        });
+
+        it('rejects a value that does not start with ocid1.tenancy.', () => {
+            assert.throws(() => validateOciTenancyOcid('ocid1.user.oc1..abc'));
+        });
+
+        it('rejects embedded INI special characters', () => {
+            assert.throws(() => validateOciTenancyOcid('ocid1.tenancy.oc1..abc]\n[other]'));
+        });
+    });
+
+    describe('validateOciRegion', () => {
+        it('accepts a well-formed region', () => {
+            assert.strictEqual(validateOciRegion('us-ashburn-1'), 'us-ashburn-1');
+        });
+
+        it('rejects a value with an embedded newline', () => {
+            assert.throws(() => validateOciRegion('us-ashburn-1\nfingerprint=evil'));
+        });
+
+        it('rejects uppercase or special characters', () => {
+            assert.throws(() => validateOciRegion('US-Ashburn-1'));
+            assert.throws(() => validateOciRegion('us-ashburn-1; rm -rf'));
+        });
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -27,6 +27,31 @@ export function resolveWifTempDir(): string {
     return tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
 }
 
+const OCI_TENANCY_OCID_RE = /^ocid1\.tenancy\.[a-z0-9.-]+$/;
+const OCI_REGION_RE = /^[a-z0-9-]+$/;
+
+/**
+ * Validates the tenancy OCID before it is interpolated into the synthetic OCI
+ * INI config (consumed via OCI_CLI_CONFIG_FILE). Without this, an embedded
+ * newline could inject or override config keys (e.g. a crafted tenancy value
+ * introducing its own key_file= line). The character set matches the OCID
+ * grammar OCI itself uses, so no legitimate tenancy OCID is rejected.
+ */
+export function validateOciTenancyOcid(value: string): string {
+    if (!OCI_TENANCY_OCID_RE.test(value)) {
+        throw new Error(`Invalid ociWifTenancyOcid '${value}': must match the tenancy OCID grammar (ocid1.tenancy.<realm>...<unique-id>), with no embedded newlines or special characters.`);
+    }
+    return value;
+}
+
+/** Same INI-injection concern as validateOciTenancyOcid, for the region field. */
+export function validateOciRegion(value: string): string {
+    if (!OCI_REGION_RE.test(value)) {
+        throw new Error(`Invalid ociWifRegion '${value}': must contain only lowercase letters, digits, and hyphens.`);
+    }
+    return value;
+}
+
 export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     constructor() {
         super();
@@ -169,8 +194,8 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         writeSecretFile(upstPath, upst);
         this.tempFiles.push(upstPath);
 
-        const tenancyOcid = tasks.getInput("ociWifTenancyOcid", true)!;
-        const region = tasks.getInput("ociWifRegion", true)!;
+        const tenancyOcid = validateOciTenancyOcid(tasks.getInput("ociWifTenancyOcid", true)!);
+        const region = validateOciRegion(tasks.getInput("ociWifRegion", true)!);
 
         const configContent = [
             '[DEFAULT]',

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "269",
+        "Minor": "270",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",


### PR DESCRIPTION
\`tenancyOcid\` and \`region\` were interpolated raw into the synthetic OCI INI config (consumed via \`OCI_CLI_CONFIG_FILE\`) and exported as \`TF_VAR_*\`. An embedded newline could inject or override config keys (e.g. a crafted tenancy value introducing its own \`key_file=\` line).

Adds \`validateOciTenancyOcid()\`/\`validateOciRegion()\`, matching the OCID grammar and region character set OCI itself uses, rejecting newlines and any other INI-special character before the config is written. Both inputs are author-controlled pipeline YAML, so this is defense in depth, not a privilege-boundary fix.

7 new direct-unit tests cover valid OCID/region acceptance plus rejection of embedded newlines, wrong-resource-type OCIDs, and special characters. 207/207 passing (200 prior + 7 new), including the existing OCI WIF integration test unaffected.

Bumped TerraformTaskV5 Minor 269->270 (runtime src changed).

Closes #296