### PR TITLE
security: support user-assigned MSI client ID

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessManagedServiceIdentityUserAssigned.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessManagedServiceIdentityUserAssigned.ts
@@ -1,0 +1,49 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// MSI connection that also carries a user-assigned identity's client ID (the
+// connection's "Service Principal Id" field) - ARM_CLIENT_ID must be set
+// alongside ARM_USE_MSI so the azurerm provider authenticates as that
+// identity rather than falling back to the agent's system-assigned one.
+let tp = path.join(__dirname, './AzureInitSuccessManagedServiceIdentityUserAssignedL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'init');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+
+tr.setInput('backendServiceArm', 'AzureRM');
+tr.setInput('backendAzureRmResourceGroupName', 'DummyResourceGroup');
+tr.setInput('backendAzureRmStorageAccountName', 'DummyStorageAccount');
+tr.setInput('backendAzureRmContainerName', 'DummyContainer');
+tr.setInput('backendAzureRmKey', 'DummyKey');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ManagedServiceIdentity';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'user-assigned-client-id';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId": {
+            "code": 0,
+            "stdout": "Executed Successfully"
+        }
+    }
+}
+
+var mock = {
+    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+}
+
+tr.registerMock('./id-token-generator', mock);
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessManagedServiceIdentityUserAssignedL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessManagedServiceIdentityUserAssignedL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { runCommand } from '../../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'init', 'AzureInitSuccessManagedServiceIdentityUserAssignedL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -16,6 +16,8 @@ import './EmergencyCleanupNoHandlerL0';
 import './ResolveToolPathL0';
 // Direct unit tests for OCI WIF synthetic-config field validation.
 import './OciWifConfigValidationL0';
+// Direct unit tests for the optional MSI user-assigned client ID.
+import './ManagedIdentityClientIdL0';
 
 describe('Terraform Test Suite', function () {
 
@@ -126,6 +128,21 @@ describe('Terraform Test Suite', function () {
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.warningIssues.length === 0, 'should have no warnings');
             assert(tr.stdOutContained('AzureInitSuccessAuthenticationSchemeManagedServiceIdentityL0 should have succeeded.'), 'Should have printed: AzureInitSuccessAuthenticationSchemeManagedServiceIdentityL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('azure init should set ARM_CLIENT_ID for a user-assigned MSI identity', async () => {
+        let tp = path.join(__dirname, './InitTests/Azure/AzureInitSuccessManagedServiceIdentityUserAssigned.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(
+                tr.stdOutContained('Set environment variable: ARM_CLIENT_ID'),
+                'ARM_CLIENT_ID should be set when the MSI connection carries a user-assigned identity client ID',
+            );
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ManagedIdentityClientIdL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ManagedIdentityClientIdL0.ts
@@ -1,0 +1,33 @@
+import * as assert from 'assert';
+import tasks = require('azure-pipelines-task-lib/task');
+import { getManagedIdentityClientId } from '../src/azure-terraform-command-handler';
+
+/**
+ * Direct unit tests for the optional user-assigned managed identity client ID.
+ * ARM_USE_MSI alone authenticates as the agent's system-assigned identity; if
+ * the connection targets a user-assigned identity instead, the azurerm
+ * provider needs ARM_CLIENT_ID to disambiguate. This reads the connection's
+ * existing "Service Principal Id" field (the same endpoint parameter the
+ * WorkloadIdentityFederation/ServicePrincipal schemes already read) rather
+ * than introducing a new connection field.
+ */
+describe('getManagedIdentityClientId', function () {
+    const originalGetEndpointAuthorizationParameter = tasks.getEndpointAuthorizationParameter;
+    afterEach(() => { (tasks as any).getEndpointAuthorizationParameter = originalGetEndpointAuthorizationParameter; });
+
+    it('returns the client ID when the MSI connection carries one', () => {
+        (tasks as any).getEndpointAuthorizationParameter = (_id: string, name: string) =>
+            name === 'serviceprincipalid' ? 'user-assigned-client-id' : undefined;
+        assert.strictEqual(getManagedIdentityClientId('AzureRM'), 'user-assigned-client-id');
+    });
+
+    it('returns undefined for a system-assigned identity (field left blank)', () => {
+        (tasks as any).getEndpointAuthorizationParameter = () => undefined;
+        assert.strictEqual(getManagedIdentityClientId('AzureRM'), undefined);
+    });
+
+    it('returns undefined when the field is an empty string', () => {
+        (tasks as any).getEndpointAuthorizationParameter = () => '';
+        assert.strictEqual(getManagedIdentityClientId('AzureRM'), undefined);
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -5,6 +5,19 @@ import { BaseTerraformCommandHandler } from "./base-terraform-command-handler";
 import { EnvironmentVariableHelper } from "./environment-variables";
 import { generateIdToken } from './id-token-generator';
 
+/**
+ * Reads the user-assigned managed identity's client ID from an MSI-scheme
+ * service connection, if the connection carries one. Returns undefined for a
+ * system-assigned identity (the connection's "Service Principal Id" field is
+ * left blank), which preserves the existing system-assigned-only behavior.
+ */
+export function getManagedIdentityClientId(serviceConnectionID: string): string | undefined {
+    // getEndpointAuthorizationParameter's 3rd param is named `optional` (true =
+    // don't throw when absent) - the opposite convention from getInput's
+    // `required`. true here is what makes this genuinely optional.
+    return tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalid", true) || undefined;
+}
+
 export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler {
     constructor() {
         super();
@@ -142,7 +155,15 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             }
             case AuthorizationScheme.ManagedServiceIdentity: {
                 const loginTool: ToolRunner = tasks.tool(azPath);
-                loginTool.arg(["login", "--identity"]);
+                const loginArgs = ["login", "--identity"];
+                // A user-assigned identity's client ID, when the connection carries one
+                // (see the matching comment in setCommonVariables) - omitted falls back
+                // to the agent's system-assigned identity, unchanged from before.
+                const msiClientId = getManagedIdentityClientId(serviceConnectionID);
+                if (msiClientId) {
+                    loginArgs.push("--username", msiClientId);
+                }
+                loginTool.arg(loginArgs);
 
                 const loginResult = await loginTool.execAsync(<IExecOptions>{ silent: true });
                 if (loginResult !== 0) {
@@ -165,9 +186,21 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
         EnvironmentVariableHelper.setEnvironmentVariable("ARM_TENANT_ID", tasks.getEndpointAuthorizationParameter(serviceConnectionID, "tenantid", false) ?? '');
 
         switch (authorizationScheme) {
-            case AuthorizationScheme.ManagedServiceIdentity:
+            case AuthorizationScheme.ManagedServiceIdentity: {
                 EnvironmentVariableHelper.setEnvironmentVariable("ARM_USE_MSI", "true");
+                // ARM_USE_MSI alone authenticates as the agent's system-assigned identity.
+                // If the connection targets a user-assigned identity instead, the azurerm
+                // provider needs ARM_CLIENT_ID to disambiguate which identity to use - the
+                // connection's "Service Principal Id" field carries that client ID for an
+                // MSI-scheme connection (same endpoint parameter the WorkloadIdentityFederation
+                // and ServicePrincipal schemes already read below). Optional: omitted falls
+                // back to system-assigned MSI, unchanged from before.
+                const msiClientId = getManagedIdentityClientId(serviceConnectionID);
+                if (msiClientId) {
+                    EnvironmentVariableHelper.setEnvironmentVariable("ARM_CLIENT_ID", msiClientId);
+                }
                 break;
+            }
 
             case AuthorizationScheme.WorkloadIdentityFederation: {
                 const workloadIdentityFederationCredentials = await this.getWorkloadIdentityFederationCredentials(serviceConnectionID, fallbackToIdTokenGeneration);

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "270",
+        "Minor": "271",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",


### PR DESCRIPTION
The \`ManagedServiceIdentity\` scheme set only \`ARM_USE_MSI\`, so the azurerm provider always authenticated as the agent's system-assigned identity. If the service connection targeted a user-assigned identity instead, terraform authenticated as the wrong principal (or failed), since \`ARM_CLIENT_ID\` is required to disambiguate a user-assigned identity — the same gap extended to the \`runAzLogin\` MSI path (no \`--username\` on \`az login --identity\`).

Adds \`getManagedIdentityClientId()\`, which reads the connection's existing "Service Principal Id" field (the same endpoint parameter the WorkloadIdentityFederation/ServicePrincipal schemes already read — not a new connection field). When present, sets \`ARM_CLIENT_ID\` alongside \`ARM_USE_MSI\` and passes \`--username\` to \`az login --identity\`. When absent (system-assigned identity), behavior is unchanged — confirmed by 3 existing MSI tests continuing to pass unmodified.

4 new tests: 3 direct-unit tests on \`getManagedIdentityClientId\` (present / system-assigned-blank / empty-string), plus 1 integration test proving the end-to-end wiring sets \`ARM_CLIENT_ID\` when the connection carries a client ID. 204/204 passing (200 prior + 4 new).

Bumped TerraformTaskV5 Minor 269->270 (runtime src changed).

**Note:** #325 also bumps this same Minor (269->270) for an unrelated fix. Whichever merges second will need a quick rebase to 271 — flagging so it isn't missed.

Closes #289