### PR TITLE
docs: document accepted az login argv credential exposure

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -79,6 +79,18 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
         tasks.debug("Finished up provider for authorization scheme: " + authorizationScheme + ".");
     }
 
+    // ACCEPTED RESIDUAL: --federated-token and --password below put the WIF token /
+    // service-principal secret on this process's argv, visible to any other process
+    // on the agent via ps / /proc/<pid>/cmdline for az login's short lifetime. az CLI
+    // has no file/stdin/env alternative for these specific flags - every documented
+    // usage pattern (including Microsoft's own "$env:AZURE_FEDERATED_TOKEN" examples)
+    // still substitutes the value into a literal argv string before az sees it; the
+    // env var only sources where the value comes FROM, not how az receives it. This
+    // is bounded: runAzLogin is opt-in (default false, only for local-exec/external
+    // data sources), and the primary terraform-provider auth path never touches argv -
+    // it sets ARM_CLIENT_SECRET/ARM_OIDC_TOKEN/etc. as environment variables exclusively
+    // (see setCommonVariables). Residual risk concentrates on shared self-hosted agents;
+    // ManagedServiceIdentity's `az login --identity` carries no secret in argv at all.
     private async runAzLogin(authorizationScheme: AuthorizationScheme, serviceConnectionID: string, subscriptionId: string): Promise<void> {
         tasks.debug("Running az login for local-exec / external data source support.");
 

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -452,7 +452,7 @@
             "type": "boolean",
             "defaultValue": "false",
             "label": "Run az login",
-            "helpMarkDown": "Run 'az login' using the provider service connection credentials before executing the terraform command. Enables Azure CLI authentication for local-exec provisioners, external data sources, and modules that use CLI-based auth (e.g. azapi). Requires the Azure CLI to be installed on the agent.",
+            "helpMarkDown": "Run 'az login' using the provider service connection credentials before executing the terraform command. Enables Azure CLI authentication for local-exec provisioners, external data sources, and modules that use CLI-based auth (e.g. azapi). Requires the Azure CLI to be installed on the agent. Security note: for WorkloadIdentityFederation/ServicePrincipal connections, the federated token or client secret is passed as an 'az login' command-line argument (an inherent az CLI limitation, not specific to this task), briefly visible to other processes on a shared self-hosted agent via the process list. ManagedServiceIdentity connections are unaffected.",
             "groupName": "providerAzureRm"
         },
         {


### PR DESCRIPTION
\`runAzLogin\` passes the WIF federated token / service-principal secret as \`az login\` command-line arguments, briefly visible to other processes on a shared agent via \`ps\` / \`/proc/<pid>/cmdline\`.

**Researched whether a safer alternative exists** (file/stdin/env input for \`--federated-token\` or \`--password\`): it does not. Azure CLI's \`az login\` has no documented mechanism to source these flags from anywhere other than a literal argv string — even Microsoft's own usage examples (\`az login --federated-token "$env:AZURE_FEDERATED_TOKEN" ...\`) just substitute an env var's *value* into the argv at the shell level; the secret still reaches \`az\`'s process arguments. Implementing an unverified CLI-flag workaround here risks silently breaking \`az login\` for every WIF/ServicePrincipal pipeline using this feature — not a risk worth taking for an unconfirmed fix.

Documented as an accepted residual instead:
- A code comment at the \`runAzLogin\` call site explaining the exposure, why it can't be cleanly closed, and what bounds it.
- A security note added to the \`runAzLogin\` input's \`helpMarkDown\` so operators on shared self-hosted agents see the consideration before enabling it.

**Why this is bounded:** \`runAzLogin\` is opt-in (default \`false\`, only needed for local-exec provisioners / external data sources). The primary terraform-provider authentication path never touches argv — \`ARM_CLIENT_SECRET\`, \`ARM_OIDC_TOKEN\`, etc. are set as environment variables exclusively (\`setCommonVariables\`). \`ManagedServiceIdentity\`'s \`az login --identity\` carries no secret in argv at all.

Comment/help-text only — no runtime behavior change. 200/200 tests passing (unchanged). No \`task.json\` Minor bump needed.

Closes #288