### PR TITLE
fix: allow PATH in installer restricted allowlists

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "4",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(policyAgent) $(version)",
@@ -104,7 +104,8 @@
         "settableVariables": {
             "allowed": [
                 "policyAgentLocation",
-                "policyAgentDownloadedFrom"
+                "policyAgentDownloadedFrom",
+                "PATH"
             ]
         }
     },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "227",
+        "Minor": "228",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",
@@ -123,7 +123,8 @@
         "settableVariables": {
             "allowed": [
                 "terraformLocation",
-                "terraformDownloadedFrom"
+                "terraformDownloadedFrom",
+                "PATH"
             ]
         }
     },

--- a/Tasks/TerraformTask/TerraformTaskV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformTask/TerraformTaskV5/Strings/resources.resjson/en-US/resources.resjson
@@ -50,5 +50,5 @@
   "loc.input.help.backendGCPBucketName": "The name of the GCP storage bucket for storing the Terraform remote state file.",
   "loc.input.label.backendGCPPrefix": "Prefix of state file",
   "loc.input.help.backendGCPPrefix": "The relative path to the state file inside the GCP bucket. For example, if you give the input as 'terraform', then the state file, named default.tfstate, will be stored inside an object called terraform.",
-  "loc.messages.TerraformToolNotFound": "Failed to find terraform tool in paths"
+  "loc.messages.TerraformToolNotFound": "Could not locate the terraform/tofu binary. Run PipelineTerraformInstaller in the same job as this task, or ensure the binary is installed on the agent's PATH."
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "272",
+        "Minor": "273",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",
@@ -959,7 +959,7 @@
         }
     ],
     "messages": {
-        "TerraformToolNotFound": "Failed to find terraform/tofu binary in PATH. Ensure the selected binary is installed on the agent.",
+        "TerraformToolNotFound": "Could not locate the terraform/tofu binary. Run PipelineTerraformInstaller in the same job as this task, or ensure the binary is installed on the agent's PATH.",
         "TerraformPlanFailed": "Terraform plan failed with exit code %s"
     }
 }


### PR DESCRIPTION
## What

Adds `PATH` to the `restrictions.settableVariables.allowed` list of the two **installer** tasks so their `tools.prependPath(...)` is no longer silently dropped under restricted command mode.

## Why

`#245` put every task in `restricted` command mode with a tight `settableVariables` allowlist. In restricted mode the agent gates `prependpath` through that allowlist under the variable name **`PATH`** — which was not listed — so the installers downloaded + cached the binary but **never put it on PATH**. Downstream `tasks.which()` lookups then failed with `TerraformToolNotFound`. The smoking gun in the installer log:

```
##[warning]Setting variable 'PATH' has been disabled by the task or build definition.
```

This re-introduced the exact failure mode of #319, this time caused by the hardening rather than a missing call. The `terraformLocation` read from #321 is defense-in-depth and stays in place, but this restores the **primary documented contract** ("…and prepend it to the PATH") for the task and for non-task steps.

Full root-cause analysis and the 7-task audit are in #329.

## Changes

- `TerraformInstallerV1/task.json` — allow `PATH`; Minor `1.227` → `1.228`
- `PolicyAgentInstallerV1/task.json` — allow `PATH` (same wall; its cross-step handoff to `PipelineTerraformPolicyCheck` relies on PATH); Minor `1.3` → `1.4`
- `TerraformTaskV5` — sync/improve the stale `TerraformToolNotFound` message in `resources.resjson` + `task.json`; Minor `5.272` → `5.273` so the corrected string reaches agents

`PATH` is scoped to the two installer tasks only — exposing a tool on PATH is an installer's documented purpose, and it already downloads+executes that binary, so this is its intended, trusted behavior. Non-installer tasks keep their tight allowlists unchanged.

## Verification

- `node scripts/check-versions.js` ✅ (all 7 tasks consistent)
- `node scripts/check-shared-modules.js` ✅
- TerraformInstallerV1 tests: **46 passing**
- PolicyAgentInstallerV1 tests: **40 passing**
- TerraformTaskV5 tests: **211 passing**

Closes #329
