### PR TITLE
docs: document Markdown2Html and PublishKbArticle

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,86 @@ Generates documentation for a Terraform module using terraform-docs. Requires te
 | ------------------- | ----------------------------------------------------------------------------- |
 | `generatedFilePath` | Path to the generated documentation file, when an output file was configured. |
 
+### `Markdown2Html@1` — Markdown to HTML Converter
+
+Converts Markdown files to a single styled HTML document (via markdown-it with highlight.js syntax highlighting) — typically the module docs produced by `PipelineTerraformDocs@1` — ready to publish as a ServiceNow knowledge base article. Pure local processing; no network access.
+
+| Input        | Default                  | Description                                                                                              |
+| ------------ | ------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `mode`       | —                        | `filelist` (combine an explicit list of files) or `frontMatter` (a primary file whose YAML front-matter declares includes). |
+| `primaryFile`| —                        | Primary Markdown file whose front-matter drives composition. Required when `mode=frontMatter`.           |
+| `inputFiles` | —                        | Newline- or comma-separated Markdown paths to convert and combine. Required when `mode=filelist`.        |
+| `outputFile` | —                        | Path to write the generated HTML file.                                                                   |
+| `title`      | `Combined Markdown Files`| Title for the generated HTML document.                                                                   |
+| `sections`   | `false`                  | Add each file's name as a section heading.                                                               |
+| `dividers`   | `false`                  | Add horizontal rules between files.                                                                       |
+
+**Output variables:**
+
+| Variable       | Description                             |
+| -------------- | --------------------------------------- |
+| `htmlFilePath` | Absolute path to the generated HTML file. |
+
+### `PublishKbArticle@1` — Publish KB Article to ServiceNow
+
+Creates or updates a ServiceNow knowledge base article from an HTML file. Idempotent: a stable `sourceKey` (or a `kb-key:` front-matter field) correlates re-runs to the same article. Optionally auto-creates categories/subcategories and uploads relative `<img>` images as attachments. Authenticates via a `ServiceNowKb` service connection (OAuth client credentials or basic) or inline credentials.
+
+| Input               | Default | Description                                                                                                   |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `serviceConnection` | —       | A `ServiceNowKb` service connection. If unset, provide `instance` + credentials inline.                       |
+| `instance`          | —       | ServiceNow instance name (e.g. `mycompany` for `mycompany.service-now.com`). Required when no connection is set. |
+| `authType`          | `oauth` | `oauth` (client credentials) or `basic`, when using inline credentials.                                        |
+| `kbId`              | —       | Knowledge base `sys_id`. Use `list` to print available knowledge bases.                                        |
+| `title`             | —       | Article title (`short_description`). Required when creating a new article.                                     |
+| `htmlFile`          | —       | Path to the HTML file whose contents become the article body.                                                 |
+| `author`            | —       | ServiceNow username of the article author. Required when creating.                                            |
+| `category`          | —       | Category name (auto-created if missing). Prefix with `sys_id:` for a raw sys_id.                               |
+| `workflowState`     | `draft` | Target state: `draft`, `review`, or `publish`.                                                                |
+| `sourceKey`         | —       | Stable correlation key for idempotent create/update.                                                          |
+| `uploadImages`      | `false` | Upload relative `<img>` images as attachments and rewrite their `src`.                                         |
+| `dryRun`            | `false` | Convert, validate, and log the planned action without writing to ServiceNow (useful on PR builds).            |
+
+Advanced inputs (`articleId`, `subcategory`, `readKeyFrom`, `emitManifest`, `imageBaseDir`, `force`, `skipJsonLookup`) are documented in the task's help text.
+
+**Output variables:**
+
+| Variable          | Description                                                        |
+| ----------------- | ----------------------------------------------------------------- |
+| `kbArticleId`     | `sys_id` of the created or updated article.                       |
+| `kbArticleNumber` | Article number (e.g. `KB0001234`).                                |
+| `kbWorkflowState` | Workflow state of the article after the task runs.                |
+
+All ServiceNow requests are sent over HTTPS only (the task refuses to transmit credentials over a non-HTTPS URL); the OAuth token and password are masked in logs via `setSecret`.
+
+### End-to-end: document a module and publish it to ServiceNow
+
+`PipelineTerraformDocs@1` → `Markdown2Html@1` → `PublishKbArticle@1`:
+
+```yaml
+- task: PipelineTerraformDocsInstaller@1
+- task: PipelineTerraformDocs@1
+  inputs:
+    modulePath: "."
+    outputFile: "MODULE.md"
+    outputMode: replace
+- task: Markdown2Html@1
+  inputs:
+    mode: filelist
+    inputFiles: "MODULE.md"
+    outputFile: "$(Build.ArtifactStagingDirectory)/module.html"
+    title: "My Terraform Module"
+- task: PublishKbArticle@1
+  inputs:
+    serviceConnection: "my-servicenow"
+    kbId: "$(kbSysId)"
+    title: "My Terraform Module"
+    htmlFile: "$(Build.ArtifactStagingDirectory)/module.html"
+    author: "svc-docs"
+    sourceKey: "my-terraform-module"
+    workflowState: publish
+    dryRun: ${{ ne(variables['Build.SourceBranch'], 'refs/heads/main') }}
+```
+
 ---
 
 ## Providers

--- a/docs/yaml-examples.md
+++ b/docs/yaml-examples.md
@@ -11,6 +11,9 @@
 - [`PipelineTerraformModulePublish@1`](#pipelineterraformmodulepublish1) — Publish a module version to HCP Terraform or a private registry
 - [`PipelineTerraformDocsInstaller@1`](#pipelineterraformdocsinstaller1) — Install terraform-docs
 - [`PipelineTerraformDocs@1`](#pipelineterraformdocs1) — Generate Terraform module documentation with terraform-docs
+- [`Markdown2Html@1`](#markdown2html1) — Convert Markdown docs to a single styled HTML file
+- [`PublishKbArticle@1`](#publishkbarticle1) — Create or update a ServiceNow knowledge base article
+- [End-to-end: docs to ServiceNow KB](#end-to-end-docs-to-servicenow-kb) — terraform-docs → Markdown2Html → PublishKbArticle
 
 ---
 
@@ -1135,3 +1138,161 @@ Available formatters: `markdown-table`, `markdown-document`, `json`, `yaml`,
 `toml`, `pretty`, `asciidoc-table`, `asciidoc-document`, `tfvars-hcl`,
 `tfvars-json`. Pass any other terraform-docs flag the task does not surface as a
 dedicated input via `additionalArgs` (e.g. `--hide-empty`).
+
+## Markdown2Html@1
+
+Converts Markdown to a single styled HTML document (markdown-it + highlight.js).
+Runs locally — no network access. Sets the `htmlFilePath` output variable.
+
+### Convert a single generated doc file
+
+```yaml
+steps:
+  - task: Markdown2Html@1
+    displayName: 'Render module docs to HTML'
+    inputs:
+      mode: 'filelist'
+      inputFiles: 'MODULE.md'
+      outputFile: '$(Build.ArtifactStagingDirectory)/module.html'
+      title: 'My Terraform Module'
+```
+
+### Combine several files with section headings and dividers
+
+```yaml
+steps:
+  - task: Markdown2Html@1
+    displayName: 'Combine docs'
+    inputs:
+      mode: 'filelist'
+      inputFiles: |
+        README.md
+        docs/inputs.md
+        docs/outputs.md
+      outputFile: '$(Build.ArtifactStagingDirectory)/combined.html'
+      title: 'Module Reference'
+      sections: true
+      dividers: true
+```
+
+### Front-matter-driven composition
+
+The primary file's YAML front-matter declares the included files and options
+(`toc`, `separator`, `heading-shift`, `section-anchors`):
+
+```yaml
+steps:
+  - task: Markdown2Html@1
+    displayName: 'Render KB page from front matter'
+    inputs:
+      mode: 'frontMatter'
+      primaryFile: 'kb/index.md'
+      outputFile: '$(Build.ArtifactStagingDirectory)/kb.html'
+```
+
+## PublishKbArticle@1
+
+Creates or updates a ServiceNow knowledge base article from an HTML file.
+Authenticates via a `ServiceNowKb` service connection (OAuth client credentials
+or basic) or inline credentials. All requests are HTTPS-only; the token/password
+are masked in logs. Sets `kbArticleId`, `kbArticleNumber`, and `kbWorkflowState`.
+
+### Create or update via a service connection (idempotent)
+
+`sourceKey` correlates re-runs to the same article, so this create-or-updates:
+
+```yaml
+steps:
+  - task: PublishKbArticle@1
+    displayName: 'Publish module docs to ServiceNow'
+    inputs:
+      serviceConnection: 'my-servicenow'
+      kbId: '$(kbSysId)'
+      title: 'My Terraform Module'
+      htmlFile: '$(Build.ArtifactStagingDirectory)/module.html'
+      author: 'svc-docs'
+      category: 'Infrastructure'
+      sourceKey: 'my-terraform-module'
+      workflowState: 'publish'
+```
+
+### Dry-run on PR builds, publish on main
+
+`dryRun` converts, validates, and logs the planned action without writing to
+ServiceNow — ideal for pull-request validation:
+
+```yaml
+steps:
+  - task: PublishKbArticle@1
+    displayName: 'Publish (dry-run off main)'
+    inputs:
+      serviceConnection: 'my-servicenow'
+      kbId: '$(kbSysId)'
+      title: 'My Terraform Module'
+      htmlFile: '$(Build.ArtifactStagingDirectory)/module.html'
+      author: 'svc-docs'
+      sourceKey: 'my-terraform-module'
+      workflowState: 'publish'
+      dryRun: ${{ ne(variables['Build.SourceBranch'], 'refs/heads/main') }}
+```
+
+### Upload images and use inline OAuth credentials
+
+Relative `<img>` images are uploaded as attachments and their `src` rewritten:
+
+```yaml
+steps:
+  - task: PublishKbArticle@1
+    displayName: 'Publish with images'
+    inputs:
+      instance: 'mycompany'
+      authType: 'oauth'
+      clientId: '$(snClientId)'
+      clientSecret: '$(snClientSecret)'
+      kbId: '$(kbSysId)'
+      title: 'My Terraform Module'
+      htmlFile: '$(Build.ArtifactStagingDirectory)/module.html'
+      author: 'svc-docs'
+      sourceKey: 'my-terraform-module'
+      uploadImages: true
+      imageBaseDir: '$(System.DefaultWorkingDirectory)'
+```
+
+## End-to-end: docs to ServiceNow KB
+
+Generate module docs with terraform-docs, render them to HTML, and publish to a
+ServiceNow knowledge base — publishing only on `main`, dry-running elsewhere:
+
+```yaml
+steps:
+  - task: PipelineTerraformDocsInstaller@1
+    displayName: 'Install terraform-docs'
+
+  - task: PipelineTerraformDocs@1
+    displayName: 'Generate module docs'
+    inputs:
+      formatter: 'markdown-document'
+      modulePath: '$(System.DefaultWorkingDirectory)'
+      outputFile: 'MODULE.md'
+      outputMode: 'replace'
+
+  - task: Markdown2Html@1
+    displayName: 'Render docs to HTML'
+    inputs:
+      mode: 'filelist'
+      inputFiles: 'MODULE.md'
+      outputFile: '$(Build.ArtifactStagingDirectory)/module.html'
+      title: 'My Terraform Module'
+
+  - task: PublishKbArticle@1
+    displayName: 'Publish to ServiceNow KB'
+    inputs:
+      serviceConnection: 'my-servicenow'
+      kbId: '$(kbSysId)'
+      title: 'My Terraform Module'
+      htmlFile: '$(Build.ArtifactStagingDirectory)/module.html'
+      author: 'svc-docs'
+      sourceKey: 'my-terraform-module'
+      workflowState: 'publish'
+      dryRun: ${{ ne(variables['Build.SourceBranch'], 'refs/heads/main') }}
+```

--- a/overview.md
+++ b/overview.md
@@ -27,6 +27,7 @@ Runs on **Windows**, **Linux**, and **macOS** agents.
 - **Provider network mirroring**: Route provider downloads through a private mirror for air-gapped environments, caching, or compliance
 - **Module publishing**: Publish module versions to HCP Terraform or a private registry (terraform-registry-backend) from a release pipeline
 - **Documentation generation**: Install terraform-docs and generate — or `--output-check`-gate — Terraform module documentation in a pipeline
+- **Documentation publishing**: Convert Markdown docs to HTML and publish them as ServiceNow knowledge base articles (idempotent create/update, image attachments) directly from a pipeline
 - **`-replace` flag** support on plan and apply (modern replacement for the deprecated `taint` command)
 - **Detailed exit code** on plan with `changesPresent` output variable for conditional apply
 - **Optional service connection for `test`**: run unit tests without provider auth, or provide a service connection for integration tests that provision real resources


### PR DESCRIPTION
## What

**PR 3 of 3** — documentation for the two documentation-publishing tasks added in #337 and #339.

- **README**: new `Markdown2Html@1` and `PublishKbArticle@1` sections (input/output tables in the existing style), plus an **end-to-end reference pipeline** — `PipelineTerraformDocs@1` → `Markdown2Html@1` → `PublishKbArticle@1` — showing how to document a module and publish it to a ServiceNow KB (with `dryRun` gated to non-main branches).
- **overview.md**: a "Documentation publishing" bullet in Key Features so the marketplace listing reflects the new capability.

Docs-only; no code or manifest changes.

## Follow-up (no action here)

The now-superseded **private** `servicenow-kb-publisher` extension can be removed whenever you like — its two tasks live here now (with fresh GUIDs, so there's no conflict).