### PR TITLE
ci: replace deprecated actions/attest-sbom with actions/attest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      attestations: write # required by attest-build-provenance / attest-sbom
+      attestations: write # required by attest-build-provenance / attest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -186,57 +186,57 @@ jobs:
         with:
           subject-path: "*.vsix"
       - name: Attest SBOM (TerraformTaskV5) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-task-v5.cdx.json"
       - name: Attest SBOM (TerraformInstallerV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-installer-v1.cdx.json"
       - name: Attest SBOM (TerraformProviderMirrorV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-provider-mirror-v1.cdx.json"
       - name: Attest SBOM (PolicyAgentInstallerV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-policy-agent-installer-v1.cdx.json"
       - name: Attest SBOM (TerraformPolicyCheckV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-policy-check-v1.cdx.json"
       - name: Attest SBOM (TerraformDriftReportV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-drift-report-v1.cdx.json"
       - name: Attest SBOM (TerraformModulePublishV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-module-publish-v1.cdx.json"
       - name: Attest SBOM (TerraformDocsInstallerV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-docs-installer-v1.cdx.json"
       - name: Attest SBOM (TerraformDocsV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-terraform-docs-v1.cdx.json"
       - name: Attest SBOM (Markdown2HtmlV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-markdown2html-v1.cdx.json"
       - name: Attest SBOM (PublishKbArticleV1) for VSIX
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "*.vsix"
           sbom-path: "sbom-publish-kb-article-v1.cdx.json"


### PR DESCRIPTION
## Summary

The release workflow's "Generate SBOM and sign VSIX" job logged deprecation warnings:

> actions/attest-sbom has been deprecated, please use actions/attest instead

As of v4, `actions/attest-sbom` is just a wrapper over [`actions/attest`](https://github.com/actions/attest), which has a built-in SBOM mode that auto-detects from `sbom-path`. This swaps all **11** `Attest SBOM (...)` steps to `actions/attest`, pinned to `v4.1.1` (`a1948c3`), keeping the identical `subject-path` / `sbom-path` inputs.

- Generated attestations are unchanged (same CycloneDX SBOM predicate); `gh attestation verify <file.vsix>` continues to work.
- Job permissions already satisfy `actions/attest` (`id-token: write` + `attestations: write`); `artifact-metadata` isn't needed here (file subject, no registry push).
- Updated the `permissions` comment from `attest-sbom` → `attest`.

Deprecation surfaced in run [28554095453](https://github.com/sethbacon/azure-pipelines-terraform/actions/runs/28554095453/job/84658401870) (Generate SBOM and sign VSIX).
