### PR TITLE
fix: support cross-cloud Terraform state backend credentials on plan/apply/etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,50 +208,50 @@ Generates documentation for a Terraform module using terraform-docs. Requires te
 
 Converts Markdown files to a single styled HTML document (via markdown-it with highlight.js syntax highlighting) — typically the module docs produced by `PipelineTerraformDocs@1` — ready to publish as a ServiceNow knowledge base article. Pure local processing; no network access.
 
-| Input        | Default                  | Description                                                                                              |
-| ------------ | ------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `mode`       | —                        | `filelist` (combine an explicit list of files) or `frontMatter` (a primary file whose YAML front-matter declares includes). |
-| `primaryFile`| —                        | Primary Markdown file whose front-matter drives composition. Required when `mode=frontMatter`.           |
-| `inputFiles` | —                        | Newline- or comma-separated Markdown paths to convert and combine. Required when `mode=filelist`.        |
-| `outputFile` | —                        | Path to write the generated HTML file.                                                                   |
-| `title`      | `Combined Markdown Files`| Title for the generated HTML document.                                                                   |
-| `sections`   | `false`                  | Add each file's name as a section heading.                                                               |
-| `dividers`   | `false`                  | Add horizontal rules between files.                                                                       |
+| Input         | Default                   | Description                                                                                                                 |
+| ------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `mode`        | —                         | `filelist` (combine an explicit list of files) or `frontMatter` (a primary file whose YAML front-matter declares includes). |
+| `primaryFile` | —                         | Primary Markdown file whose front-matter drives composition. Required when `mode=frontMatter`.                              |
+| `inputFiles`  | —                         | Newline- or comma-separated Markdown paths to convert and combine. Required when `mode=filelist`.                           |
+| `outputFile`  | —                         | Path to write the generated HTML file.                                                                                      |
+| `title`       | `Combined Markdown Files` | Title for the generated HTML document.                                                                                      |
+| `sections`    | `false`                   | Add each file's name as a section heading.                                                                                  |
+| `dividers`    | `false`                   | Add horizontal rules between files.                                                                                         |
 
 **Output variables:**
 
-| Variable       | Description                             |
-| -------------- | --------------------------------------- |
+| Variable       | Description                               |
+| -------------- | ----------------------------------------- |
 | `htmlFilePath` | Absolute path to the generated HTML file. |
 
 ### `PublishKbArticle@1` — Publish KB Article to ServiceNow
 
 Creates or updates a ServiceNow knowledge base article from an HTML file. Idempotent: a stable `sourceKey` (or a `kb-key:` front-matter field) correlates re-runs to the same article. Optionally auto-creates categories/subcategories and uploads relative `<img>` images as attachments. Authenticates via a `ServiceNowKb` service connection (OAuth client credentials or basic) or inline credentials.
 
-| Input               | Default | Description                                                                                                   |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
-| `serviceConnection` | —       | A `ServiceNowKb` service connection. If unset, provide `instance` + credentials inline.                       |
+| Input               | Default | Description                                                                                                      |
+| ------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `serviceConnection` | —       | A `ServiceNowKb` service connection. If unset, provide `instance` + credentials inline.                          |
 | `instance`          | —       | ServiceNow instance name (e.g. `mycompany` for `mycompany.service-now.com`). Required when no connection is set. |
-| `authType`          | `oauth` | `oauth` (client credentials) or `basic`, when using inline credentials.                                        |
-| `kbId`              | —       | Knowledge base `sys_id`. Use `list` to print available knowledge bases.                                        |
-| `title`             | —       | Article title (`short_description`). Required when creating a new article.                                     |
-| `htmlFile`          | —       | Path to the HTML file whose contents become the article body.                                                 |
-| `author`            | —       | ServiceNow username of the article author. Required when creating.                                            |
-| `category`          | —       | Category name (auto-created if missing). Prefix with `sys_id:` for a raw sys_id.                               |
-| `workflowState`     | `draft` | Target state: `draft`, `review`, or `publish`.                                                                |
-| `sourceKey`         | —       | Stable correlation key for idempotent create/update.                                                          |
-| `uploadImages`      | `false` | Upload relative `<img>` images as attachments and rewrite their `src`.                                         |
-| `dryRun`            | `false` | Convert, validate, and log the planned action without writing to ServiceNow (useful on PR builds).            |
+| `authType`          | `oauth` | `oauth` (client credentials) or `basic`, when using inline credentials.                                          |
+| `kbId`              | —       | Knowledge base `sys_id`. Use `list` to print available knowledge bases.                                          |
+| `title`             | —       | Article title (`short_description`). Required when creating a new article.                                       |
+| `htmlFile`          | —       | Path to the HTML file whose contents become the article body.                                                    |
+| `author`            | —       | ServiceNow username of the article author. Required when creating.                                               |
+| `category`          | —       | Category name (auto-created if missing). Prefix with `sys_id:` for a raw sys_id.                                 |
+| `workflowState`     | `draft` | Target state: `draft`, `review`, or `publish`.                                                                   |
+| `sourceKey`         | —       | Stable correlation key for idempotent create/update.                                                             |
+| `uploadImages`      | `false` | Upload relative `<img>` images as attachments and rewrite their `src`.                                           |
+| `dryRun`            | `false` | Convert, validate, and log the planned action without writing to ServiceNow (useful on PR builds).               |
 
 Advanced inputs (`articleId`, `subcategory`, `readKeyFrom`, `emitManifest`, `imageBaseDir`, `force`, `skipJsonLookup`) are documented in the task's help text.
 
 **Output variables:**
 
-| Variable          | Description                                                        |
-| ----------------- | ----------------------------------------------------------------- |
-| `kbArticleId`     | `sys_id` of the created or updated article.                       |
-| `kbArticleNumber` | Article number (e.g. `KB0001234`).                                |
-| `kbWorkflowState` | Workflow state of the article after the task runs.                |
+| Variable          | Description                                        |
+| ----------------- | -------------------------------------------------- |
+| `kbArticleId`     | `sys_id` of the created or updated article.        |
+| `kbArticleNumber` | Article number (e.g. `KB0001234`).                 |
+| `kbWorkflowState` | Workflow state of the article after the task runs. |
 
 All ServiceNow requests are sent over HTTPS only (the task refuses to transmit credentials over a non-HTTPS URL); the OAuth token and password are masked in logs via `setSecret`.
 
@@ -312,6 +312,17 @@ If `backendType` is not set, it defaults to the value of the `provider` input (p
 | `hcp`         | HCP Terraform Cloud  | Requires `backendHCPToken`, `backendHCPOrganization`, `backendHCPWorkspace`.                     |
 | `generic`     | Any backend          | Pass a `.tfbackend` file via `backendConfigFile` and/or key=value pairs via `backendConfigArgs`. |
 | `local`       | Local filesystem     | No remote state.                                                                                 |
+
+**Cross-cloud credentials aren't just an `init`-time concern.** When the backend
+detected from the initialized working directory differs from the `provider`
+input, the task automatically supplies that backend's credentials (as
+environment variables) on every state-accessing command — `plan`, `apply`,
+`destroy`, `refresh`, `import`, `output`, `state`, `workspace`, and
+`forceunlock`. Add the matching backend inputs (`backendServiceArm`, `backendServiceAWS`,
+`backendServiceGCP`, `backendHCP*`, ...) to **each** of those steps, not only
+`init` — see [Cross-cloud state backends](docs/yaml-examples.md#cross-cloud-state-backends)
+for complete examples. A step missing the required backend inputs fails fast
+with an actionable error naming the detected backend, the provider, and the command.
 
 ---
 
@@ -415,6 +426,13 @@ Most commands that interact with cloud resources require a provider service conn
 | `test`        | **Optional**       | Unit/validation tests run without auth. Integration tests that provision real resources (test files with `run` blocks using `command = apply`) need a service connection — provide it in YAML and the task will use it. |
 
 All other commands (`plan`, `apply`, `destroy`, `show`, `output`, `import`, `refresh`, `custom`) require a provider service connection.
+
+> **Cross-cloud state:** the "Not required" commands above assume the state
+> backend is on the *same* cloud as `provider`. If the backend detected from
+> the working directory is on a *different* cloud (e.g. an `azurerm` backend
+> with `provider: aws`), that backend's service connection inputs are still
+> required on `state`, `workspace`, and `forceunlock` — see
+> [Cross-cloud state backends](docs/yaml-examples.md#cross-cloud-state-backends).
 
 ### Running `terraform test` without a service connection
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/BackendDetectionTests/BackendDetectionL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/BackendDetectionTests/BackendDetectionL0.ts
@@ -1,0 +1,94 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { detectBackendCloud, MAX_BACKEND_STATE_BYTES } from '../../src/backend-detection';
+
+/**
+ * Direct unit tests for cross-cloud backend detection. `detectBackendCloud`
+ * reads the real `.terraform/terraform.tfstate` file Terraform writes at
+ * `init` time — this is the ground truth for which backend a state-accessing
+ * command (plan/apply/...) will actually use, independent of the task's
+ * `provider`/`backendType` inputs.
+ */
+describe('detectBackendCloud', function () {
+  const tmpDirs: string[] = [];
+
+  function makeWorkingDirectory(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'backend-detect-'));
+    tmpDirs.push(dir);
+    fs.mkdirSync(path.join(dir, '.terraform'));
+    return dir;
+  }
+
+  function writeTfstate(dir: string, content: string): void {
+    fs.writeFileSync(path.join(dir, '.terraform', 'terraform.tfstate'), content);
+  }
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const cloudMappings: Array<[string, 'azurerm' | 'aws' | 'gcp' | 'hcp']> = [
+    ['azurerm', 'azurerm'],
+    ['s3', 'aws'],
+    ['gcs', 'gcp'],
+    ['cloud', 'hcp'],
+    ['remote', 'hcp'],
+  ];
+
+  for (const [backendType, expectedCloud] of cloudMappings) {
+    it(`maps backend type '${backendType}' to cloud '${expectedCloud}'`, () => {
+      const dir = makeWorkingDirectory();
+      writeTfstate(dir, JSON.stringify({ backend: { type: backendType } }));
+      assert.strictEqual(detectBackendCloud(dir), expectedCloud);
+    });
+  }
+
+  const noCredentialBackends = ['local', 'http', 'oci', 'pg', 'consul', 'kubernetes', 'oss'];
+  for (const backendType of noCredentialBackends) {
+    it(`returns null for backend type '${backendType}' (no cloud credentials to inject)`, () => {
+      const dir = makeWorkingDirectory();
+      writeTfstate(dir, JSON.stringify({ backend: { type: backendType } }));
+      assert.strictEqual(detectBackendCloud(dir), null);
+    });
+  }
+
+  it('returns null when .terraform/terraform.tfstate has no backend.type', () => {
+    const dir = makeWorkingDirectory();
+    writeTfstate(dir, JSON.stringify({}));
+    assert.strictEqual(detectBackendCloud(dir), null);
+  });
+
+  it('returns null when .terraform/terraform.tfstate does not exist (not yet initialized)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'backend-detect-'));
+    tmpDirs.push(dir);
+    assert.strictEqual(detectBackendCloud(dir), null);
+  });
+
+  it('returns null when the .terraform directory itself does not exist', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'backend-detect-'));
+    tmpDirs.push(dir);
+    assert.strictEqual(detectBackendCloud(dir), null);
+  });
+
+  it('returns null when terraform.tfstate is malformed JSON', () => {
+    const dir = makeWorkingDirectory();
+    writeTfstate(dir, '{ this is not valid json');
+    assert.strictEqual(detectBackendCloud(dir), null);
+  });
+
+  it('returns null and does not attempt to parse a terraform.tfstate larger than the size guard', () => {
+    const dir = makeWorkingDirectory();
+    const huge = Buffer.alloc(MAX_BACKEND_STATE_BYTES + 1, 'a');
+    fs.writeFileSync(path.join(dir, '.terraform', 'terraform.tfstate'), huge);
+    assert.strictEqual(detectBackendCloud(dir), null);
+  });
+
+  it('defaults to the current directory when workingDirectory is empty', () => {
+    // Should not throw even if '.'/.terraform doesn't contain a tfstate.
+    assert.doesNotThrow(() => detectBackendCloud(''));
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/AwsConfigureBackendCredentialsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/AwsConfigureBackendCredentialsL0.ts
@@ -1,0 +1,88 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import tasks = require('azure-pipelines-task-lib/task');
+import { TerraformCommandHandlerAWS } from '../../src/aws-terraform-command-handler';
+import { EnvironmentVariableHelper } from '../../src/environment-variables';
+import * as idTokenGenerator from '../../src/id-token-generator';
+
+/**
+ * Direct unit tests for the AWS handler's cross-cloud
+ * `configureBackendCredentials()` — invoked by ParentCommandHandler on
+ * state-accessing commands when the initialized backend is s3 but the
+ * `provider` input is a different cloud.
+ */
+describe('TerraformCommandHandlerAWS.configureBackendCredentials (cross-cloud)', function () {
+  const originalGetInput = tasks.getInput;
+  const originalGetEndpointAuthorizationParameter = tasks.getEndpointAuthorizationParameter;
+  const originalSetSecret = tasks.setSecret;
+  const originalGenerateIdToken = idTokenGenerator.generateIdToken;
+
+  afterEach(() => {
+    (tasks as any).getInput = originalGetInput;
+    (tasks as any).getEndpointAuthorizationParameter = originalGetEndpointAuthorizationParameter;
+    (tasks as any).setSecret = originalSetSecret;
+    (idTokenGenerator as any).generateIdToken = originalGenerateIdToken;
+    EnvironmentVariableHelper.clearTrackedVariables();
+  });
+
+  it('ServiceConnection (static credentials): sets AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY', async () => {
+    (tasks as any).getInput = (name: string) => {
+      if (name === 'backendServiceAWS') return 'AWS-Backend';
+      if (name === 'backendAuthSchemeAWS') return undefined; // defaults to ServiceConnection
+      return undefined;
+    };
+    (tasks as any).setSecret = () => { /* no-op */ };
+    (tasks as any).getEndpointAuthorizationParameter = (_id: string, name: string) => {
+      if (name === 'username') return 'AKIA-DUMMY';
+      if (name === 'password') return 'dummy-secret-key';
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerAWS();
+    await handler.configureBackendCredentials();
+
+    assert.strictEqual(process.env['AWS_ACCESS_KEY_ID'], 'AKIA-DUMMY');
+    assert.strictEqual(process.env['AWS_SECRET_ACCESS_KEY'], 'dummy-secret-key');
+  });
+
+  it('WorkloadIdentityFederation: sets AWS_ROLE_ARN/AWS_REGION/AWS_WEB_IDENTITY_TOKEN_FILE and writes+cleans a token file', async () => {
+    (tasks as any).getInput = (name: string) => {
+      switch (name) {
+        case 'backendServiceAWS': return 'AWS-Backend';
+        case 'backendAuthSchemeAWS': return 'WorkloadIdentityFederation';
+        case 'backendAWSRoleArn': return 'arn:aws:iam::922142189708:role/ADO-role';
+        case 'backendAWSRegion': return 'us-east-1';
+        case 'backendAWSSessionName': return undefined; // use default
+        default: return undefined;
+      }
+    };
+    (tasks as any).setSecret = () => { /* no-op */ };
+    (idTokenGenerator as any).generateIdToken = async () => 'fake-oidc-jwt';
+
+    const handler = new TerraformCommandHandlerAWS();
+    await handler.configureBackendCredentials();
+
+    assert.strictEqual(process.env['AWS_ROLE_ARN'], 'arn:aws:iam::922142189708:role/ADO-role');
+    assert.strictEqual(process.env['AWS_REGION'], 'us-east-1');
+    assert.strictEqual(process.env['AWS_ROLE_SESSION_NAME'], 'AzureDevOps-Terraform-Backend');
+
+    const tokenFilePath = process.env['AWS_WEB_IDENTITY_TOKEN_FILE']!;
+    assert.ok(tokenFilePath, 'AWS_WEB_IDENTITY_TOKEN_FILE should be set');
+    assert.strictEqual(fs.readFileSync(tokenFilePath, 'utf-8'), 'fake-oidc-jwt');
+
+    // The token file is tracked for cleanup — verify it actually gets removed.
+    (handler as any).cleanupTempFiles();
+    assert.strictEqual(fs.existsSync(tokenFilePath), false, 'token file should be removed by cleanupTempFiles()');
+  });
+
+  it('throws for an unrecognized backendAuthSchemeAWS value', async () => {
+    (tasks as any).getInput = (name: string) => {
+      if (name === 'backendServiceAWS') return 'AWS-Backend';
+      if (name === 'backendAuthSchemeAWS') return 'NotARealScheme';
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerAWS();
+    await assert.rejects(() => handler.configureBackendCredentials(), /Unrecognized authorization scheme/);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/AzureConfigureBackendCredentialsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/AzureConfigureBackendCredentialsL0.ts
@@ -1,0 +1,109 @@
+import * as assert from 'assert';
+import tasks = require('azure-pipelines-task-lib/task');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { EnvironmentVariableHelper } from '../../src/environment-variables';
+
+/**
+ * Direct unit tests for the azurerm handler's cross-cloud
+ * `configureBackendCredentials()` — the method ParentCommandHandler calls on
+ * state-accessing commands (plan/apply/...) when the initialized backend is
+ * azurerm but the `provider` input is a different cloud (e.g. aws, the
+ * tbd4770 case). Asserts the same ARM_* environment variables `handleBackend`
+ * (init) would set are (re)supplied, and that nothing is written to
+ * `-backend-config` (this method never touches a ToolRunner at all).
+ */
+describe('TerraformCommandHandlerAzureRM.configureBackendCredentials (cross-cloud)', function () {
+  const originalGetInput = tasks.getInput;
+  const originalGetBoolInput = tasks.getBoolInput;
+  const originalGetEndpointAuthorizationScheme = tasks.getEndpointAuthorizationScheme;
+  const originalGetEndpointAuthorizationParameter = tasks.getEndpointAuthorizationParameter;
+  const originalGetEndpointDataParameter = tasks.getEndpointDataParameter;
+  const originalSetSecret = tasks.setSecret;
+
+  afterEach(() => {
+    (tasks as any).getInput = originalGetInput;
+    (tasks as any).getBoolInput = originalGetBoolInput;
+    (tasks as any).getEndpointAuthorizationScheme = originalGetEndpointAuthorizationScheme;
+    (tasks as any).getEndpointAuthorizationParameter = originalGetEndpointAuthorizationParameter;
+    (tasks as any).getEndpointDataParameter = originalGetEndpointDataParameter;
+    (tasks as any).setSecret = originalSetSecret;
+    EnvironmentVariableHelper.clearTrackedVariables();
+  });
+
+  function mockCommonInputs(overrides: Record<string, string | undefined> = {}): void {
+    (tasks as any).getInput = (name: string, _required?: boolean) => {
+      if (name === 'backendServiceArm') return 'AzureRM-Backend';
+      if (name in overrides) return overrides[name];
+      return undefined;
+    };
+    (tasks as any).getBoolInput = () => false;
+    (tasks as any).setSecret = () => { /* no-op */ };
+    (tasks as any).getEndpointDataParameter = (_id: string, name: string) =>
+      name === 'subscriptionid' ? 'sub-1234' : undefined;
+  }
+
+  it('ManagedServiceIdentity: sets ARM_USE_MSI, ARM_TENANT_ID, and ARM_SUBSCRIPTION_ID', async () => {
+    mockCommonInputs();
+    (tasks as any).getEndpointAuthorizationScheme = () => 'ManagedServiceIdentity';
+    (tasks as any).getEndpointAuthorizationParameter = (_id: string, name: string) =>
+      name === 'tenantid' ? 'tenant-msi' : undefined;
+
+    const handler = new TerraformCommandHandlerAzureRM();
+    await handler.configureBackendCredentials();
+
+    assert.strictEqual(process.env['ARM_USE_MSI'], 'true');
+    assert.strictEqual(process.env['ARM_TENANT_ID'], 'tenant-msi');
+    assert.strictEqual(process.env['ARM_SUBSCRIPTION_ID'], 'sub-1234');
+  });
+
+  it('ServicePrincipal: sets ARM_CLIENT_ID, ARM_CLIENT_SECRET, and ARM_TENANT_ID', async () => {
+    mockCommonInputs();
+    (tasks as any).getEndpointAuthorizationScheme = () => 'ServicePrincipal';
+    (tasks as any).getEndpointAuthorizationParameter = (_id: string, name: string) => {
+      if (name === 'tenantid') return 'tenant-spn';
+      if (name === 'serviceprincipalid') return 'spn-id';
+      if (name === 'serviceprincipalkey') return 'spn-secret';
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerAzureRM();
+    await handler.configureBackendCredentials();
+
+    assert.strictEqual(process.env['ARM_CLIENT_ID'], 'spn-id');
+    assert.strictEqual(process.env['ARM_CLIENT_SECRET'], 'spn-secret');
+    assert.strictEqual(process.env['ARM_TENANT_ID'], 'tenant-spn');
+  });
+
+  it('WorkloadIdentityFederation (token refresh): sets ARM_USE_OIDC, ARM_CLIENT_ID, and the ADO request token', async () => {
+    mockCommonInputs(); // backendAzureRmUseIdTokenGeneration defaults false -> token-refresh path (no network call)
+    (tasks as any).getEndpointAuthorizationScheme = () => 'WorkloadIdentityFederation';
+    (tasks as any).getEndpointAuthorizationParameter = (id: string, name: string) => {
+      if (id === 'SystemVssConnection' && name === 'AccessToken') return 'fake-ado-access-token';
+      if (name === 'tenantid') return 'tenant-wif';
+      if (name === 'serviceprincipalid') return 'wif-client-id';
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerAzureRM();
+    await handler.configureBackendCredentials();
+
+    assert.strictEqual(process.env['ARM_USE_OIDC'], 'true');
+    assert.strictEqual(process.env['ARM_CLIENT_ID'], 'wif-client-id');
+    assert.strictEqual(process.env['ARM_TENANT_ID'], 'tenant-wif');
+    assert.strictEqual(process.env['ARM_OIDC_REQUEST_TOKEN'], 'fake-ado-access-token');
+    // Cross-cloud injection never uses CLI-flag/backend-config auth.
+    assert.strictEqual(process.env['ARM_OIDC_AZURE_SERVICE_CONNECTION_ID'], 'AzureRM-Backend');
+  });
+
+  it('throws when backendServiceArm is not provided on this step', async () => {
+    (tasks as any).getInput = (name: string, required?: boolean) => {
+      if (name === 'backendServiceArm' && required) {
+        throw new Error("Input required: backendServiceArm");
+      }
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerAzureRM();
+    await assert.rejects(() => handler.configureBackendCredentials(), /backendServiceArm/);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/GcpConfigureBackendCredentialsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/GcpConfigureBackendCredentialsL0.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import tasks = require('azure-pipelines-task-lib/task');
+import { TerraformCommandHandlerGCP } from '../../src/gcp-terraform-command-handler';
+import { EnvironmentVariableHelper } from '../../src/environment-variables';
+import * as idTokenGenerator from '../../src/id-token-generator';
+
+/**
+ * Direct unit tests for the GCP handler's cross-cloud
+ * `configureBackendCredentials()`, and a regression guard for the GCS
+ * credentials-caching fix: credentials must be supplied via the
+ * `GOOGLE_BACKEND_CREDENTIALS` environment variable only, never via a cached
+ * `-backend-config=credentials=<path>` (which HashiCorp's own precedence
+ * rules make override the environment variable, and which goes stale the
+ * moment this task's temp file is cleaned up).
+ */
+describe('TerraformCommandHandlerGCP.configureBackendCredentials (cross-cloud)', function () {
+  const originalGetInput = tasks.getInput;
+  const originalGetEndpointAuthorizationParameter = tasks.getEndpointAuthorizationParameter;
+  const originalSetSecret = tasks.setSecret;
+  const originalGenerateIdToken = idTokenGenerator.generateIdToken;
+
+  afterEach(() => {
+    (tasks as any).getInput = originalGetInput;
+    (tasks as any).getEndpointAuthorizationParameter = originalGetEndpointAuthorizationParameter;
+    (tasks as any).setSecret = originalSetSecret;
+    (idTokenGenerator as any).generateIdToken = originalGenerateIdToken;
+    EnvironmentVariableHelper.clearTrackedVariables();
+  });
+
+  it('ServiceConnection (static JSON key): sets GOOGLE_BACKEND_CREDENTIALS to a fresh service_account credentials file', async () => {
+    (tasks as any).getInput = (name: string) => {
+      if (name === 'backendServiceGCP') return 'GCP-Backend';
+      if (name === 'backendAuthSchemeGCP') return undefined; // defaults to ServiceConnection
+      return undefined;
+    };
+    (tasks as any).setSecret = () => { /* no-op */ };
+    (tasks as any).getEndpointAuthorizationParameter = (_id: string, name: string) => {
+      if (name === 'Issuer') return 'sa@project.iam.gserviceaccount.com';
+      if (name === 'Audience') return 'https://oauth2.googleapis.com/token';
+      if (name === 'PrivateKey') return '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n';
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerGCP();
+    await handler.configureBackendCredentials();
+
+    const credsPath = process.env['GOOGLE_BACKEND_CREDENTIALS']!;
+    assert.ok(credsPath, 'GOOGLE_BACKEND_CREDENTIALS should be set');
+    const written = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
+    assert.strictEqual(written.type, 'service_account');
+    assert.strictEqual(written.client_email, 'sa@project.iam.gserviceaccount.com');
+
+    (handler as any).cleanupTempFiles();
+    assert.strictEqual(fs.existsSync(credsPath), false, 'credentials file should be removed by cleanupTempFiles()');
+  });
+
+  it('WorkloadIdentityFederation: sets GOOGLE_BACKEND_CREDENTIALS to a fresh external_account credentials file', async () => {
+    (tasks as any).getInput = (name: string) => {
+      switch (name) {
+        case 'backendServiceGCP': return 'GCP-Backend';
+        case 'backendAuthSchemeGCP': return 'WorkloadIdentityFederation';
+        case 'backendGCPProjectNumber': return '123456789012';
+        case 'backendGCPWorkloadIdentityPoolId': return 'pool-1';
+        case 'backendGCPWorkloadIdentityProviderId': return 'provider-1';
+        case 'backendGCPServiceAccountEmail': return 'sa@project.iam.gserviceaccount.com';
+        default: return undefined;
+      }
+    };
+    (tasks as any).setSecret = () => { /* no-op */ };
+    (idTokenGenerator as any).generateIdToken = async () => 'fake-oidc-jwt';
+
+    const handler = new TerraformCommandHandlerGCP();
+    await handler.configureBackendCredentials();
+
+    const credsPath = process.env['GOOGLE_BACKEND_CREDENTIALS']!;
+    assert.ok(credsPath, 'GOOGLE_BACKEND_CREDENTIALS should be set');
+    const written = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
+    assert.strictEqual(written.type, 'external_account');
+    assert.ok(written.audience.includes('pool-1'));
+
+    (handler as any).cleanupTempFiles();
+    assert.strictEqual(fs.existsSync(credsPath), false, 'credentials file should be removed by cleanupTempFiles()');
+  });
+
+  it('throws for an unrecognized backendAuthSchemeGCP value', async () => {
+    (tasks as any).getInput = (name: string) => {
+      if (name === 'backendServiceGCP') return 'GCP-Backend';
+      if (name === 'backendAuthSchemeGCP') return 'NotARealScheme';
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerGCP();
+    await assert.rejects(() => handler.configureBackendCredentials(), /Unrecognized authorization scheme/);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/HcpOciGenericConfigureBackendCredentialsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/HcpOciGenericConfigureBackendCredentialsL0.ts
@@ -1,0 +1,65 @@
+import * as assert from 'assert';
+import tasks = require('azure-pipelines-task-lib/task');
+import { TerraformCommandHandlerHCP } from '../../src/hcp-terraform-command-handler';
+import { TerraformCommandHandlerOCI } from '../../src/oci-terraform-command-handler';
+import { TerraformCommandHandlerGeneric } from '../../src/generic-terraform-command-handler';
+import { EnvironmentVariableHelper } from '../../src/environment-variables';
+
+/**
+ * Direct unit tests for the HCP handler's cross-cloud
+ * `configureBackendCredentials()`, and the OCI/generic no-ops (these backends
+ * have no separate cloud identity to inject: OCI's http/PAR backend embeds
+ * auth in its cached, pre-authenticated request URL; generic/local backends
+ * are authenticated, if at all, via the user's own environment).
+ */
+describe('HCP/OCI/Generic configureBackendCredentials (cross-cloud)', function () {
+  const originalGetInput = tasks.getInput;
+  const originalSetSecret = tasks.setSecret;
+
+  afterEach(() => {
+    (tasks as any).getInput = originalGetInput;
+    (tasks as any).setSecret = originalSetSecret;
+    EnvironmentVariableHelper.clearTrackedVariables();
+  });
+
+  it('HCP: sets TF_TOKEN_app_terraform_io, TF_CLOUD_ORGANIZATION, and TF_WORKSPACE', async () => {
+    (tasks as any).getInput = (name: string) => {
+      switch (name) {
+        case 'backendHCPToken': return 'hcp-token';
+        case 'backendHCPOrganization': return 'NavicoCloudTeam';
+        case 'backendHCPWorkspace': return 'my-workspace';
+        default: return undefined;
+      }
+    };
+    (tasks as any).setSecret = () => { /* no-op */ };
+
+    const handler = new TerraformCommandHandlerHCP();
+    await handler.configureBackendCredentials();
+
+    assert.strictEqual(process.env['TF_TOKEN_app_terraform_io'], 'hcp-token');
+    assert.strictEqual(process.env['TF_CLOUD_ORGANIZATION'], 'NavicoCloudTeam');
+    assert.strictEqual(process.env['TF_WORKSPACE'], 'my-workspace');
+  });
+
+  it('HCP: throws when backendHCPToken is not provided on this step', async () => {
+    (tasks as any).getInput = (name: string, required?: boolean) => {
+      if (name === 'backendHCPToken' && required) {
+        throw new Error('Input required: backendHCPToken');
+      }
+      return undefined;
+    };
+
+    const handler = new TerraformCommandHandlerHCP();
+    await assert.rejects(() => handler.configureBackendCredentials(), /backendHCPToken/);
+  });
+
+  it('OCI: is a no-op (no env vars set, does not throw)', async () => {
+    const handler = new TerraformCommandHandlerOCI();
+    await assert.doesNotReject(() => handler.configureBackendCredentials());
+  });
+
+  it('Generic: is a no-op (no env vars set, does not throw)', async () => {
+    const handler = new TerraformCommandHandlerGeneric();
+    await assert.doesNotReject(() => handler.configureBackendCredentials());
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
@@ -22,9 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
-let credentialsFilePath = path.join(os.tmpdir(), 'credentials-123.json');
-
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -32,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        [`terraform init -no-color -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix -backend-config=credentials=${credentialsFilePath}`]: {
+        "terraform init -no-color -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix": {
             "code": 1,
             "stdout": "There are some problems with the configuration, described below.\n\nThe Terraform configuration must be valid before initialization so that Terraform can determine which modules and providers need to be installed."
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
@@ -22,9 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
-let credentialsFilePath = path.join(os.tmpdir(), 'credentials-123.json');
-
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -32,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        [`terraform init -no-color -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix -backend-config=credentials=${credentialsFilePath}`]: {
+        "terraform init -no-color -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
@@ -22,9 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
-let credentialsFilePath = path.join(os.tmpdir(), 'credentials-123.json');
-
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -32,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        [`terraform init -no-color -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix -backend-config=credentials=${credentialsFilePath}`]: {
+        "terraform init -no-color -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
@@ -22,9 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
-let credentialsFilePath = path.join(os.tmpdir(), 'credentials-123.json');
-
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -32,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        [`terraform init -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix -backend-config=credentials=${credentialsFilePath}`]: {
+        "terraform init -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitWIFSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitWIFSuccess.ts
@@ -20,16 +20,13 @@ tr.setInput('backendGCPWorkloadIdentityPoolId', 'my-wif-pool');
 tr.setInput('backendGCPWorkloadIdentityProviderId', 'my-oidc-provider');
 tr.setInput('backendGCPServiceAccountEmail', 'terraform@my-project.iam.gserviceaccount.com');
 
-let credentialsFilePath = path.join(os.tmpdir(), 'gcp-backend-wif-credentials-test-uuid-1234.json');
-
 var mock = {
-    "generateIdToken": function(_serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
+    "generateIdToken": function (_serviceConnectionId: string) { return Promise.resolve('mock-oidc-token-12345'); }
 };
 
 tr.registerMock('./id-token-generator', mock);
-tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -37,7 +34,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        [`terraform init -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix -backend-config=credentials=${credentialsFilePath}`]: {
+        "terraform init -backend-config=bucket=DummyBucket -backend-config=prefix=DummyPrefix": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -18,6 +18,15 @@ import './ResolveToolPathL0';
 import './OciWifConfigValidationL0';
 // Direct unit tests for the optional MSI user-assigned client ID.
 import './ManagedIdentityClientIdL0';
+// Direct unit tests for cross-cloud state backend detection.
+import './BackendDetectionTests/BackendDetectionL0';
+// Direct unit tests for ParentCommandHandler's cross-cloud injection decisions.
+import './ParentHandlerTests/CrossCloudInjectionL0';
+// Direct unit tests for each handler's cross-cloud configureBackendCredentials().
+import './CrossCloudBackendCredentialTests/AzureConfigureBackendCredentialsL0';
+import './CrossCloudBackendCredentialTests/AwsConfigureBackendCredentialsL0';
+import './CrossCloudBackendCredentialTests/GcpConfigureBackendCredentialsL0';
+import './CrossCloudBackendCredentialTests/HcpOciGenericConfigureBackendCredentialsL0';
 
 describe('Terraform Test Suite', function () {
 
@@ -2016,6 +2025,40 @@ describe('Terraform Test Suite', function () {
             assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.stdOutContained('S3BackendAzureProviderInitSuccessL0 should have succeeded.'));
+        }, tr);
+    });
+
+    /* cross-cloud state backend credential injection tests (plan/apply/...) */
+
+    it('aws provider + azurerm backend plan should succeed via cross-cloud backend credential injection', async () => {
+        let tp = path.join(__dirname, './PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('CrossCloudAwsProviderAzurermBackendPlanSuccessL0 should have succeeded.'));
+        }, tr);
+    });
+
+    it('aws provider + s3 backend plan should succeed without any azurerm inputs (same-cloud, no injection)', async () => {
+        let tp = path.join(__dirname, './PlanTests/BackendDecoupling/SameCloudAwsProviderS3BackendPlanSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('SameCloudAwsProviderS3BackendPlanSuccessL0 should have succeeded.'));
+        }, tr);
+    });
+
+    it('aws provider + azurerm backend plan should fail with an actionable error when azurerm backend inputs are missing', async () => {
+        let tp = path.join(__dirname, './PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanMissingBackendInputsFail.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.stdOutContained("Cross-cloud state backend credential setup failed for command 'plan'"), 'should show the actionable cross-cloud error');
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ParentHandlerTests/CrossCloudInjectionL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ParentHandlerTests/CrossCloudInjectionL0.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import tasks = require('azure-pipelines-task-lib/task');
+import { ParentCommandHandler, STATE_COMMANDS } from '../../src/parent-handler';
+import { EnvironmentVariableHelper } from '../../src/environment-variables';
+
+/**
+ * Direct unit tests for ParentCommandHandler's cross-cloud backend credential
+ * injection decision logic. `tasks.getInput` is mocked by function
+ * reassignment (as the other direct-style tests in this suite do) rather than
+ * via raw `process.env['INPUT_*']` values: the real azure-pipelines-task-lib
+ * reads inputs from an in-memory vault that is populated once per process
+ * from `process.env` and then has those variables deleted — only
+ * TaskMockRunner's full sandbox (which swaps in a separate mock-task module)
+ * makes plain env vars work, so a direct-style test must mock the function
+ * itself. The full success path (cross-cloud plan actually succeeding
+ * end-to-end with a mocked terraform exec) is covered by the TaskMockRunner
+ * scenarios under Tests/PlanTests/BackendDecoupling/.
+ */
+describe('ParentCommandHandler cross-cloud backend credential injection', function () {
+  const tmpDirs: string[] = [];
+  const originalGetInput = tasks.getInput;
+
+  function makeWorkingDirectoryWithBackend(backendType: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'parent-handler-cross-cloud-'));
+    tmpDirs.push(dir);
+    fs.mkdirSync(path.join(dir, '.terraform'));
+    fs.writeFileSync(
+      path.join(dir, '.terraform', 'terraform.tfstate'),
+      JSON.stringify({ backend: { type: backendType } }),
+    );
+    return dir;
+  }
+
+  /** Mimics the real getInput(name, required) contract: throws when required and falsy. */
+  function mockInputs(values: Record<string, string | undefined>): void {
+    (tasks as any).getInput = (name: string, required?: boolean) => {
+      const val = values[name];
+      if (required && !val) {
+        throw new Error(`Input required: ${name}`);
+      }
+      return val;
+    };
+  }
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    (tasks as any).getInput = originalGetInput;
+    EnvironmentVariableHelper.clearTrackedVariables();
+  });
+
+  it('cross-cloud (aws provider + azurerm backend) plan throws an actionable error naming the detected backend when backend inputs are missing', async () => {
+    const workDir = makeWorkingDirectoryWithBackend('azurerm');
+    mockInputs({ workingDirectory: workDir }); // no backendServiceArm
+
+    await assert.rejects(
+      () => new ParentCommandHandler().execute('aws', 'plan'),
+      (err: Error) => {
+        assert.match(err.message, /Cross-cloud state backend credential setup failed for command 'plan'/);
+        assert.match(err.message, /'azurerm'/);
+        assert.match(err.message, /'aws'/);
+        return true;
+      },
+    );
+  });
+
+  it('same-cloud (aws provider + s3 backend) does not attempt cross-cloud injection', async () => {
+    const workDir = makeWorkingDirectoryWithBackend('s3');
+    mockInputs({ workingDirectory: workDir }); // no AWS provider inputs either
+
+    await assert.rejects(
+      () => new ParentCommandHandler().execute('aws', 'plan'),
+      (err: Error) => {
+        assert.ok(
+          !/Cross-cloud state backend credential setup failed/.test(err.message),
+          `same-cloud setup should not report a cross-cloud backend error, got: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('STATE_COMMANDS includes only commands that read/write remote state', () => {
+    for (const expected of ['plan', 'apply', 'destroy', 'refresh', 'import', 'output', 'state', 'workspace', 'forceunlock']) {
+      assert.ok(STATE_COMMANDS.has(expected), `expected STATE_COMMANDS to include '${expected}'`);
+    }
+    for (const excluded of ['init', 'validate', 'fmt', 'get', 'test', 'show', 'custom']) {
+      assert.ok(!STATE_COMMANDS.has(excluded), `expected STATE_COMMANDS to exclude '${excluded}'`);
+    }
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanMissingBackendInputsFail.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanMissingBackendInputsFail.ts
@@ -1,0 +1,44 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// Real working directory whose .terraform/terraform.tfstate records an
+// azurerm backend, but this step deliberately supplies NO azurerm backend
+// inputs — it should fail fast with an actionable error, not the opaque
+// "Please run 'az login'" failure this cross-cloud gap used to produce.
+const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'cross-cloud-missing-backend-inputs-'));
+fs.mkdirSync(path.join(workingDirectory, '.terraform'));
+fs.writeFileSync(
+  path.join(workingDirectory, '.terraform', 'terraform.tfstate'),
+  JSON.stringify({ backend: { type: 'azurerm' } }),
+);
+
+let tp = path.join(__dirname, './CrossCloudAwsProviderAzurermBackendPlanMissingBackendInputsFailL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('commandOptions', '');
+
+tr.setInput('environmentServiceNameAWS', 'AWS');
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'DummyAccessKeyId';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'DummySecretAccessKey';
+
+// Deliberately no backendServiceArm / azurerm inputs.
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+  "which": {
+    "terraform": "terraform"
+  },
+  "checkPath": {
+    "terraform": true
+  },
+  "exec": {}
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanMissingBackendInputsFailL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanMissingBackendInputsFailL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../../test-l0-helpers';
+
+runViaParentHandler('CrossCloudAwsProviderAzurermBackendPlanMissingBackendInputsFailL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanSuccess.ts
@@ -1,0 +1,63 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// Real working directory with a real .terraform/terraform.tfstate recording an
+// azurerm backend. detectBackendCloud() reads this straight off disk (it is
+// not something the mock-run task-lib answers can fake), so the cross-cloud
+// injection path under test needs a genuine file, not just mocked inputs.
+const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'cross-cloud-aws-azurerm-'));
+fs.mkdirSync(path.join(workingDirectory, '.terraform'));
+fs.writeFileSync(
+  path.join(workingDirectory, '.terraform', 'terraform.tfstate'),
+  JSON.stringify({ backend: { type: 'azurerm' } }),
+);
+
+let tp = path.join(__dirname, './CrossCloudAwsProviderAzurermBackendPlanSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('commandOptions', '');
+
+// AWS provider credentials (ServiceConnection scheme, static keys) — same as
+// any ordinary aws-provider plan step.
+tr.setInput('environmentServiceNameAWS', 'AWS');
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'DummyAccessKeyId';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'DummySecretAccessKey';
+
+// azurerm backend credentials — required on THIS step only because the
+// backend (azurerm, detected above) differs from the provider (aws). This is
+// exactly the tbd4770 scenario: an AWS WIF provider with Azure Blob state.
+tr.setInput('backendServiceArm', 'AzureRM');
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+  "which": {
+    "terraform": "terraform"
+  },
+  "checkPath": {
+    "terraform": true
+  },
+  "exec": {
+    "terraform providers": {
+      "code": 0,
+      "stdout": "provider aws"
+    },
+    "terraform plan -detailed-exitcode": {
+      "code": 0,
+      "stdout": "Executed successfully"
+    }
+  }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/CrossCloudAwsProviderAzurermBackendPlanSuccessL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../../test-l0-helpers';
+
+runViaParentHandler('CrossCloudAwsProviderAzurermBackendPlanSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/SameCloudAwsProviderS3BackendPlanSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/SameCloudAwsProviderS3BackendPlanSuccess.ts
@@ -1,0 +1,55 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// Real working directory whose .terraform/terraform.tfstate records an s3
+// backend — the SAME cloud as the aws provider below. This is a regression
+// guard: cross-cloud injection must be a no-op here (no azurerm inputs are
+// supplied, and none should be required) — only the aws provider's own
+// credentials matter, exactly as before this change.
+const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'same-cloud-aws-s3-'));
+fs.mkdirSync(path.join(workingDirectory, '.terraform'));
+fs.writeFileSync(
+  path.join(workingDirectory, '.terraform', 'terraform.tfstate'),
+  JSON.stringify({ backend: { type: 's3' } }),
+);
+
+let tp = path.join(__dirname, './SameCloudAwsProviderS3BackendPlanSuccessL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('commandOptions', '');
+
+tr.setInput('environmentServiceNameAWS', 'AWS');
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'DummyAccessKeyId';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'DummySecretAccessKey';
+
+// Deliberately NO backendServiceArm / azurerm inputs — proving cross-cloud
+// injection did not fire and none were required.
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+  "which": {
+    "terraform": "terraform"
+  },
+  "checkPath": {
+    "terraform": true
+  },
+  "exec": {
+    "terraform providers": {
+      "code": 0,
+      "stdout": "provider aws"
+    },
+    "terraform plan -detailed-exitcode": {
+      "code": 0,
+      "stdout": "Executed successfully"
+    }
+  }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/SameCloudAwsProviderS3BackendPlanSuccessL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/BackendDecoupling/SameCloudAwsProviderS3BackendPlanSuccessL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../../test-l0-helpers';
+
+runViaParentHandler('SameCloudAwsProviderS3BackendPlanSuccessL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/test-l0-helpers.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/test-l0-helpers.ts
@@ -1,5 +1,6 @@
 import tl = require('azure-pipelines-task-lib');
 import { BaseTerraformCommandHandler } from '../src/base-terraform-command-handler';
+import { ParentCommandHandler } from '../src/parent-handler';
 
 /**
  * Run a command on a handler and report success/failure to the test framework.
@@ -33,3 +34,38 @@ export async function runCommand(
         }
     }
 }
+
+/**
+ * Runs a scenario through the real `ParentCommandHandler.execute()` dispatch —
+ * unlike `runCommand` (which instantiates one specific provider handler and
+ * calls a single command method directly) — so that cross-cloud backend
+ * credential injection (which lives in ParentCommandHandler, not in any one
+ * handler) is actually exercised. `provider` and `command` are read from the
+ * task's own inputs, matching what the outer mock-run scenario configured.
+ */
+export async function runViaParentHandler(
+    testName: string,
+    expectSuccess: boolean = true
+): Promise<void> {
+    try {
+        const provider = tl.getInput('provider', true)!;
+        const command = tl.getInput('command', true)!;
+        const response = await new ParentCommandHandler().execute(provider, command);
+        if (expectSuccess) {
+            tl.setResult(tl.TaskResult.Succeeded, `${testName} should have succeeded.`);
+        } else {
+            tl.setResult(tl.TaskResult.Failed, `${testName} should have failed but succeeded (code ${response}).`);
+        }
+    } catch (error) {
+        if (!expectSuccess) {
+            // Include the underlying error message (not just a generic "should have
+            // failed") so callers can assert on *which* error was thrown — e.g. that
+            // a cross-cloud backend credential failure produced the actionable
+            // message naming the missing inputs, not some other unrelated failure.
+            tl.setResult(tl.TaskResult.Failed, `${testName} should have failed: ${error}`);
+        } else {
+            tl.setResult(tl.TaskResult.Failed, `${testName} should have succeeded but failed: ${error}`);
+        }
+    }
+}
+

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -5,8 +5,8 @@ import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
 import { generateIdToken } from './id-token-generator';
 import { writeSecretFile } from './secure-temp';
+import { resolveWifTempDir } from './temp-dir';
 import path = require('path');
-import os = require('os');
 import { randomUUID as uuidV4 } from 'crypto';
 
 const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
@@ -23,18 +23,27 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
         }
     }
 
+    /**
+     * Sets the static AWS credential environment variables from a service
+     * connection. Environment variables (rather than CLI args) avoid exposing
+     * secrets in process listings. Shared by `setupBackend` (init) and
+     * `configureBackendCredentials` (cross-cloud injection on later commands).
+     */
+    private setEnvOnlyAwsCredentials(backendServiceName: string): void {
+        const accessKey = tasks.getEndpointAuthorizationParameter(backendServiceName, "username", true)!;
+        const secretKey = tasks.getEndpointAuthorizationParameter(backendServiceName, "password", true)!;
+        if (secretKey) { tasks.setSecret(secretKey); }
+
+        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ACCESS_KEY_ID", accessKey);
+        EnvironmentVariableHelper.setEnvironmentVariable("AWS_SECRET_ACCESS_KEY", secretKey, true);
+    }
+
     private setupBackend(backendServiceName: string) {
         this.backendConfig.set('bucket', tasks.getInput("backendAWSBucketName", true)!);
         this.backendConfig.set('key', tasks.getInput("backendAWSKey", true)!);
         this.backendConfig.set('region', tasks.getEndpointAuthorizationParameter(backendServiceName, "region", true)!);
 
-        const accessKey = tasks.getEndpointAuthorizationParameter(backendServiceName, "username", true)!;
-        const secretKey = tasks.getEndpointAuthorizationParameter(backendServiceName, "password", true)!;
-        if (secretKey) { tasks.setSecret(secretKey); }
-
-        // Use environment variables instead of CLI args to avoid exposing secrets in process listings
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_ACCESS_KEY_ID", accessKey);
-        EnvironmentVariableHelper.setEnvironmentVariable("AWS_SECRET_ACCESS_KEY", secretKey, true);
+        this.setEnvOnlyAwsCredentials(backendServiceName);
     }
 
     /**
@@ -53,7 +62,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
         const oidcToken = await generateIdToken(params.serviceConnection);
         tasks.setSecret(oidcToken);
 
-        const tokenFilePath = path.join(os.tmpdir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
+        const tokenFilePath = path.join(resolveWifTempDir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
         writeSecretFile(tokenFilePath, oidcToken);
         this.tempFiles.push(tokenFilePath);
 
@@ -87,6 +96,33 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
             this.setupBackend(backendServiceName);
         }
         this.applyBackendConfig(terraformToolRunner);
+    }
+
+    /**
+     * Cross-cloud path: called instead of `handleBackend` on state-accessing
+     * commands (plan/apply/...) when this s3 backend is paired with a
+     * *different* cloud's `provider` input. Sets the same AWS_* credential
+     * environment variables as init; the non-secret bucket/key/region fields
+     * were already cached by `terraform init` and need not be resupplied.
+     */
+    public async configureBackendCredentials(): Promise<void> {
+        const backendServiceName = tasks.getInput("backendServiceAWS", true)!;
+        const authScheme = tasks.getInput("backendAuthSchemeAWS", false) || "ServiceConnection";
+        this.validateAuthScheme(authScheme, "backendAuthSchemeAWS");
+
+        tasks.debug("Configuring cross-cloud s3 backend credentials (environment variables only).");
+        if (authScheme === "WorkloadIdentityFederation") {
+            await this.applyWifEnvironment({
+                serviceConnection: backendServiceName,
+                roleArn: tasks.getInput("backendAWSRoleArn", true)!,
+                region: tasks.getInput("backendAWSRegion", true)!,
+                sessionName: tasks.getInput("backendAWSSessionName", false) || "AzureDevOps-Terraform-Backend",
+                tokenFilePrefix: "aws-backend-oidc-token",
+            });
+        } else {
+            this.setEnvOnlyAwsCredentials(backendServiceName);
+        }
+        tasks.debug("Finished configuring cross-cloud s3 backend credentials.");
     }
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -24,11 +24,35 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
         this.providerName = "azurerm";
     }
 
-    public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
-        const serviceConnectionID = tasks.getInput("backendServiceArm", true)!;
+    /**
+     * Resolves the backend service connection's auth scheme and sets the
+     * shared ARM_* credential environment variables (tenant, and whichever of
+     * client-id/secret/OIDC-token/MSI the scheme needs), plus ARM_SUBSCRIPTION_ID
+     * when resolvable. Shared by `handleBackend` (init, where
+     * `useCliFlagsForBackend` may route some values into cached backend-config
+     * instead) and `configureBackendCredentials` (every later state-accessing
+     * command, which always passes `false` — cross-cloud injection is env-only,
+     * per HashiCorp's guidance against caching backend credentials on disk).
+     */
+    private async applyBackendCredentialEnv(serviceConnectionID: string, useCliFlagsForBackend: boolean): Promise<AuthorizationScheme> {
         const authorizationScheme = this.mapAuthorizationScheme(tasks.getEndpointAuthorizationScheme(serviceConnectionID, true)!);
 
-        tasks.debug("Setting up backend for authorization scheme: " + authorizationScheme + ".");
+        let subscriptionId = tasks.getInput("backendAzureRmOverrideSubscriptionID", false);
+        if (!subscriptionId) {
+            subscriptionId = tasks.getEndpointDataParameter(serviceConnectionID, "subscriptionid", true);
+        }
+        if (subscriptionId) {
+            EnvironmentVariableHelper.setEnvironmentVariable("ARM_SUBSCRIPTION_ID", subscriptionId);
+        }
+
+        const fallbackToIdTokenGeneration = tasks.getBoolInput("backendAzureRmUseIdTokenGeneration", false);
+        await this.setCommonVariables(authorizationScheme, serviceConnectionID, fallbackToIdTokenGeneration, useCliFlagsForBackend);
+
+        return authorizationScheme;
+    }
+
+    public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
+        const serviceConnectionID = tasks.getInput("backendServiceArm", true)!;
 
         // Setup required backend configuration for storage account blob location
         this.backendConfig.set("storage_account_name", tasks.getInput("backendAzureRmStorageAccountName", true)!);
@@ -55,14 +79,32 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             this.backendConfig.set("use_azuread_auth", "true");
         }
 
-        const fallbackToIdTokenGeneration = tasks.getBoolInput("backendAzureRmUseIdTokenGeneration", false);
         const backendAzureRmUseCliFlagsForAuthentication = tasks.getBoolInput("backendAzureRmUseCliFlagsForAuthentication", false);
 
-        await this.setCommonVariables(authorizationScheme, serviceConnectionID, fallbackToIdTokenGeneration, backendAzureRmUseCliFlagsForAuthentication);
+        tasks.debug("Setting up backend for authorization scheme.");
+        const authorizationScheme = await this.applyBackendCredentialEnv(serviceConnectionID, backendAzureRmUseCliFlagsForAuthentication);
 
         this.applyBackendConfig(terraformToolRunner);
 
         tasks.debug("Finished setting up backend for authorization scheme: " + authorizationScheme + ".");
+    }
+
+    /**
+     * Cross-cloud path: called instead of `handleBackend` on state-accessing
+     * commands (plan/apply/...) when this azurerm backend is paired with a
+     * *different* cloud's `provider` input. Sets the same ARM_* credential
+     * environment variables as init — never `-backend-config`, since that
+     * would be silently ignored here anyway (this method never touches a tool
+     * runner) and would only risk confusion. The non-secret location fields
+     * (storage account, container, key, resource group, subscription,
+     * use_azuread_auth) were already cached by `terraform init` and need not
+     * be resupplied.
+     */
+    public async configureBackendCredentials(): Promise<void> {
+        const serviceConnectionID = tasks.getInput("backendServiceArm", true)!;
+        tasks.debug("Configuring cross-cloud azurerm backend credentials (environment variables only).");
+        const authorizationScheme = await this.applyBackendCredentialEnv(serviceConnectionID, /* useCliFlagsForBackend */ false);
+        tasks.debug("Finished configuring cross-cloud azurerm backend credentials for authorization scheme: " + authorizationScheme + ".");
     }
 
     public async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/backend-detection.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/backend-detection.ts
@@ -1,0 +1,104 @@
+import fs = require('fs');
+import path = require('path');
+import tasks = require('azure-pipelines-task-lib/task');
+
+/** Cloud whose credentials a managed Terraform state backend needs. */
+export type BackendCloud = 'azurerm' | 'aws' | 'gcp' | 'hcp';
+
+/**
+ * Upper bound on the `.terraform/terraform.tfstate` file we'll read for
+ * backend detection. A real Terraform/OpenTofu-written backend record is a
+ * few KB; this guards against an unbounded read (and JSON.parse) of a
+ * pathological or corrupted file causing excessive memory use or a hang.
+ */
+export const MAX_BACKEND_STATE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/**
+ * Maps a Terraform `backend.type` (as recorded in `.terraform/terraform.tfstate`
+ * by `terraform init`) to the cloud whose credentials that backend needs.
+ * Backends with no cloud identity to inject (local, generic http/pg/consul/
+ * kubernetes, oci's PAR-based http backend, ...) are intentionally absent —
+ * `detectBackendCloud` returns null for them.
+ */
+const BACKEND_TYPE_TO_CLOUD: Readonly<Record<string, BackendCloud>> = {
+  azurerm: 'azurerm',
+  s3: 'aws',
+  gcs: 'gcp',
+  cloud: 'hcp',
+  remote: 'hcp',
+};
+
+/**
+ * Detects which cloud's credentials the *state backend* needs, by reading the
+ * backend type Terraform recorded at `terraform init` time from
+ * `<workingDirectory>/.terraform/terraform.tfstate`. This is the ground truth
+ * for the backend actually in use — independent of this task's `provider` or
+ * `backendType` inputs (the latter's `azurerm` default would otherwise be
+ * indistinguishable from an explicit value on a step that omits it) — and is
+ * what lets a state-accessing command (plan/apply/...) decide whether it must
+ * inject a *different* cloud's backend credentials than the ones the
+ * `provider` input already supplies.
+ *
+ * Returns `null` (no managed-cloud credentials to inject) when:
+ *  - `.terraform/terraform.tfstate` does not exist, is not a regular file, is
+ *    larger than {@link MAX_BACKEND_STATE_BYTES}, or fails to parse as JSON
+ *    (e.g. the working directory has not been initialized yet).
+ *  - the recorded `backend.type` is missing, or is not one of the backends
+ *    that require injected cloud credentials.
+ *
+ * Only the `backend.type` string is ever read; `backend.config` — which may
+ * hold cached, non-secret backend settings — is intentionally never inspected
+ * or logged. Never throws: callers should let Terraform surface its own error
+ * (e.g. "not initialized") when something is genuinely wrong.
+ */
+export function detectBackendCloud(workingDirectory: string): BackendCloud | null {
+  const tfstatePath = path.join(workingDirectory || '.', '.terraform', 'terraform.tfstate');
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(tfstatePath);
+  } catch {
+    tasks.debug(`Backend detection: no ${tfstatePath} found (not yet initialized?); skipping cross-cloud backend credential injection.`);
+    return null;
+  }
+
+  if (!stats.isFile()) {
+    tasks.debug(`Backend detection: ${tfstatePath} is not a regular file; skipping.`);
+    return null;
+  }
+
+  if (stats.size > MAX_BACKEND_STATE_BYTES) {
+    tasks.debug(`Backend detection: ${tfstatePath} is ${stats.size} bytes, exceeding the ${MAX_BACKEND_STATE_BYTES}-byte guard; skipping rather than risk an unbounded read.`);
+    return null;
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(tfstatePath, 'utf-8');
+  } catch (err) {
+    tasks.debug(`Backend detection: failed to read ${tfstatePath}: ${err instanceof Error ? err.message : err}`);
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    tasks.debug(`Backend detection: failed to parse ${tfstatePath} as JSON: ${err instanceof Error ? err.message : err}`);
+    return null;
+  }
+
+  const backendType = (parsed as { backend?: { type?: unknown } } | null)?.backend?.type;
+  if (typeof backendType !== 'string') {
+    tasks.debug(`Backend detection: ${tfstatePath} has no backend.type; skipping.`);
+    return null;
+  }
+
+  const cloud = BACKEND_TYPE_TO_CLOUD[backendType];
+  if (!cloud) {
+    tasks.debug(`Backend detection: backend type '${backendType}' has no managed cloud credentials to inject; skipping.`);
+    return null;
+  }
+
+  return cloud;
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -58,6 +58,20 @@ export abstract class BaseTerraformCommandHandler {
     abstract handleBackend(terraformToolRunner: ToolRunner): Promise<void>;
     abstract handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void>;
 
+    /**
+     * Configures this handler's cloud credentials as environment variables
+     * ONLY — never `-backend-config` args, never a tool-runner argument — so a
+     * *different* cloud's state backend can authenticate on a state-accessing
+     * command (plan/apply/destroy/refresh/import/output/state/workspace/
+     * forceunlock). Invoked by ParentCommandHandler exclusively when
+     * `backend-detection.ts` finds the initialized backend is a managed cloud
+     * backend that differs from the `provider` input — never during `init`
+     * (handleBackend already owns backend auth there) and never for the
+     * provider's own handler. Implementations that have no cloud identity to
+     * inject (OCI's PAR-based http backend, generic/local) are no-ops.
+     */
+    abstract configureBackendCredentials(): Promise<void>;
+
     constructor() {
         this.providerName = "";
         this.terraformToolHandler = new TerraformToolHandler(tasks);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -5,8 +5,8 @@ import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
 import { generateIdToken } from './id-token-generator';
 import { writeSecretFile } from './secure-temp';
+import { resolveWifTempDir } from './temp-dir';
 import path = require('path');
-import os = require('os');
 import { randomUUID as uuidV4 } from 'crypto';
 
 const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
@@ -25,7 +25,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
 
     private getJsonKeyFilePath(serviceName: string) {
         // Get credentials for json file
-        const jsonKeyFilePath = path.join(os.tmpdir(), `credentials-${uuidV4()}.json`);
+        const jsonKeyFilePath = path.join(resolveWifTempDir(), `credentials-${uuidV4()}.json`);
 
         const clientEmail = tasks.getEndpointAuthorizationParameter(serviceName, "Issuer", false);
         const tokenUri = tasks.getEndpointAuthorizationParameter(serviceName, "Audience", false);
@@ -51,6 +51,22 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         return jsonKeyFilePath;
     }
 
+    /**
+     * Points the gcs backend at a credentials file via the `GOOGLE_BACKEND_CREDENTIALS`
+     * environment variable — NEVER via `-backend-config=credentials=<path>`. A
+     * cached backend-config `credentials` path is written in plain text into
+     * `.terraform/terraform.tfstate` *and* any saved plan file, and (per
+     * HashiCorp's own precedence rules) OVERRIDES the environment variable —
+     * so it also goes stale the moment this task's temp file is cleaned up,
+     * breaking any later command (plan/apply) that reuses the cached backend
+     * config, even within the same gcp+gcs pipeline. `bucket`/`prefix` are
+     * non-secret location fields and stay as backend-config.
+     * See https://developer.hashicorp.com/terraform/language/backend#credentials-and-sensitive-data
+     */
+    private applyBackendCredentialFile(credentialsFilePath: string): void {
+        EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_BACKEND_CREDENTIALS", credentialsFilePath);
+    }
+
     private setupBackend(backendServiceName: string) {
         this.backendConfig.set('bucket', tasks.getInput("backendGCPBucketName", true)!);
         const prefix = tasks.getInput("backendGCPPrefix", false);
@@ -58,9 +74,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             this.backendConfig.set('prefix', prefix);
         }
 
-        const jsonKeyFilePath = this.getJsonKeyFilePath(backendServiceName);
-
-        this.backendConfig.set('credentials', jsonKeyFilePath);
+        this.applyBackendCredentialFile(this.getJsonKeyFilePath(backendServiceName));
     }
 
     /**
@@ -81,7 +95,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         const oidcToken = await generateIdToken(params.serviceConnection);
         tasks.setSecret(oidcToken);
 
-        const tokenFilePath = path.join(os.tmpdir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
+        const tokenFilePath = path.join(resolveWifTempDir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
         writeSecretFile(tokenFilePath, oidcToken);
         this.tempFiles.push(tokenFilePath);
 
@@ -96,11 +110,24 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             service_account_impersonation_url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${params.serviceAccountEmail}:generateAccessToken`
         };
 
-        const credentialsFilePath = path.join(os.tmpdir(), `${params.credentialsFilePrefix}-${uuidV4()}.json`);
+        const credentialsFilePath = path.join(resolveWifTempDir(), `${params.credentialsFilePrefix}-${uuidV4()}.json`);
         writeSecretFile(credentialsFilePath, JSON.stringify(credentials));
         this.tempFiles.push(credentialsFilePath);
 
         return credentialsFilePath;
+    }
+
+    /** Shared by `setupBackendWIF` (init) and `configureBackendCredentials` (cross-cloud). */
+    private async writeBackendWifCredentials(backendServiceName: string): Promise<string> {
+        return this.writeWifCredentials({
+            serviceConnection: backendServiceName,
+            projectNumber: tasks.getInput("backendGCPProjectNumber", true)!,
+            poolId: tasks.getInput("backendGCPWorkloadIdentityPoolId", true)!,
+            providerId: tasks.getInput("backendGCPWorkloadIdentityProviderId", true)!,
+            serviceAccountEmail: tasks.getInput("backendGCPServiceAccountEmail", true)!,
+            tokenFilePrefix: "gcp-backend-oidc-token",
+            credentialsFilePrefix: "gcp-backend-wif-credentials",
+        });
     }
 
     private async setupBackendWIF(backendServiceName: string): Promise<void> {
@@ -110,17 +137,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             this.backendConfig.set('prefix', prefix);
         }
 
-        const credentialsFilePath = await this.writeWifCredentials({
-            serviceConnection: backendServiceName,
-            projectNumber: tasks.getInput("backendGCPProjectNumber", true)!,
-            poolId: tasks.getInput("backendGCPWorkloadIdentityPoolId", true)!,
-            providerId: tasks.getInput("backendGCPWorkloadIdentityProviderId", true)!,
-            serviceAccountEmail: tasks.getInput("backendGCPServiceAccountEmail", true)!,
-            tokenFilePrefix: "gcp-backend-oidc-token",
-            credentialsFilePrefix: "gcp-backend-wif-credentials",
-        });
-
-        this.backendConfig.set('credentials', credentialsFilePath);
+        this.applyBackendCredentialFile(await this.writeBackendWifCredentials(backendServiceName));
     }
 
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
@@ -136,6 +153,27 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         }
         this.applyBackendConfig(terraformToolRunner);
         tasks.debug('Finished setting up backend GCP.');
+    }
+
+    /**
+     * Cross-cloud path: called instead of `handleBackend` on state-accessing
+     * commands (plan/apply/...) when this gcs backend is paired with a
+     * *different* cloud's `provider` input. Writes a fresh credentials file
+     * and points GOOGLE_BACKEND_CREDENTIALS at it; `bucket`/`prefix` were
+     * already cached by `terraform init` and need not be resupplied.
+     */
+    public async configureBackendCredentials(): Promise<void> {
+        tasks.debug('Configuring cross-cloud gcs backend credentials (environment variable only).');
+        const backendServiceName = tasks.getInput("backendServiceGCP", true)!;
+        const authScheme = tasks.getInput("backendAuthSchemeGCP", false) || "ServiceConnection";
+        this.validateAuthScheme(authScheme, "backendAuthSchemeGCP");
+
+        if (authScheme === "WorkloadIdentityFederation") {
+            this.applyBackendCredentialFile(await this.writeBackendWifCredentials(backendServiceName));
+        } else {
+            this.applyBackendCredentialFile(this.getJsonKeyFilePath(backendServiceName));
+        }
+        tasks.debug('Finished configuring cross-cloud gcs backend credentials.');
     }
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {
@@ -171,3 +209,4 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_PROJECT", projectNumber);
     }
 }
+

--- a/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
@@ -29,4 +29,17 @@ export class TerraformCommandHandlerGeneric extends BaseTerraformCommandHandler 
     public async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> {
         // No provider credentials needed for generic/local backend type
     }
+
+    /**
+     * Cross-cloud path: called instead of `handleBackend` on state-accessing
+     * commands (plan/apply/...) when this generic/local backend is paired
+     * with a *different* cloud's `provider` input. No-op: generic backends
+     * (http, PostgreSQL, Consul, Kubernetes, ...) and the local backend are
+     * authenticated, if at all, via the user's own environment variables or
+     * config (e.g. CONSUL_HTTP_TOKEN, TF_HTTP_*) — there is nothing for this
+     * task to inject.
+     */
+    public async configureBackendCredentials(): Promise<void> {
+        tasks.debug('Generic/local backend requires no cross-cloud credential injection (user-managed).');
+    }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
@@ -10,7 +10,8 @@ export class TerraformCommandHandlerHCP extends BaseTerraformCommandHandler {
         this.providerName = "hcp";
     }
 
-    public async handleBackend(_terraformToolRunner: ToolRunner): Promise<void> {
+    /** Shared by `handleBackend` (init) and `configureBackendCredentials` (cross-cloud). */
+    private applyBackendEnv(): void {
         const token = tasks.getInput("backendHCPToken", true)!;
         if (token) { tasks.setSecret(token); }
         EnvironmentVariableHelper.setEnvironmentVariable("TF_TOKEN_app_terraform_io", token, true);
@@ -24,6 +25,22 @@ export class TerraformCommandHandlerHCP extends BaseTerraformCommandHandler {
         if (workspace && workspace.trim()) {
             EnvironmentVariableHelper.setEnvironmentVariable("TF_WORKSPACE", workspace.trim());
         }
+    }
+
+    public async handleBackend(_terraformToolRunner: ToolRunner): Promise<void> {
+        this.applyBackendEnv();
+    }
+
+    /**
+     * Cross-cloud path: called instead of `handleBackend` on state-accessing
+     * commands (plan/apply/...) when this HCP Terraform/Terraform Cloud
+     * backend is paired with a *different* cloud's `provider` input. Sets the
+     * same TF_TOKEN_app_terraform_io/TF_CLOUD_ORGANIZATION/TF_WORKSPACE
+     * environment variables as init.
+     */
+    public async configureBackendCredentials(): Promise<void> {
+        tasks.debug("Configuring cross-cloud HCP backend credentials (environment variables only).");
+        this.applyBackendEnv();
     }
 
     public async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -7,25 +7,20 @@ import { generateIdToken } from './id-token-generator';
 import { exchangeOidcForUpst } from './oci-token-exchange';
 import { writeSecretFile } from './secure-temp';
 import { normalizePem } from './pem-normalizer';
+import { resolveWifTempDir } from './temp-dir';
 import path = require('path');
-import os = require('os');
 import fs = require('fs');
 import crypto = require('crypto');
 import { randomUUID as uuidV4 } from 'crypto';
 
 const VALID_AUTH_SCHEMES = ["ServiceConnection", "WorkloadIdentityFederation"] as const;
 
-/**
- * Resolves the directory for the ephemeral WIF credential files (private key,
- * UPST, synthetic OCI config). Prefer Agent.TempDirectory — which the agent
- * auto-purges at job end — over os.tmpdir() so the residual-on-disk window for
- * these short-lived secrets is bounded to the job, even if both the finally
- * cleanup and the signal handlers are bypassed (SIGKILL/host crash). Falls back
- * to os.tmpdir() when running off a pipeline agent (no Agent.TempDirectory set).
- */
-export function resolveWifTempDir(): string {
-    return tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
-}
+// Re-exported for backward compatibility: existing tests and any external
+// consumers import `resolveWifTempDir` from this module. The implementation
+// now lives in `./temp-dir` and is shared with the AWS/GCP handlers, whose
+// ephemeral WIF token/credential files follow the same Agent.TempDirectory
+// preference.
+export { resolveWifTempDir } from './temp-dir';
 
 const OCI_TENANCY_OCID_RE = /^ocid1\.tenancy\.[a-z0-9.-]+$/;
 const OCI_REGION_RE = /^[a-z0-9-]+$/;
@@ -67,7 +62,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     private getPrivateKeyFilePath(privateKey: string) {
         tasks.setSecret(privateKey);
         const normalized = normalizePem(privateKey);
-        const privateKeyFilePath = path.join(os.tmpdir(), `keyfile-${uuidV4()}.pem`);
+        const privateKeyFilePath = path.join(resolveWifTempDir(), `keyfile-${uuidV4()}.pem`);
         writeSecretFile(privateKeyFilePath, normalized);
         this.tempFiles.push(privateKeyFilePath);
         return privateKeyFilePath;
@@ -131,6 +126,18 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         const backendServiceName = tasks.getInput("backendServiceOCI", true)!;
         this.setupBackend(backendServiceName);
         this.applyBackendConfig(terraformToolRunner);
+    }
+
+    /**
+     * Cross-cloud path: called instead of `handleBackend` on state-accessing
+     * commands (plan/apply/...) when this OCI backend is paired with a
+     * *different* cloud's `provider` input. No-op: OCI's http/PAR backend
+     * authentication is embedded in the pre-authenticated request URL, which
+     * was already generated into a cached backend config file at init — there
+     * is no separate cloud-credential identity to (re-)supply on later commands.
+     */
+    public async configureBackendCredentials(): Promise<void> {
+        tasks.debug('OCI backend requires no cross-cloud credential injection (PAR URL is self-authenticating).');
     }
 
     public async handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void> {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/parent-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/parent-handler.ts
@@ -7,49 +7,120 @@ import { TerraformCommandHandlerOCI } from './oci-terraform-command-handler';
 import { TerraformCommandHandlerGeneric } from './generic-terraform-command-handler';
 import { TerraformCommandHandlerHCP } from './hcp-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
+import { detectBackendCloud, BackendCloud } from './backend-detection';
 
 export interface IParentCommandHandler {
     execute(providerName: string, command: string): Promise<number>;
     emergencyCleanup(): void;
 }
 
+/**
+ * Commands that read or write Terraform state and therefore need the *state
+ * backend's* credentials, not just the deployment provider's. When the
+ * backend detected from `.terraform/terraform.tfstate` (see
+ * backend-detection.ts) is a managed cloud backend on a *different* cloud
+ * than the `provider` input, the matching backend handler's
+ * `configureBackendCredentials()` is invoked before the command runs — as
+ * environment variables only, never `-backend-config`.
+ *
+ * `init` is handled separately (backendType already selects the right handler
+ * and calls handleBackend()). `show` and `custom` are intentionally excluded:
+ * `show` commonly targets a local saved plan file with no backend access, and
+ * `custom` covers arbitrary commands (e.g. `terraform providers`, `version`)
+ * that don't touch the backend either — auto-injecting for either would
+ * demand backend inputs that aren't actually needed and produce a confusing
+ * error. `validate`/`fmt`/`get`/`test` never touch remote state and are
+ * excluded too.
+ */
+export const STATE_COMMANDS: ReadonlySet<string> = new Set([
+    'plan', 'apply', 'destroy', 'refresh', 'import', 'output', 'state', 'workspace', 'forceunlock',
+]);
+
 export class ParentCommandHandler implements IParentCommandHandler {
-    private activeHandler: BaseTerraformCommandHandler | null = null;
+    // Every handler constructed for this invocation — the provider handler,
+    // plus the backend handler when cross-cloud credential injection fires —
+    // tracked from the moment each is created, so cleanupTempFiles() and
+    // emergencyCleanup() can always find them, including if construction,
+    // injection, or command execution itself throws or a termination signal
+    // arrives mid-injection.
+    private handlers: BaseTerraformCommandHandler[] = [];
 
     public async execute(providerName: string, command: string): Promise<number> {
-        let handler: BaseTerraformCommandHandler;
-
-        if (command === 'init') {
+        const handler = command === 'init'
             // For init: backendType drives handler selection (falls back to providerName for backwards compat)
-            const backendType = tasks.getInput("backendType", false) || providerName;
-            handler = this.createHandler(backendType);
-        } else {
+            ? this.createHandler(tasks.getInput("backendType", false) || providerName)
             // For all other commands: provider drives handler selection
-            handler = this.createHandler(providerName);
-        }
+            : this.createHandler(providerName);
+        this.handlers.push(handler);
 
-        this.activeHandler = handler;
         try {
+            if (STATE_COMMANDS.has(command)) {
+                await this.injectCrossCloudBackendCredentials(providerName, command);
+            }
             return await handler.executeCommand(command);
         } finally {
-            handler.cleanupTempFiles();
-            EnvironmentVariableHelper.clearTrackedVariables();
-            this.activeHandler = null;
+            this.cleanupAllHandlers();
         }
+    }
+
+    /**
+     * When the working directory's initialized state backend (per
+     * `.terraform/terraform.tfstate`) is a managed cloud backend that differs
+     * from `providerName`, constructs that backend's handler and asks it to
+     * set its credentials as environment variables — so e.g. an `aws`
+     * provider plan/apply against an `azurerm` state backend can still
+     * authenticate to Azure Blob Storage. No-op for same-cloud setups and for
+     * backends with no cloud identity to inject (local, generic, OCI's
+     * PAR-based http backend).
+     */
+    private async injectCrossCloudBackendCredentials(providerName: string, command: string): Promise<void> {
+        const workingDirectory = tasks.getInput("workingDirectory") || '';
+        const backendCloud: BackendCloud | null = detectBackendCloud(workingDirectory);
+        if (!backendCloud || backendCloud === providerName) {
+            return;
+        }
+
+        tasks.debug(`Detected '${backendCloud}' state backend with '${providerName}' provider on command '${command}'; configuring cross-cloud backend credentials.`);
+        const backendHandler = this.createHandler(backendCloud);
+        // Tracked before the (possibly-throwing, possibly async-interrupted)
+        // credential setup so its temp files are always cleaned up.
+        this.handlers.push(backendHandler);
+
+        try {
+            await backendHandler.configureBackendCredentials();
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            throw new Error(
+                `Cross-cloud state backend credential setup failed for command '${command}': detected a '${backendCloud}' ` +
+                `state backend while the 'provider' input is '${providerName}'. Add the '${backendCloud}' backend inputs to ` +
+                `this step so its credentials can be supplied (e.g. backendServiceArm for azurerm, backendServiceAWS for ` +
+                `aws, backendServiceGCP for gcp, backendHCPToken for hcp). Underlying error: ${reason}. See ` +
+                `docs/yaml-examples.md#cross-cloud-state-backends for examples.`
+            );
+        }
+    }
+
+    private cleanupAllHandlers(): void {
+        for (const handler of this.handlers) {
+            handler.cleanupTempFiles();
+        }
+        this.handlers = [];
+        EnvironmentVariableHelper.clearTrackedVariables();
     }
 
     public emergencyCleanup(): void {
         // Called from the SIGTERM/SIGINT/uncaughtException handlers, which can fire
-        // during execute() before activeHandler is assigned (handler construction,
-        // input resolution) — or even before execute() is reached at all. Tracked
-        // credential env vars must be cleared unconditionally in that window:
-        // clearTrackedVariables() operates on a process-wide static Set and is
-        // independent of any handler. Only the per-handler temp-file sweep depends
-        // on a handler existing, so that alone stays guarded.
-        EnvironmentVariableHelper.clearTrackedVariables();
-        if (this.activeHandler) {
-            this.activeHandler.cleanupTempFiles();
+        // at any point during execute() — including mid-construction of a handler,
+        // input resolution, or while a (possibly cross-cloud) handler is writing its
+        // credential temp files. Every handler created so far is tracked in
+        // `this.handlers` from the moment it's constructed, so iterating that list
+        // (rather than depending on a single "active" handler) covers that whole
+        // window. clearTrackedVariables() operates on a process-wide static Set and
+        // is independent of any handler, so it always runs.
+        for (const handler of this.handlers) {
+            handler.cleanupTempFiles();
         }
+        EnvironmentVariableHelper.clearTrackedVariables();
     }
 
     private createHandler(name: string): BaseTerraformCommandHandler {
@@ -67,3 +138,4 @@ export class ParentCommandHandler implements IParentCommandHandler {
         }
     }
 }
+

--- a/Tasks/TerraformTask/TerraformTaskV5/src/temp-dir.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/temp-dir.ts
@@ -1,0 +1,15 @@
+import tasks = require('azure-pipelines-task-lib/task');
+import os = require('os');
+
+/**
+ * Resolves the directory for ephemeral WIF credential/token files (private
+ * keys, security tokens, JWTs, synthetic config files) shared by the AWS/GCP/
+ * OCI handlers. Prefers Agent.TempDirectory — which the agent auto-purges at
+ * job end — over os.tmpdir() so the residual-on-disk window for these
+ * short-lived secrets is bounded to the job, even if both the finally cleanup
+ * and the signal handlers are bypassed (SIGKILL/host crash). Falls back to
+ * os.tmpdir() when running off a pipeline agent (no Agent.TempDirectory set).
+ */
+export function resolveWifTempDir(): string {
+  return tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "273",
+        "Minor": "274",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -165,6 +165,16 @@ Common issues and their solutions when using Pipeline Tasks for Terraform.
 
 **Fix:** Valid `backendType` values are: `azurerm`, `s3`, `gcs`, `oci`, `hcp`, `generic`, `local`. If you don't set `backendType`, it defaults to the `provider` value.
 
+### Cross-cloud state backend — "unable to build authorizer" / "Please run 'az login'" / "NoCredentialProviders" on `plan`/`apply`
+
+**Cause:** `init` succeeded (it uses `backendType` to pick the right backend handler), but a later state-accessing command — `plan`, `apply`, `destroy`, `refresh`, `import`, `output`, `state`, `workspace`, or `forceunlock` — is missing the backend's credential inputs. This is the classic symptom when the state backend is on a *different* cloud than `provider` (e.g. an `azurerm` backend with `provider: aws`): the step only had AWS credentials, so the azurerm backend had no way to authenticate.
+
+**Fix:** Add the backend's inputs to **every** state-accessing step, not just `init` — `backendServiceArm`/`backendAzureRm*` for azurerm, `backendServiceAWS`/`backendAWS*` for s3, `backendServiceGCP`/`backendGCP*` for gcs, or `backendHCP*` for HCP Terraform. See [Cross-cloud state backends](yaml-examples.md#cross-cloud-state-backends) for full examples of every combination.
+
+Since this fix, a step missing the required backend inputs fails immediately with an actionable error (naming the detected backend, the provider, and the command) instead of the opaque authorizer/login error above — if you still see the opaque error, you're on an older task version; update to the latest `PipelineTerraformTask@5`.
+
+**Note on `local-exec`/`external` data sources:** when using Workload Identity Federation for the azurerm backend/provider with `runAzLogin: true`, the ADO pipeline OIDC access token (`ARM_OIDC_REQUEST_TOKEN`) is present in the process environment for the whole Terraform run and is therefore inherited by any `local-exec` provisioner or `external` data source. Avoid combining `runAzLogin` with untrusted modules on shared agents.
+
 ### Multiple provider blocks warning
 
 **Cause:** The task runs `terraform providers` after `handleProvider` and greps the output for names of _other_ cloud providers the extension supports. When a match is found, it emits a non-fatal warning so the pipeline author is aware that credentials for only the selected provider have been configured.

--- a/docs/yaml-examples.md
+++ b/docs/yaml-examples.md
@@ -5,7 +5,7 @@
 - [`PipelineTerraformInstaller@1`](#pipelineterraforminstaller1) — Install Terraform or OpenTofu
 - [`PipelineTerraformProviderMirror@1`](#pipelineterraformprovidermirror1) — Configure provider network mirror
 - [`PipelineTerraformTask@5`](#pipelineterraformtask5) — Run Terraform commands (init, plan, apply, destroy, etc.)
-- [Cross-cloud examples](#cross-cloud-examples) — AzureRM state with AWS/GCP resources; HCP Terraform with AzureRM resources
+- [Cross-cloud state backends](#cross-cloud-state-backends) — AzureRM state with AWS/GCP resources; HCP Terraform with AzureRM resources
 - [Policy as code](#policy-as-code) — Install OPA/Sentinel and evaluate policies against plan JSON
 - [`PipelineTerraformDriftReport@1`](#pipelineterraformdriftreport1) — Summarise plan drift, optional SARIF report + TSM callback
 - [`PipelineTerraformModulePublish@1`](#pipelineterraformmodulepublish1) — Publish a module version to HCP Terraform or a private registry
@@ -543,11 +543,28 @@ stages:
 
 ---
 
-## Cross-cloud examples
+## Cross-cloud state backends
 
 These examples combine a remote state backend from one cloud with provider credentials for another.
 The `provider` input controls which cloud authenticates for the Terraform *provider* (resources).
 The `backendType` input (on `init`) controls which cloud stores *state*.
+
+**Every state-accessing command needs backend credentials, not just `init`.** The
+task detects the initialized backend from `.terraform/terraform.tfstate` and, when
+it differs from the `provider` input, automatically supplies that backend's
+credentials as environment variables on `plan`, `apply`, `destroy`, `refresh`,
+`import`, `output`, `state`, `workspace`, and `forceunlock` — so add the backend
+inputs (`backendServiceArm`/`backendAzureRm*`, `backendServiceAWS`/`backendAWS*`,
+`backendServiceGCP`/`backendGCP*`, or `backendHCP*`) to **every** step below that
+runs one of those commands, not just `init`. (`show` and `custom` are not
+auto-injected — they commonly operate on a saved plan file or run backend-agnostic
+commands like `terraform providers`, so requiring backend inputs there would be
+confusing; add them manually if a particular `custom` command needs backend access.)
+
+If a state-accessing step is missing the required backend inputs, the task fails
+fast with an actionable error naming the detected backend, the provider, and the
+command — instead of the opaque `Please run 'az login'`-style failure this gap
+used to produce.
 
 ---
 
@@ -584,6 +601,12 @@ steps:
       commandOptions: '-out=tfplan'
       environmentServiceNameAWS: 'my-aws-service-connection'
       publishPlanResults: 'AWSPlan'
+      # Required because the state backend (azurerm) differs from the provider (aws) —
+      # without these, plan fails trying to authenticate the azurerm backend.
+      backendServiceArm: 'my-azure-service-connection'
+      backendAzureRmStorageAccountName: 'mytfstateaccount'
+      backendAzureRmContainerName: 'tfstate'
+      backendAzureRmKey: 'aws-prod.terraform.tfstate'
 
   - task: PipelineTerraformTask@5
     displayName: 'Terraform Apply'
@@ -593,6 +616,11 @@ steps:
       command: 'apply'
       commandOptions: 'tfplan'
       environmentServiceNameAWS: 'my-aws-service-connection'
+      # Same reasoning as the plan step above — apply also re-reads state.
+      backendServiceArm: 'my-azure-service-connection'
+      backendAzureRmStorageAccountName: 'mytfstateaccount'
+      backendAzureRmContainerName: 'tfstate'
+      backendAzureRmKey: 'aws-prod.terraform.tfstate'
 ```
 
 ---
@@ -630,6 +658,11 @@ steps:
       commandOptions: '-out=tfplan'
       environmentServiceNameGCP: 'my-gcp-service-connection'
       publishPlanResults: 'GCPPlan'
+      # Required because the state backend (azurerm) differs from the provider (gcp).
+      backendServiceArm: 'my-azure-service-connection'
+      backendAzureRmStorageAccountName: 'mytfstateaccount'
+      backendAzureRmContainerName: 'tfstate'
+      backendAzureRmKey: 'gcp-prod.terraform.tfstate'
 
   - task: PipelineTerraformTask@5
     displayName: 'Terraform Apply'
@@ -639,6 +672,10 @@ steps:
       command: 'apply'
       commandOptions: 'tfplan'
       environmentServiceNameGCP: 'my-gcp-service-connection'
+      backendServiceArm: 'my-azure-service-connection'
+      backendAzureRmStorageAccountName: 'mytfstateaccount'
+      backendAzureRmContainerName: 'tfstate'
+      backendAzureRmKey: 'gcp-prod.terraform.tfstate'
 ```
 
 ---
@@ -675,6 +712,10 @@ steps:
       commandOptions: '-out=tfplan'
       environmentServiceNameAzureRM: 'my-azure-service-connection'
       publishPlanResults: 'AzurePlan'
+      # Required because the state backend (hcp) differs from the provider (azurerm).
+      backendHCPToken: '$(HCP_TOKEN)'
+      backendHCPOrganization: 'my-org'
+      backendHCPWorkspace: 'azure-prod'
 
   - task: PipelineTerraformTask@5
     displayName: 'Terraform Apply'
@@ -684,6 +725,9 @@ steps:
       command: 'apply'
       commandOptions: 'tfplan'
       environmentServiceNameAzureRM: 'my-azure-service-connection'
+      backendHCPToken: '$(HCP_TOKEN)'
+      backendHCPOrganization: 'my-org'
+      backendHCPWorkspace: 'azure-prod'
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes cross-cloud Terraform state backend credentials: previously, `PipelineTerraformTask@5` only configured state-backend credentials during `init` (via `backendType`). Every other state-accessing command (`plan`, `apply`, `destroy`, `refresh`, `import`, `output`, `state`, `workspace`, `forceunlock`) authenticated using only the `provider` input's credentials. When the state backend was on a **different cloud** than the provider (e.g. an `azurerm` backend with an `aws` provider — the triggering real-world case), those commands had no way to authenticate to the backend and failed with opaque errors such as `Please run 'az login'`.

## What changed

- **`src/backend-detection.ts`** (new): reads `.terraform/terraform.tfstate` (size-guarded, read-only, `backend.type` only) to determine the real state backend, independent of the `provider`/`backendType` inputs.
- **`src/parent-handler.ts`**: on state-accessing commands, when the detected backend cloud differs from `provider`, constructs that backend's handler and calls a new `configureBackendCredentials()` method — environment variables only, never `-backend-config` (per HashiCorp's own guidance against caching backend credentials on disk/in plan files). Handler lifecycle hardened: all handlers (provider + backend) are tracked from creation so `cleanupTempFiles()`/`emergencyCleanup()` always cover both, including if credential setup itself throws or a termination signal arrives mid-injection.
- **All six handlers** (azurerm, aws, gcp, hcp, oci, generic) implement `configureBackendCredentials()`.
- **GCS fix**: the gcp handler no longer caches `-backend-config=credentials=<path>` at init (overridden by, and inconsistent with, `GOOGLE_BACKEND_CREDENTIALS`, and stale the moment the temp file is cleaned up); now uses `GOOGLE_BACKEND_CREDENTIALS` consistently at init and on later commands.
- A step missing required backend inputs now fails fast with an actionable error naming the detected backend, provider, and command.
- **`docs/yaml-examples.md`**: cross-cloud section renamed to `#cross-cloud-state-backends` (matches the new error message's doc link) and all three examples corrected to show backend inputs on every state-accessing step, not just `init`.
- **`README.md`** / **`docs/troubleshooting.md`**: updated to describe the new behavior and error patterns.
- **`task.json`**: version bump (5.273.0 → 5.274.0).

## Tests

- New `BackendDetectionTests`, `CrossCloudBackendCredentialTests` (one per handler), and end-to-end mock-run scenarios (`Tests/PlanTests/BackendDecoupling/`) covering: cross-cloud plan success, same-cloud non-regression (no injection/no extra inputs required), and missing-backend-input failure with the actionable error.
- Fixed 5 pre-existing GCP init test fixtures that asserted on the old, leaking `-backend-config=credentials=...` command line.
- Full suite: **249 passing, 0 failing** locally.

## Security

- Credentials are supplied via environment variables only on the cross-cloud injection path — never written to `-backend-config`, argv, `.terraform/terraform.tfstate`, or saved plan files.
- All secrets registered via `tasks.setSecret`; ephemeral token/credential files written with `writeSecretFile` (0o600) under `Agent.TempDirectory` where available.
- No same-cloud regression: injection only fires when the detected backend cloud differs from `provider`.
