### PR TITLE
docs: document the Entra token argv-exposure risk and its 10-minute lifetime mitigation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,16 @@ You can expect an acknowledgement within a few business days. Fixes will be rele
 
 Only the latest published release receives security fixes. If you are running an older version, please upgrade before reporting.
 
+## Release pipeline residual risk: Entra token visible via process arguments
+
+The `publish-marketplace` job in `release.yml` mints a Microsoft Entra access token, scoped only to the Azure DevOps resource app, and passes it to `tfx extension publish --token "$ENTRA_TOKEN"` to authenticate the Marketplace publish. The token is registered with `::add-mask::` so it never appears in the GitHub Actions log, but it is still visible in `/proc/<pid>/cmdline` for the lifetime of the `tfx` process — GitHub Actions runners do not hide process arguments from other processes in the same job. This was not fixed in code because `tfx-cli` 0.23.2 (the currently pinned version) has no non-argv way to supply `--token`: no token-file option and no interactive stdin prompt.
+
+**Mitigated by a 10-minute token lifetime.** A Microsoft Graph `tokenLifetimePolicy` (`AccessTokenLifetime: 00:10:00`, the platform minimum) is assigned to the `tsm-azdo-marketplace-publisher` service principal — shared with the `azure-pipelines-packer` extension's identical publish flow — capping the token well below the platform default of ~60-90 minutes. The `tfx extension publish` step completes in seconds, so this costs nothing operationally while sharply narrowing the window in which an exfiltrated token would still be valid.
+
+**Not yet mitigated here: dependency-script isolation.** The sibling `azure-pipelines-packer` extension additionally runs `npm ci --ignore-scripts` in its `sbom-and-sign` and `publish-marketplace` jobs, denying a compromised transitive dependency a foothold to go looking for the token in the first place. This repository's equivalent jobs still run a plain `npm ci` with lifecycle scripts enabled — that hardening has not yet been ported here.
+
+If a future `tfx-cli` release adds a non-argv token option, this job should switch to it.
+
 ## Preferred Languages
 
 English preferred.


### PR DESCRIPTION
## Summary

Documents a release-pipeline residual risk surfaced during azure-pipelines-packer's second security re-audit (issue #109) that also applies here since both extensions share the same publish-marketplace pattern and the same Entra service principal:

- The Entra access token passed to `tfx extension publish --token` is visible in `/proc/<pid>/cmdline` for the process lifetime (tfx-cli 0.23.2 has no non-argv token option).
- **Mitigated**: the shared `tsm-azdo-marketplace-publisher` service principal now has a Microsoft Graph `tokenLifetimePolicy` capping tokens at 10 minutes (platform minimum), down from the ~60-90 minute default — applies to both this repo and packer's publish jobs.
- **Flagged as not yet done here**: packer's `sbom-and-sign`/`publish-marketplace` jobs additionally run `npm ci --ignore-scripts`; this repo's equivalent jobs still run plain `npm ci`. Noted honestly rather than ported silently — a separate decision if you want that hardening here too.

Docs-only, no functional change.

## Test plan

- [x] Docs-only change, no source/test impact
- [ ] CI