### PR TITLE
security: port release-pipeline hardening from azure-pipelines-packer's second security audit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
       - name: Check tag reachable from main
@@ -55,6 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -77,6 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -108,66 +111,72 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+      # --ignore-scripts: this job holds id-token/attestations:write. tfx-cli and
+      # @cyclonedx/cyclonedx-npm are pure-JS and need no lifecycle scripts to run
+      # (verified against azure-pipelines-packer's identical fix, #102); skipping
+      # scripts denies a compromised transitive dependency (e.g. a routine
+      # lockfile bump) code execution in this privileged context.
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Generate SBOM for TerraformTaskV5
         run: |
           cd Tasks/TerraformTask/TerraformTaskV5
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-task-v5.cdx.json --omit dev
       - name: Generate SBOM for TerraformInstallerV1
         run: |
           cd Tasks/TerraformInstaller/TerraformInstallerV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-installer-v1.cdx.json --omit dev
       - name: Generate SBOM for TerraformProviderMirrorV1
         run: |
           cd Tasks/TerraformProviderMirror/TerraformProviderMirrorV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-provider-mirror-v1.cdx.json --omit dev
       - name: Generate SBOM for PolicyAgentInstallerV1
         run: |
           cd Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-policy-agent-installer-v1.cdx.json --omit dev
       - name: Generate SBOM for TerraformPolicyCheckV1
         run: |
           cd Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-policy-check-v1.cdx.json --omit dev
       - name: Generate SBOM for TerraformDriftReportV1
         run: |
           cd Tasks/TerraformDriftReport/TerraformDriftReportV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-drift-report-v1.cdx.json --omit dev
       - name: Generate SBOM for TerraformModulePublishV1
         run: |
           cd Tasks/TerraformModulePublish/TerraformModulePublishV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-module-publish-v1.cdx.json --omit dev
       - name: Generate SBOM for TerraformDocsInstallerV1
         run: |
           cd Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-docs-installer-v1.cdx.json --omit dev
       - name: Generate SBOM for TerraformDocsV1
         run: |
           cd Tasks/TerraformDocs/TerraformDocsV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-terraform-docs-v1.cdx.json --omit dev
       - name: Generate SBOM for Markdown2HtmlV1
         run: |
           cd Tasks/Markdown2Html/Markdown2HtmlV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-markdown2html-v1.cdx.json --omit dev
       - name: Generate SBOM for PublishKbArticleV1
         run: |
           cd Tasks/PublishKbArticle/PublishKbArticleV1
-          npm ci --omit=dev
+          npm ci --omit=dev --ignore-scripts
           npx --no-install cyclonedx-npm --output-file ../../../sbom-publish-kb-article-v1.cdx.json --omit dev
       - name: Download vsix artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -260,6 +269,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
       - name: Download vsix artifact
@@ -293,12 +303,17 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+      # --ignore-scripts: this job holds id-token:write for the Entra federated
+      # credential. tfx-cli is pure-JS and needs no lifecycle scripts to run;
+      # skipping scripts denies a compromised transitive dependency code
+      # execution alongside the token-minting step below (see SECURITY.md).
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Download vsix artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -322,6 +337,12 @@ jobs:
             --query accessToken -o tsv)
           # Mask the runtime-minted token so it is redacted from any log output.
           echo "::add-mask::$ENTRA_TOKEN"
+          # tfx-cli 0.23.2 offers no non-argv way to supply --token (no token-file
+          # or stdin-prompt option), so this is visible in /proc/<pid>/cmdline for
+          # the process lifetime. The only observers on this ephemeral runner would
+          # be other code in the same job; --ignore-scripts above is the actual
+          # mitigation, plus a 10-minute Entra token-lifetime policy on the shared
+          # publishing service principal (see SECURITY.md).
           ./node_modules/.bin/tfx extension publish --vsix "$VSIX_FILE" --auth-type pat --token "$ENTRA_TOKEN"
         env:
           VARS_AZDO_PUBLISH_TENANT_ID: ${{ vars.AZDO_PUBLISH_TENANT_ID }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -367,7 +367,11 @@ jobs:
           persist-credentials: false
       - name: Install actionlint
         shell: bash
-        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        # Installer script pinned to a commit SHA (not `main`, which is mutable
+        # and previously untracked here) and given an explicit version, so both
+        # the fetched script and the resulting binary are deterministic —
+        # matches azure-pipelines-packer's identical fix.
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
       - name: Run actionlint
         run: ./actionlint -color
 


### PR DESCRIPTION
## Summary

Ports 4 release-pipeline fixes from azure-pipelines-packer's second security re-audit (issues #102, #109) — both extensions share an identical `release.yml`/`unit-test.yml`/`release-please.yml` structure and the same publish-marketplace Entra OIDC flow, so these gaps existed here too.

- **`npm ci --ignore-scripts`** in `sbom-and-sign` and `publish-marketplace` — the two OIDC-privileged jobs. Verified locally against 5 of the 11 task subdirectories plus the root tooling install; none need lifecycle scripts.
- **Tag-ref checkout pinning** across every job in `release.yml` — previously a `workflow_dispatch` run (including the `guard` job's own tag/manifest-version check) operated on the dispatched ref rather than the tag, so a post-tag commit to `main` could cause a release to build/sign/attest a `.vsix` from the wrong commit under the tag's name.
- **actionlint pinned to a commit SHA** — was tracking the mutable `main` branch directly with no version argument, worse than packer's pre-fix state.
- **`release-please.yml` permissions reduced to `contents: read`** — dead privilege, both its steps already use the scoped GitHub App token exclusively.

Also cross-references the Entra-token-lifetime documentation from #346 (already merged) in the new inline comments.

## Test plan

- [x] `actionlint` clean on all 3 edited workflow files
- [x] YAML syntax valid on all 3 files
- [x] Verified `npm ci --ignore-scripts` works for root tooling + 5/11 task subdirectories with real `cyclonedx-npm` SBOM generation
- [ ] CI (including zizmor workflow scan)