### PR TITLE
security: backport azure-pipelines-packer's http-client.ts hardening

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/.nycrc.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/.nycrc.json
@@ -15,7 +15,7 @@
         "src/hashicorp-gpg-key.js"
     ],
     "check-coverage": true,
-    "lines": 75,
-    "functions": 75,
+    "lines": 82,
+    "functions": 86,
     "branches": 70
 }

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/HttpClientL0.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 import assert = require('assert');
 import * as net from 'net';
 import tasks = require('azure-pipelines-task-lib/task');
-import { fetchWithTimeout, fetchJson, fetchText, fetchBuffer } from '../src/http-client';
+import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404 } from '../src/http-client';
 
 // Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
 // These run in the mocha parent process; the MockTestRunner integration tests in
@@ -29,6 +29,68 @@ describe('http-client: fetchWithTimeout', () => {
             );
         } finally {
             server.close();
+        }
+    });
+
+    it('follows an https-to-https redirect', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (url: string) => {
+            if (url === 'https://example.com/start') {
+                return new Response(null, { status: 302, headers: { Location: 'https://example.com/final' } });
+            }
+            return new Response('ok', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            const result = await fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text());
+            assert.strictEqual(result, 'ok');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects a redirect that downgrades to http://', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'http://attacker.example.com/payload' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text()),
+                /InsecureUrlRejected/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('refuses an off-host redirect even when it stays https', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'https://evil.example.net/payload' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text()),
+                /off-host redirect/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('aborts a redirect loop after the hop limit', async () => {
+        const originalFetch = globalThis.fetch;
+        // Always redirect to a same-host URL -> exceeds MAX_REDIRECTS.
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'https://example.com/loop' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/loop', 1000, async (r) => r.text()),
+                /Too many redirects/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
         }
     });
 });
@@ -58,10 +120,14 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         assert.deepStrictEqual(data, { ok: true, n: 7 });
     });
 
-    it('fetchJson throws on a non-OK status', async () => {
-        globalThis.fetch = (async () =>
-            new Response('nope', { status: 500 })) as unknown as typeof globalThis.fetch;
-        await assert.rejects(fetchJson('https://api.example.com/v'), /RegistryRequestFailed|500/);
+    it('fetchJson throws on a non-OK status and does not retry a 4xx', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return new Response('nope', { status: 404 });
+        }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchJson('https://api.example.com/v'), /RegistryRequestFailed|404/);
+        assert.strictEqual(calls, 1, '4xx must not be retried');
     });
 
     it('fetchText returns a 200 text body', async () => {
@@ -70,10 +136,32 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         assert.strictEqual(await fetchText('https://files.example.com/SHA256SUMS'), 'hello-sums');
     });
 
-    it('fetchText throws on a non-OK status', async () => {
-        globalThis.fetch = (async () =>
-            new Response('', { status: 404 })) as unknown as typeof globalThis.fetch;
-        await assert.rejects(fetchText('https://files.example.com/missing'), /Failed to fetch .*HTTP 404/);
+    it('fetchText retries a transient 5xx and then succeeds', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return calls === 1
+                ? new Response('busy', { status: 503 })
+                : new Response('payload', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        const text = await fetchText('https://files.example.com/SHA256SUMS');
+        assert.strictEqual(text, 'payload');
+        assert.strictEqual(calls, 2, '5xx should trigger exactly one retry here');
+    });
+
+    it('fetchText retries a network error and then gives up after the attempt limit', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => { calls++; throw new TypeError('network down'); }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchText('https://files.example.com/SHA256SUMS'), /network down/);
+        assert.strictEqual(calls, 3, 'network errors are retried up to the attempt limit');
+    });
+
+    it('fetchTextAllow404 returns null on 404 but text on 200', async () => {
+        globalThis.fetch = (async () => new Response(null, { status: 404 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchTextAllow404('https://files.example.com/SHA256SUMS'), null);
+
+        globalThis.fetch = (async () => new Response('sums-body', { status: 200 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchTextAllow404('https://files.example.com/SHA256SUMS'), 'sums-body');
     });
 
     it('fetchBuffer returns 200 bytes', async () => {
@@ -87,6 +175,16 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         globalThis.fetch = (async () =>
             new Response('', { status: 403 })) as unknown as typeof globalThis.fetch;
         await assert.rejects(fetchBuffer('https://files.example.com/sig'), /Failed to fetch .*HTTP 403/);
+    });
+
+    it('fetchBufferAllow404 returns null on 404 but bytes on 200', async () => {
+        globalThis.fetch = (async () => new Response(null, { status: 404 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchBufferAllow404('https://files.example.com/sig'), null);
+
+        globalThis.fetch = (async () =>
+            new Response(new Uint8Array([4, 5, 6]), { status: 200 })) as unknown as typeof globalThis.fetch;
+        const buf = await fetchBufferAllow404('https://files.example.com/sig');
+        assert.deepStrictEqual(buf && Array.from(buf), [4, 5, 6]);
     });
 
     it('routes through a proxy with embedded credentials when configured', async () => {
@@ -103,6 +201,34 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         await fetchJson('https://api.example.com/v');
         // A dispatcher (undici ProxyAgent) must have been attached.
         assert.ok(seenInit && 'dispatcher' in seenInit, 'proxy dispatcher should be set');
+    });
+
+    it('masks the proxy password as a secret when credentials are configured', async () => {
+        const setSecretCalls: string[] = [];
+        const origSetSecret = t.setSecret;
+        t.setSecret = (v: string) => setSecretCalls.push(v);
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'http://proxy.example.com:8080',
+            proxyUsername: 'user',
+            proxyPassword: 'p@ss',
+        });
+        globalThis.fetch = (async () => new Response('{}', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            await fetchJson('https://api.example.com/v');
+            assert.ok(setSecretCalls.includes('p@ss'), 'proxy password should be registered as a secret');
+        } finally {
+            t.setSecret = origSetSecret;
+        }
+    });
+
+    it('throws a clear error on a malformed proxy URL instead of an unhandled TypeError', async () => {
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'not a url',
+            proxyUsername: 'user',
+            proxyPassword: 'p@ss',
+        });
+        globalThis.fetch = (async () => new Response('{}', { status: 200 })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchJson('https://api.example.com/v'), /Invalid proxy URL/);
     });
 
     it('uses a proxy without credentials when username is empty', async () => {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
@@ -1,8 +1,16 @@
-// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src and
-// PolicyAgentInstallerV1/src. CI (scripts/check-shared-modules.js) enforces that
-// the copies stay byte-identical, failing the build on any divergence, so a fix or
-// key rotation here MUST be applied to BOTH copies. This duplication is deliberate
-// (each task bundles independently) — not drift to be flagged.
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src, and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay
+// byte-identical, failing the build on any divergence, so a fix or key
+// rotation here MUST be applied to ALL THREE copies. This duplication is
+// deliberate (each task bundles independently) — not drift to be flagged.
+//
+// Also shared conceptually (not CI-enforced across repos) with
+// azure-pipelines-packer's PackerInstallerV1 copy: this file was brought up
+// to parity with packer's hardening on 2026-07-04 (redirect re-validation +
+// MAX_REDIRECTS, a typed HttpError + withRetry backoff wrapper,
+// fetchTextAllow404/fetchBufferAllow404, and proxy-password masking).
+// Apply future fixes to both repos' copies where they still apply.
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 
@@ -14,14 +22,34 @@ import { ProxyAgent } from 'undici';
 export const METADATA_TIMEOUT_MS = 60_000;
 export const DOWNLOAD_TIMEOUT_MS = 600_000;
 
+const MAX_REDIRECTS = 5;
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_MS = 200;
+
+/** Error carrying whether the failure is worth retrying (transient) vs deterministic (4xx / insecure URL). */
+class HttpError extends Error {
+    constructor(message: string, readonly retryable: boolean) {
+        super(message);
+        this.name = 'HttpError';
+    }
+}
+
 function buildFetchOptions(): RequestInit {
     const proxy = tasks.getHttpProxyConfiguration();
     if (!proxy) return {};
 
     let proxyUrl = proxy.proxyUrl;
-    if (proxy.proxyUsername !== "") {
-        const url = new URL(proxy.proxyUrl);
-        url.username = proxy.proxyUsername ?? "";
+    if (proxy.proxyUsername) {
+        if (proxy.proxyPassword) {
+            tasks.setSecret(proxy.proxyPassword);
+        }
+        let url: URL;
+        try {
+            url = new URL(proxy.proxyUrl);
+        } catch (err) {
+            throw new Error(`Invalid proxy URL configured on the agent: ${err instanceof Error ? err.message : err}`);
+        }
+        url.username = proxy.proxyUsername;
         url.password = proxy.proxyPassword ?? "";
         proxyUrl = url.toString();
     }
@@ -34,9 +62,17 @@ function buildFetchOptions(): RequestInit {
 
 /**
  * Fetches an https:// URL under a wall-clock timeout that covers the connection,
- * the response headers, AND body consumption — the consume callback runs inside
- * the timeout guard, so a stalled body stream is bounded too. On timeout the
- * request is aborted and a clear error is thrown rather than hanging the job.
+ * every redirect hop, the response headers, AND body consumption — the consume
+ * callback runs inside the timeout guard, so a stalled body stream is bounded
+ * too. On timeout the request is aborted and a clear error is thrown rather
+ * than hanging the job.
+ *
+ * Redirects are followed manually (not via fetch's automatic redirect:'follow')
+ * so each hop's Location can be re-validated before following it: it must stay
+ * https:// AND stay on the original host. These callers (checkpoint API,
+ * registry version/info endpoints, SHA256SUMS, .sig) have no legitimate reason
+ * to redirect to a different host, so an off-host redirect is refused rather
+ * than followed.
  */
 export async function fetchWithTimeout<T>(
     url: string,
@@ -44,17 +80,35 @@ export async function fetchWithTimeout<T>(
     consume: (response: Response) => Promise<T>,
 ): Promise<T> {
     if (!url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", url));
+        throw new HttpError(tasks.loc("InsecureUrlRejected", url), false);
     }
+    const originHost = new URL(url).host;
 
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-        const response = await fetch(url, { ...buildFetchOptions(), signal: controller.signal });
-        return await consume(response);
+        let currentUrl = url;
+        for (let redirects = 0; ; redirects++) {
+            const response = await fetch(currentUrl, { ...buildFetchOptions(), signal: controller.signal, redirect: 'manual' });
+            const location = response.status >= 300 && response.status < 400 ? response.headers.get('location') : null;
+            if (!location) {
+                return await consume(response);
+            }
+            if (redirects >= MAX_REDIRECTS) {
+                throw new HttpError(`Too many redirects fetching ${url} (limit ${MAX_REDIRECTS}).`, false);
+            }
+            const next = new URL(location, currentUrl);
+            if (next.protocol !== 'https:') {
+                throw new HttpError(tasks.loc("InsecureUrlRejected", next.toString()), false);
+            }
+            if (next.host !== originHost) {
+                throw new HttpError(`Refusing to follow an off-host redirect (${originHost} -> ${next.host}) while fetching ${url}.`, false);
+            }
+            currentUrl = next.toString();
+        }
     } catch (err) {
         if (controller.signal.aborted) {
-            throw new Error(`Request to ${url} timed out after ${timeoutMs}ms.`);
+            throw new HttpError(`Request to ${url} timed out after ${timeoutMs}ms.`, true);
         }
         throw err;
     } finally {
@@ -62,31 +116,81 @@ export async function fetchWithTimeout<T>(
     }
 }
 
+/** Retries a fetch on transient failures (network error, timeout, 5xx) with exponential backoff. */
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastErr = err;
+            // A non-HttpError is a network/DNS/TLS failure — treat as transient.
+            const retryable = err instanceof HttpError ? err.retryable : true;
+            if (!retryable || attempt === RETRY_ATTEMPTS) throw err;
+            tasks.debug(`Fetch attempt ${attempt} failed (${err instanceof Error ? err.message : err}); retrying...`);
+            await new Promise(resolve => setTimeout(resolve, RETRY_BASE_MS * Math.pow(2, attempt - 1)));
+        }
+    }
+    throw lastErr;
+}
+
 export function fetchJson<T>(url: string): Promise<T> {
-    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(tasks.loc("RegistryRequestFailed", url, response.status));
+            throw new HttpError(tasks.loc("RegistryRequestFailed", url, response.status), response.status >= 500);
         }
         return (await response.json()) as T;
-    });
+    }));
 }
 
 export function fetchText(url: string): Promise<string> {
-    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
         // The returned promise is awaited inside fetchWithTimeout's guard, so the
         // body read stays bounded by the timeout without a redundant await here.
         return response.text();
-    });
+    }));
+}
+
+/**
+ * Like fetchText, but returns null on a 404 (resource genuinely absent) so
+ * callers can distinguish "not published" from a transient/other failure
+ * without substring-matching error text. Other non-2xx and network errors
+ * still throw (5xx is retried).
+ */
+export function fetchTextAllow404(url: string): Promise<string | null> {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) {
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
+        }
+        return response.text();
+    }));
 }
 
 export function fetchBuffer(url: string): Promise<Uint8Array> {
-    return fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
         return new Uint8Array(await response.arrayBuffer());
-    });
+    }));
+}
+
+/**
+ * Like fetchBuffer, but returns null on a 404 (resource genuinely absent) so
+ * callers can distinguish "not published" from a transient/other failure
+ * without substring-matching error text. Other non-2xx and network errors
+ * still throw (5xx is retried).
+ */
+export function fetchBufferAllow404(url: string): Promise<Uint8Array | null> {
+    return withRetry(() => fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) {
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
+        }
+        return new Uint8Array(await response.arrayBuffer());
+    }));
 }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/.nycrc.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/.nycrc.json
@@ -14,7 +14,7 @@
     "src/index.js"
   ],
   "check-coverage": true,
-  "lines": 75,
-  "functions": 75,
-  "branches": 70
+  "lines": 86,
+  "functions": 89,
+  "branches": 77
 }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/HttpClientL0.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 import assert = require('assert');
 import * as net from 'net';
 import tasks = require('azure-pipelines-task-lib/task');
-import { fetchWithTimeout, fetchJson, fetchText, fetchBuffer } from '../src/http-client';
+import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404 } from '../src/http-client';
 
 // Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
 // These run in the mocha parent process; the MockTestRunner integration tests in
@@ -29,6 +29,68 @@ describe('http-client: fetchWithTimeout', () => {
             );
         } finally {
             server.close();
+        }
+    });
+
+    it('follows an https-to-https redirect', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (url: string) => {
+            if (url === 'https://example.com/start') {
+                return new Response(null, { status: 302, headers: { Location: 'https://example.com/final' } });
+            }
+            return new Response('ok', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            const result = await fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text());
+            assert.strictEqual(result, 'ok');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects a redirect that downgrades to http://', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'http://attacker.example.com/payload' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text()),
+                /InsecureUrlRejected/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('refuses an off-host redirect even when it stays https', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'https://evil.example.net/payload' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text()),
+                /off-host redirect/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('aborts a redirect loop after the hop limit', async () => {
+        const originalFetch = globalThis.fetch;
+        // Always redirect to a same-host URL -> exceeds MAX_REDIRECTS.
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'https://example.com/loop' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/loop', 1000, async (r) => r.text()),
+                /Too many redirects/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
         }
     });
 });
@@ -58,10 +120,14 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         assert.deepStrictEqual(data, { ok: true, n: 7 });
     });
 
-    it('fetchJson throws on a non-OK status', async () => {
-        globalThis.fetch = (async () =>
-            new Response('nope', { status: 500 })) as unknown as typeof globalThis.fetch;
-        await assert.rejects(fetchJson('https://api.example.com/v'), /RegistryRequestFailed|500/);
+    it('fetchJson throws on a non-OK status and does not retry a 4xx', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return new Response('nope', { status: 404 });
+        }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchJson('https://api.example.com/v'), /RegistryRequestFailed|404/);
+        assert.strictEqual(calls, 1, '4xx must not be retried');
     });
 
     it('fetchText returns a 200 text body', async () => {
@@ -70,10 +136,32 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         assert.strictEqual(await fetchText('https://files.example.com/SHA256SUMS'), 'hello-sums');
     });
 
-    it('fetchText throws on a non-OK status', async () => {
-        globalThis.fetch = (async () =>
-            new Response('', { status: 404 })) as unknown as typeof globalThis.fetch;
-        await assert.rejects(fetchText('https://files.example.com/missing'), /Failed to fetch .*HTTP 404/);
+    it('fetchText retries a transient 5xx and then succeeds', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return calls === 1
+                ? new Response('busy', { status: 503 })
+                : new Response('payload', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        const text = await fetchText('https://files.example.com/SHA256SUMS');
+        assert.strictEqual(text, 'payload');
+        assert.strictEqual(calls, 2, '5xx should trigger exactly one retry here');
+    });
+
+    it('fetchText retries a network error and then gives up after the attempt limit', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => { calls++; throw new TypeError('network down'); }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchText('https://files.example.com/SHA256SUMS'), /network down/);
+        assert.strictEqual(calls, 3, 'network errors are retried up to the attempt limit');
+    });
+
+    it('fetchTextAllow404 returns null on 404 but text on 200', async () => {
+        globalThis.fetch = (async () => new Response(null, { status: 404 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchTextAllow404('https://files.example.com/SHA256SUMS'), null);
+
+        globalThis.fetch = (async () => new Response('sums-body', { status: 200 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchTextAllow404('https://files.example.com/SHA256SUMS'), 'sums-body');
     });
 
     it('fetchBuffer returns 200 bytes', async () => {
@@ -87,6 +175,16 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         globalThis.fetch = (async () =>
             new Response('', { status: 403 })) as unknown as typeof globalThis.fetch;
         await assert.rejects(fetchBuffer('https://files.example.com/sig'), /Failed to fetch .*HTTP 403/);
+    });
+
+    it('fetchBufferAllow404 returns null on 404 but bytes on 200', async () => {
+        globalThis.fetch = (async () => new Response(null, { status: 404 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchBufferAllow404('https://files.example.com/sig'), null);
+
+        globalThis.fetch = (async () =>
+            new Response(new Uint8Array([4, 5, 6]), { status: 200 })) as unknown as typeof globalThis.fetch;
+        const buf = await fetchBufferAllow404('https://files.example.com/sig');
+        assert.deepStrictEqual(buf && Array.from(buf), [4, 5, 6]);
     });
 
     it('routes through a proxy with embedded credentials when configured', async () => {
@@ -103,6 +201,34 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         await fetchJson('https://api.example.com/v');
         // A dispatcher (undici ProxyAgent) must have been attached.
         assert.ok(seenInit && 'dispatcher' in seenInit, 'proxy dispatcher should be set');
+    });
+
+    it('masks the proxy password as a secret when credentials are configured', async () => {
+        const setSecretCalls: string[] = [];
+        const origSetSecret = t.setSecret;
+        t.setSecret = (v: string) => setSecretCalls.push(v);
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'http://proxy.example.com:8080',
+            proxyUsername: 'user',
+            proxyPassword: 'p@ss',
+        });
+        globalThis.fetch = (async () => new Response('{}', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            await fetchJson('https://api.example.com/v');
+            assert.ok(setSecretCalls.includes('p@ss'), 'proxy password should be registered as a secret');
+        } finally {
+            t.setSecret = origSetSecret;
+        }
+    });
+
+    it('throws a clear error on a malformed proxy URL instead of an unhandled TypeError', async () => {
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'not a url',
+            proxyUsername: 'user',
+            proxyPassword: 'p@ss',
+        });
+        globalThis.fetch = (async () => new Response('{}', { status: 200 })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchJson('https://api.example.com/v'), /Invalid proxy URL/);
     });
 
     it('uses a proxy without credentials when username is empty', async () => {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
@@ -1,8 +1,16 @@
-// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src and
-// PolicyAgentInstallerV1/src. CI (scripts/check-shared-modules.js) enforces that
-// the copies stay byte-identical, failing the build on any divergence, so a fix or
-// key rotation here MUST be applied to BOTH copies. This duplication is deliberate
-// (each task bundles independently) — not drift to be flagged.
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src, and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay
+// byte-identical, failing the build on any divergence, so a fix or key
+// rotation here MUST be applied to ALL THREE copies. This duplication is
+// deliberate (each task bundles independently) — not drift to be flagged.
+//
+// Also shared conceptually (not CI-enforced across repos) with
+// azure-pipelines-packer's PackerInstallerV1 copy: this file was brought up
+// to parity with packer's hardening on 2026-07-04 (redirect re-validation +
+// MAX_REDIRECTS, a typed HttpError + withRetry backoff wrapper,
+// fetchTextAllow404/fetchBufferAllow404, and proxy-password masking).
+// Apply future fixes to both repos' copies where they still apply.
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 
@@ -14,14 +22,34 @@ import { ProxyAgent } from 'undici';
 export const METADATA_TIMEOUT_MS = 60_000;
 export const DOWNLOAD_TIMEOUT_MS = 600_000;
 
+const MAX_REDIRECTS = 5;
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_MS = 200;
+
+/** Error carrying whether the failure is worth retrying (transient) vs deterministic (4xx / insecure URL). */
+class HttpError extends Error {
+    constructor(message: string, readonly retryable: boolean) {
+        super(message);
+        this.name = 'HttpError';
+    }
+}
+
 function buildFetchOptions(): RequestInit {
     const proxy = tasks.getHttpProxyConfiguration();
     if (!proxy) return {};
 
     let proxyUrl = proxy.proxyUrl;
-    if (proxy.proxyUsername !== "") {
-        const url = new URL(proxy.proxyUrl);
-        url.username = proxy.proxyUsername ?? "";
+    if (proxy.proxyUsername) {
+        if (proxy.proxyPassword) {
+            tasks.setSecret(proxy.proxyPassword);
+        }
+        let url: URL;
+        try {
+            url = new URL(proxy.proxyUrl);
+        } catch (err) {
+            throw new Error(`Invalid proxy URL configured on the agent: ${err instanceof Error ? err.message : err}`);
+        }
+        url.username = proxy.proxyUsername;
         url.password = proxy.proxyPassword ?? "";
         proxyUrl = url.toString();
     }
@@ -34,9 +62,17 @@ function buildFetchOptions(): RequestInit {
 
 /**
  * Fetches an https:// URL under a wall-clock timeout that covers the connection,
- * the response headers, AND body consumption — the consume callback runs inside
- * the timeout guard, so a stalled body stream is bounded too. On timeout the
- * request is aborted and a clear error is thrown rather than hanging the job.
+ * every redirect hop, the response headers, AND body consumption — the consume
+ * callback runs inside the timeout guard, so a stalled body stream is bounded
+ * too. On timeout the request is aborted and a clear error is thrown rather
+ * than hanging the job.
+ *
+ * Redirects are followed manually (not via fetch's automatic redirect:'follow')
+ * so each hop's Location can be re-validated before following it: it must stay
+ * https:// AND stay on the original host. These callers (checkpoint API,
+ * registry version/info endpoints, SHA256SUMS, .sig) have no legitimate reason
+ * to redirect to a different host, so an off-host redirect is refused rather
+ * than followed.
  */
 export async function fetchWithTimeout<T>(
     url: string,
@@ -44,17 +80,35 @@ export async function fetchWithTimeout<T>(
     consume: (response: Response) => Promise<T>,
 ): Promise<T> {
     if (!url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", url));
+        throw new HttpError(tasks.loc("InsecureUrlRejected", url), false);
     }
+    const originHost = new URL(url).host;
 
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-        const response = await fetch(url, { ...buildFetchOptions(), signal: controller.signal });
-        return await consume(response);
+        let currentUrl = url;
+        for (let redirects = 0; ; redirects++) {
+            const response = await fetch(currentUrl, { ...buildFetchOptions(), signal: controller.signal, redirect: 'manual' });
+            const location = response.status >= 300 && response.status < 400 ? response.headers.get('location') : null;
+            if (!location) {
+                return await consume(response);
+            }
+            if (redirects >= MAX_REDIRECTS) {
+                throw new HttpError(`Too many redirects fetching ${url} (limit ${MAX_REDIRECTS}).`, false);
+            }
+            const next = new URL(location, currentUrl);
+            if (next.protocol !== 'https:') {
+                throw new HttpError(tasks.loc("InsecureUrlRejected", next.toString()), false);
+            }
+            if (next.host !== originHost) {
+                throw new HttpError(`Refusing to follow an off-host redirect (${originHost} -> ${next.host}) while fetching ${url}.`, false);
+            }
+            currentUrl = next.toString();
+        }
     } catch (err) {
         if (controller.signal.aborted) {
-            throw new Error(`Request to ${url} timed out after ${timeoutMs}ms.`);
+            throw new HttpError(`Request to ${url} timed out after ${timeoutMs}ms.`, true);
         }
         throw err;
     } finally {
@@ -62,31 +116,81 @@ export async function fetchWithTimeout<T>(
     }
 }
 
+/** Retries a fetch on transient failures (network error, timeout, 5xx) with exponential backoff. */
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastErr = err;
+            // A non-HttpError is a network/DNS/TLS failure — treat as transient.
+            const retryable = err instanceof HttpError ? err.retryable : true;
+            if (!retryable || attempt === RETRY_ATTEMPTS) throw err;
+            tasks.debug(`Fetch attempt ${attempt} failed (${err instanceof Error ? err.message : err}); retrying...`);
+            await new Promise(resolve => setTimeout(resolve, RETRY_BASE_MS * Math.pow(2, attempt - 1)));
+        }
+    }
+    throw lastErr;
+}
+
 export function fetchJson<T>(url: string): Promise<T> {
-    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(tasks.loc("RegistryRequestFailed", url, response.status));
+            throw new HttpError(tasks.loc("RegistryRequestFailed", url, response.status), response.status >= 500);
         }
         return (await response.json()) as T;
-    });
+    }));
 }
 
 export function fetchText(url: string): Promise<string> {
-    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
         // The returned promise is awaited inside fetchWithTimeout's guard, so the
         // body read stays bounded by the timeout without a redundant await here.
         return response.text();
-    });
+    }));
+}
+
+/**
+ * Like fetchText, but returns null on a 404 (resource genuinely absent) so
+ * callers can distinguish "not published" from a transient/other failure
+ * without substring-matching error text. Other non-2xx and network errors
+ * still throw (5xx is retried).
+ */
+export function fetchTextAllow404(url: string): Promise<string | null> {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) {
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
+        }
+        return response.text();
+    }));
 }
 
 export function fetchBuffer(url: string): Promise<Uint8Array> {
-    return fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
         return new Uint8Array(await response.arrayBuffer());
-    });
+    }));
+}
+
+/**
+ * Like fetchBuffer, but returns null on a 404 (resource genuinely absent) so
+ * callers can distinguish "not published" from a transient/other failure
+ * without substring-matching error text. Other non-2xx and network errors
+ * still throw (5xx is retried).
+ */
+export function fetchBufferAllow404(url: string): Promise<Uint8Array | null> {
+    return withRetry(() => fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) {
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
+        }
+        return new Uint8Array(await response.arrayBuffer());
+    }));
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/.nycrc.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/.nycrc.json
@@ -15,7 +15,7 @@
         "src/hashicorp-gpg-key.js"
     ],
     "check-coverage": true,
-    "lines": 75,
-    "functions": 68,
-    "branches": 55
+    "lines": 80,
+    "functions": 82,
+    "branches": 66
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
@@ -1,7 +1,8 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
 import * as net from 'net';
-import { fetchWithTimeout } from '../src/http-client';
+import tasks = require('azure-pipelines-task-lib/task');
+import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404 } from '../src/http-client';
 
 // Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
 // These run in the mocha parent process; the MockTestRunner integration tests in
@@ -29,5 +30,219 @@ describe('http-client: fetchWithTimeout', () => {
         } finally {
             server.close();
         }
+    });
+
+    it('follows an https-to-https redirect', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (url: string) => {
+            if (url === 'https://example.com/start') {
+                return new Response(null, { status: 302, headers: { Location: 'https://example.com/final' } });
+            }
+            return new Response('ok', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            const result = await fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text());
+            assert.strictEqual(result, 'ok');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects a redirect that downgrades to http://', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'http://attacker.example.com/payload' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text()),
+                /InsecureUrlRejected/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('refuses an off-host redirect even when it stays https', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'https://evil.example.net/payload' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/start', 1000, async (r) => r.text()),
+                /off-host redirect/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('aborts a redirect loop after the hop limit', async () => {
+        const originalFetch = globalThis.fetch;
+        // Always redirect to a same-host URL -> exceeds MAX_REDIRECTS.
+        globalThis.fetch = (async () =>
+            new Response(null, { status: 302, headers: { Location: 'https://example.com/loop' } })
+        ) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => fetchWithTimeout('https://example.com/loop', 1000, async (r) => r.text()),
+                /Too many redirects/
+            );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
+describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
+    let originalFetch: typeof globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch the shared task-lib module
+    const t = tasks as any;
+    const origProxy = t.getHttpProxyConfiguration;
+    const origLoc = t.loc;
+
+    beforeEach(() => {
+        originalFetch = globalThis.fetch;
+        t.getHttpProxyConfiguration = () => undefined;
+        t.loc = (k: string, ...args: unknown[]) => `${k} ${args.join(' ')}`.trim();
+    });
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        t.getHttpProxyConfiguration = origProxy;
+        t.loc = origLoc;
+    });
+
+    it('fetchJson parses a 200 JSON body', async () => {
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ ok: true, n: 7 }), { status: 200 })) as unknown as typeof globalThis.fetch;
+        const data = await fetchJson<{ ok: boolean; n: number }>('https://api.example.com/v');
+        assert.deepStrictEqual(data, { ok: true, n: 7 });
+    });
+
+    it('fetchJson throws on a non-OK status and does not retry a 4xx', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return new Response('nope', { status: 404 });
+        }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchJson('https://api.example.com/v'), /RegistryRequestFailed|404/);
+        assert.strictEqual(calls, 1, '4xx must not be retried');
+    });
+
+    it('fetchText returns a 200 text body', async () => {
+        globalThis.fetch = (async () =>
+            new Response('hello-sums', { status: 200 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchText('https://files.example.com/SHA256SUMS'), 'hello-sums');
+    });
+
+    it('fetchText retries a transient 5xx and then succeeds', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return calls === 1
+                ? new Response('busy', { status: 503 })
+                : new Response('payload', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        const text = await fetchText('https://files.example.com/SHA256SUMS');
+        assert.strictEqual(text, 'payload');
+        assert.strictEqual(calls, 2, '5xx should trigger exactly one retry here');
+    });
+
+    it('fetchText retries a network error and then gives up after the attempt limit', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => { calls++; throw new TypeError('network down'); }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchText('https://files.example.com/SHA256SUMS'), /network down/);
+        assert.strictEqual(calls, 3, 'network errors are retried up to the attempt limit');
+    });
+
+    it('fetchTextAllow404 returns null on 404 but text on 200', async () => {
+        globalThis.fetch = (async () => new Response(null, { status: 404 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchTextAllow404('https://files.example.com/SHA256SUMS'), null);
+
+        globalThis.fetch = (async () => new Response('sums-body', { status: 200 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchTextAllow404('https://files.example.com/SHA256SUMS'), 'sums-body');
+    });
+
+    it('fetchBuffer returns 200 bytes', async () => {
+        globalThis.fetch = (async () =>
+            new Response(new Uint8Array([1, 2, 3]), { status: 200 })) as unknown as typeof globalThis.fetch;
+        const buf = await fetchBuffer('https://files.example.com/sig');
+        assert.deepStrictEqual(Array.from(buf), [1, 2, 3]);
+    });
+
+    it('fetchBuffer throws on a non-OK status', async () => {
+        globalThis.fetch = (async () =>
+            new Response('', { status: 403 })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchBuffer('https://files.example.com/sig'), /Failed to fetch .*HTTP 403/);
+    });
+
+    it('fetchBufferAllow404 returns null on 404 but bytes on 200', async () => {
+        globalThis.fetch = (async () => new Response(null, { status: 404 })) as unknown as typeof globalThis.fetch;
+        assert.strictEqual(await fetchBufferAllow404('https://files.example.com/sig'), null);
+
+        globalThis.fetch = (async () =>
+            new Response(new Uint8Array([4, 5, 6]), { status: 200 })) as unknown as typeof globalThis.fetch;
+        const buf = await fetchBufferAllow404('https://files.example.com/sig');
+        assert.deepStrictEqual(buf && Array.from(buf), [4, 5, 6]);
+    });
+
+    it('routes through a proxy with embedded credentials when configured', async () => {
+        let seenInit: RequestInit | undefined;
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'http://proxy.example.com:8080',
+            proxyUsername: 'user',
+            proxyPassword: 'p@ss',
+        });
+        globalThis.fetch = (async (_url: string, init: RequestInit) => {
+            seenInit = init;
+            return new Response('{}', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        await fetchJson('https://api.example.com/v');
+        // A dispatcher (undici ProxyAgent) must have been attached.
+        assert.ok(seenInit && 'dispatcher' in seenInit, 'proxy dispatcher should be set');
+    });
+
+    it('masks the proxy password as a secret when credentials are configured', async () => {
+        const setSecretCalls: string[] = [];
+        const origSetSecret = t.setSecret;
+        t.setSecret = (v: string) => setSecretCalls.push(v);
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'http://proxy.example.com:8080',
+            proxyUsername: 'user',
+            proxyPassword: 'p@ss',
+        });
+        globalThis.fetch = (async () => new Response('{}', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            await fetchJson('https://api.example.com/v');
+            assert.ok(setSecretCalls.includes('p@ss'), 'proxy password should be registered as a secret');
+        } finally {
+            t.setSecret = origSetSecret;
+        }
+    });
+
+    it('throws a clear error on a malformed proxy URL instead of an unhandled TypeError', async () => {
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'not a url',
+            proxyUsername: 'user',
+            proxyPassword: 'p@ss',
+        });
+        globalThis.fetch = (async () => new Response('{}', { status: 200 })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchJson('https://api.example.com/v'), /Invalid proxy URL/);
+    });
+
+    it('uses a proxy without credentials when username is empty', async () => {
+        let seenInit: RequestInit | undefined;
+        t.getHttpProxyConfiguration = () => ({
+            proxyUrl: 'http://proxy.example.com:8080',
+            proxyUsername: '',
+            proxyPassword: '',
+        });
+        globalThis.fetch = (async (_url: string, init: RequestInit) => {
+            seenInit = init;
+            return new Response('{}', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        await fetchJson('https://api.example.com/v');
+        assert.ok(seenInit && 'dispatcher' in seenInit, 'proxy dispatcher should be set');
     });
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
@@ -1,8 +1,16 @@
-// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src and
-// PolicyAgentInstallerV1/src. CI (scripts/check-shared-modules.js) enforces that
-// the copies stay byte-identical, failing the build on any divergence, so a fix or
-// key rotation here MUST be applied to BOTH copies. This duplication is deliberate
-// (each task bundles independently) — not drift to be flagged.
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src, and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay
+// byte-identical, failing the build on any divergence, so a fix or key
+// rotation here MUST be applied to ALL THREE copies. This duplication is
+// deliberate (each task bundles independently) — not drift to be flagged.
+//
+// Also shared conceptually (not CI-enforced across repos) with
+// azure-pipelines-packer's PackerInstallerV1 copy: this file was brought up
+// to parity with packer's hardening on 2026-07-04 (redirect re-validation +
+// MAX_REDIRECTS, a typed HttpError + withRetry backoff wrapper,
+// fetchTextAllow404/fetchBufferAllow404, and proxy-password masking).
+// Apply future fixes to both repos' copies where they still apply.
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 
@@ -14,14 +22,34 @@ import { ProxyAgent } from 'undici';
 export const METADATA_TIMEOUT_MS = 60_000;
 export const DOWNLOAD_TIMEOUT_MS = 600_000;
 
+const MAX_REDIRECTS = 5;
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_MS = 200;
+
+/** Error carrying whether the failure is worth retrying (transient) vs deterministic (4xx / insecure URL). */
+class HttpError extends Error {
+    constructor(message: string, readonly retryable: boolean) {
+        super(message);
+        this.name = 'HttpError';
+    }
+}
+
 function buildFetchOptions(): RequestInit {
     const proxy = tasks.getHttpProxyConfiguration();
     if (!proxy) return {};
 
     let proxyUrl = proxy.proxyUrl;
-    if (proxy.proxyUsername !== "") {
-        const url = new URL(proxy.proxyUrl);
-        url.username = proxy.proxyUsername ?? "";
+    if (proxy.proxyUsername) {
+        if (proxy.proxyPassword) {
+            tasks.setSecret(proxy.proxyPassword);
+        }
+        let url: URL;
+        try {
+            url = new URL(proxy.proxyUrl);
+        } catch (err) {
+            throw new Error(`Invalid proxy URL configured on the agent: ${err instanceof Error ? err.message : err}`);
+        }
+        url.username = proxy.proxyUsername;
         url.password = proxy.proxyPassword ?? "";
         proxyUrl = url.toString();
     }
@@ -34,9 +62,17 @@ function buildFetchOptions(): RequestInit {
 
 /**
  * Fetches an https:// URL under a wall-clock timeout that covers the connection,
- * the response headers, AND body consumption — the consume callback runs inside
- * the timeout guard, so a stalled body stream is bounded too. On timeout the
- * request is aborted and a clear error is thrown rather than hanging the job.
+ * every redirect hop, the response headers, AND body consumption — the consume
+ * callback runs inside the timeout guard, so a stalled body stream is bounded
+ * too. On timeout the request is aborted and a clear error is thrown rather
+ * than hanging the job.
+ *
+ * Redirects are followed manually (not via fetch's automatic redirect:'follow')
+ * so each hop's Location can be re-validated before following it: it must stay
+ * https:// AND stay on the original host. These callers (checkpoint API,
+ * registry version/info endpoints, SHA256SUMS, .sig) have no legitimate reason
+ * to redirect to a different host, so an off-host redirect is refused rather
+ * than followed.
  */
 export async function fetchWithTimeout<T>(
     url: string,
@@ -44,17 +80,35 @@ export async function fetchWithTimeout<T>(
     consume: (response: Response) => Promise<T>,
 ): Promise<T> {
     if (!url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", url));
+        throw new HttpError(tasks.loc("InsecureUrlRejected", url), false);
     }
+    const originHost = new URL(url).host;
 
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-        const response = await fetch(url, { ...buildFetchOptions(), signal: controller.signal });
-        return await consume(response);
+        let currentUrl = url;
+        for (let redirects = 0; ; redirects++) {
+            const response = await fetch(currentUrl, { ...buildFetchOptions(), signal: controller.signal, redirect: 'manual' });
+            const location = response.status >= 300 && response.status < 400 ? response.headers.get('location') : null;
+            if (!location) {
+                return await consume(response);
+            }
+            if (redirects >= MAX_REDIRECTS) {
+                throw new HttpError(`Too many redirects fetching ${url} (limit ${MAX_REDIRECTS}).`, false);
+            }
+            const next = new URL(location, currentUrl);
+            if (next.protocol !== 'https:') {
+                throw new HttpError(tasks.loc("InsecureUrlRejected", next.toString()), false);
+            }
+            if (next.host !== originHost) {
+                throw new HttpError(`Refusing to follow an off-host redirect (${originHost} -> ${next.host}) while fetching ${url}.`, false);
+            }
+            currentUrl = next.toString();
+        }
     } catch (err) {
         if (controller.signal.aborted) {
-            throw new Error(`Request to ${url} timed out after ${timeoutMs}ms.`);
+            throw new HttpError(`Request to ${url} timed out after ${timeoutMs}ms.`, true);
         }
         throw err;
     } finally {
@@ -62,31 +116,81 @@ export async function fetchWithTimeout<T>(
     }
 }
 
+/** Retries a fetch on transient failures (network error, timeout, 5xx) with exponential backoff. */
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastErr = err;
+            // A non-HttpError is a network/DNS/TLS failure — treat as transient.
+            const retryable = err instanceof HttpError ? err.retryable : true;
+            if (!retryable || attempt === RETRY_ATTEMPTS) throw err;
+            tasks.debug(`Fetch attempt ${attempt} failed (${err instanceof Error ? err.message : err}); retrying...`);
+            await new Promise(resolve => setTimeout(resolve, RETRY_BASE_MS * Math.pow(2, attempt - 1)));
+        }
+    }
+    throw lastErr;
+}
+
 export function fetchJson<T>(url: string): Promise<T> {
-    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(tasks.loc("RegistryRequestFailed", url, response.status));
+            throw new HttpError(tasks.loc("RegistryRequestFailed", url, response.status), response.status >= 500);
         }
         return (await response.json()) as T;
-    });
+    }));
 }
 
 export function fetchText(url: string): Promise<string> {
-    return fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
         // The returned promise is awaited inside fetchWithTimeout's guard, so the
         // body read stays bounded by the timeout without a redundant await here.
         return response.text();
-    });
+    }));
+}
+
+/**
+ * Like fetchText, but returns null on a 404 (resource genuinely absent) so
+ * callers can distinguish "not published" from a transient/other failure
+ * without substring-matching error text. Other non-2xx and network errors
+ * still throw (5xx is retried).
+ */
+export function fetchTextAllow404(url: string): Promise<string | null> {
+    return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) {
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
+        }
+        return response.text();
+    }));
 }
 
 export function fetchBuffer(url: string): Promise<Uint8Array> {
-    return fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+    return withRetry(() => fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
-            throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
         return new Uint8Array(await response.arrayBuffer());
-    });
+    }));
+}
+
+/**
+ * Like fetchBuffer, but returns null on a 404 (resource genuinely absent) so
+ * callers can distinguish "not published" from a transient/other failure
+ * without substring-matching error text. Other non-2xx and network errors
+ * still throw (5xx is retried).
+ */
+export function fetchBufferAllow404(url: string): Promise<Uint8Array | null> {
+    return withRetry(() => fetchWithTimeout(url, DOWNLOAD_TIMEOUT_MS, async (response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) {
+            throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
+        }
+        return new Uint8Array(await response.arrayBuffer());
+    }));
 }


### PR DESCRIPTION
## Summary

The shared `http-client.ts` (canonical copy: `TerraformInstallerV1/src`, byte-identical to `PolicyAgentInstallerV1/src` and `TerraformDocsInstallerV1/src` per `scripts/check-shared-modules.js`) had drifted behind azure-pipelines-packer's copy, which accumulated real hardening across its own security audit rounds that was never backported:

- **No retry logic** — a single transient network blip failed the whole install. Now wrapped in a typed `HttpError` + exponential-backoff retry, distinguishing transient (5xx, network, timeout) from deterministic (4xx, insecure URL) failures.
- **No redirect re-validation** — automatic redirect-following didn't check a redirect stayed `https://` or same-host. Redirects are now followed manually (5-hop cap), rejecting downgrades or off-host jumps.
- **Proxy password wasn't masked** as a secret before use, and a malformed proxy URL threw a raw `TypeError` instead of a clear error.
- **`fetchTextAllow404`/`fetchBufferAllow404` didn't exist** — no way to distinguish "genuinely not published" (404) from a transient/other failure.

Ported into all 3 byte-identical copies plus their test suites, and nyc coverage floors ratcheted to lock in the gain (`http-client.js` now measures 96.6/88.5/97.1/97.0 stmts/branch/funcs/lines across all three, up from near-zero direct coverage). Companion change in azure-pipelines-packer (#122) marks its copy's shared-module header IN-SYNC.

## Test plan

- [x] `npm test` passes in all 3 tasks (63/49/41 tests respectively, including full existing scenario-integration suites — no regressions from the new retry/redirect behavior)
- [x] `npx eslint src/` clean in all 3 tasks
- [x] `npm run test:coverage` passes with ratcheted floors in all 3 tasks
- [x] `node scripts/check-shared-modules.js` confirms all 3 copies remain byte-identical
- [ ] CI