### PR TITLE
security: TerraformTaskV5 secret-hygiene hardening

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
@@ -15,7 +15,7 @@
         "src/parent-handler.js"
     ],
     "check-coverage": true,
-    "lines": 75,
-    "functions": 75,
-    "branches": 70
+    "lines": 85,
+    "functions": 80,
+    "branches": 71
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyFailEmptyWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPApplyFailEmptyWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplyFailInvalidWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPApplyFailInvalidWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplySuccessAdditionalArgsWithAutoApprove.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplySuccessAdditionalArgsWithAutoApprove.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPApplySuccessAdditionalArgsWithAutoApproveL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplySuccessAdditionalArgsWithoutAutoApprove.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplySuccessAdditionalArgsWithoutAutoApprove.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPApplySuccessAdditionalArgsWithoutAutoApproveL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplySuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/GCP/GCPApplySuccessNoAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPApplySuccessNoAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/GcpConfigureBackendCredentialsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/GcpConfigureBackendCredentialsL0.ts
@@ -4,6 +4,7 @@ import tasks = require('azure-pipelines-task-lib/task');
 import { TerraformCommandHandlerGCP } from '../../src/gcp-terraform-command-handler';
 import { EnvironmentVariableHelper } from '../../src/environment-variables';
 import * as idTokenGenerator from '../../src/id-token-generator';
+import { TEST_GCP_PRIVATE_KEY_PEM } from '../test-gcp-fixtures';
 
 /**
  * Direct unit tests for the GCP handler's cross-cloud
@@ -28,17 +29,18 @@ describe('TerraformCommandHandlerGCP.configureBackendCredentials (cross-cloud)',
     EnvironmentVariableHelper.clearTrackedVariables();
   });
 
-  it('ServiceConnection (static JSON key): sets GOOGLE_BACKEND_CREDENTIALS to a fresh service_account credentials file', async () => {
+  it('ServiceConnection (static JSON key): sets GOOGLE_BACKEND_CREDENTIALS to a fresh service_account credentials file, masking the key per-line', async () => {
+    const maskedValues: string[] = [];
     (tasks as any).getInput = (name: string) => {
       if (name === 'backendServiceGCP') return 'GCP-Backend';
       if (name === 'backendAuthSchemeGCP') return undefined; // defaults to ServiceConnection
       return undefined;
     };
-    (tasks as any).setSecret = () => { /* no-op */ };
+    (tasks as any).setSecret = (v: string) => { maskedValues.push(v); };
     (tasks as any).getEndpointAuthorizationParameter = (_id: string, name: string) => {
       if (name === 'Issuer') return 'sa@project.iam.gserviceaccount.com';
       if (name === 'Audience') return 'https://oauth2.googleapis.com/token';
-      if (name === 'PrivateKey') return '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n';
+      if (name === 'PrivateKey') return TEST_GCP_PRIVATE_KEY_PEM;
       return undefined;
     };
 
@@ -50,6 +52,18 @@ describe('TerraformCommandHandlerGCP.configureBackendCredentials (cross-cloud)',
     const written = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
     assert.strictEqual(written.type, 'service_account');
     assert.strictEqual(written.client_email, 'sa@project.iam.gserviceaccount.com');
+    // The credentials file stores the normalized (re-wrapped) form, not the
+    // raw input -- and every non-boundary line of it must have been
+    // individually registered as a secret (#351), since ADO's log masker
+    // matches per line, not across embedded newlines.
+    const normalizedBodyLines = written.private_key
+      .split('\n')
+      .map((l: string) => l.trim())
+      .filter((l: string) => l && !l.startsWith('-----'));
+    for (const line of normalizedBodyLines) {
+      assert.ok(maskedValues.includes(line), `normalized PEM line should be masked: ${line}`);
+    }
+    assert.ok(maskedValues.length > normalizedBodyLines.length, 'raw form should also have been masked, on top of the normalized lines');
 
     (handler as any).cleanupTempFiles();
     assert.strictEqual(fs.existsSync(credsPath), false, 'credentials file should be removed by cleanupTempFiles()');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroyFailInvalidWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPDestroyFailInvalidWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroySuccessAdditionalArgsWithAutoApprove.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroySuccessAdditionalArgsWithAutoApprove.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPDestroySuccessAdditionalArgsWithAutoApproveL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroySuccessAdditionalArgsWithoutAutoApprove.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroySuccessAdditionalArgsWithoutAutoApprove.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPDestroySuccessAdditionalArgsWithoutAutoApproveL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroySuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/GCP/GCPDestroySuccessNoAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPDestroySuccessNoAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPInitSuccessEmptyWorkingDirL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -18,7 +19,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
@@ -36,7 +37,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     }
 }
 
-tr.registerMock('crypto', { randomUUID: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123', createPrivateKey: require('crypto').createPrivateKey });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPInitSuccessAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -18,7 +19,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
@@ -36,7 +37,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     }
 }
 
-tr.registerMock('crypto', { randomUUID: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123', createPrivateKey: require('crypto').createPrivateKey });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPInitSuccessEmptyWorkingDirL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -18,7 +19,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
@@ -36,7 +37,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     }
 }
 
-tr.registerMock('crypto', { randomUUID: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123', createPrivateKey: require('crypto').createPrivateKey });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPInitSuccessNoAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -18,7 +19,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
@@ -36,7 +37,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     }
 }
 
-tr.registerMock('crypto', { randomUUID: () => '123' });
+tr.registerMock('crypto', { randomUUID: () => '123', createPrivateKey: require('crypto').createPrivateKey });
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -8,6 +8,8 @@ import './OciTokenExchangeL0';
 import './IdTokenGeneratorL0';
 // Direct unit tests for the secure var-file loader.
 import './SecureFileLoaderL0';
+// Direct unit tests for post-hoc chmod on third-party secure-file downloads.
+import './SecureTempL0';
 // Direct unit tests for OCI WIF temp-dir resolution (Agent.TempDirectory).
 import './OciWifTempDirL0';
 // Direct unit test for emergency cleanup before a handler is assigned.
@@ -1909,6 +1911,29 @@ describe('Terraform Test Suite', function () {
             assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.stdOutContained('GCPOutputSuccessL0 should have succeeded.'), 'Should have printed: GCPOutputSuccessL0 should have succeeded.');
+        }, tr);
+    });
+
+    it('aws output rejects a control-character-laced value instead of forwarding it unsanitized', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputControlCharsRejected.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'the command itself should still succeed');
+            assert(
+                tr.warningIssues.some((w) => w.includes("Output 'malicious_output' failed output-variable validation")),
+                'should warn that the malicious output was rejected. warnings: ' + tr.warningIssues
+            );
+            // terraform's own raw command output is always echoed to the log by
+            // the ToolRunner regardless of sanitization -- that's unavoidable and
+            // not the risk this guards against. The actual security property is
+            // that the malicious value never reaches an ADO ##vso[task.setvariable]
+            // logging command, which is what a downstream step actually consumes.
+            assert(!tr.stdout.includes('##vso[task.setvariable variable=TF_OUT_malicious_output'),
+                'the control-character value must never reach a ##vso[task.setvariable] line');
+            assert(tr.stdout.includes('##vso[task.setvariable variable=TF_OUT_safe_output'), 'the well-formed sibling output should still be set');
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputControlCharsRejected.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputControlCharsRejected.ts
@@ -1,0 +1,36 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// A compromised module/provider fully controls terraform output -json's
+// content. An output value containing a newline could forge additional ADO
+// logging commands in the console output that consumes this variable
+// downstream -- setOutputVariables must reject it rather than pass it
+// through to tasks.setVariable() unsanitized.
+let tp = path.join(__dirname, './AWSOutputControlCharsRejectedL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"safe_output\": { \"value\": \"hello\" }, \"malicious_output\": { \"value\": \"ami-0123\\nrm -rf /\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputControlCharsRejectedL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputControlCharsRejectedL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'output', 'AWSOutputControlCharsRejectedL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/GCPOutputSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/GCPOutputSuccess.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPOutputSuccessL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'test-project';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'test@test.iam.gserviceaccount.com';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'https://oauth2.googleapis.com/token';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'test-private-key';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'https://www.googleapis.com/auth/cloud-platform';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanFailEmptyWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPPlanFailEmptyWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanFailInvalidWorkingDirectory.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPPlanFailInvalidWorkingDirectoryL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanSuccessAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanSuccessAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPPlanSuccessAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/GCP/GCPPlanSuccessNoAdditionalArgs.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPPlanSuccessNoAdditionalArgsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'Dummyissuer';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'DummyAudience';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'DummyScope';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SecureFileLoaderL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SecureFileLoaderL0.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import tasks = require('azure-pipelines-task-lib/task');
 import { SecureFileLoader, getSecureVarFileArgs, ISecureFileLoader } from '../src/secure-file-loader';
 
@@ -26,15 +29,23 @@ describe('Secure var-file loader', function () {
 
     /* SecureFileLoader class (helpers injected) */
 
-    it('downloadSecureFile delegates to the injected helper and returns the path', async () => {
+    it('downloadSecureFile delegates to the injected helper, returns the path, and tightens its permissions', async () => {
+        // A real file: downloadSecureFile chmods the path after "download",
+        // which needs an actual file on disk to chmod (#355).
+        const realPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'tf-securefile-')), 'vars.tfvars');
+        fs.writeFileSync(realPath, 'secret = "value"\n', { mode: 0o644 });
+
         let requested = '';
         const loader = new SecureFileLoader({
-            downloadSecureFile: async (id: string) => { requested = id; return '/tmp/vars.tfvars'; },
+            downloadSecureFile: async (id: string) => { requested = id; return realPath; },
             deleteSecureFile: () => { /* unused */ },
         });
         const filePath = await loader.downloadSecureFile('file-1');
-        assert.strictEqual(filePath, '/tmp/vars.tfvars');
+        assert.strictEqual(filePath, realPath);
         assert.strictEqual(requested, 'file-1');
+        if (process.platform !== 'win32') {
+            assert.strictEqual(fs.statSync(realPath).mode & 0o777, 0o600, 'downloaded secure file should be chmod 0600');
+        }
     });
 
     it('downloadSecureFile fails fast when the download exceeds the timeout', async () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SecureTempL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SecureTempL0.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+import fs = require('fs');
+import { tightenFilePermissions } from '../src/secure-temp';
+
+/**
+ * Direct unit tests for tightenFilePermissions (#355): chmods a file already
+ * on disk (e.g. one downloaded by a third-party library) to 0600, matching
+ * writeSecretFile's platform-aware fail-closed/Windows-swallow behavior.
+ */
+describe('tightenFilePermissions — post-hoc chmod for third-party downloads', function () {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch the shared fs module
+    const f = fs as any;
+    const origChmodSync = f.chmodSync;
+    const origPlatform = process.platform;
+
+    afterEach(() => {
+        f.chmodSync = origChmodSync;
+        Object.defineProperty(process, 'platform', { value: origPlatform });
+    });
+
+    it('chmods the file to 0600 when chmod succeeds', () => {
+        let calledWith: unknown[] | undefined;
+        f.chmodSync = (...args: unknown[]) => { calledWith = args; };
+        tightenFilePermissions('/tmp/downloaded-secure-file-does-not-matter.txt');
+        assert.deepStrictEqual(calledWith, ['/tmp/downloaded-secure-file-does-not-matter.txt', 0o600]);
+    });
+
+    it('re-throws when chmod fails on a non-Windows platform (fail closed)', () => {
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        f.chmodSync = () => { throw new Error('EPERM'); };
+        assert.throws(
+            () => tightenFilePermissions('/tmp/downloaded-secure-file.txt'),
+            /Failed to set restrictive permissions/,
+        );
+    });
+
+    it('swallows a chmod failure on Windows (ACLs apply instead)', () => {
+        Object.defineProperty(process, 'platform', { value: 'win32' });
+        f.chmodSync = () => { throw new Error('not supported'); };
+        assert.doesNotThrow(() => tightenFilePermissions('/tmp/downloaded-secure-file.txt'));
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/GCPShowConsoleSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/GCPShowConsoleSuccess.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPShowConsoleSuccessL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -17,7 +18,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'test-project';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'test@test.iam.gserviceaccount.com';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'https://oauth2.googleapis.com/token';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'test-private-key';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'https://www.googleapis.com/auth/cloud-platform';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/GCPTestSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/GCPTestSuccess.ts
@@ -1,6 +1,7 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
+import { TEST_GCP_PRIVATE_KEY_SPACES } from '../test-gcp-fixtures';
 
 let tp = path.join(__dirname, './GCPTestSuccessL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
@@ -15,7 +16,7 @@ process.env['ENDPOINT_AUTH_SCHEME_GCP'] = 'Jwt';
 process.env['ENDPOINT_DATA_GCP_PROJECT'] = 'DummyProject';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_ISSUER'] = 'DummyClientEmail';
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_AUDIENCE'] = 'https://oauth2.googleapis.com/token';
-process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = 'DummyPrivateKey';
+process.env['ENDPOINT_AUTH_PARAMETER_GCP_PRIVATEKEY'] = TEST_GCP_PRIVATE_KEY_SPACES;
 process.env['ENDPOINT_AUTH_PARAMETER_GCP_SCOPE'] = 'https://www.googleapis.com/auth/cloud-platform';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/test-gcp-fixtures.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/test-gcp-fixtures.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared GCP test fixtures.
+ *
+ * The EC P-256 key below is used ONLY in tests — it has zero access to any
+ * real infrastructure. It is stored in "spaces" format (how Azure DevOps
+ * service connections deliver PEM keys) so tests exercise normalizePem's
+ * real parsing/re-wrapping path, matching test-oci-fixtures.ts's pattern.
+ */
+
+/** PKCS#8 EC P-256 private key with spaces instead of newlines (ADO format). */
+export const TEST_GCP_PRIVATE_KEY_SPACES =
+    '-----BEGIN PRIVATE KEY----- MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgAsTcK0hjp14AQ2R/ ydQ/xaW4sw7LUoZf9aH18iqkwOuhRANCAAThCrUbXtVpePEkWziaFVt3zrxq+esh iOkuCq5fQ/DCaunhtz7/EMOdUNInRWRl5Qq+cjbu1yeM6IjkrifPTKLS -----END PRIVATE KEY-----';
+
+/** Same key in proper PEM format (LF line endings, 64-char wrapped). */
+export const TEST_GCP_PRIVATE_KEY_PEM =
+    '-----BEGIN PRIVATE KEY-----\n' +
+    'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgAsTcK0hjp14AQ2R/\n' +
+    'ydQ/xaW4sw7LUoZf9aH18iqkwOuhRANCAAThCrUbXtVpePEkWziaFVt3zrxq+esh\n' +
+    'iOkuCq5fQ/DCaunhtz7/EMOdUNInRWRl5Qq+cjbu1yeM6IjkrifPTKLS\n' +
+    '-----END PRIVATE KEY-----\n';

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -54,6 +54,7 @@ export abstract class BaseTerraformCommandHandler {
     backendConfig: Map<string, string>;
     protected tempFiles: string[];
     private secureFileId: string | null = null;
+    private static readonly OUTPUT_VAR_MAX_LENGTH = 1024;
 
     abstract handleBackend(terraformToolRunner: ToolRunner): Promise<void>;
     abstract handleProvider(command: TerraformAuthorizationCommandInitializer): Promise<void>;
@@ -205,7 +206,10 @@ export abstract class BaseTerraformCommandHandler {
                     tasks.debug(`Cleaned up temp file: ${filePath}`);
                 }
             } catch (err) {
-                tasks.debug(`Failed to clean up temp file ${filePath}: ${err}`);
+                // A leftover credential temp file (OIDC token / GCP or OCI key)
+                // is a real exposure on a self-hosted agent -- surface it
+                // above debug.
+                tasks.warning(`Failed to clean up temp file ${filePath}: ${err}`);
             }
         }
         this.tempFiles = [];
@@ -214,7 +218,7 @@ export abstract class BaseTerraformCommandHandler {
             try {
                 new SecureFileLoader().deleteSecureFile(this.secureFileId);
             } catch (err) {
-                tasks.debug(`Failed to clean up secure file: ${err}`);
+                tasks.warning(`Failed to clean up secure file: ${err}`);
             }
             this.secureFileId = null;
         }
@@ -697,6 +701,18 @@ export abstract class BaseTerraformCommandHandler {
 
     // --- Pipeline variable helpers ---
 
+    /**
+     * State/output content a compromised module or provider can fully
+     * control must not reach tasks.setVariable() unsanitized: a value
+     * containing control characters (e.g. an embedded newline) could forge
+     * additional ADO logging commands in the console output that consumes
+     * this variable downstream. Also caps length as a sanity bound.
+     */
+    private sanitizeOutputVariableValue(value: string): string | null {
+        if (!value || value.length > BaseTerraformCommandHandler.OUTPUT_VAR_MAX_LENGTH) return null;
+        return /^[\x20-\x7E]+$/.test(value) ? value : null;
+    }
+
     private setOutputVariables(jsonOutput: string): void {
         try {
             const outputs = JSON.parse(jsonOutput);
@@ -708,8 +724,14 @@ export abstract class BaseTerraformCommandHandler {
                     ? JSON.stringify(def.value)
                     : String(def.value);
 
+                const safeValue = this.sanitizeOutputVariableValue(stringValue);
+                if (safeValue === null) {
+                    tasks.warning(`Output '${key}' failed output-variable validation (length/printable-ASCII); skipping TF_OUT_${key}.`);
+                    continue;
+                }
+
                 const isSecret = def.sensitive === true;
-                tasks.setVariable(`TF_OUT_${key}`, stringValue, isSecret, true);
+                tasks.setVariable(`TF_OUT_${key}`, safeValue, isSecret, true);
                 tasks.debug(`Set pipeline variable TF_OUT_${key}${isSecret ? ' (secret)' : ''}`);
             }
         } catch (err) {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -4,6 +4,7 @@ import { TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 import { EnvironmentVariableHelper } from './environment-variables';
 import { generateIdToken } from './id-token-generator';
+import { normalizePem } from './pem-normalizer';
 import { writeSecretFile } from './secure-temp';
 import { resolveWifTempDir } from './temp-dir';
 import path = require('path');
@@ -36,12 +37,27 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
                 .filter(Boolean).join(", ");
             throw new Error(`GCP service connection is missing required fields: ${missing}`);
         }
-        tasks.setSecret(privateKey);
+        // Mask the raw value first: a service connection may deliver the key
+        // flattened to a single line (which itself starts with "-----BEGIN"),
+        // so no boundary-line filtering here.
+        for (const line of privateKey.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed) tasks.setSecret(trimmed);
+        }
+        const normalized = normalizePem(privateKey);
+        // ADO's log masker matches per line, not across embedded newlines, so
+        // the normalized (always multi-line) form needs its own per-line
+        // masking too -- registering the raw string alone would never match
+        // this byte-different on-disk form if it were ever echoed to a log.
+        for (const line of normalized.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed && !trimmed.startsWith('-----')) tasks.setSecret(trimmed);
+        }
 
         // Create json string and write it to the file
         const jsonCredsString = JSON.stringify({
             type: "service_account",
-            private_key: privateKey,
+            private_key: normalized,
             client_email: clientEmail,
             token_uri: tokenUri
         });

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -60,8 +60,22 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
     }
 
     private getPrivateKeyFilePath(privateKey: string) {
-        tasks.setSecret(privateKey);
+        // Mask the raw value first: a service connection may deliver the key
+        // flattened to a single line (which itself starts with "-----BEGIN"),
+        // so no boundary-line filtering here.
+        for (const line of privateKey.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed) tasks.setSecret(trimmed);
+        }
         const normalized = normalizePem(privateKey);
+        // ADO's log masker matches per line, not across embedded newlines, so
+        // the normalized (always multi-line) form needs its own per-line
+        // masking too -- registering the raw string alone would never match
+        // this byte-different on-disk form if it were ever echoed to a log.
+        for (const line of normalized.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed && !trimmed.startsWith('-----')) tasks.setSecret(trimmed);
+        }
         const privateKeyFilePath = path.join(resolveWifTempDir(), `keyfile-${uuidV4()}.pem`);
         writeSecretFile(privateKeyFilePath, normalized);
         this.tempFiles.push(privateKeyFilePath);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/secure-file-loader.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/secure-file-loader.ts
@@ -1,4 +1,5 @@
 import tasks = require('azure-pipelines-task-lib/task');
+import { tightenFilePermissions } from './secure-temp';
 
 export interface ISecureFileLoader {
     downloadSecureFile(secureFileId: string): Promise<string>;
@@ -43,6 +44,10 @@ export class SecureFileLoader implements ISecureFileLoader {
         });
         try {
             const filePath = await Promise.race([this.helpers.downloadSecureFile(secureFileId), timeout]);
+            // The secure file (which may carry secrets in a .pkrvars/.tfvars
+            // file) is downloaded by the upstream library with its own
+            // default (often 0644) permissions and never tightened.
+            tightenFilePermissions(filePath);
             tasks.debug(`Secure file downloaded to: ${filePath}`);
             return filePath;
         } finally {
@@ -57,7 +62,9 @@ export class SecureFileLoader implements ISecureFileLoader {
             this.helpers.deleteSecureFile(secureFileId);
             tasks.debug(`Deleted secure file: ${secureFileId}`);
         } catch (err) {
-            tasks.debug(`Failed to delete secure file ${secureFileId}: ${err}`);
+            // A leftover secure file (which can hold -var-file secrets) is a
+            // real exposure on a self-hosted agent -- surface it above debug.
+            tasks.warning(`Failed to delete secure file ${secureFileId}: ${err}`);
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/secure-temp.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/secure-temp.ts
@@ -17,3 +17,21 @@ export function writeSecretFile(filePath: string, content: string): void {
         tasks.debug('Skipping chmod on Windows platform (ACLs apply instead).');
     }
 }
+
+/**
+ * Chmods an existing file to 0600 after the fact. Unlike writeSecretFile
+ * (which controls the initial write), this is for files this task did not
+ * write itself -- e.g. a secure file downloaded by the third-party
+ * azure-pipelines-tasks-securefiles-common helper, which applies its own
+ * (often less restrictive) default permissions.
+ */
+export function tightenFilePermissions(filePath: string): void {
+    try {
+        fs.chmodSync(filePath, 0o600);
+    } catch (err) {
+        if (process.platform !== 'win32') {
+            throw new Error(`Failed to set restrictive permissions on ${filePath}: ${err instanceof Error ? err.message : err}`);
+        }
+        tasks.debug('Skipping chmod on Windows platform (ACLs apply instead).');
+    }
+}


### PR DESCRIPTION
## Summary

Closes #351, #354, #355, #358 — a cross-repo parity audit against azure-pipelines-packer's own security-hardening rounds surfaced four gaps in TerraformTaskV5's credential/output handling.

- **#351 (high)**: GCP service-account keys were `setSecret`'d once as a single raw multi-line string with no PEM normalization — ADO's log masker matches per line, so a genuine multi-line key echoed to a log would not have been redacted at all. Now per-line-masks both raw and normalized forms and stores the normalized form on disk. **Incidentally found and fixed the same partial gap in the OCI handler** while porting the pattern (it normalized but never per-line-masked).
- **#354 (medium)**: `terraform output -json` values — fully controllable by a compromised module/provider — flowed into `tasks.setVariable()` with no sanitization. Added the same length-cap + printable-ASCII filter packer uses for its manifest-derived outputs.
- **#355 (medium)**: downloaded `secureVarsFile` content was left at the securefiles-common library's default permissions. Added `tightenFilePermissions` (platform-aware, mirrors `writeSecretFile`'s fail-closed/Windows-swallow behavior) and wired it into the download path.
- **#358 (low)**: temp-file/secure-file cleanup failures were logged at `debug`, invisible in a normal build log, despite holding OIDC JWTs and cloud credentials. Escalated to `warning`.

19 existing GCP test fixtures used a non-PEM-shaped fake key that fails `normalizePem`'s real crypto validation — updated to a shared real EC test key (`test-gcp-fixtures.ts`, mirroring the existing `test-oci-fixtures.ts`), plus fixed 4 Init tests whose `crypto` mock lacked `createPrivateKey`.

## Test plan

- [x] `npm test` — 253 passing (0 failing), full existing scenario suite unaffected
- [x] `npx eslint src/` clean
- [x] `npm run test:coverage` passing, floors ratcheted 75/75/70 → 85/80/71
- [ ] CI