### PR TITLE
security: TerraformInstallerV1 supply-chain hardening

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/GpgVerifierL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/GpgVerifierL0.ts
@@ -7,10 +7,11 @@ import { verifyGpgSignature } from '../src/gpg-verifier';
 
 // Direct (parent-process) unit tests for the GPG signature gate. These use the
 // REAL openpgp/crypto (the MockTestRunner integration scenarios stub openpgp away,
-// so the verification logic itself is only exercised here). fetchBuffer is stubbed
-// so no network is touched. The happy path requires HashiCorp's private key and is
-// therefore unreachable; the security-relevant behaviour — rejecting a wrong-key
-// signature and honouring the required/optional toggle — is what we assert.
+// so the verification logic itself is only exercised here). fetchBufferAllow404 is
+// stubbed so no network is touched. The happy path requires HashiCorp's private key
+// and is therefore unreachable; the security-relevant behaviour — rejecting a
+// wrong-key signature, honouring the required/optional toggle, and distinguishing a
+// genuine 404 (absent) from a transient failure — is what we assert.
 
 describe('gpg-verifier: SHA256SUMS signature gate', function () {
     this.timeout(15000); // key generation can be slow on cold CI runners
@@ -20,24 +21,29 @@ describe('gpg-verifier: SHA256SUMS signature gate', function () {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const hc = httpClient as any;
     const origWarning = t.warning;
-    const origFetchBuffer = hc.fetchBuffer;
+    const origFetchBufferAllow404 = hc.fetchBufferAllow404;
     let warnings: string[] = [];
 
     beforeEach(() => { warnings = []; t.warning = (m: string) => warnings.push(m); });
-    afterEach(() => { t.warning = origWarning; hc.fetchBuffer = origFetchBuffer; });
+    afterEach(() => { t.warning = origWarning; hc.fetchBufferAllow404 = origFetchBufferAllow404; });
 
     const SUMS = `${'a'.repeat(64)}  opa_linux_amd64\n`;
     const SIG_URL = 'https://releases.example.com/SHA256SUMS.sig';
 
-    it('throws when the signature is unavailable and verification is required', async () => {
-        hc.fetchBuffer = async () => { throw new Error('HTTP 404'); };
+    it('throws when the signature is genuinely absent (404) and verification is required', async () => {
+        hc.fetchBufferAllow404 = async () => null;
         await assert.rejects(verifyGpgSignature(SUMS, SIG_URL, true), /signature verification is required/);
     });
 
-    it('warns and proceeds when the signature is unavailable and not required', async () => {
-        hc.fetchBuffer = async () => { throw new Error('HTTP 404'); };
+    it('warns and proceeds when the signature is genuinely absent (404) and not required', async () => {
+        hc.fetchBufferAllow404 = async () => null;
         await verifyGpgSignature(SUMS, SIG_URL, false);
         assert.ok(warnings.some(w => /without signature verification/i.test(w)), 'should warn about skipping verification');
+    });
+
+    it('propagates a transient fetch error fatally even when not required (does not conflate with a genuine 404)', async () => {
+        hc.fetchBufferAllow404 = async () => { throw new Error('HTTP 503'); };
+        await assert.rejects(verifyGpgSignature(SUMS, SIG_URL, false), /HTTP 503/);
     });
 
     it('rejects a signature made by a key other than HashiCorp\'s', async () => {
@@ -49,7 +55,7 @@ describe('gpg-verifier: SHA256SUMS signature gate', function () {
         const detached = await openpgp.sign({ message, signingKeys: signingKey, detached: true, format: 'binary' });
         const sigBytes = detached as Uint8Array;
 
-        hc.fetchBuffer = async () => sigBytes;
+        hc.fetchBufferAllow404 = async () => sigBytes;
         await assert.rejects(verifyGpgSignature(SUMS, SIG_URL, true), /GPG signature verification failed/);
     });
 });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/gpg-verifier.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/gpg-verifier.ts
@@ -6,7 +6,7 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import * as openpgp from 'openpgp';
 
-import { fetchBuffer } from './http-client';
+import { fetchBufferAllow404 } from './http-client';
 import { HASHICORP_GPG_PUBLIC_KEY } from './hashicorp-gpg-key';
 
 /**
@@ -14,15 +14,16 @@ import { HASHICORP_GPG_PUBLIC_KEY } from './hashicorp-gpg-key';
  * Fetches the `.sig` file from the same base URL as the SHA256SUMS file.
  *
  * - If verification succeeds, returns the SHA256SUMS content (already fetched).
- * - If the `.sig` file is unavailable and `required` is false, warns and returns unverified.
+ * - If the `.sig` file is genuinely absent (HTTP 404) and `required` is false, warns
+ *   and returns unverified. Any OTHER fetch error (5xx / network / timeout) is
+ *   transient and propagates fatally even when `required` is false -- only a
+ *   confirmed absence should downgrade to a warning.
  * - If the `.sig` file is unavailable and `required` is true, throws (hard fail).
  * - If the signature is invalid, throws (hard fail).
  */
 export async function verifyGpgSignature(sha256SumsContent: string, signatureUrl: string, required: boolean = false): Promise<void> {
-    let signatureBytes: Uint8Array;
-    try {
-        signatureBytes = await fetchBuffer(signatureUrl);
-    } catch {
+    const signatureBytes = await fetchBufferAllow404(signatureUrl);
+    if (signatureBytes === null) {
         if (required) {
             throw new Error(`GPG signature file unavailable (${signatureUrl}) and signature verification is required. Set 'requireGpgSignature' to false to skip.`);
         }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointDownFallback.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointDownFallback.ts
@@ -1,0 +1,78 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #359: a transient checkpoint-API failure (network/timeout/5xx) still falls
+// back to the pinned FALLBACK_TERRAFORM_VERSION with a warning -- that's an
+// intentional availability tradeoff, distinct from a malformed API response
+// (see HashiCorpLatestCheckpointInvalidResponseFail).
+const tp = path.join(__dirname, 'HashiCorpLatestCheckpointDownFallbackL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', 'latest');
+tr.setInput('downloadSource', 'hashicorp');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (new URL(url).hostname === 'checkpoint-api.hashicorp.com') {
+            throw new Error('network down');
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => {
+        // Falls back to FALLBACK_TERRAFORM_VERSION = 1.14.8.
+        if (url.includes('SHA256SUMS')) {
+            return `${EXPECTED_SHA256}  terraform_1.14.8_windows_amd64.zip\n`;
+        }
+        throw new Error('Unexpected fetchText URL: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+    chmodSync: (_path: string, _mode: string) => { },
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => EXPECTED_SHA256
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointDownFallbackL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointDownFallbackL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('latest');
+        tl.setResult(tl.TaskResult.Succeeded, 'HashiCorpLatestCheckpointDownFallbackL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointDownFallbackL0 failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointInvalidResponseFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointInvalidResponseFail.ts
@@ -1,0 +1,53 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #359: a malformed checkpoint-API response (the API contract itself broke)
+// must now fail fatally instead of being silently swallowed into the same
+// fallback path as a transient network error -- proves the try-scope narrowing
+// that moved the "!data.current_version" validation outside the catch.
+const tp = path.join(__dirname, 'HashiCorpLatestCheckpointInvalidResponseFailL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', 'latest');
+tr.setInput('downloadSource', 'hashicorp');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (new URL(url).hostname === 'checkpoint-api.hashicorp.com') {
+            return {}; // missing current_version
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => {
+        throw new Error('Should not fetch SHA256SUMS: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async () => { throw new Error('Should not reach GPG verification'); }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async () => { throw new Error('Should not download when the checkpoint response is malformed'); },
+    extractZip: async () => { throw new Error('Should not extract'); },
+    cacheDir: async () => { throw new Error('Should not cache'); },
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointInvalidResponseFailL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointInvalidResponseFailL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('latest');
+        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointInvalidResponseFailL0 should have failed but succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointInvalidResponseFailL0 failed as expected: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -57,6 +57,35 @@ describe('TerraformInstaller Test Suite', function () {
         }, tr);
     });
 
+    // --- 'latest' checkpoint resolution (#359): a transient failure still falls
+    // back, but a malformed API response is now fatal instead of silently
+    // downgrading ---
+
+    it('hashicorp latest checkpoint down: falls back to the pinned version with a warning', async () => {
+        const tp = path.join(__dirname, 'HashiCorpLatestCheckpointDownFallback.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(
+                tr.warningIssues.some((w) => /could not|not found|version/i.test(w)),
+                'should warn that the latest version could not be resolved. warnings: ' + tr.warningIssues
+            );
+        }, tr);
+    });
+
+    it('hashicorp latest checkpoint invalid response: fails instead of silently downgrading', async () => {
+        const tp = path.join(__dirname, 'HashiCorpLatestCheckpointInvalidResponseFail.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(tr.errorIssues.length > 0, 'should have an error issue');
+        }, tr);
+    });
+
     it('path prepended: installed terraform directory is added to PATH', async () => {
         const tp = path.join(__dirname, 'PathPrependedOnInstall.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -94,6 +123,41 @@ describe('TerraformInstaller Test Suite', function () {
         runValidations(() => {
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
+    // --- Registry pre-signed download-URL token masking (#352) ---
+    // The registry download_url carries a live storage credential in its query
+    // string and tool-lib logs the URL at INFO. Assert every token component is
+    // registered as a secret (so the agent masks it) while benign params stay
+    // visible.
+    it('registry download token masking: sensitive query params are registered as secrets', async () => {
+        const tp = path.join(__dirname, 'RegistryDownloadTokenMasked.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+            const maskedTokens = [
+                'AWSSIGNATUREtoken1111',   // X-Amz-Signature
+                'AWSCREDENTIALtoken2222',  // X-Amz-Credential
+                'AWSSECURITYtoken3333',    // X-Amz-Security-Token
+                'GOOGSIGNATUREtoken4444',  // X-Goog-Signature
+                'GOOGCREDENTIALtoken5555', // X-Goog-Credential
+                'AZURESIGtoken6666'        // Azure SAS sig
+            ];
+            for (const token of maskedTokens) {
+                assert(
+                    tr.stdout.includes('##vso[task.setsecret]' + token),
+                    `expected ##vso[task.setsecret] for token ${token}. stdout: ${tr.stdout}`
+                );
+            }
+            // Benign query parameters must NOT be masked (guards against over-redaction).
+            assert(!tr.stdout.includes('##vso[task.setsecret]20260703T000000Z'),
+                'benign X-Amz-Date must not be registered as a secret');
+            assert(!tr.stdout.includes('##vso[task.setsecret]host'),
+                'benign X-Amz-SignedHeaders must not be registered as a secret');
         }, tr);
     });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -1,0 +1,99 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #352: the registry download_url carries a live storage credential in its
+// query string, and tool-lib logs the URL at INFO (fully redacting only
+// Azure `sig=`). Assert every sensitive token component is registered as a
+// secret (so the agent masks it) while benign params stay visible.
+const tp = path.join(__dirname, 'RegistryDownloadTokenMaskedL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+const EXPECTED_SHA256 = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
+
+const AWS_SIGNATURE = 'AWSSIGNATUREtoken1111';        // X-Amz-Signature       -> masked
+const AWS_CREDENTIAL = 'AWSCREDENTIALtoken2222';      // X-Amz-Credential      -> masked
+const AWS_SECURITY_TOKEN = 'AWSSECURITYtoken3333';    // X-Amz-Security-Token  -> masked
+const GOOG_SIGNATURE = 'GOOGSIGNATUREtoken4444';      // X-Goog-Signature      -> masked
+const GOOG_CREDENTIAL = 'GOOGCREDENTIALtoken5555';    // X-Goog-Credential     -> masked
+const AZURE_SIG = 'AZURESIGtoken6666';                // sig (Azure SAS)       -> masked
+const BENIGN_DATE = '20260703T000000Z';               // X-Amz-Date            -> NOT masked
+const BENIGN_SIGNED_HEADERS = 'host';                 // X-Amz-SignedHeaders   -> NOT masked
+
+const PRESIGNED_URL =
+    'https://storage.example.com/signed/terraform_1.9.8_windows_amd64.zip' +
+    '?X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+    `&X-Amz-Credential=${AWS_CREDENTIAL}` +
+    `&X-Amz-Date=${BENIGN_DATE}` +
+    '&X-Amz-Expires=900' +
+    `&X-Amz-SignedHeaders=${BENIGN_SIGNED_HEADERS}` +
+    `&X-Amz-Security-Token=${AWS_SECURITY_TOKEN}` +
+    `&X-Amz-Signature=${AWS_SIGNATURE}` +
+    `&X-Goog-Credential=${GOOG_CREDENTIAL}` +
+    `&X-Goog-Signature=${GOOG_SIGNATURE}` +
+    `&sig=${AZURE_SIG}`;
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        if (url.includes('/terraform/binaries/terraform/versions/1.9.8/windows/amd64')) {
+            return {
+                download_url: PRESIGNED_URL,
+                sha256: EXPECTED_SHA256
+            };
+        }
+        throw new Error('Unexpected fetchJson URL: ' + url);
+    },
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch SHA256SUMS text: ' + url); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async () => { throw new Error('Registry path should not GPG-verify'); }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+    chmodSync: (_path: string, _mode: string) => { },
+    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => EXPECTED_SHA256
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMaskedL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMaskedL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+    try {
+        await downloadTerraform('1.9.8');
+        tl.setResult(tl.TaskResult.Succeeded, 'RegistryDownloadTokenMaskedL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, 'RegistryDownloadTokenMaskedL0 failed: ' + error.message);
+    }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/gpg-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/gpg-verifier.ts
@@ -6,7 +6,7 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import * as openpgp from 'openpgp';
 
-import { fetchBuffer } from './http-client';
+import { fetchBufferAllow404 } from './http-client';
 import { HASHICORP_GPG_PUBLIC_KEY } from './hashicorp-gpg-key';
 
 /**
@@ -14,15 +14,16 @@ import { HASHICORP_GPG_PUBLIC_KEY } from './hashicorp-gpg-key';
  * Fetches the `.sig` file from the same base URL as the SHA256SUMS file.
  *
  * - If verification succeeds, returns the SHA256SUMS content (already fetched).
- * - If the `.sig` file is unavailable and `required` is false, warns and returns unverified.
+ * - If the `.sig` file is genuinely absent (HTTP 404) and `required` is false, warns
+ *   and returns unverified. Any OTHER fetch error (5xx / network / timeout) is
+ *   transient and propagates fatally even when `required` is false -- only a
+ *   confirmed absence should downgrade to a warning.
  * - If the `.sig` file is unavailable and `required` is true, throws (hard fail).
  * - If the signature is invalid, throws (hard fail).
  */
 export async function verifyGpgSignature(sha256SumsContent: string, signatureUrl: string, required: boolean = false): Promise<void> {
-    let signatureBytes: Uint8Array;
-    try {
-        signatureBytes = await fetchBuffer(signatureUrl);
-    } catch {
+    const signatureBytes = await fetchBufferAllow404(signatureUrl);
+    if (signatureBytes === null) {
         if (required) {
             throw new Error(`GPG signature file unavailable (${signatureUrl}) and signature verification is required. Set 'requireGpgSignature' to false to skip.`);
         }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -20,6 +20,56 @@ const FALLBACK_TERRAFORM_VERSION = '1.14.8';
 /** Fallback version used when the OpenTofu GitHub API is unreachable. Update periodically. */
 const FALLBACK_TOFU_VERSION = '1.11.6';
 
+function isSensitiveQueryParam(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower === 'sig'
+        || lower.includes('signature')
+        || lower.includes('credential')
+        || lower.includes('token');
+}
+
+/**
+ * Extracts the values of every sensitive query-string token in `url`. Values are
+ * returned in the raw form they appear in the URL (still percent-encoded) so they
+ * match the exact substring tool-lib logs at INFO; the decoded form is added too when
+ * it differs, so a consumer that logs the decoded value is masked as well. Used to
+ * setSecret() the tokens before download and to scrub them from any failure message.
+ */
+function extractUrlTokenSecrets(url: string): string[] {
+    const qIndex = url.indexOf('?');
+    if (qIndex === -1) return [];
+    const query = url.slice(qIndex + 1).split('#')[0];
+    const secrets: string[] = [];
+    for (const pair of query.split('&')) {
+        const eq = pair.indexOf('=');
+        if (eq === -1) continue;
+        const name = pair.slice(0, eq);
+        const rawValue = pair.slice(eq + 1);
+        if (!rawValue || !isSensitiveQueryParam(name)) continue;
+        secrets.push(rawValue);
+        let decoded: string;
+        try { decoded = decodeURIComponent(rawValue); } catch { decoded = rawValue; }
+        if (decoded !== rawValue) secrets.push(decoded);
+    }
+    return secrets;
+}
+
+/**
+ * Strips the ENTIRE query string (which can carry a pre-signed signature/token —
+ * Azure `sig`, AWS `X-Amz-Signature`/`X-Amz-Credential`/`X-Amz-Security-Token`,
+ * GCS `X-Goog-Signature`/`X-Goog-Credential`) from a URL for safe logging. The whole
+ * query is dropped rather than redacting known parameter names one at a time, so an
+ * unforeseen token parameter can never leak through the error path.
+ */
+function redactUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        return u.origin + u.pathname + (u.search ? '?<redacted>' : '');
+    } catch {
+        return url.split('?')[0];
+    }
+}
+
 export async function downloadTerraform(inputVersion: string): Promise<string> {
     const binary = tasks.getInput("binary") || "terraform";
 
@@ -104,16 +154,23 @@ async function resolveVersionFromHashiCorp(inputVersion: string): Promise<string
         return inputVersion;
     }
     console.log(tasks.loc("GettingLatestTerraformVersion"));
+    // Only a genuine request failure (network/timeout/5xx, already retried by
+    // fetchJson) falls back to the pinned version -- that's an availability
+    // tradeoff worth keeping. A malformed response (the API contract itself
+    // broke) is NOT caught here: it throws fatally instead of silently
+    // downgrading, since trusting the fallback in that case would mask a real
+    // API-shape regression rather than a transient blip.
+    let data: { current_version: string };
     try {
-        const data = await fetchJson<{ current_version: string }>('https://checkpoint-api.hashicorp.com/v1/check/terraform');
-        if (!data.current_version) {
-            throw new Error("HashiCorp checkpoint API returned invalid response: missing current_version");
-        }
-        return data.current_version;
+        data = await fetchJson<{ current_version: string }>('https://checkpoint-api.hashicorp.com/v1/check/terraform');
     } catch {
         tasks.warning(tasks.loc("TerraformVersionNotFound"));
         return FALLBACK_TERRAFORM_VERSION;
     }
+    if (!data.current_version) {
+        throw new Error("HashiCorp checkpoint API returned invalid response: missing current_version");
+    }
+    return data.current_version;
 }
 
 async function resolveVersionFromRegistry(inputVersion: string, registryUrl: string, mirrorName: string): Promise<string> {
@@ -189,11 +246,33 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     }
 
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
+    // The pre-signed download_url carries a live, read-scoped storage credential in
+    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
+    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
+    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
+    // normal registry run. Register each token component as a secret FIRST so the
+    // agent masks it in tool-lib's log line (and in any failure message).
+    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
+    for (const secret of urlTokenSecrets) {
+        tasks.setSecret(secret);
+    }
     let zipPath: string;
     try {
         zipPath = await tools.downloadTool(data.download_url, fileName);
     } catch (exception) {
-        throw new Error(tasks.loc("TerraformDownloadFailed", data.download_url, exception));
+        // download_url is a pre-signed URL whose query string carries the signing
+        // token; drop the whole query (redactUrl) and scrub the raw URL out of the
+        // tool-lib exception text so the live credential never reaches the build
+        // log via the failure message.
+        const safeUrl = redactUrl(data.download_url);
+        let safeMsg = String(exception instanceof Error ? exception.message : exception).split(data.download_url).join(safeUrl);
+        // Belt-and-suspenders: tool-lib may embed a URL it partially transformed
+        // (its own `sig=` redaction) that the exact-URL replace above misses, so
+        // also scrub each known token value out of the message.
+        for (const secret of urlTokenSecrets) {
+            safeMsg = safeMsg.split(secret).join('<redacted>');
+        }
+        throw new Error(tasks.loc("TerraformDownloadFailed", safeUrl, safeMsg));
     }
 
     if (data.sha256) {
@@ -389,17 +468,20 @@ async function resolveVersionFromOpenTofu(inputVersion: string): Promise<string>
         return inputVersion;
     }
     console.log(tasks.loc("GettingLatestOpenTofuVersion"));
+    // Same split as resolveVersionFromHashiCorp: only a genuine request
+    // failure falls back silently; a malformed response throws fatally.
+    let data: { tag_name: string };
     try {
-        const data = await fetchJson<{ tag_name: string }>('https://api.github.com/repos/opentofu/opentofu/releases/latest');
-        if (!data.tag_name) {
-            throw new Error("GitHub API returned invalid response: missing tag_name");
-        }
-        // tag_name is "v1.11.6" — strip the leading "v"
-        return data.tag_name.replace(/^v/, '');
+        data = await fetchJson<{ tag_name: string }>('https://api.github.com/repos/opentofu/opentofu/releases/latest');
     } catch {
         tasks.warning(tasks.loc("TerraformVersionNotFound"));
         return FALLBACK_TOFU_VERSION;
     }
+    if (!data.tag_name) {
+        throw new Error("GitHub API returned invalid response: missing tag_name");
+    }
+    // tag_name is "v1.11.6" — strip the leading "v"
+    return data.tag_name.replace(/^v/, '');
 }
 
 async function downloadZipFromOpenTofu(version: string): Promise<string> {


### PR DESCRIPTION
## Summary

Closes #352, #356, #359 — the same cross-repo parity audit against azure-pipelines-packer's own security-hardening rounds that produced #360 surfaced three gaps in the installer's download/verification chain.

- **#352 (high)**: the registry `download_url` is a pre-signed storage URL with a live credential in its query string. `tool-lib` logs it at INFO and only auto-redacts Azure's `sig=`, so AWS/GCS token components would print unredacted on every normal registry install. Ports packer's `extractUrlTokenSecrets`/`isSensitiveQueryParam` to mask each token before download, and `redactUrl()` to scrub the failure message too.
- **#356 (medium)**: `gpg-verifier.ts` called plain `fetchBuffer`, conflating a genuine 404 (signature not published) with a transient 5xx/network failure — both fell into the same warn-and-skip branch when `requireGpgSignature` is false. Switches to `fetchBufferAllow404` (already in the shared `http-client.ts` since #350 but never wired up). Byte-identical across `TerraformInstallerV1` and `PolicyAgentInstallerV1` — ported to both.
- **#359 (low)**: `resolveVersionFromHashiCorp`/`resolveVersionFromOpenTofu` swallowed a malformed API response into the same silent fallback as a transient network blip. Narrows the try-scope so only the fetch itself falls back; a validation failure now throws fatally.

`PolicyAgentInstallerV1`'s existing `GpgVerifierL0.ts` mocked the now-dead `fetchBuffer` name and would have made real network calls in CI — fixed to mock `fetchBufferAllow404` with the correct contract, plus a new transient-failure regression test.

## Test plan

- [x] `npm test` — TerraformInstallerV1 66 passing (up from 63), PolicyAgentInstallerV1 50 passing
- [x] `npx eslint src/` clean in both tasks
- [x] `npm run test:coverage` passing in both (floors already had adequate margin, not ratcheted further)
- [x] `node scripts/check-shared-modules.js` confirms gpg-verifier.ts/http-client.ts stay byte-identical
- [ ] CI