### PR TITLE
security: OIDC token lifecycle and process termination hardening

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/IdTokenGeneratorL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/IdTokenGeneratorL0.ts
@@ -70,11 +70,22 @@ describe('OIDC ID token generator — retry, timeout & secret handling', functio
         assert.strictEqual(seenInit.method, 'POST');
         const headers = seenInit.headers as Record<string, string>;
         assert.strictEqual(headers['Authorization'], 'Bearer access-token');
+        // This token exchange has no legitimate redirect -- the Bearer access
+        // token must never be silently carried to a redirect target (#353).
+        assert.strictEqual(seenInit.redirect, 'error');
     });
 
     it('throws when SYSTEM_OIDCREQUESTURI is not set', async () => {
         delete process.env['SYSTEM_OIDCREQUESTURI'];
         await assert.rejects(new TokenGenerator().generate('sc-123'), /SYSTEM_OIDCREQUESTURI is not set/);
+    });
+
+    it('throws when SYSTEM_OIDCREQUESTURI is not an https:// URL (#353)', async () => {
+        process.env['SYSTEM_OIDCREQUESTURI'] = 'http://vstoken.dev.azure.com/oidc';
+        let called = false;
+        globalThis.fetch = (async () => { called = true; return new Response('{}'); }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(new TokenGenerator().generate('sc-123'), /must be an https:\/\/ URL/);
+        assert.strictEqual(called, false, 'must not call fetch with a non-https request URI');
     });
 
     it('throws when the SystemVssConnection access token is unavailable', async () => {
@@ -111,10 +122,24 @@ describe('OIDC ID token generator — retry, timeout & secret handling', functio
         assert.strictEqual(calls, 3, 'should attempt MAX_RETRIES times');
     });
 
-    it('throws a clear HTTP error on a non-OK response', async () => {
-        globalThis.fetch = (async () =>
-            new Response('nope', { status: 403, statusText: 'Forbidden' })) as unknown as typeof globalThis.fetch;
+    it('throws a clear HTTP error on a non-OK response and does not retry a deterministic 4xx (#353)', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return new Response('nope', { status: 403, statusText: 'Forbidden' });
+        }) as unknown as typeof globalThis.fetch;
         await assert.rejects(new TokenGenerator().generate('sc-123'), /HTTP 403 Forbidden/);
+        assert.strictEqual(calls, 1, 'a deterministic 4xx must not be retried');
+    });
+
+    it('retries a transient 5xx and then gives up after the attempt limit (#353)', async () => {
+        let calls = 0;
+        globalThis.fetch = (async () => {
+            calls++;
+            return new Response('busy', { status: 503, statusText: 'Service Unavailable' });
+        }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(new TokenGenerator().generate('sc-123'), /HTTP 503/);
+        assert.strictEqual(calls, 3, 'a transient 5xx should be retried up to the attempt limit');
     });
 
     it('throws the localized error when the response omits oidcToken', async () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
@@ -5,11 +5,15 @@ export async function generateIdToken(serviceConnectionID: string): Promise<stri
     return tokenGenerator.generate(serviceConnectionID);
 }
 
-export interface ITokenGenerator {
-    generate(serviceConnectionID: string): Promise<string>;
+/** Carries whether a federated-token fetch failure is worth retrying (transient) vs deterministic (4xx). */
+class FederatedTokenError extends Error {
+    constructor(message: string, readonly retryable: boolean) {
+        super(message);
+        this.name = 'FederatedTokenError';
+    }
 }
 
-export class TokenGenerator implements ITokenGenerator {
+export class TokenGenerator {
     private static readonly MAX_RETRIES = 3;
     private static readonly INITIAL_BACKOFF_MS = 200;
 
@@ -17,6 +21,17 @@ export class TokenGenerator implements ITokenGenerator {
         const oidcRequestUri = process.env["SYSTEM_OIDCREQUESTURI"];
         if (!oidcRequestUri) {
             throw new Error("SYSTEM_OIDCREQUESTURI is not set. Ensure the pipeline is running on an agent that supports OIDC token generation.");
+        }
+        // SYSTEM_OIDCREQUESTURI carries the job's System.AccessToken as a Bearer
+        // header; assert https:// before that token is ever sent anywhere.
+        let scheme: string;
+        try {
+            scheme = new URL(oidcRequestUri).protocol;
+        } catch {
+            throw new Error(`SYSTEM_OIDCREQUESTURI is not a valid URL: ${oidcRequestUri}`);
+        }
+        if (scheme !== 'https:') {
+            throw new Error(`SYSTEM_OIDCREQUESTURI must be an https:// URL, got '${oidcRequestUri}'.`);
         }
 
         // The federated token is requested with only the service-connection id; no
@@ -33,49 +48,76 @@ export class TokenGenerator implements ITokenGenerator {
                 return await this.fetchToken(url, oidcRequestUri);
             } catch (error) {
                 lastError = error instanceof Error ? error : new Error(String(error));
-                if (attempt < TokenGenerator.MAX_RETRIES) {
-                    const delayMs = TokenGenerator.INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
-                    tasks.debug(`OIDC token request attempt ${attempt} failed: ${lastError.message}. Retrying in ${delayMs}ms...`);
-                    await new Promise(resolve => setTimeout(resolve, delayMs));
-                }
+                // A non-FederatedTokenError is a network/DNS/abort failure -- treat as
+                // transient. A deterministic 4xx (bad/expired access token,
+                // misconfigured service connection) is non-retryable and skips the
+                // remaining attempts and their backoff delay.
+                const retryable = !(error instanceof FederatedTokenError) || error.retryable;
+                if (!retryable || attempt === TokenGenerator.MAX_RETRIES) break;
+                const delayMs = TokenGenerator.INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
+                tasks.debug(`OIDC token request attempt ${attempt} failed: ${lastError.message}. Retrying in ${delayMs}ms...`);
+                await new Promise(resolve => setTimeout(resolve, delayMs));
             }
         }
         throw lastError!;
     }
 
     private async fetchToken(url: string, oidcRequestUri: string): Promise<string> {
-        let response: Response;
+        const accessToken = tasks.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', false);
+        if (!accessToken) {
+            throw new Error(
+                "SystemVssConnection AccessToken is not available. " +
+                "Ensure the pipeline has 'Allow scripts to access the OAuth token' enabled and OIDC is configured for the service connection."
+            );
+        }
+
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 30000);
+        let oidcObject: { oidcToken: string };
         try {
-            const accessToken = tasks.getEndpointAuthorizationParameter('SystemVssConnection', 'AccessToken', false);
-            if (!accessToken) {
-                throw new Error(
-                    "SystemVssConnection AccessToken is not available. " +
-                    "Ensure the pipeline has 'Allow scripts to access the OAuth token' enabled and OIDC is configured for the service connection."
-                );
+            let response: Response;
+            try {
+                response = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + accessToken
+                    },
+                    signal: controller.signal,
+                    // This token exchange has no legitimate redirect.
+                    redirect: 'error'
+                });
+            } catch (error) {
+                if (error instanceof Error && error.name === 'AbortError') {
+                    throw new Error(`Timed out acquiring federated token from ${oidcRequestUri} (30s timeout).`);
+                }
+                throw new Error(`Failed to acquire federated token from ${oidcRequestUri}: ${error instanceof Error ? error.message : error}`);
             }
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 30000);
-            response = await fetch(url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': 'Bearer ' + accessToken
-                },
-                signal: controller.signal
-            });
+
+            if (!response.ok) {
+                // Retry only on transient failures (5xx); a deterministic 4xx
+                // (bad/expired token, misconfigured service connection) will not
+                // change on retry.
+                throw new FederatedTokenError(`Failed to acquire federated token: HTTP ${response.status} ${response.statusText}`, response.status >= 500);
+            }
+
+            // Read the body while the abort signal is still armed, so a stalled
+            // body stream is bounded by the same 30s timeout as the connection.
+            try {
+                oidcObject = await response.json() as { oidcToken: string };
+            } catch (error) {
+                if (error instanceof Error && error.name === 'AbortError') {
+                    throw new Error(`Timed out acquiring federated token from ${oidcRequestUri} (30s timeout).`);
+                }
+                throw error;
+            }
+        } finally {
+            // Runs on every path (success, network error, non-OK, body-parse
+            // failure) -- a bare try/catch previously left the timer armed on
+            // every failure, keeping the event loop alive for up to 30s/attempt.
             clearTimeout(timeoutId);
-        } catch (error) {
-            if (error instanceof Error && error.name === 'AbortError') {
-                throw new Error(`Timed out acquiring federated token from ${oidcRequestUri} (30s timeout).`);
-            }
-            throw new Error(`Failed to acquire federated token from ${oidcRequestUri}: ${error instanceof Error ? error.message : error}`);
         }
 
-        if (!response.ok) {
-            throw new Error(`Failed to acquire federated token: HTTP ${response.status} ${response.statusText}`);
-        }
-
-        const oidcObject = await response.json() as { oidcToken: string };
         if (!oidcObject?.oidcToken) {
             throw new Error(tasks.loc("Error_FederatedTokenAquisitionFailed"));
         }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/index.ts
@@ -9,8 +9,17 @@ async function run() {
 
     // Register process-level cleanup as defense-in-depth for unexpected termination
     const cleanup = () => parentHandler.emergencyCleanup();
-    process.on('SIGTERM', cleanup);
-    process.on('SIGINT', cleanup);
+    // Registering a signal listener suppresses Node's default terminate-on-signal
+    // behavior, so SIGTERM/SIGINT must clean up AND re-raise the signal with its
+    // default disposition -- otherwise a pipeline cancellation could leave this
+    // process lingering past its own execute() call instead of dying promptly.
+    const handleTerminationSignal = (signal: NodeJS.Signals) => {
+        cleanup();
+        process.removeListener(signal, handleTerminationSignal);
+        process.kill(process.pid, signal);
+    };
+    process.on('SIGTERM', handleTerminationSignal);
+    process.on('SIGINT', handleTerminationSignal);
     process.on('uncaughtException', (err) => {
         cleanup();
         tasks.setResult(tasks.TaskResult.Failed, `Uncaught exception: ${err instanceof Error ? err.message : String(err)}`);
@@ -28,8 +37,8 @@ async function run() {
     } catch (error) {
         tasks.setResult(tasks.TaskResult.Failed, error instanceof Error ? error.message : String(error));
     } finally {
-        process.removeListener('SIGTERM', cleanup);
-        process.removeListener('SIGINT', cleanup);
+        process.removeListener('SIGTERM', handleTerminationSignal);
+        process.removeListener('SIGINT', handleTerminationSignal);
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #353, #357 — the final two gaps from the cross-repo parity audit against azure-pipelines-packer's security-hardening rounds (following #360, #361).

- **#353 (high)**: `id-token-generator.ts` — which mints the OIDC token used to obtain federated credentials for every WIF-capable provider — was missing four hardening measures packer's identical file already had: no `https://` scheme assertion on `SYSTEM_OIDCREQUESTURI` before attaching the Bearer access token; no retryable/deterministic failure classification (a bad/expired token was retried exactly like a transient blip); `clearTimeout` only covered the fetch call and never ran on a fetch-level failure, leaving the 30s abort timer armed for the rest of its duration; and no `redirect: 'error'`, so the default `'follow'` would have silently carried the Bearer token to a redirect target. Also removes the unused `ITokenGenerator` interface.
- **#357 (medium)**: `index.ts`'s `SIGTERM`/`SIGINT` handler ran cleanup but never re-raised the signal, so a pipeline cancellation could leave the process lingering past its own `execute()` call instead of dying promptly. Splits the plain cleanup (still used for `uncaughtException`/`unhandledRejection`) from a dedicated `handleTerminationSignal` that re-raises after cleanup.

## Test plan

- [x] `npm test` — 255 passing (up from 253)
- [x] `npx eslint src/` clean
- [x] `npm run test:coverage` passing (existing floors already had adequate margin)
- [ ] CI

Note: the SIGTERM/SIGINT re-raise itself isn't directly unit tested — `index.ts`'s top-level side-effecting `run()` call isn't exercised by the test suite either way, matching packer's own scope for this file.