### PR TITLE
fix: remediate P0/P1 security audit findings (#384-#389)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build release
         run: npm run build:release
       - name: Upload build artifact
@@ -85,7 +85,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,10 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
    - `Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json` — if TerraformPolicyCheckV1 changed
    - `Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json` — if TerraformDriftReportV1 changed
    - `Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json` — if TerraformModulePublishV1 changed
+   - `Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json` — if TerraformDocsInstallerV1 changed
+   - `Tasks/TerraformDocs/TerraformDocsV1/task.json` — if TerraformDocsV1 changed
+   - `Tasks/Markdown2Html/Markdown2HtmlV1/task.json` — if Markdown2HtmlV1 changed
+   - `Tasks/PublishKbArticle/PublishKbArticleV1/task.json` — if PublishKbArticleV1 changed
 
    Increment `Minor` by 1, leave `Patch` at 0.
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -8,6 +8,8 @@ import './HttpClientL0';
 import './InstallerHelpersL0';
 // Direct unit tests for the GPG signature gate (real openpgp).
 import './GpgVerifierL0';
+// Direct unit tests for the registry download-host allowlist.
+import './RegistryAllowedHostsL0';
 
 describe('PolicyAgentInstaller Test Suite', function () {
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialChecksumSkip.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialChecksumSkip.ts
@@ -6,10 +6,13 @@ const tp = path.join(__dirname, 'RunInstaller.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 // OPA official download where the per-asset .sha256 is unavailable and
-// requireChecksum is not set — the task warns and proceeds (fail-open).
+// requireChecksum is explicitly disabled — the task warns and proceeds. With the
+// fail-closed default (requireChecksum defaults to true) a missing checksum is fatal,
+// so this scenario opts out to exercise the warn-and-skip path.
 tr.setInput('policyAgent', 'opa');
 tr.setInput('version', '1.17.1');
 tr.setInput('downloadSource', 'official');
+tr.setInput('requireChecksum', 'false');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256Warns.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256Warns.ts
@@ -2,8 +2,10 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-// Registry returns an empty sha256 and requireChecksum is not set (default false).
+// Registry returns an empty sha256 and requireChecksum is explicitly disabled.
 // The install proceeds but must emit a warning that local verification was skipped.
+// With the fail-closed default (requireChecksum defaults to true) this is fatal — see
+// OpaRegistryEmptySha256RequireChecksum for that path — so this scenario opts out.
 const tp = path.join(__dirname, 'RunInstaller.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
@@ -12,6 +14,7 @@ tr.setInput('version', '1.17.1');
 tr.setInput('downloadSource', 'registry');
 tr.setInput('registryUrl', 'https://registry.example.com');
 tr.setInput('registryMirrorName', 'opa');
+tr.setInput('requireChecksum', 'false');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryAllowedHostsL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryAllowedHostsL0.ts
@@ -1,0 +1,49 @@
+import * as assert from 'assert';
+import { parseAllowedHosts, isRegistryHostAllowed } from '../src/policy-agent-installer';
+
+/**
+ * Direct unit tests for the optional registry download_url host allowlist.
+ * Ported from TerraformInstallerV1 — this installer implements the identical
+ * parseAllowedHosts/isRegistryHostAllowed pair, so it must carry the same
+ * coverage. The registry API response is partially attacker-influenced if the
+ * registry is compromised (download_url is registry-controlled), and
+ * tools.downloadTool follows redirects with no way to disable that — so an
+ * operator who wants to pin the trusted storage host(s) can opt in via
+ * registryAllowedHosts. Empty input preserves the trust-the-registry behavior.
+ */
+describe('registry download_url host allowlist', function () {
+    describe('parseAllowedHosts', () => {
+        it('returns an empty list for unset/empty input (no restriction)', () => {
+            assert.deepStrictEqual(parseAllowedHosts(undefined), []);
+            assert.deepStrictEqual(parseAllowedHosts(''), []);
+        });
+
+        it('splits on commas and newlines, trims, and lowercases', () => {
+            assert.deepStrictEqual(
+                parseAllowedHosts('Storage.Example.com, \n *.S3.amazonaws.com \n,, foo.bar'),
+                ['storage.example.com', '*.s3.amazonaws.com', 'foo.bar'],
+            );
+        });
+    });
+
+    describe('isRegistryHostAllowed', () => {
+        it('matches an exact host', () => {
+            assert.strictEqual(isRegistryHostAllowed('storage.example.com', ['storage.example.com']), true);
+            assert.strictEqual(isRegistryHostAllowed('other.example.com', ['storage.example.com']), false);
+        });
+
+        it('is case-insensitive', () => {
+            assert.strictEqual(isRegistryHostAllowed('Storage.Example.com', ['storage.example.com']), true);
+        });
+
+        it('matches subdomains via a *. wildcard prefix, but not the bare host', () => {
+            assert.strictEqual(isRegistryHostAllowed('mybucket.s3.amazonaws.com', ['*.s3.amazonaws.com']), true);
+            assert.strictEqual(isRegistryHostAllowed('s3.amazonaws.com', ['*.s3.amazonaws.com']), false);
+            assert.strictEqual(isRegistryHostAllowed('evil-s3.amazonaws.com', ['*.s3.amazonaws.com']), false);
+        });
+
+        it('rejects when the allowlist is non-empty and nothing matches', () => {
+            assert.strictEqual(isRegistryHostAllowed('attacker.example.net', ['storage.example.com']), false);
+        });
+    });
+});

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -150,6 +150,17 @@ async function downloadArtifact(agent: string, downloadSource: string, version: 
     }
 }
 
+/**
+ * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
+ * raw input rather than getBoolInput(name, false) so the default still holds on an
+ * agent that does not materialize task.json defaultValues into the input env var
+ * (where getBoolInput would silently return false). Mirrors TerraformInstaller's helper.
+ */
+function getBoolInputDefaultTrue(name: string): boolean {
+    const raw = tasks.getInput(name, false);
+    return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
+}
+
 async function downloadSentinelOfficial(version: string): Promise<string> {
     const osPlatform = getPlatformString();
     const arch = getArchString();
@@ -160,7 +171,7 @@ async function downloadSentinelOfficial(version: string): Promise<string> {
 
     const sha256SumsUrl = `https://releases.hashicorp.com/sentinel/${version}/sentinel_${version}_SHA256SUMS`;
     const sha256SumsContent = await fetchText(sha256SumsUrl);
-    const requireGpg = tasks.getBoolInput("requireGpgSignature", false);
+    const requireGpg = getBoolInputDefaultTrue("requireGpgSignature");
     await verifyGpgSignature(sha256SumsContent, `${sha256SumsUrl}.sig`, requireGpg);
 
     const expectedHash = parseSha256(sha256SumsContent, zipFileName);
@@ -181,7 +192,7 @@ async function downloadOpaOfficial(version: string): Promise<string> {
     // authenticity against a poisoned release. requireChecksum (default true) keeps
     // the check mandatory; HTTPS + GitHub's release infrastructure is the trust root.
     const sha256Url = `${downloadUrl}.sha256`;
-    const requireChecksum = tasks.getBoolInput("requireChecksum", false);
+    const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
     try {
         const sha256Body = await fetchText(sha256Url);
         const expectedHash = parseFirstSha256(sha256Body);
@@ -255,7 +266,7 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
 
     if (data.sha256) {
         await verifySha256(filePath, data.sha256);
-    } else if (tasks.getBoolInput("requireChecksum", false)) {
+    } else if (getBoolInputDefaultTrue("requireChecksum")) {
         // Empty sha256 means no local integrity check is possible. Fail closed when
         // the operator requires checksum verification rather than trusting the binary.
         throw new Error(`Checksum verification is required but the registry did not provide a sha256 for ${infoUrl}.`);
@@ -286,7 +297,7 @@ async function downloadFromMirror(agent: string, version: string, mirrorBaseUrl:
     const downloadUrl = `${mirrorBaseUrl}/${version}/${assetName}`;
     const binaryPath = await downloadTo(downloadUrl, `opa-${version}-${uuidV4()}${isWindows ? '.exe' : ''}`);
 
-    const requireChecksum = tasks.getBoolInput("requireChecksum", false);
+    const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
     try {
         const sha256Body = await fetchText(`${downloadUrl}.sha256`);
         await verifySha256(binaryPath, parseFirstSha256(sha256Body));
@@ -303,7 +314,7 @@ async function downloadFromMirror(agent: string, version: string, mirrorBaseUrl:
 }
 
 async function verifyMirrorChecksum(filePath: string, sha256SumsUrl: string, fileName: string): Promise<void> {
-    const requireChecksum = tasks.getBoolInput("requireChecksum", false);
+    const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
     try {
         const body = await fetchText(sha256SumsUrl);
         await verifySha256(filePath, parseSha256(body, fileName));

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -468,6 +468,58 @@ describe('htmlValidate.validateHtmlContent', () => {
         assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
     });
 
+    it('throws on an inline <script> element when force=false', () => {
+        const html = '<html><body><script>alert(1)</script></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /Inline <script> elements are not allowed/,
+        );
+    });
+
+    it('does not throw on an inline <script> when force=true', () => {
+        const html = '<html><body><script>alert(1)</script></body></html>';
+        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
+    });
+
+    it('throws on an inline event-handler attribute (onerror) when force=false', () => {
+        const html = '<html><body><img src="x" onerror="alert(1)"></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /event-handler attributes .* are not allowed/,
+        );
+    });
+
+    it('does not throw on an inline event-handler when force=true', () => {
+        const html = '<html><body><img src="x" onerror="alert(1)"></body></html>';
+        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
+    });
+
+    it('throws on a javascript: URI when force=false', () => {
+        const html = '<html><body><a href="javascript:alert(1)">x</a></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /javascript:.*URIs are not allowed/,
+        );
+    });
+
+    it('throws on a non-image data: URI when force=false', () => {
+        const html = '<html><body><a href="data:text/html,alert">x</a></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /data: URIs are not allowed/,
+        );
+    });
+
+    it('does not throw on an image data: URI (allowed)', () => {
+        const html = '<html><body><img src="data:image/png;base64,iVBORw0KGgo="></body></html>';
+        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, false));
+    });
+
+    it('does not throw on a dangerous URI when force=true', () => {
+        const html = '<html><body><a href="javascript:alert(1)">x</a></body></html>';
+        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
+    });
+
     it('throws on content loss when force=false', () => {
         // Construct input that will lose significant content after cheerio parse.
         // cheerio wraps fragments in html/head/body which adds bytes, so this

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -262,6 +262,19 @@ export async function createCategory(
 }
 
 /**
+ * ServiceNow encoded queries use `^` (AND / `^OR` / `^NQ`) and operator tokens as
+ * control syntax with no value-escaping mechanism. Any value interpolated into a
+ * sysparm_query must be rejected if it contains `^` or a newline, so an operator- or
+ * document-derived value (e.g. a markdown front-matter sourceKey) cannot inject query
+ * clauses that redirect the lookup onto an unrelated record.
+ */
+function assertQueryValueSafe(value: string, field: string): void {
+    if (/[\^\r\n]/.test(value)) {
+        throw new Error(`Invalid ${field}: values used in a ServiceNow query must not contain '^' or newline characters.`);
+    }
+}
+
+/**
  * Find a category by name in the given KB (optionally under a parent), creating
  * it if not found and autoCreate is true.
  * This is the canonical implementation — the Python source had three duplicate
@@ -276,6 +289,9 @@ export async function findOrCreateCategory(
     autoCreate: boolean = true,
 ): Promise<string | null> {
     const url = `${baseUrl(instance)}/api/now/table/kb_category`;
+    assertQueryValueSafe(kbId, 'knowledge base id');
+    assertQueryValueSafe(categoryName, 'category name');
+    if (parentCategoryId) assertQueryValueSafe(parentCategoryId, 'parent category id');
     let query = `kb_knowledge_base=${kbId}^label=${categoryName}`;
     if (parentCategoryId) query += `^parent=${parentCategoryId}`;
 
@@ -336,6 +352,8 @@ export async function findArticleBySourceKey(
     kbId?: string,
 ): Promise<string | null> {
     const url = `${baseUrl(instance)}/api/now/table/kb_knowledge`;
+    assertQueryValueSafe(sourceKey, 'source key');
+    if (kbId) assertQueryValueSafe(kbId, 'knowledge base id');
     const sentinel = `wiki-source: ${sourceKey}`;
     let query = `meta_descriptionLIKE${sentinel}`;
     if (kbId) query = `kb_knowledge_base=${kbId}^${query}`;

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
@@ -6,6 +6,8 @@ import * as path from 'path';
 import './HttpClientL0';
 // Direct unit tests for the checksum/platform helpers.
 import './InstallerHelpersL0';
+// Direct unit tests for the registry download-host allowlist.
+import './RegistryAllowedHostsL0';
 
 describe('TerraformDocsInstaller Test Suite', function () {
 

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryAllowedHostsL0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryAllowedHostsL0.ts
@@ -1,0 +1,49 @@
+import * as assert from 'assert';
+import { parseAllowedHosts, isRegistryHostAllowed } from '../src/terraform-docs-installer';
+
+/**
+ * Direct unit tests for the optional registry download_url host allowlist.
+ * Ported from TerraformInstallerV1 — this installer implements the identical
+ * parseAllowedHosts/isRegistryHostAllowed pair, so it must carry the same
+ * coverage. The registry API response is partially attacker-influenced if the
+ * registry is compromised (download_url is registry-controlled), and
+ * tools.downloadTool follows redirects with no way to disable that — so an
+ * operator who wants to pin the trusted storage host(s) can opt in via
+ * registryAllowedHosts. Empty input preserves the trust-the-registry behavior.
+ */
+describe('registry download_url host allowlist', function () {
+  describe('parseAllowedHosts', () => {
+    it('returns an empty list for unset/empty input (no restriction)', () => {
+      assert.deepStrictEqual(parseAllowedHosts(undefined), []);
+      assert.deepStrictEqual(parseAllowedHosts(''), []);
+    });
+
+    it('splits on commas and newlines, trims, and lowercases', () => {
+      assert.deepStrictEqual(
+        parseAllowedHosts('Storage.Example.com, \n *.S3.amazonaws.com \n,, foo.bar'),
+        ['storage.example.com', '*.s3.amazonaws.com', 'foo.bar'],
+      );
+    });
+  });
+
+  describe('isRegistryHostAllowed', () => {
+    it('matches an exact host', () => {
+      assert.strictEqual(isRegistryHostAllowed('storage.example.com', ['storage.example.com']), true);
+      assert.strictEqual(isRegistryHostAllowed('other.example.com', ['storage.example.com']), false);
+    });
+
+    it('is case-insensitive', () => {
+      assert.strictEqual(isRegistryHostAllowed('Storage.Example.com', ['storage.example.com']), true);
+    });
+
+    it('matches subdomains via a *. wildcard prefix, but not the bare host', () => {
+      assert.strictEqual(isRegistryHostAllowed('mybucket.s3.amazonaws.com', ['*.s3.amazonaws.com']), true);
+      assert.strictEqual(isRegistryHostAllowed('s3.amazonaws.com', ['*.s3.amazonaws.com']), false);
+      assert.strictEqual(isRegistryHostAllowed('evil-s3.amazonaws.com', ['*.s3.amazonaws.com']), false);
+    });
+
+    it('rejects when the allowlist is non-empty and nothing matches', () => {
+      assert.strictEqual(isRegistryHostAllowed('attacker.example.net', ['storage.example.com']), false);
+    });
+  });
+});

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -12,6 +12,17 @@ const toolName = "terraform-docs";
 const isWindows = os.type().match(/^Win/);
 
 /**
+ * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
+ * raw input rather than getBoolInput(name, false) so the default still holds on an
+ * agent that does not materialize task.json defaultValues into the input env var
+ * (where getBoolInput would silently return false). Mirrors TerraformInstaller's helper.
+ */
+function getBoolInputDefaultTrue(name: string): boolean {
+  const raw = tasks.getInput(name, false);
+  return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
+}
+
+/**
  * Downloads the requested terraform-docs version, verifies its SHA256 checksum,
  * caches it via the tool cache, and returns the path to the executable.
  *
@@ -194,7 +205,7 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
 
   if (data.sha256) {
     await verifySha256(filePath, data.sha256);
-  } else if (tasks.getBoolInput("requireChecksum", false)) {
+  } else if (getBoolInputDefaultTrue("requireChecksum")) {
     // Empty sha256 means no local integrity check is possible. Fail closed when
     // the operator requires checksum verification rather than trusting the archive.
     throw new Error(`Checksum verification is required but the registry did not provide a sha256 for ${infoUrl}.`);
@@ -223,7 +234,7 @@ async function downloadFromMirror(version: string, mirrorBaseUrl: string): Promi
  * is unavailable and requireChecksum is false, warn and skip; otherwise fail closed.
  */
 async function verifyChecksumOrSkip(filePath: string, sha256Url: string, assetName: string, sourceLabel: string): Promise<void> {
-  const requireChecksum = tasks.getBoolInput("requireChecksum", false);
+  const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
   // Only a genuine 404 (fetchTextAllow404 returns null) counts as "no checksum file
   // published". Any other non-2xx / network / TLS failure propagates fatally,
   // regardless of requireChecksum, instead of being classified by error-string.


### PR DESCRIPTION
Remediates the **P0 + P1** findings from the 2026-07-06 blind security re-audit (the pre-release + same-sprint set).

## P0
- fix(installers): keep `require*` verification fail-closed (`getBoolInputDefaultTrue`) on PolicyAgentInstaller + TerraformDocsInstaller — Closes #384
- ci(release): `npm ci --ignore-scripts` in build/package (tamper-before-sign) — Closes #385
- docs(contributing): add the 4 newer tasks to the Minor-bump checklist — Closes #386

## P1
- fix(publish-kb-article): reject `sysparm_query` metacharacters (front-matter injection) — Closes #387
- test(publish-kb-article): cover html-validate rejection branches — Closes #388
- test(installers): port registryAllowedHosts unit tests to the two installers — Closes #389

## Validation (local, Windows)
- PolicyAgentInstaller 56 passing · TerraformDocsInstaller 47 passing · PublishKbArticle 78 passing
- `eslint src/` clean on all three tasks
- No shared module touched (parity gate unaffected); no task.json Minor bump (handled at release per CONTRIBUTING)

Generated from the audit report `TERRAFORM_REAUDIT_2026-07-06.md` (security-orchestration).