### PR TITLE
fix: remediate P2 security audit findings (#390-#393)

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorOpaSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorOpaSuccess.ts
@@ -16,11 +16,11 @@ const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccd
 
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => { throw new Error('Mirror path should not call fetchJson: ' + url); },
-    fetchText: async (url: string) => {
+    fetchTextAllow404: async (url: string) => {
         if (url === 'https://mirror.example.com/1.17.1/opa_linux_amd64.sha256') {
             return `${EXPECTED_SHA256}  opa_linux_amd64\n`;
         }
-        throw new Error('Unexpected fetchText URL: ' + url);
+        throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
     }
 });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinelSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinelSuccess.ts
@@ -16,11 +16,11 @@ const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccd
 
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => { throw new Error('Mirror path should not call fetchJson: ' + url); },
-    fetchText: async (url: string) => {
+    fetchTextAllow404: async (url: string) => {
         if (url === 'https://mirror.example.com/0.40.0/sentinel_0.40.0_SHA256SUMS') {
             return `${EXPECTED_SHA256}  sentinel_0.40.0_linux_amd64.zip\n`;
         }
-        throw new Error('Unexpected fetchText URL: ' + url);
+        throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
     }
 });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaLatestSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaLatestSuccess.ts
@@ -20,11 +20,11 @@ tr.registerMock('./http-client', {
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
-    fetchText: async (url: string) => {
+    fetchTextAllow404: async (url: string) => {
         if (url.endsWith('.sha256')) {
             return `${EXPECTED_SHA256}\n`;
         }
-        throw new Error('Unexpected fetchText URL: ' + url);
+        throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
     }
 });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialChecksumSkip.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialChecksumSkip.ts
@@ -18,7 +18,7 @@ tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/
 
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => { throw new Error('Specific version should not call fetchJson: ' + url); },
-    fetchText: async (url: string) => { throw new Error(`Failed to fetch ${url}: HTTP 404`); }
+    fetchTextAllow404: async () => null
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialSuccess.ts
@@ -15,11 +15,11 @@ const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccd
 
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => { throw new Error('Specific version should not call fetchJson: ' + url); },
-    fetchText: async (url: string) => {
+    fetchTextAllow404: async (url: string) => {
         if (url.endsWith('.sha256')) {
             return `${EXPECTED_SHA256}  opa_linux_amd64\n`;
         }
-        throw new Error('Unexpected fetchText URL: ' + url);
+        throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
     }
 });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryAllowedHostsL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryAllowedHostsL0.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { parseAllowedHosts, isRegistryHostAllowed } from '../src/policy-agent-installer';
+import { parseAllowedHosts, isRegistryHostAllowed } from '../src/registry-allowlist';
 
 /**
  * Direct unit tests for the optional registry download_url host allowlist.

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/Sha256Fail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/Sha256Fail.ts
@@ -17,9 +17,9 @@ const WRONG_SHA256 = '0000000000000000000000000000000000000000000000000000000000
 
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => { throw new Error('Unexpected fetchJson: ' + url); },
-    fetchText: async (url: string) => {
+    fetchTextAllow404: async (url: string) => {
         if (url.endsWith('.sha256')) { return `${EXPECTED_SHA256}\n`; }
-        throw new Error('Unexpected fetchText URL: ' + url);
+        throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
     }
 });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -6,7 +6,8 @@ import fs = require('fs');
 import crypto = require('crypto');
 
 import { randomUUID as uuidV4 } from 'crypto';
-import { fetchJson, fetchText } from './http-client';
+import { fetchJson, fetchText, fetchTextAllow404 } from './http-client';
+import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { verifyGpgSignature } from './gpg-verifier';
 
 const isWindows = os.type().match(/^Win/);
@@ -193,45 +194,19 @@ async function downloadOpaOfficial(version: string): Promise<string> {
     // the check mandatory; HTTPS + GitHub's release infrastructure is the trust root.
     const sha256Url = `${downloadUrl}.sha256`;
     const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
-    try {
-        const sha256Body = await fetchText(sha256Url);
-        const expectedHash = parseFirstSha256(sha256Body);
-        await verifySha256(binaryPath, expectedHash);
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        const checksumUnavailable = message.includes('SHA256 checksum not found') || message.includes('Failed to fetch');
-        if (checksumUnavailable && !requireChecksum) {
-            tasks.warning(`SHA256 verification skipped for OPA download: ${message}`);
-        } else {
-            throw error;
+    // Only a genuine 404 (fetchTextAllow404 returns null) means "no checksum
+    // published". Any other non-2xx / network / TLS failure is fatal regardless of
+    // requireChecksum, rather than being classified by matching an error string.
+    const sha256Body = await fetchTextAllow404(sha256Url);
+    if (sha256Body === null) {
+        if (requireChecksum) {
+            throw new Error(`Checksum verification is required but no .sha256 is published for the OPA download (${sha256Url}).`);
         }
+        tasks.warning(`SHA256 verification skipped for OPA download: no checksum file published at ${sha256Url}.`);
+    } else {
+        await verifySha256(binaryPath, parseFirstSha256(sha256Body));
     }
     return binaryPath;
-}
-
-// --- Registry download-host allowlist (mirrors TerraformInstaller) ---
-
-/** Parses a comma/newline-separated registryAllowedHosts input into a normalized list. */
-export function parseAllowedHosts(raw: string | undefined): string[] {
-    if (!raw) {
-        return [];
-    }
-    return raw
-        .split(/[\n,]/)
-        .map(h => h.trim().toLowerCase())
-        .filter(h => h.length > 0);
-}
-
-/**
- * Matches a download_url hostname against the allowlist. A `*.` prefix on an
- * allowlist entry matches only its subdomains (not the bare host itself),
- * mirroring TLS wildcard-SAN semantics.
- */
-export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]): boolean {
-    const host = hostname.toLowerCase();
-    return allowedHosts.some(allowed =>
-        allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
-    );
 }
 
 async function downloadFromRegistry(agent: string, version: string, registryUrl: string, mirrorName: string): Promise<string> {
@@ -298,37 +273,31 @@ async function downloadFromMirror(agent: string, version: string, mirrorBaseUrl:
     const binaryPath = await downloadTo(downloadUrl, `opa-${version}-${uuidV4()}${isWindows ? '.exe' : ''}`);
 
     const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
-    try {
-        const sha256Body = await fetchText(`${downloadUrl}.sha256`);
-        await verifySha256(binaryPath, parseFirstSha256(sha256Body));
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        const checksumUnavailable = message.includes('SHA256 checksum not found') || message.includes('Failed to fetch');
-        if (checksumUnavailable && !requireChecksum) {
-            tasks.warning(`SHA256 verification skipped for mirror download: ${message}`);
-        } else {
-            throw error;
+    const sha256Url = `${downloadUrl}.sha256`;
+    const sha256Body = await fetchTextAllow404(sha256Url);
+    if (sha256Body === null) {
+        if (requireChecksum) {
+            throw new Error(`Checksum verification is required but no .sha256 is published for the mirror download (${sha256Url}).`);
         }
+        tasks.warning(`SHA256 verification skipped for mirror download: no checksum file published at ${sha256Url}.`);
+    } else {
+        await verifySha256(binaryPath, parseFirstSha256(sha256Body));
     }
     return binaryPath;
 }
 
 async function verifyMirrorChecksum(filePath: string, sha256SumsUrl: string, fileName: string): Promise<void> {
     const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
-    try {
-        const body = await fetchText(sha256SumsUrl);
-        await verifySha256(filePath, parseSha256(body, fileName));
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        const checksumUnavailable = message.includes('SHA256 checksum not found') || message.includes('Failed to fetch');
-        if (checksumUnavailable && !requireChecksum) {
-            tasks.warning(`SHA256 verification skipped for mirror download: ${message}`);
-        } else if (checksumUnavailable) {
-            throw new Error(`Checksum verification is required but the mirror did not provide a usable SHA256SUMS file (${sha256SumsUrl}): ${message}`);
-        } else {
-            throw error;
+    const body = await fetchTextAllow404(sha256SumsUrl);
+    if (body === null) {
+        if (requireChecksum) {
+            throw new Error(`Checksum verification is required but the mirror did not publish a SHA256SUMS file (${sha256SumsUrl}).`);
         }
+        tasks.warning(`SHA256 verification skipped for mirror download: no SHA256SUMS published at ${sha256SumsUrl}.`);
+        return;
     }
+    // The file exists: a missing asset entry or a hash mismatch is always fatal.
+    await verifySha256(filePath, parseSha256(body, fileName));
 }
 
 // --- Helpers ---

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-allowlist.ts
@@ -1,0 +1,27 @@
+// Registry download-host allowlist. Duplicated byte-identically across the
+// installer tasks and enforced by scripts/check-shared-modules.js — a fix to the
+// matching logic must be applied to every copy or CI fails.
+
+/** Parses a comma/newline-separated registryAllowedHosts input into a normalized list. */
+export function parseAllowedHosts(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(/[\n,]/)
+    .map(h => h.trim().toLowerCase())
+    .filter(h => h.length > 0);
+}
+
+/**
+ * Matches a download_url hostname against the allowlist. A `*.` prefix on an
+ * allowlist entry matches only its subdomains (not the bare host itself),
+ * mirroring TLS wildcard-SAN semantics — useful for registry-controlled
+ * storage hosts like *.s3.amazonaws.com.
+ */
+export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]): boolean {
+  const host = hostname.toLowerCase();
+  return allowedHosts.some(allowed =>
+    allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
+  );
+}

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "5",
+        "Minor": "6",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(policyAgent) $(version)",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
@@ -263,6 +263,18 @@ async function run() {
         console.log(`Workflow State: ${article['workflow_state']}`);
 
         // -----------------------------------------------------------------
+        // Emit manifest line + output variables BEFORE the image-upload phase, so a
+        // failure uploading images cannot orphan the just-created article: a retry
+        // can find it (via the manifest / kbArticleId) and update it in place
+        // instead of creating a duplicate draft.
+        // -----------------------------------------------------------------
+        emitArticleOutput(article, sourceKey, emitManifest, kbId);
+
+        tasks.setVariable('kbArticleId', article['sys_id'] as string, false, true);
+        tasks.setVariable('kbArticleNumber', article['number'] as string, false, true);
+        tasks.setVariable('kbWorkflowState', article['workflow_state'] as string, false, true);
+
+        // -----------------------------------------------------------------
         // Phase 2: upload referenced images as attachments and rewrite the body.
         // Runs only when there is body content and image upload is enabled. The
         // article must already exist (we need its sys_id), which it does here.
@@ -287,15 +299,6 @@ async function run() {
                 console.log(`${result.missing.length} image(s) not found and left unchanged.`);
             }
         }
-
-        // -----------------------------------------------------------------
-        // Emit manifest line + output variables
-        // -----------------------------------------------------------------
-        emitArticleOutput(article, sourceKey, emitManifest, kbId);
-
-        tasks.setVariable('kbArticleId', article['sys_id'] as string, false, true);
-        tasks.setVariable('kbArticleNumber', article['number'] as string, false, true);
-        tasks.setVariable('kbWorkflowState', article['workflow_state'] as string, false, true);
 
         tasks.setResult(tasks.TaskResult.Succeeded, '');
     } catch (error) {

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "1",
+        "Minor": "2",
         "Patch": "0"
     },
     "minimumAgentVersion": "3.232.1",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryAllowedHostsL0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryAllowedHostsL0.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { parseAllowedHosts, isRegistryHostAllowed } from '../src/terraform-docs-installer';
+import { parseAllowedHosts, isRegistryHostAllowed } from '../src/registry-allowlist';
 
 /**
  * Direct unit tests for the optional registry download_url host allowlist.

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-allowlist.ts
@@ -1,0 +1,27 @@
+// Registry download-host allowlist. Duplicated byte-identically across the
+// installer tasks and enforced by scripts/check-shared-modules.js — a fix to the
+// matching logic must be applied to every copy or CI fails.
+
+/** Parses a comma/newline-separated registryAllowedHosts input into a normalized list. */
+export function parseAllowedHosts(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(/[\n,]/)
+    .map(h => h.trim().toLowerCase())
+    .filter(h => h.length > 0);
+}
+
+/**
+ * Matches a download_url hostname against the allowlist. A `*.` prefix on an
+ * allowlist entry matches only its subdomains (not the bare host itself),
+ * mirroring TLS wildcard-SAN semantics — useful for registry-controlled
+ * storage hosts like *.s3.amazonaws.com.
+ */
+export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]): boolean {
+  const host = hostname.toLowerCase();
+  return allowedHosts.some(allowed =>
+    allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
+  );
+}

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -7,6 +7,7 @@ import crypto = require('crypto');
 
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchTextAllow404 } from './http-client';
+import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 
 const toolName = "terraform-docs";
 const isWindows = os.type().match(/^Win/);
@@ -112,31 +113,6 @@ async function resolveVersionFromRegistry(registryUrl: string, mirrorName: strin
   }
   console.log(tasks.loc("ResolvedVersionFromRegistry", data.version));
   return data.version;
-}
-
-// --- Registry download-host allowlist (mirrors TerraformInstaller) ---
-
-/** Parses a comma/newline-separated registryAllowedHosts input into a normalized list. */
-export function parseAllowedHosts(raw: string | undefined): string[] {
-  if (!raw) {
-    return [];
-  }
-  return raw
-    .split(/[\n,]/)
-    .map(h => h.trim().toLowerCase())
-    .filter(h => h.length > 0);
-}
-
-/**
- * Matches a download_url hostname against the allowlist. A `*.` prefix on an
- * allowlist entry matches only its subdomains (not the bare host itself),
- * mirroring TLS wildcard-SAN semantics.
- */
-export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]): boolean {
-  const host = hostname.toLowerCase();
-  return allowedHosts.some(allowed =>
-    allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
-  );
 }
 
 // --- Download strategies (return the path to the downloaded archive) ---

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "1",
+    "Minor": "2",
     "Patch": "0"
   },
   "instanceNameFormat": "Install terraform-docs $(version)",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
@@ -22,9 +22,10 @@ tr.registerMock('./http-client', {
     fetchJson: async (url: string) => {
         throw new Error('fetchJson should not be called for mirror download. Called with: ' + url);
     },
-    fetchText: async (url: string) => {
-        // Mirror SHA256SUMS is unavailable — the installer catches this and warns
-        throw new Error('Failed to fetch ' + url + ': HTTP 404');
+    fetchTextAllow404: async () => {
+        // Mirror SHA256SUMS is genuinely absent (404) — fetchTextAllow404 returns
+        // null; with requireChecksum=false the installer warns and proceeds.
+        return null;
     }
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostsL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostsL0.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { parseAllowedHosts, isRegistryHostAllowed } from '../src/terraform-installer';
+import { parseAllowedHosts, isRegistryHostAllowed } from '../src/registry-allowlist';
 
 /**
  * Direct unit tests for the optional registry download_url host allowlist.

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-allowlist.ts
@@ -1,0 +1,27 @@
+// Registry download-host allowlist. Duplicated byte-identically across the
+// installer tasks and enforced by scripts/check-shared-modules.js — a fix to the
+// matching logic must be applied to every copy or CI fails.
+
+/** Parses a comma/newline-separated registryAllowedHosts input into a normalized list. */
+export function parseAllowedHosts(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(/[\n,]/)
+    .map(h => h.trim().toLowerCase())
+    .filter(h => h.length > 0);
+}
+
+/**
+ * Matches a download_url hostname against the allowlist. A `*.` prefix on an
+ * allowlist entry matches only its subdomains (not the bare host itself),
+ * mirroring TLS wildcard-SAN semantics — useful for registry-controlled
+ * storage hosts like *.s3.amazonaws.com.
+ */
+export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]): boolean {
+  const host = hostname.toLowerCase();
+  return allowedHosts.some(allowed =>
+    allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
+  );
+}

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -6,7 +6,8 @@ import fs = require('fs');
 import crypto = require('crypto');
 
 import { randomUUID as uuidV4 } from 'crypto';
-import { fetchJson, fetchText } from './http-client';
+import { fetchJson, fetchText, fetchTextAllow404 } from './http-client';
+import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';
 
@@ -299,30 +300,6 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     return zipPath;
 }
 
-/** Parses a comma/newline-separated registryAllowedHosts input into a normalized list. */
-export function parseAllowedHosts(raw: string | undefined): string[] {
-    if (!raw) {
-        return [];
-    }
-    return raw
-        .split(/[\n,]/)
-        .map(h => h.trim().toLowerCase())
-        .filter(h => h.length > 0);
-}
-
-/**
- * Matches a download_url hostname against the allowlist. A `*.` prefix on an
- * allowlist entry matches only its subdomains (not the bare host itself),
- * mirroring TLS wildcard-SAN semantics — useful for registry-controlled
- * storage hosts like *.s3.amazonaws.com.
- */
-export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]): boolean {
-    const host = hostname.toLowerCase();
-    return allowedHosts.some(allowed =>
-        allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
-    );
-}
-
 async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Promise<string> {
     if (!mirrorBaseUrl.startsWith('https://')) {
         throw new Error(tasks.loc("InsecureUrlRejected", mirrorBaseUrl));
@@ -344,21 +321,18 @@ async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Pr
     const zipFileName = `terraform_${version}_${osPlatform}_${arch}.zip`;
     const sha256SumsUrl = `${mirrorBaseUrl}/${version}/terraform_${version}_SHA256SUMS`;
     const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
-    try {
-        const expectedHash = await fetchExpectedSha256(sha256SumsUrl, zipFileName);
-        await verifySha256(zipPath, expectedHash);
-    } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const checksumUnavailable = errorMessage.includes('SHA256 checksum not found') || errorMessage.includes('Failed to fetch');
-        // A genuine hash mismatch is always fatal. An unavailable SHA256SUMS file is
-        // fatal only when the user requires checksum verification; otherwise warn.
-        if (checksumUnavailable && !requireChecksum) {
-            tasks.warning(`SHA256 verification skipped for mirror download: ${errorMessage}`);
-        } else if (checksumUnavailable) {
-            throw new Error(`Checksum verification is required but the mirror did not provide a usable SHA256SUMS file (${sha256SumsUrl}): ${errorMessage}`);
-        } else {
-            throw error;
+    // Only a genuine 404 (fetchTextAllow404 returns null) means "no SHA256SUMS
+    // published". Any other non-2xx / network / TLS failure is fatal regardless of
+    // requireChecksum, rather than being classified by matching an error string.
+    const sumsBody = await fetchTextAllow404(sha256SumsUrl);
+    if (sumsBody === null) {
+        if (requireChecksum) {
+            throw new Error(`Checksum verification is required but the mirror did not publish a SHA256SUMS file (${sha256SumsUrl}).`);
         }
+        tasks.warning(`SHA256 verification skipped for mirror download: no SHA256SUMS published at ${sha256SumsUrl}.`);
+    } else {
+        // The file exists: a missing asset entry or a hash mismatch is always fatal.
+        await verifySha256(zipPath, parseSha256(sumsBody, zipFileName));
     }
 
     return zipPath;
@@ -381,12 +355,6 @@ function parseSha256(sha256SumsContent: string, zipFileName: string): string {
         }
     }
     throw new Error(`SHA256 checksum not found for ${zipFileName}`);
-}
-
-async function fetchExpectedSha256(sha256SumsUrl: string, zipFileName: string): Promise<string> {
-    tasks.debug(`Fetching SHA256SUMS from ${sha256SumsUrl}`);
-    const body = await fetchText(sha256SumsUrl);
-    return parseSha256(body, zipFileName);
 }
 
 async function verifySha256(filePath: string, expectedHash: string): Promise<void> {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "229",
+        "Minor": "230",
         "Patch": "0"
     },
     "instanceNameFormat": "Install $(binary) $(terraformVersion)",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitShaCheckout.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitShaCheckout.ts
@@ -22,7 +22,6 @@ tr.registerMock('crypto', { randomUUID: () => FIXED_UUID });
 
 const sha = '0123456789abcdef0123456789abcdef01234567';
 const token = 'secrettoken';
-const header = `Authorization: Basic ${Buffer.from(`:${token}`).toString('base64')}`;
 const url = 'https://github.com/example/private';
 
 tr.setInput('engine', 'opa');
@@ -30,7 +29,7 @@ tr.setInput('inputFile', planFile);
 tr.setInput('policySource', 'gitUrl');
 tr.setInput('policyRepoUrl', url);
 // A full 40-char SHA takes the clone --no-checkout + checkout path; a token
-// exercises the http.extraheader auth branch.
+// exercises the credential-via-GIT_CONFIG-env auth branch (no token on argv).
 tr.setInput('policyRepoRef', sha);
 tr.setInput('policyRepoToken', token);
 tr.setInput('publishTestResults', 'false');
@@ -41,7 +40,7 @@ const a: ma.TaskLibAnswers = {
     which: { git: gitPath, opa: opaPath },
     checkPath: { [gitPath]: true, [opaPath]: true },
     exec: {
-        [`${gitPath} -c http.extraheader=${header} clone --no-checkout -- ${url} ${cloneDir}`]: {
+        [`${gitPath} clone --no-checkout -- ${url} ${cloneDir}`]: {
             code: 0, stdout: 'Cloning...'
         },
         [`${gitPath} -C ${cloneDir} checkout ${sha}`]: {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
@@ -69,12 +69,18 @@ async function cloneRepo(url: string, ref: string, token: string | undefined, cl
     const gitPath = tasks.which('git', true);
     const isSha = /^[0-9a-fA-F]{40}$/.test(ref);
 
-    const authArgs: string[] = [];
+    const authEnv: Record<string, string> = {};
     if (token) {
         tasks.setSecret(token);
-        const header = `Authorization: Basic ${Buffer.from(`:${token}`).toString('base64')}`;
-        tasks.setSecret(Buffer.from(`:${token}`).toString('base64'));
-        authArgs.push('-c', `http.extraheader=${header}`);
+        const basic = Buffer.from(`:${token}`).toString('base64');
+        tasks.setSecret(basic);
+        // Pass the credential to git via per-invocation config ENV VARS (git >= 2.31)
+        // instead of `-c http.extraheader=...` on argv, so the token never appears in
+        // the child process's command line (readable via ps / /proc/<pid>/cmdline by
+        // other processes on a shared agent).
+        authEnv['GIT_CONFIG_COUNT'] = '1';
+        authEnv['GIT_CONFIG_KEY_0'] = 'http.extraheader';
+        authEnv['GIT_CONFIG_VALUE_0'] = `Authorization: Basic ${basic}`;
     }
 
     if (isSha) {
@@ -82,9 +88,8 @@ async function cloneRepo(url: string, ref: string, token: string | undefined, cl
         // git option-parsing before the url/dir positionals; `ref` is a
         // validated 40-char SHA here, so the checkout positional is safe.
         const clone = tasks.tool(gitPath);
-        clone.arg(authArgs);
         clone.arg(['clone', '--no-checkout', '--', url, cloneDir]);
-        await execGit(clone);
+        await execGit(clone, authEnv);
 
         const checkout = tasks.tool(gitPath);
         checkout.arg(['-C', cloneDir, 'checkout', ref]);
@@ -93,9 +98,8 @@ async function cloneRepo(url: string, ref: string, token: string | undefined, cl
         // `--` stops option-parsing before url/dir; `ref` is the `--branch`
         // value and is constrained by SAFE_REF (no leading dash).
         const clone = tasks.tool(gitPath);
-        clone.arg(authArgs);
         clone.arg(['clone', '--depth', '1', '--branch', ref, '--', url, cloneDir]);
-        await execGit(clone);
+        await execGit(clone, authEnv);
     }
 }
 
@@ -103,13 +107,14 @@ async function cloneRepo(url: string, ref: string, token: string | undefined, cl
  * Runs a git ToolRunner with a hard wall-clock timeout and a fail-fast
  * environment (never prompt for credentials; abort a stalled HTTP transfer).
  */
-async function execGit(tool: ToolRunner): Promise<void> {
+async function execGit(tool: ToolRunner, extraEnv: Record<string, string> = {}): Promise<void> {
     const options = <IExecOptions>{
         env: {
             ...process.env,
             GIT_TERMINAL_PROMPT: '0',
             GIT_HTTP_LOW_SPEED_LIMIT: '1000',
-            GIT_HTTP_LOW_SPEED_TIME: '60'
+            GIT_HTTP_LOW_SPEED_TIME: '60',
+            ...extraEnv,
         }
     };
     let timer: NodeJS.Timeout | undefined;

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "5",
+        "Minor": "6",
         "Patch": "0"
     },
     "instanceNameFormat": "Policy check ($(engine))",

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -50,6 +50,18 @@ const FAMILIES = [
             'http-client.ts',
         ],
     },
+    {
+        // Registry download-host allowlist (SSRF-relevant): shared across all three
+        // installer tasks that accept a registryAllowedHosts input.
+        dirs: [
+            'Tasks/TerraformInstaller/TerraformInstallerV1/src',
+            'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src',
+            'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src',
+        ],
+        modules: [
+            'registry-allowlist.ts',
+        ],
+    },
 ];
 
 // These two families are deliberately NOT merged into one shared client, even


### PR DESCRIPTION
Remediates the **P2** findings from the 2026-07-06 blind security re-audit.

## Fixes
- fix(installers) **sc1**: replace the `Failed to fetch` substring classification with `fetchTextAllow404` in the terraform-mirror + OPA-official/mirror + Sentinel-mirror checksum paths, so only a genuine 404 skips verification (when `requireChecksum=false`) while any 5xx/network/TLS failure is fatal — Closes #390
- refactor(installers) **ar0**: extract `parseAllowedHosts`/`isRegistryHostAllowed` into a shared `registry-allowlist.ts` (byte-identical across all 3 installers) and add it to the `check-shared-modules` parity gate — Closes #391
- fix(publish-kb-article) **e2**: emit the manifest + `kbArticleId` outputs before the image-upload phase, so a failure there cannot orphan the article (a retry updates in place instead of creating a duplicate draft) — Closes #392
- fix(policy-check) **s0**: pass the policy-repo git credential via `GIT_CONFIG_COUNT/KEY_0/VALUE_0` env instead of `-c http.extraheader=...` on argv (keeps the token off the child-process command line) — Closes #393

## Mandatory security Minor bumps (CLAUDE.md)
TerraformInstaller 229→230 · PolicyAgentInstaller 5→6 · TerraformDocsInstaller 1→2 · TerraformPolicyCheck 5→6 · PublishKbArticle 1→2. A single `+1` vs v1.8.3 also covers the P0/P1 (#401) security work that shipped without bumps.

## Validation (local, Windows)
- Shared-module parity gate passes (registry-allowlist.ts identical ×3)
- TerraformInstaller 67 · PolicyAgentInstaller 56 · TerraformDocsInstaller 47 · TerraformPolicyCheck ✓ · PublishKbArticle 78 — all passing
- `eslint src/` clean on all affected tasks
- Test mocks updated for the `fetchTextAllow404` refactor and the `GIT_CONFIG` env change