### PR TITLE
fix: remediate P3 security audit residuals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ Tests are organized by command x provider: `InitTests/`, `PlanTests/`, `ApplyTes
 
 ## CI/CD
 
-- `.github/workflows/unit-test.yml` — **Active CI.** Runs on push/PR to `main` and on `workflow_call` (reused by release). Jobs: `Check Version Consistency`, `Build and Test V5`, `Build and Test Installer V1`, `Build and Test Provider Mirror V1`, `Build and Test Policy Agent Installer V1`, `Build and Test Policy Check V1`, `Build and Test terraform-docs Installer V1`, `Build and Test terraform-docs V1`, `Build and Test Tab`, `Lint GitHub Actions`.
+- `.github/workflows/unit-test.yml` — **Active CI.** Runs on push/PR to `main` and on `workflow_call` (reused by release). Jobs: `Check Version Consistency`, `Check Shared Module Parity`, `Build and Test V5`, `Build and Test Installer V1`, `Build and Test Provider Mirror V1`, `Build and Test Module Publish V1`, `Build and Test Policy Agent Installer V1`, `Build and Test Policy Check V1`, `Build and Test Drift Report V1`, `Build and Test terraform-docs Installer V1`, `Build and Test terraform-docs V1`, `Build and Test Markdown2Html V1`, `Build and Test Publish KB Article V1`, `Build and Test Tab`, `Lint GitHub Actions`.
 - `.github/workflows/release-please.yml` — **Release automation.** Runs on push to `main`; uses a GitHub App token to open/update the Release PR (version bump + changelog).
 - `.github/workflows/release.yml` — **Release pipeline.** Triggered by semver tags (`v*.*.*`) or manual dispatch. Verifies tag is on `main`, runs full CI via `workflow_call`, builds release bundle, packages `.vsix`, generates CycloneDX SBOMs, signs with cosign (keyless), creates draft GitHub Release, publishes to VS Marketplace (requires `marketplace` environment approval), then undrafts the release.
 - `.github/workflows/codeql.yml` — **Code scanning.** CodeQL static analysis for TypeScript (GitHub Advanced Security).
@@ -380,7 +380,7 @@ CI and local development both target Node 24 LTS (Active LTS, EOL April 2028). N
 
 **`main` branch:**
 
-- Required status checks (strict — branch must be up-to-date): the complete `unit-test.yml` matrix (23 contexts) — `Check Version Consistency`, `Check Shared Module Parity`, every `Build and Test *` job on both `ubuntu-latest` and `windows-2025` (V5, Installer V1, Provider Mirror V1, Module Publish V1, Policy Agent Installer V1, Policy Check V1, Drift Report V1, terraform-docs Installer V1, terraform-docs V1), `Build and Test Tab`, `Lint GitHub Actions`, and `Scan Workflows (zizmor)`. Pinned to the GitHub Actions app (`app_id` 15368). Add both matrix legs of any new task's job here when introducing a task.
+- Required status checks (strict — branch must be up-to-date): the complete `unit-test.yml` matrix (27 contexts) — `Check Version Consistency`, `Check Shared Module Parity`, every `Build and Test *` job on both `ubuntu-latest` and `windows-2025` (V5, Installer V1, Provider Mirror V1, Module Publish V1, Policy Agent Installer V1, Policy Check V1, Drift Report V1, terraform-docs Installer V1, terraform-docs V1, Markdown2Html V1, Publish KB Article V1), `Build and Test Tab`, `Lint GitHub Actions`, and `Scan Workflows (zizmor)`. Pinned to the GitHub Actions app (`app_id` 15368). Add both matrix legs of any new task's job here when introducing a task.
 - Required pull request reviews: 1 approving review, dismiss stale reviews, require code owner review
 - Enforce admins: no (admin/owner can bypass review requirements as sole maintainer)
 - Required linear history: yes (squash/rebase only, no merge commits)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,54 @@ npm run compile
 npm test
 ```
 
+### PolicyAgentInstallerV1
+
+```bash
+cd Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1
+npm run compile
+npm test
+```
+
+### TerraformPolicyCheckV1
+
+```bash
+cd Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1
+npm run compile
+npm test
+```
+
+### TerraformDriftReportV1
+
+```bash
+cd Tasks/TerraformDriftReport/TerraformDriftReportV1
+npm run compile
+npm test
+```
+
+### TerraformModulePublishV1
+
+```bash
+cd Tasks/TerraformModulePublish/TerraformModulePublishV1
+npm run compile
+npm test
+```
+
+### Markdown2HtmlV1
+
+```bash
+cd Tasks/Markdown2Html/Markdown2HtmlV1
+npm run compile
+npm test
+```
+
+### PublishKbArticleV1
+
+```bash
+cd Tasks/PublishKbArticle/PublishKbArticleV1
+npm run compile
+npm test
+```
+
 ### Test structure
 
 Test files come in pairs under `Tests/`:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,14 @@ The `publish-marketplace` job in `release.yml` mints a Microsoft Entra access to
 
 If a future `tfx-cli` release adds a non-argv token option, this job should switch to it.
 
+## Supply-chain residual risk: same-origin checksum trust for OPA and terraform-docs
+
+The terraform (TerraformInstaller) and Sentinel (PolicyAgentInstaller) download paths verify a GPG-signed `SHA256SUMS` manifest against HashiCorp's pinned public key, and the OpenTofu path uses cosign keyless verification with an anchored certificate identity. **OPA and terraform-docs, however, publish no detached GPG/cosign signature** — only a per-release `.sha256`/`.sha256sum` file served from the same GitHub release as the binary. The installers verify that checksum (fail-closed by default via `requireChecksum`), which guarantees transport integrity but **not authenticity against a poisoned release**: an attacker who compromised the upstream release (or the account/CI publishing it) would control both the binary and its checksum. This is an accepted residual driven by upstream tooling, not a defect in this extension; it will be revisited if OPA/terraform-docs publish signed checksums or GitHub-native build-provenance attestations a CI verifier can anchor to.
+
+## Optional-feature residual risk: `runAzLogin` passes credentials on argv
+
+The TerraformTask `runAzLogin` helper (opt-in, **default false**) invokes `az login` with the WIF federated token or service-principal secret on the command line, which is visible via `ps` / `/proc/<pid>/cmdline` to other processes on a shared agent — the Azure CLI offers no non-argv way to supply these. The primary provider-auth path never touches argv (credentials flow via environment variables). Scope `runAzLogin` to single-tenant / non-shared agents; leave it disabled otherwise.
+
 ## Preferred Languages
 
 English preferred.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,28 @@
 # Third-Party Notices
 
-This project incorporates or is inspired by the following open-source projects:
+This project bundles the third-party npm packages listed below into the published task
+handlers (via webpack), and is additionally inspired by the projects credited further down.
+
+## Bundled runtime dependencies
+
+These packages are compiled into one or more shipped task bundles. Each is distributed under
+a permissive OSI license; full license texts ship in each package's distribution and are
+available at the linked repositories.
+
+| Package      | Bundled into                                                          | License           |
+| ------------ | --------------------------------------------------------------------- | ----------------- |
+| markdown-it  | Markdown2Html                                                         | MIT               |
+| highlight.js | Markdown2Html                                                         | BSD-3-Clause      |
+| js-yaml      | Markdown2Html (front matter)                                          | MIT               |
+| cheerio      | Markdown2Html, PublishKbArticle (HTML sanitize/validate)              | MIT               |
+| openpgp      | TerraformInstaller, PolicyAgentInstaller (GPG signature verification) | LGPL-3.0-or-later |
+
+> Maintained manually: when adding or removing a bundled runtime dependency, update this
+> table. (A generated SPDX/license report is a tracked future improvement.)
+
+---
+
+This project is also inspired by the following open-source projects:
 
 ---
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -2,6 +2,7 @@ import tasks = require('azure-pipelines-task-lib/task');
 import path = require('path');
 import fs = require('fs');
 import os = require('os');
+import { randomUUID } from 'crypto';
 import { summarize, moduleCallsPlan, Plan } from 'terraform-drift-contract';
 import { postJson, truncateBody, resolveRejectUnauthorized } from './callback';
 import { writeSarif } from './sarif';
@@ -52,8 +53,14 @@ async function run(): Promise<void> {
             body.module_locks = readModuleLocks(manifest);
         }
 
-        const summaryFile = path.join(os.tmpdir(), 'tsm-drift-report.json');
-        fs.writeFileSync(summaryFile, JSON.stringify(body, null, 2), 'utf8');
+        // The summary can include plan resource values (sensitive), so write it to
+        // the agent's private temp dir with a unique name and owner-only (0600)
+        // permissions, using O_EXCL to defeat a pre-existing-symlink hazard, rather
+        // than a fixed, world-readable path in the shared OS temp directory.
+        const tempDir = tasks.getVariable('Agent.TempDirectory') || os.tmpdir();
+        const summaryFile = path.join(tempDir, `tsm-drift-report-${randomUUID()}.json`);
+        fs.writeFileSync(summaryFile, JSON.stringify(body, null, 2), { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+        try { fs.chmodSync(summaryFile, 0o600); } catch { /* platforms without POSIX perms */ }
 
         tasks.setVariable('driftDetected', String(result.drifted), false, true);
         tasks.setVariable('addedCount', String(result.added), false, true);

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "5",
+    "Minor": "6",
     "Patch": "0"
   },
   "instanceNameFormat": "Drift report",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
@@ -124,8 +124,14 @@ async function execGit(tool: ToolRunner, extraEnv: Record<string, string> = {}):
             reject(new Error(tasks.loc('PolicyRepoCloneTimedOut', GIT_TIMEOUT_MS)));
         }, GIT_TIMEOUT_MS);
     });
+    // If the deadline wins the race, killChildProcess() makes this promise reject
+    // later; attach a no-op catch so that late rejection is swallowed intentionally
+    // rather than surfacing as an unhandled promise rejection (this task has no
+    // process-level unhandledRejection handler).
+    const exec = tool.execAsync(options);
+    exec.catch(() => { /* swallowed: the timeout is reported via the deadline branch */ });
     try {
-        await Promise.race([tool.execAsync(options), deadline]);
+        await Promise.race([exec, deadline]);
     } finally {
         if (timer) {
             clearTimeout(timer);

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
@@ -51,7 +51,7 @@ export async function runSentinel(
     const code = await tool.execAsync(<IExecOptions>{ cwd: workingDir, ignoreReturnCode: true });
 
     if (code === 3 || code === 9) {
-        throw new Error(`Sentinel returned a non-policy error (exit code ${code}). Output:\n${stdout}`);
+        throw new Error(`Sentinel returned a non-policy error (exit code ${code}). Output:\n${stdout.slice(0, 2000)}`);
     }
 
     const policyFailed = code === 1 || code === 2;
@@ -81,7 +81,7 @@ function applyEnforcement(
     const failedNames = cases.filter(c => !c.passed).map(c => c.name);
     const violations = failedNames.length > 0
         ? failedNames.map(n => `Policy failed: ${n}`)
-        : (policyFailed ? [`Sentinel policy evaluation failed.\n${stdout}`.trim()] : []);
+        : (policyFailed ? [`Sentinel policy evaluation failed.\n${stdout.slice(0, 2000)}`.trim()] : []);
 
     if (!policyFailed) return { passed: true, violations: [] };
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -75,6 +75,19 @@ npm run package:release   # or package:self for a private test extension
 - [ ] `PipelineTerraformDocs@1` with `formatter: markdown-table`, `outputFile: README.md` — writes documentation and sets `generatedFilePath`
 - [ ] `PipelineTerraformDocs@1` with `outputCheck: true` against stale docs — fails the task
 
+## 4i. Markdown2Html smoke test
+
+- [ ] `PipelineMarkdown2Html@1` on a sample `.md` — writes HTML and sets `htmlFilePath`
+- [ ] Front matter (`title`, `includes`) is honored; an `includes:` entry outside the base directory is rejected
+- [ ] A raw `<script>`, an `onerror=` handler, and a `javascript:`/non-image `data:` URI in the source are stripped by the sanitizer (inspect the generated HTML)
+
+## 4j. PublishKbArticle smoke test
+
+- [ ] `PipelinePublishKbArticle@1` with `dryRun: true` — reports the planned create/update without calling ServiceNow
+- [ ] Create then update against a test ServiceNow instance — `kbArticleId`/`kbArticleNumber`/`kbWorkflowState` outputs are set
+- [ ] HTML that fails validation (inline `<script>`, `on*` handler, `javascript:`/`data:` URI) is rejected unless `force: true`
+- [ ] Image upload rewrites `<img src>` to ServiceNow attachments; a missing image fails unless `force: true`; a crafted `instance` value (not `^[a-z0-9-]+$`) is rejected
+
 ## 5. Core commands smoke test (AzureRM)
 
 Use a minimal Terraform configuration with an AzureRM backend and provider.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -265,7 +265,8 @@ in your policies, or supply your own `sentinelConfigPath` with matching mock dat
 ### Private policy repo clone fails (gitUrl source)
 
 - The URL must be HTTPS. Provide `policyRepoToken` (a pipeline secret variable)
-  for private repos; it is injected via `http.extraheader` and masked in logs.
+  for private repos; it is injected via a per-invocation `GIT_CONFIG` environment
+  variable (never on the command line) and masked in logs.
 - When pinning a commit, use the full 40-character SHA — short SHAs are treated
   as branch/tag names and shallow-cloned.
 
@@ -323,3 +324,47 @@ ignores directories without Terraform configuration).
 
 **Fix:** Point `modulePath` at the module directory containing the `.tf` files,
 or enable `recursive` to walk submodules under `recursivePath`.
+
+## Documentation publishing (Markdown2Html / PublishKbArticle)
+
+### Markdown2Html: content is stripped from the generated HTML
+
+**Cause:** The converter sanitizes the rendered HTML — inline `<script>`, `on*=`
+event-handler attributes, and `javascript:`/`vbscript:`/non-image `data:` URIs are
+removed as stored-XSS vectors before the HTML reaches the KB pipeline.
+
+**Fix:** This is by design. Only static formatting HTML (tables, `<br>`, code blocks,
+images) survives sanitization; move any dynamic behavior out of the document.
+
+### Markdown2Html: "include path is outside the base directory"
+
+**Cause:** A front-matter `includes:` entry (or an `<img src>`) resolves outside the
+primary document's directory / `imageBaseDir`. Path traversal is blocked by design.
+
+**Fix:** Keep includes and images within the document's directory (or the configured
+base dir) and use relative paths that stay inside it.
+
+### PublishKbArticle: OAuth token acquisition fails / 401
+
+**Cause:** Wrong `instance`, or invalid OAuth client credentials / Basic auth.
+
+**Fix:** `instance` must match `^[a-z0-9-]+$` — the subdomain only (e.g. `acme` for
+`acme.service-now.com`), not a full URL. Supply `clientId`/`clientSecret` for OAuth or
+`username`/`password` for Basic; the secret and the resulting token are masked in logs.
+
+### PublishKbArticle: HTML rejected before publish
+
+**Cause:** `html-validate` fail-closes on inline `<script>`, `on*` handlers, and
+`javascript:`/`vbscript:`/non-image `data:` URIs.
+
+**Fix:** Clean the source (preferred). `force: true` downgrades the rejection to a
+warning — use only for trusted content.
+
+### PublishKbArticle: a duplicate draft article appears on re-run
+
+**Cause:** An earlier run failed during the image-upload phase. (Current versions
+persist the article's `sys_id` before uploading images, so this no longer happens.)
+
+**Fix:** Update to the latest `PipelinePublishKbArticle@1`, and provide a stable
+`sourceKey` (front-matter `wiki-source`) so re-runs update the same article instead of
+creating a new one.

--- a/docs/yaml-examples.md
+++ b/docs/yaml-examples.md
@@ -929,6 +929,13 @@ resources and exposes its path via the `sarifFilePath` output variable. When
 the path is exposed via `sarifFilePath`. Publish it as a build artifact to
 surface drift in SARIF-aware tooling.
 
+> **SARIF has no native Azure DevOps viewer.** `PipelineTerraformPolicyCheck@1` exposes the
+> same `sarifOutput`/`sarifPath` inputs and `sarifFilePath` output as the drift task. For
+> either task the SARIF is only actionable once published (e.g. as the `CodeAnalysisLogs`
+> artifact shown above) and read by a SARIF-aware Marketplace extension or an external sink
+> (GitHub code scanning, a SIEM). The JUnit results the policy-check task also emits render
+> natively in the **Tests** tab, so JUnit is the zero-setup path.
+
 Module provenance: `includeModuleProvenance` (default `true`) adds the
 configuration's `module_calls` and locked module versions — read from
 `moduleManifest` (default `.terraform/modules/modules.json`) — to the report and

--- a/overview.md
+++ b/overview.md
@@ -32,6 +32,8 @@ Runs on **Windows**, **Linux**, and **macOS** agents.
 - **Detailed exit code** on plan with `changesPresent` output variable for conditional apply
 - **Optional service connection for `test`**: run unit tests without provider auth, or provide a service connection for integration tests that provision real resources
 
+> **Download verification trust model:** Terraform and Sentinel downloads are verified against a GPG-signed `SHA256SUMS` (HashiCorp's pinned key); OpenTofu uses cosign keyless verification. OPA and terraform-docs publish no signature, so they are verified by their GitHub-release SHA256 checksum (same-origin — transport integrity, not independent authenticity), enforced fail-closed by default. See [SECURITY.md](SECURITY.md).
+
 ## Quick Start
 
 ### Install Terraform


### PR DESCRIPTION
Remediates the **P3** residual-cluster findings from the 2026-07-06 blind security re-audit.

## Code hardening
- **e3**: swallow the late git-timeout rejection in TerraformPolicyCheck (no unhandled rejection) — #395
- **e4**: bound Sentinel stdout embedded in error/violation messages — #395
- **s1**: write the drift summary to `Agent.TempDirectory` with a unique name, `0600` perms, and `O_EXCL` — #398

## Documentation & transparency
- **d0/d2/d3/d4/d5/d6**: CLAUDE CI + branch-protection lists, troubleshooting + release-checklist sections for the newer tasks, THIRD_PARTY_NOTICES bundled-dependency table, CONTRIBUTING testing section — #399
- **SECURITY.md**: OPA/terraform-docs same-origin checksum residual (sc2, #394) + `runAzLogin` argv residual (a1, #398)
- **ec1/ec3**: download-verification trust model in overview.md; SARIF-needs-a-viewer note in yaml-examples — #400
- Corrected the stale `http.extraheader` troubleshooting note after the P2 `GIT_CONFIG` change

## Mandatory security bump
TerraformDriftReport 5 -> 6 (s1 touched its code).

## Validation (local, Windows)
TerraformPolicyCheck 24 passing - TerraformDriftReport 17 passing - shared-module parity - eslint clean.

## Accepted / deferred (documented, not code-changed)
- **sc3** (registry download via `downloadTool`): accepted - mitigated by opt-in `registryAllowedHosts`; signed paths still hash-checked.
- **c1** (`tfx --token` argv), **a1** (`az login` argv), **c3** (marketplace environment protection): documented residuals / repo-settings verification.
- **Deferred, remain open:** **c2** (#396 - `npm audit --audit-level=moderate` would fail CI on the current `uuid` advisory), **t2** (#400 - raising the plan-tab coverage gate needs new tab tests first), **ar1/ar2** (#397 - servicenow-http is a single non-duplicated file; `run()` decomposition is a no-behavior refactor).

Closes #394, Closes #395, Closes #398, Closes #399