### PR TITLE
fix: guard terraform-docs configFile against empty-filePath-to-cwd

### DIFF
--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ArgsBuilderL0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ArgsBuilderL0.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
-import { resolveFormatter, buildTerraformDocsArgs, TerraformDocsConfig } from '../src/args-builder';
+import { resolveFormatter, buildTerraformDocsArgs, sanitizeConfigFile, StatLike, StatSyncFn, TerraformDocsConfig } from '../src/args-builder';
 
 // Direct (parent-process) unit tests for the pure argument-building logic. These
 // cover every formatter mapping and flag branch that the MockTestRunner integration
@@ -113,5 +113,75 @@ describe('args-builder: buildTerraformDocsArgs', () => {
       }),
       ['asciidoc', 'document', '--config', 'cfg.yml', '--output-file', 'README.adoc', '--output-mode', 'replace', '--output-check', '--sort-by', 'type', '--recursive', '--recursive-path', 'submodules', './modules/vpc']
     );
+  });
+});
+
+describe('args-builder: sanitizeConfigFile', () => {
+  const asFile: StatLike = { isFile: () => true, isDirectory: () => false };
+  const asDir: StatLike = { isFile: () => false, isDirectory: () => true };
+  const asOther: StatLike = { isFile: () => false, isDirectory: () => false };
+
+  /** A statSync stub that always reports the given kind. */
+  const statAs = (s: StatLike): StatSyncFn => () => s;
+  /** A statSync stub that fails as if the path does not exist. */
+  const statMissing: StatSyncFn = () => {
+    const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    throw err;
+  };
+
+  it('returns undefined for undefined', () => {
+    assert.strictEqual(sanitizeConfigFile(undefined, statAs(asFile)), undefined);
+  });
+
+  it('returns undefined for null', () => {
+    assert.strictEqual(sanitizeConfigFile(null, statAs(asFile)), undefined);
+  });
+
+  it('returns undefined for an empty string (never calls statSync)', () => {
+    let called = false;
+    const spy: StatSyncFn = () => { called = true; return asFile; };
+    assert.strictEqual(sanitizeConfigFile('', spy), undefined);
+    assert.strictEqual(called, false, 'statSync must not be called for an empty input');
+  });
+
+  it('returns undefined for a whitespace-only string', () => {
+    assert.strictEqual(sanitizeConfigFile('   \t  ', statAs(asFile)), undefined);
+  });
+
+  // The core regression: Azure Pipelines resolves an unset optional filePath
+  // input to the working directory, so an omitted configFile arrives as a
+  // directory. It must NOT be forwarded as `--config <dir>`.
+  it('returns undefined when the path resolves to an existing directory', () => {
+    assert.strictEqual(sanitizeConfigFile('/agent/_work/1/s', statAs(asDir)), undefined);
+  });
+
+  it('returns the path when it is an existing regular file', () => {
+    assert.strictEqual(sanitizeConfigFile('.terraform-docs.yml', statAs(asFile)), '.terraform-docs.yml');
+  });
+
+  it('trims surrounding whitespace on a valid file path', () => {
+    assert.strictEqual(sanitizeConfigFile('  cfg.yml  ', statAs(asFile)), 'cfg.yml');
+  });
+
+  it('throws a clear error when a genuinely-supplied path does not exist', () => {
+    assert.throws(
+      () => sanitizeConfigFile('./missing.yml', statMissing),
+      /terraform-docs config file not found: \.\/missing\.yml/
+    );
+  });
+
+  it('throws when the path exists but is not a regular file (e.g. a socket/device)', () => {
+    assert.throws(
+      () => sanitizeConfigFile('/dev/null', statAs(asOther)),
+      /terraform-docs config file is not a regular file: \/dev\/null/
+    );
+  });
+
+  it('produces no --config arg end-to-end when configFile is the working-directory artifact', () => {
+    const configFile = sanitizeConfigFile('/agent/_work/1/s', statAs(asDir));
+    const args = buildTerraformDocsArgs({ formatter: 'markdown-table', modulePath: '/agent/_work/1/s', configFile });
+    assert.ok(!args.includes('--config'), 'no --config should be emitted for the directory artifact');
+    assert.deepStrictEqual(args, ['markdown', 'table', '/agent/_work/1/s']);
   });
 });

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileDirectoryIgnored.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileDirectoryIgnored.ts
@@ -1,0 +1,30 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// The agent resolves an unset optional `filePath` input to the working
+// directory, so `configFile` can arrive as an existing directory. It must be
+// dropped (no `--config`) rather than forwarded to terraform-docs. Point it at
+// a real directory (the task root) and assert no `--config` is emitted.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const existingDirectory = path.join(__dirname, '..');
+
+tr.setInput('formatter', 'markdown-table');
+tr.setInput('modulePath', '.');
+tr.setInput('configFile', existingDirectory);
+
+const a: ma.TaskLibAnswers = {
+  which: { 'terraform-docs': 'terraform-docs' },
+  checkPath: { 'terraform-docs': true },
+  exec: {
+    'terraform-docs markdown table .': {
+      code: 0,
+      stdout: 'generated'
+    }
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileNotFoundFail.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileNotFoundFail.ts
@@ -1,0 +1,23 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// A genuinely-supplied but non-existent config file must fail closed with a
+// clear error, rather than being silently dropped or passed through unvalidated.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const missingFile = path.join(__dirname, '..', 'this-config-does-not-exist.yml');
+
+tr.setInput('formatter', 'markdown-table');
+tr.setInput('modulePath', '.');
+tr.setInput('configFile', missingFile);
+
+const a: ma.TaskLibAnswers = {
+  which: { 'terraform-docs': 'terraform-docs' },
+  checkPath: { 'terraform-docs': true },
+  exec: {}
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileProvidedSuccess.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileProvidedSuccess.ts
@@ -1,0 +1,29 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// A genuinely-provided config file (an existing regular file) must be forwarded
+// as `--config <file>`. Use the task's own task.json as a guaranteed-present
+// regular file.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const existingFile = path.join(__dirname, '..', 'task.json');
+
+tr.setInput('formatter', 'markdown-table');
+tr.setInput('modulePath', '.');
+tr.setInput('configFile', existingFile);
+
+const a: ma.TaskLibAnswers = {
+  which: { 'terraform-docs': 'terraform-docs' },
+  checkPath: { 'terraform-docs': true },
+  exec: {
+    [`terraform-docs markdown table --config ${existingFile} .`]: {
+      code: 0,
+      stdout: 'generated'
+    }
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/L0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/L0.ts
@@ -68,7 +68,14 @@ describe('TerraformDocs Test Suite', function () {
   expectSuccess('ConsoleOutputSuccess');
   expectSuccess('AdditionalArgsSuccess');
 
+  // Exercises the real fs.statSync wiring in index.ts (the pure unit tests inject
+  // a fake stat): an existing config file is forwarded, and the working-directory
+  // artifact from an unset optional filePath input is dropped.
+  expectSuccess('ConfigFileProvidedSuccess');
+  expectSuccess('ConfigFileDirectoryIgnored');
+
   // --- Failure cases ---
   expectFailure('OutputCheckFail');
   expectFailure('UnsupportedFormatterFail');
+  expectFailure('ConfigFileNotFoundFail');
 });

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
@@ -46,6 +46,70 @@ export function resolveFormatter(formatter: string): string[] {
   return [...subcommand];
 }
 
+/** Minimal `fs.Stats` surface used to classify a candidate config-file path. */
+export interface StatLike {
+  isFile(): boolean;
+  isDirectory(): boolean;
+}
+
+/** The `fs.statSync`-shaped dependency `sanitizeConfigFile` needs (injected for testability). */
+export type StatSyncFn = (p: string) => StatLike;
+
+/**
+ * Validates and sanitizes the optional terraform-docs `--config` path.
+ *
+ * Azure Pipelines resolves an *unset* optional `filePath` input to the agent
+ * working directory (`path.resolve(workingDir, '') === workingDir`), so a caller
+ * that omits `configFile` still receives a non-empty value pointing at a
+ * directory. Forwarding that verbatim as `terraform-docs --config <dir>` fails
+ * with `Unsupported Config Type ""`. This guard fails closed on anything that is
+ * not a genuine, existing regular file:
+ *
+ *  - `undefined` / empty / whitespace-only  -> `undefined` (emit no `--config`).
+ *  - an existing **directory**               -> `undefined` (the empty-input
+ *    artifact above; a directory is never a valid terraform-docs config).
+ *  - an existing **regular file**            -> the trimmed path (a real config).
+ *  - anything else — a non-existent path, a device/socket/FIFO, or a path that
+ *    cannot be stat'd (e.g. contains a NUL byte) -> throws, so genuinely bad
+ *    input is surfaced clearly instead of being silently dropped or passed
+ *    through unvalidated.
+ *
+ * The returned value is only ever used as a single, separate `ToolRunner.arg()`
+ * token (never concatenated into a shell command line), so there is no
+ * argument/command-injection surface to escape here — the responsibility of this
+ * function is strictly to reject non-file inputs.
+ */
+export function sanitizeConfigFile(raw: string | undefined | null, statSync: StatSyncFn): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  let stat: StatLike;
+  try {
+    stat = statSync(trimmed);
+  } catch {
+    // Non-existent / unstat-able path. The agent's empty-filePath -> working
+    // directory resolution always yields an existing directory, so a path that
+    // cannot be stat'd can only be a genuinely user-supplied (mistyped) value.
+    throw new Error(`terraform-docs config file not found: ${trimmed}`);
+  }
+
+  if (stat.isDirectory()) {
+    return undefined;
+  }
+
+  if (!stat.isFile()) {
+    throw new Error(`terraform-docs config file is not a regular file: ${trimmed}`);
+  }
+
+  return trimmed;
+}
+
 /**
  * Builds the ordered terraform-docs argument list (excluding the binary itself and
  * any free-form additional arguments) for the given configuration. The module path

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
@@ -1,7 +1,8 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
+import fs = require('fs');
 import path = require('path');
-import { buildTerraformDocsArgs, TerraformDocsConfig } from './args-builder';
+import { buildTerraformDocsArgs, sanitizeConfigFile, TerraformDocsConfig } from './args-builder';
 
 async function run() {
   tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
@@ -10,7 +11,10 @@ async function run() {
     const config: TerraformDocsConfig = {
       formatter: tasks.getInput('formatter', true)!,
       modulePath: tasks.getPathInput('modulePath', false, false) || '.',
-      configFile: tasks.getPathInput('configFile', false, false),
+      // Azure Pipelines resolves an unset optional `filePath` input to the agent
+      // working directory, so `configFile` must be validated (not trusted) before
+      // it is forwarded as `--config`; a resolved directory means "not provided".
+      configFile: sanitizeConfigFile(tasks.getPathInput('configFile', false, false), (p) => fs.statSync(p)),
       outputFile: tasks.getInput('outputFile', false),
       outputMode: tasks.getInput('outputMode', false),
       outputCheck: tasks.getBoolInput('outputCheck', false),

--- a/Tasks/TerraformDocs/TerraformDocsV1/task.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "1",
+    "Minor": "2",
     "Patch": "0"
   },
   "instanceNameFormat": "terraform-docs $(formatter)",


### PR DESCRIPTION
## Problem

Every module build using the shared `PipelineTerraformDocs@1` "Update README.md" step fails with:

```
terraform-docs markdown table --config /agent/_work/1/s --output-file README.md --output-mode inject /agent/_work/1/s
Error: Unsupported Config Type ""
```

even though the caller never sets `configFile`.

## Root cause (task bug, not usage)

`configFile` is declared `type: filePath` with `defaultValue: ""`. Azure Pipelines resolves every `filePath` input against the working directory, and `path.resolve(workingDir, "")` **is** the working directory. So an unset/optional `configFile` is materialized by the agent as `INPUT_CONFIGFILE=/agent/_work/1/s` — never actually empty at runtime. The task then forwarded that verbatim as `--config <dir>`, and terraform-docs cannot load a directory as a config file. The consumer cannot avoid this (omitting the input still triggers it via the empty default); the only escape was `skipReadmeGeneration`.

## Fix

New pure, dependency-injected `sanitizeConfigFile(raw, statSync)` in `args-builder.ts`, consumed by `index.ts` with the real `fs.statSync`. It **fails closed**:

- empty / whitespace / `undefined` / `null` -> no `--config`
- existing **directory** -> dropped (the empty-input->cwd artifact; never a valid config)
- existing **regular file** -> forwarded
- non-existent path, or non-regular file (socket/device/FIFO, NUL-byte path, ...) -> throws a clear error rather than silently dropping or passing unvalidated input

### Security notes (input sanitization)

- The value is only ever emitted as a single, separate `ToolRunner.arg()` token — never concatenated into a shell command line — so there is no argument/command-injection surface to escape; the guard's sole responsibility is rejecting non-file inputs.
- Validation is **fail-closed**: genuinely-bad input (a mistyped path) errors clearly instead of being swallowed.
- Not confined to the repo root by design: `configFile` comes from the trusted pipeline-authoring surface, and a shared config outside the module dir is a legitimate use — path-confinement would break legit use without mitigating the actual threat model.

## Tests (TDD)

Wrote the tests first and confirmed **red** (reverted the guard to a pass-through -> 7 of the new unit tests failed, including the directory bug case), then **green** with the implementation.

- **10** pure unit tests for `sanitizeConfigFile` (injected `statSync`) covering every branch.
- **3** integration mock-runner scenarios exercising the real `fs.statSync` wiring in `index.ts`: `ConfigFileProvidedSuccess`, `ConfigFileDirectoryIgnored`, `ConfigFileNotFoundFail`.
- Full task suite: **32 passing**, lint clean.

## Versioning

Bumps `PipelineTerraformDocs` task **Minor 1.1 -> 1.2** so ADO agents re-fetch the updated task code (they cache by `Major.Minor`).
