### PR TITLE
fix: remediate P2 re-audit findings (bool-input parity, resilience residuals, mirror tests, release-safety)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,13 @@ jobs:
             echo "::error::Tag version (${TAG_VERSION}) does not match azure-devops-extension.json version (${EXT_VERSION}). Merge the release-please PR before tagging."
             exit 1
           fi
+      - name: Verify per-task Minor bumps
+        run: |
+          # Fail the release if any task's src/ changed since the previous release tag
+          # without its task.json Minor being bumped: ADO agents cache tasks by
+          # Major.Minor, so an un-bumped fix would ship to the Marketplace but never
+          # reach running agents.
+          node scripts/check-minor-bumps.js
 
   ci:
     name: CI (build + test)

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -90,6 +90,7 @@ describe('PolicyAgentInstaller Test Suite', function () {
     // --- Failure cases ---
     expectFailure('InsecureUrlReject');
     expectFailure('Sha256Fail');
+    expectFailure('MirrorSentinel5xxFail');
     expectFailure('InvalidVersionFail');
     expectFailure('OpaRegistryInsecureUrl');
     expectFailure('OpaRegistryEmptySha256RequireChecksum');

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinel5xxFail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinel5xxFail.ts
@@ -1,0 +1,51 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'sentinel');
+tr.setInput('version', '0.40.0');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://mirror.example.com');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+// A NON-404 mirror SHA256SUMS fetch failure (e.g. a 5xx after http-client retries)
+// must be FATAL, not treated as "checksum absent". fetchTextAllow404 returns null
+// ONLY for a genuine 404; here it throws, so the Sentinel install must fail closed.
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('Mirror path should not call fetchJson: ' + url); },
+  fetchTextAllow404: async () => {
+    throw new Error('HTTP 503 fetching SHA256SUMS (server error, exhausted retries)');
+  }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('fs', {
+  chmodSync: () => { },
+  readFileSync: () => Buffer.from('fake-zip')
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => 'deadbeef' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => '/tmp/sentinel.zip',
+  extractZip: async () => '/tmp/sentinel-extracted',
+  cacheDir: async () => '/tmp/sentinel-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/sentinel-cached': ['/tmp/sentinel-cached/sentinel'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/bool-input.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/bool-input.ts
@@ -1,0 +1,19 @@
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay byte-identical,
+// so a change to the fail-closed default semantics can never be applied to one
+// installer and silently missed in the others. This duplication is deliberate
+// (each task bundles independently) — not drift to be flagged.
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
+ * raw input rather than getBoolInput(name, false) so the default still holds on an
+ * agent that does not materialize task.json defaultValues into the input env var
+ * (where getBoolInput would silently return false): unset/empty -> true; any value
+ * other than "false" (case-insensitive) -> true.
+ */
+export function getBoolInputDefaultTrue(name: string): boolean {
+  const raw = tasks.getInput(name, false);
+  return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
+}

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -8,6 +8,7 @@ import crypto = require('crypto');
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchText, fetchTextAllow404 } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
+import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 
 const isWindows = os.type().match(/^Win/);
@@ -150,17 +151,6 @@ async function downloadArtifact(agent: string, downloadSource: string, version: 
             return filePath;
         }
     }
-}
-
-/**
- * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
- * raw input rather than getBoolInput(name, false) so the default still holds on an
- * agent that does not materialize task.json defaultValues into the input env var
- * (where getBoolInput would silently return false). Mirrors TerraformInstaller's helper.
- */
-function getBoolInputDefaultTrue(name: string): boolean {
-    const raw = tasks.getInput(name, false);
-    return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
 }
 
 async function downloadSentinelOfficial(version: string): Promise<string> {

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
@@ -6,7 +6,18 @@ export function appendToManifest(manifestPath: string, entry: Record<string, unk
     if (fs.existsSync(manifestPath)) {
         try {
             entries = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-        } catch {
+        } catch (e: unknown) {
+            // The manifest exists but is unreadable/corrupt. Do NOT silently reset it
+            // to [] -- that would overwrite and permanently discard every prior article
+            // mapping. Preserve the original as a timestamped .bak and warn loudly so
+            // the prior entries can be recovered.
+            const backup = `${manifestPath}.corrupt-${Date.now()}.bak`;
+            try {
+                fs.renameSync(manifestPath, backup);
+                console.warn(`Warning: kb-manifest '${manifestPath}' exists but could not be parsed (${e}); preserved the unreadable file as '${backup}' and starting a fresh manifest.`);
+            } catch {
+                console.warn(`Warning: kb-manifest '${manifestPath}' exists but could not be parsed (${e}) and could not be backed up; a fresh manifest will overwrite it.`);
+            }
             entries = [];
         }
     }

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "2",
+        "Minor": "3",
         "Patch": "0"
     },
     "minimumAgentVersion": "3.232.1",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/bool-input.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/bool-input.ts
@@ -1,0 +1,19 @@
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay byte-identical,
+// so a change to the fail-closed default semantics can never be applied to one
+// installer and silently missed in the others. This duplication is deliberate
+// (each task bundles independently) — not drift to be flagged.
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
+ * raw input rather than getBoolInput(name, false) so the default still holds on an
+ * agent that does not materialize task.json defaultValues into the input env var
+ * (where getBoolInput would silently return false): unset/empty -> true; any value
+ * other than "false" (case-insensitive) -> true.
+ */
+export function getBoolInputDefaultTrue(name: string): boolean {
+  const raw = tasks.getInput(name, false);
+  return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
+}

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -8,20 +8,10 @@ import crypto = require('crypto');
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchTextAllow404 } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
+import { getBoolInputDefaultTrue } from './bool-input';
 
 const toolName = "terraform-docs";
 const isWindows = os.type().match(/^Win/);
-
-/**
- * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
- * raw input rather than getBoolInput(name, false) so the default still holds on an
- * agent that does not materialize task.json defaultValues into the input env var
- * (where getBoolInput would silently return false). Mirrors TerraformInstaller's helper.
- */
-function getBoolInputDefaultTrue(name: string): boolean {
-  const raw = tasks.getInput(name, false);
-  return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
-}
 
 /**
  * Downloads the requested terraform-docs version, verifies its SHA256 checksum,

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "2",
+    "Minor": "3",
     "Patch": "0"
   },
   "instanceNameFormat": "Install terraform-docs $(version)",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -23,6 +23,8 @@ function readModuleLocks(manifestPath: string): unknown {
 
 async function run(): Promise<void> {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
+    // Hoisted so the finally can optionally clean it up (see cleanupSummaryFile).
+    let summaryFile: string | undefined;
     try {
         const planFile = path.resolve(tasks.getInput('planJsonFile', true)!);
         if (!fs.existsSync(planFile)) {
@@ -58,7 +60,7 @@ async function run(): Promise<void> {
         // permissions, using O_EXCL to defeat a pre-existing-symlink hazard, rather
         // than a fixed, world-readable path in the shared OS temp directory.
         const tempDir = tasks.getVariable('Agent.TempDirectory') || os.tmpdir();
-        const summaryFile = path.join(tempDir, `tsm-drift-report-${randomUUID()}.json`);
+        summaryFile = path.join(tempDir, `tsm-drift-report-${randomUUID()}.json`);
         fs.writeFileSync(summaryFile, JSON.stringify(body, null, 2), { encoding: 'utf8', mode: 0o600, flag: 'wx' });
         try { fs.chmodSync(summaryFile, 0o600); } catch { /* platforms without POSIX perms */ }
 
@@ -117,6 +119,14 @@ async function run(): Promise<void> {
         }
     } catch (error) {
         tasks.setResult(tasks.TaskResult.Failed, error instanceof Error ? error.message : String(error));
+    } finally {
+        // The summary file backs the summaryFilePath output var by default (downstream
+        // steps read it). Operators who don't consume it -- and want the potentially
+        // sensitive temp file gone immediately, e.g. on a self-hosted agent whose temp
+        // dir is not wiped between jobs -- can opt into deleting it here.
+        if (summaryFile && tasks.getBoolInput('cleanupSummaryFile', false)) {
+            try { fs.unlinkSync(summaryFile); } catch { /* best effort */ }
+        }
     }
 }
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "6",
+    "Minor": "7",
     "Patch": "0"
   },
   "instanceNameFormat": "Drift report",
@@ -92,6 +92,14 @@
       "required": false,
       "visibleRule": "sarifOutput = true",
       "helpMarkDown": "Optional explicit path for the SARIF report. When empty, a file is written to the agent temp directory; either way its path is exposed via the `sarifFilePath` output variable."
+    },
+    {
+      "name": "cleanupSummaryFile",
+      "type": "boolean",
+      "label": "Delete the summary file at task end",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Delete the JSON summary file (written to the agent temp directory) when the task finishes. It is retained by default so downstream steps can read it via the `summaryFilePath` output variable. Enable to remove it immediately after the callback -- e.g. on a self-hosted agent whose temp directory is not wiped between jobs and where the summary may contain sensitive plan values."
     }
   ],
   "OutputVariables": [

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -204,6 +204,20 @@ describe('TerraformInstaller Test Suite', function () {
         }, tr);
     });
 
+    it('mirror SHA256SUMS 5xx (not 404): fails closed instead of skipping verification', async () => {
+        const tp = path.join(__dirname, 'MirrorChecksumFetch5xxFail.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed closed on a non-404 checksum fetch error');
+            assert(
+                tr.errorIssues.some((e) => /503|SHA256SUMS/i.test(e)),
+                'failure should stem from the SHA256SUMS fetch error. errors: ' + tr.errorIssues
+            );
+        }, tr);
+    });
+
     it('registry insecure download_url: should reject a non-https pre-signed URL', async () => {
         const tp = path.join(__dirname, 'RegistryInsecureUrlReject.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorChecksumFetch5xxFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorChecksumFetch5xxFail.ts
@@ -1,0 +1,56 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Reuses the generic MirrorCustomUrlSuccessL0 entry (runs downloadTerraform).
+const tp = path.join(__dirname, 'MirrorCustomUrlSuccessL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://artifacts.example.com/hashicorp/terraform');
+
+tr.registerMock('os', {
+  type: () => 'Windows_NT',
+  arch: () => 'x64'
+});
+
+// A NON-404 mirror SHA256SUMS fetch failure (e.g. a 5xx after the retries baked into
+// http-client) must be FATAL, not classified as "checksum absent". fetchTextAllow404
+// returns null ONLY for a genuine 404; here it throws, so the install must fail closed
+// even though requireChecksum / requireGpgSignature are left at their (true) defaults.
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    throw new Error('fetchJson should not be called for mirror download. Called with: ' + url);
+  },
+  fetchTextAllow404: async () => {
+    throw new Error('HTTP 503 fetching SHA256SUMS (server error, exhausted retries)');
+  }
+});
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', {
+  verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
+});
+tr.registerMock('./cosign-verifier', {
+  verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: (_toolName: string, _version: string) => null,
+  downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform.zip',
+  extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+  cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+  cleanVersion: (version: string) => version,
+  prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  'find': {
+    '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/bool-input.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/bool-input.ts
@@ -1,0 +1,19 @@
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay byte-identical,
+// so a change to the fail-closed default semantics can never be applied to one
+// installer and silently missed in the others. This duplication is deliberate
+// (each task bundles independently) — not drift to be flagged.
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
+ * raw input rather than getBoolInput(name, false) so the default still holds on an
+ * agent that does not materialize task.json defaultValues into the input env var
+ * (where getBoolInput would silently return false): unset/empty -> true; any value
+ * other than "false" (case-insensitive) -> true.
+ */
+export function getBoolInputDefaultTrue(name: string): boolean {
+  const raw = tasks.getInput(name, false);
+  return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
+}

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -8,24 +8,13 @@ import crypto = require('crypto');
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchText, fetchTextAllow404 } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
+import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';
 
 const terraformToolName = "terraform";
 const tofuToolName = "tofu";
 const isWindows = os.type().match(/^Win/);
-
-/**
- * Reads a boolean input whose intended default is TRUE (fail-closed). It reads the
- * raw input rather than getBoolInput(name, false) so the default still holds on an
- * agent that does not materialize task.json defaultValues into the input env var
- * (where getBoolInput would silently return false). Mirrors the requireCosignVerification
- * handling: unset/empty -> true; any value other than "false" (case-insensitive) -> true.
- */
-function getBoolInputDefaultTrue(name: string): boolean {
-    const raw = tasks.getInput(name, false);
-    return raw === undefined || raw.trim() === '' ? true : raw.trim().toLowerCase() !== 'false';
-}
 
 function isSensitiveQueryParam(name: string): boolean {
     const lower = name.toLowerCase();

--- a/Tasks/TerraformTask/TerraformTaskV5/src/secure-file-loader.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/secure-file-loader.ts
@@ -42,8 +42,14 @@ export class SecureFileLoader implements ISecureFileLoader {
                 this.timeoutMs,
             );
         });
+        const download = this.helpers.downloadSecureFile(secureFileId);
+        // If the timeout wins the race, `download` keeps running unobserved. Attach a
+        // no-op catch (on a normalized promise) so a late rejection cannot surface as a
+        // process-level unhandledRejection and clobber an already-reported task result
+        // -- mirroring the guard in TerraformPolicyCheck's policy-source.ts execGit().
+        Promise.resolve(download).catch(() => { /* superseded by the timeout below */ });
         try {
-            const filePath = await Promise.race([this.helpers.downloadSecureFile(secureFileId), timeout]);
+            const filePath = await Promise.race([download, timeout]);
             // The secure file (which may carry secrets in a .pkrvars/.tfvars
             // file) is downloaded by the upstream library with its own
             // default (often 0644) permissions and never tightened.

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "275",
+        "Minor": "276",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -6,9 +6,10 @@ Manual verification steps to run before publishing a release to the VS Marketpla
 
 ## 1. CI gate
 
-- [ ] All CI checks pass on the `development → main` PR
-- [ ] Version in `azure-devops-extension.json` matches the intended tag (e.g. `1.0.0` for `v1.0.0`)
-- [ ] `CHANGELOG.md` has an entry for the release version
+- [ ] All CI checks pass on `main` (release-please opens the Release PR from `main`)
+- [ ] Version in `azure-devops-extension.json` matches the intended tag (e.g. `1.0.0` for `v1.0.0`) — release-please sets this in the Release PR
+- [ ] `CHANGELOG.md` has an entry for the release version (release-please generates this)
+- [ ] **Minor bumps (mandatory):** every task whose `src/` changed since the last release tag has its `Minor` incremented in `task.json`. ADO agents cache tasks by `Major.Minor`, so a code (especially security) fix to an un-bumped task would ship to the Marketplace but never reach running agents. The release `guard` job enforces this via `scripts/check-minor-bumps.js`; run it locally too: `node scripts/check-minor-bumps.js` (defaults to comparing `HEAD` against the previous `v*` tag).
 
 ## 2. Build the `.vsix` locally
 
@@ -114,16 +115,17 @@ Use a minimal Terraform configuration with an AzureRM backend and provider.
 - [ ] Run a `plan` with `publishPlanResults: <name>` — plan tab appears in build results
 - [ ] Plan output renders correctly (ANSI colors, no truncation for reasonable-sized plans)
 
-## 8. Tag and release
+## 8. Tag and release (release-please)
 
-- [ ] Squash-merge `development → main`
-- [ ] Tag the merge commit: `git tag vX.Y.Z origin/main && git push origin vX.Y.Z`
-- [ ] Release workflow triggers automatically
-- [ ] Draft GitHub release is created with `.vsix`, SBOM, and cosign signature
-- [ ] Approve the `marketplace` environment deployment
-- [ ] Extension appears on the VS Marketplace with the correct version
+Releases are automated by release-please — do NOT hand-tag.
+
+- [ ] Conventional-commit PRs are merged to `main`; release-please accumulates them into a **Release PR** ("chore(main): release X.Y.Z") that bumps `azure-devops-extension.json` and updates `CHANGELOG.md`
+- [ ] Before merging the Release PR, confirm the per-task `Minor` bumps (see section 1) — bump any missed task in the same PR
+- [ ] Merge the Release PR — release-please pushes the `vX.Y.Z` tag automatically (the `guard` job fails the release if the tag version doesn't match `azure-devops-extension.json`)
+- [ ] The `release.yml` workflow triggers on the tag: verifies the tag is on `main`, runs full CI + the Minor-bump check, builds the `.vsix`, generates SBOMs + cosign signature, and creates a draft GitHub release
+- [ ] Approve the `marketplace` environment deployment when prompted
+- [ ] Extension appears on the VS Marketplace with the correct version; the GitHub release is undrafted
 
 ## 9. Post-release
 
-- [ ] Sync `development` with `main`: merge `origin/main` into `development`
 - [ ] Verify the extension installs correctly from the public marketplace in a fresh ADO org

--- a/scripts/check-minor-bumps.js
+++ b/scripts/check-minor-bumps.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Enforces the mandatory Minor-bump rule at release time: any task whose src/
+// changed since the previous release tag MUST have its task.json Minor incremented.
+// ADO agents cache tasks by Major.Minor, so a code (especially security) fix that
+// ships without a Minor bump would be published to the Marketplace but never reach
+// running agents. Wired into the release `guard` job; also runnable locally.
+//
+// Usage: node scripts/check-minor-bumps.js [prevRef] [currRef]
+//   prevRef defaults to the newest v*.*.* tag that is not the current HEAD commit
+//           (i.e. the previous release); currRef defaults to HEAD.
+// Only changes under <task>/src count — test/doc-only changes do not require a bump.
+
+const { execSync } = require('child_process');
+
+const TASKS = [
+  'Tasks/TerraformTask/TerraformTaskV5',
+  'Tasks/TerraformInstaller/TerraformInstallerV1',
+  'Tasks/TerraformProviderMirror/TerraformProviderMirrorV1',
+  'Tasks/TerraformModulePublish/TerraformModulePublishV1',
+  'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1',
+  'Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1',
+  'Tasks/TerraformDriftReport/TerraformDriftReportV1',
+  'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1',
+  'Tasks/TerraformDocs/TerraformDocsV1',
+  'Tasks/Markdown2Html/Markdown2HtmlV1',
+  'Tasks/PublishKbArticle/PublishKbArticleV1',
+];
+
+function git(args) {
+  return execSync(`git ${args}`, { encoding: 'utf8' }).trim();
+}
+
+function minorAt(ref, taskDir) {
+  const raw = git(`show ${ref}:${taskDir}/task.json`);
+  return parseInt(JSON.parse(raw).version.Minor, 10);
+}
+
+let prevRef = process.argv[2];
+const currRef = process.argv[3] || 'HEAD';
+
+if (!prevRef) {
+  const head = git(`rev-parse ${currRef}`);
+  const tags = git('tag --sort=-v:refname')
+    .split('\n')
+    .map((t) => t.trim())
+    .filter((t) => /^v\d+\.\d+\.\d+$/.test(t));
+  // The previous release is the newest v* tag that does not point at the commit
+  // being released (which typically already carries this release's own tag).
+  prevRef = tags.find((t) => {
+    try {
+      return git(`rev-list -n1 ${t}`) !== head;
+    } catch {
+      return false;
+    }
+  });
+}
+
+if (!prevRef) {
+  console.log('check-minor-bumps: no previous release tag found; nothing to compare.');
+  process.exit(0);
+}
+
+console.log(`check-minor-bumps: comparing ${prevRef} -> ${currRef}`);
+let failed = false;
+
+for (const task of TASKS) {
+  let changed;
+  try {
+    changed = git(`diff --name-only ${prevRef} ${currRef} -- ${task}/src`);
+  } catch (e) {
+    console.error(`  ! ${task}: could not diff (${e.message})`);
+    failed = true;
+    continue;
+  }
+  if (!changed) {
+    continue; // src unchanged since the last release; no bump required
+  }
+  let prevMinor;
+  let currMinor;
+  try {
+    prevMinor = minorAt(prevRef, task);
+    currMinor = minorAt(currRef, task);
+  } catch (e) {
+    console.error(`  ! ${task}: could not read task.json version (${e.message})`);
+    failed = true;
+    continue;
+  }
+  if (currMinor > prevMinor) {
+    console.log(`  OK   ${task}: src changed, Minor ${prevMinor} -> ${currMinor}`);
+  } else {
+    console.error(
+      `  FAIL ${task}: src changed since ${prevRef} but Minor did not increase (still ${currMinor}). ` +
+      `Bump Minor in ${task}/task.json.`,
+    );
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error(
+    '\ncheck-minor-bumps: FAILED. Every task whose src/ changed since the last release ' +
+    'must have its Minor bumped — ADO agents cache tasks by Major.Minor. See CLAUDE.md > Release Process.',
+  );
+  process.exit(1);
+}
+console.log('check-minor-bumps: all changed tasks have a Minor bump.');

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -62,6 +62,21 @@ const FAMILIES = [
             'registry-allowlist.ts',
         ],
     },
+    {
+        // Fail-closed boolean-input helper: requireGpgSignature / requireChecksum /
+        // requireCosignVerification default to TRUE even on agents that do not
+        // materialize task.json defaultValues. A drift here could silently flip a
+        // verification default to fail-open, so keep it byte-identical across the
+        // three installer tasks.
+        dirs: [
+            'Tasks/TerraformInstaller/TerraformInstallerV1/src',
+            'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src',
+            'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src',
+        ],
+        modules: [
+            'bool-input.ts',
+        ],
+    },
 ];
 
 // These two families are deliberately NOT merged into one shared client, even


### PR DESCRIPTION
Remediates the **P2** findings from the 2026-07-06 post-remediation blind re-audit.

## Fixes
- **ARCH1 (#405):** extract the fail-closed `getBoolInputDefaultTrue` helper into a byte-identical `bool-input.ts` across all three installers and register it in `check-shared-modules.js` -- it backs the `requireGpgSignature`/`requireChecksum`/`requireCosignVerification` defaults and could previously drift silently to fail-open.
- **ERR1 (#423):** opt-in `cleanupSummaryFile` input (default false) deletes the sensitive drift summary temp file at task end, without breaking the documented `summaryFilePath` output that downstream steps consume.
- **ERR2 (#424):** no-op `.catch` on the losing `downloadSecureFile` promise so a post-timeout rejection cannot surface as an `unhandledRejection` that clobbers an already-reported result.
- **ERR3 (#425):** a corrupt KB manifest is backed up (`.corrupt-<ts>.bak`) and warned about instead of silently discarding every prior article mapping.

## Tests
- **TEST3 (#440):** new tests for both installers proving a non-404 mirror `SHA256SUMS` fetch failure (e.g. a 5xx after http-client retries) is FATAL, not classified as "checksum absent".

## Release safety
- **DOC2 (#416):** new `scripts/check-minor-bumps.js` wired into the release `guard` job -- fails the release if any task's `src/` changed since the previous tag without a Minor bump (ADO agents cache by Major.Minor). It also caught, and this PR heals, that TerraformTaskV5's P0/P1 change had not been bumped.
- **DOC1 (#415):** added the mandatory Minor-bump step to `docs/release-checklist.md`.
- **DOC5 (#419):** replaced the stale `development -> main` hand-tag workflow with the actual release-please flow.

## Validation (local)
parity - version-check - check-minor-bumps (v1.8.4 -> HEAD, all 7 changed tasks bumped) - eslint - TerraformInstaller 68 - PolicyAgent 57 - TerraformDocsInstaller 47 - TerraformTaskV5 264 - DriftReport 17 - PublishKbArticle 85, all passing.

## Version bumps
`Minor`: TerraformDocsInstaller 2->3, TerraformDriftReport 6->7, TerraformTaskV5 275->276, PublishKbArticle 2->3 (TerraformInstaller/PolicyAgent already bumped in P0/P1).

Closes #405, Closes #423, Closes #424, Closes #425, Closes #440, Closes #415, Closes #416, Closes #419
