### PR TITLE
fix: remediate P0-P3 findings from the 5th re-audit (KB XSS, registry-URL leak, Sentinel fail-open, KB identity, CI coverage, hygiene)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,5 +57,7 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
-          fail-on-severity: high
+          # Moderate-severity new/changed dependencies are blocked at PR time too
+          # (not just high/critical), matching the root/per-task npm audit gates.
+          fail-on-severity: moderate
           comment-summary-in-pr: on-failure

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -353,6 +353,13 @@ jobs:
           node-version: "24"
       - name: Install dependencies
         run: npm ci
+      - name: Audit root tooling (tfx-cli, webpack, cyclonedx-npm, jest, …)
+        # The root package.json has no "dependencies" — everything here
+        # (tfx-cli used by the marketplace publish job, webpack, cyclonedx-npm,
+        # jest, …) is a devDependency, so --omit=dev (used by the per-task
+        # audits below) would audit nothing. This is the one CI job that
+        # installs the root toolchain, so it is the natural place to gate it.
+        run: npm audit --audit-level=high
       - name: Type-check tab
         run: npx tsc -p src/tab/tsconfig.json --noEmit
       - name: Run tab unit tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,19 +43,19 @@ TypeScript (`tsc`) and `tfx-cli` are installed as dev dependencies; no global in
 # Clone the fork
 git clone https://github.com/sethbacon/azure-pipelines-terraform
 cd azure-pipelines-terraform
+```
 
-# Install dependencies for TerraformTaskV5
-cd Tasks/TerraformTask/TerraformTaskV5
-npm install --include=dev
+Each task under `Tasks/` is an independent npm package — install dependencies in
+the task directory you're changing before running `npm test` there for the
+first time:
 
-# Install dependencies for TerraformInstallerV1
-cd ../../../Tasks/TerraformInstaller/TerraformInstallerV1
-npm install --include=dev
-
-# Install dependencies for TerraformProviderMirrorV1
-cd ../../../Tasks/TerraformProviderMirror/TerraformProviderMirrorV1
+```bash
+cd Tasks/<TaskName>/<TaskName>V<N>
 npm install --include=dev
 ```
+
+See the [Testing](#testing) section below for the full list of the 11 task
+directories and their per-task test commands.
 
 ## Development workflow
 

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -448,6 +448,25 @@ describe('convertMarkdownToHtml', () => {
         assert.ok(html.includes('<table>'), 'benign table markup should survive');
         assert.ok(html.includes('<br'), 'benign <br> should survive');
     });
+
+    it('strips a javascript: href obfuscated with an HTML-entity-encoded control char (#446)', () => {
+        // Browsers strip ASCII tab/newline/CR before parsing a URL scheme, so
+        // "jav&#9;ascript:" decodes to a literal tab that a naive
+        // trim()+startsWith('javascript:') check would miss.
+        const cases = ['jav&#9;ascript:alert(1)', 'jav&#10;ascript:alert(1)', 'jav&#13;ascript:alert(1)', 'jav&Tab;ascript:alert(1)', '&#1;javascript:alert(1)'];
+        for (const payload of cases) {
+            const html = convertMarkdownToHtml(`<a href="${payload}">x</a>`);
+            assert.ok(!/href\s*=/.test(html), `href must be stripped for payload: ${payload} (got: ${html})`);
+        }
+    });
+
+    it('removes a <base> element and a javascript: <meta http-equiv="refresh"> (#446)', () => {
+        const html = convertMarkdownToHtml(
+            '<base href="//evil.example.com/">\n\n<meta http-equiv="refresh" content="0;url=javascript:alert(1)">\n\nOk',
+        );
+        assert.ok(!/<base[\s>]/i.test(html), '<base> must be removed');
+        assert.ok(!/<meta/i.test(html), 'the dangerous <meta refresh> must be removed');
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
@@ -54,6 +54,21 @@ function escapeHtml(s: string): string {
         .replace(/"/g, '&quot;');
 }
 
+/**
+ * Normalizes an attribute value before a URI-scheme check. Browsers (per the
+ * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
+ * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can
+ * be bypassed with an HTML-entity-encoded control char INSIDE the scheme (e.g.
+ * `jav&#9;ascript:`) — `.trim()` only removes leading/trailing whitespace, so
+ * the interior tab survives the check but is stripped by the browser at parse
+ * time, yielding a working `javascript:` URI. Stripping every ASCII control
+ * character (U+0000–U+001F, U+007F) from anywhere in the string — not just
+ * the edges — before lower-casing closes this bypass.
+ */
+function normalizeUriForSchemeCheck(value: string): string {
+    return value.replace(/[\u0000-\u001F\u007F]/g, '').trim().toLowerCase();
+}
+
 function highlightCode(code: string, lang: string): string {
     if (lang && hljs.getLanguage(lang)) {
         try {
@@ -105,12 +120,25 @@ export function sanitizeRenderedHtml(html: string): string {
     const $ = cheerio.load(html, { xmlMode: false });
     // Remove executable / embedding elements outright.
     $('script, iframe, object, embed, noscript').remove();
+    // <base> can redirect every relative URL in the document; not needed in a
+    // KB article fragment, so drop it outright rather than trying to validate it.
+    $('base').remove();
+    // <meta http-equiv="refresh" content="0;url=javascript:..."> is a redirect-based
+    // active-content vector the href/src attribute check below never sees (it's in
+    // a `content` attribute, not `href`/`src`).
+    $('meta').each((_, el) => {
+        const httpEquiv = normalizeUriForSchemeCheck(String($(el).attr('http-equiv') ?? ''));
+        const content = normalizeUriForSchemeCheck(String($(el).attr('content') ?? ''));
+        if (httpEquiv === 'refresh' && (content.includes('javascript:') || content.includes('vbscript:'))) {
+            $(el).remove();
+        }
+    });
     // Strip event-handler attributes and dangerous URIs from every element.
     $('*').each((_, el) => {
         const attribs = $(el).attr() ?? {};
         for (const name of Object.keys(attribs)) {
             const lname = name.toLowerCase();
-            const value = String(attribs[name]).trim().toLowerCase();
+            const value = normalizeUriForSchemeCheck(String(attribs[name]));
             if (lname.startsWith('on')) {
                 $(el).removeAttr(name);
             } else if (

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "2",
+        "Minor": "3",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -87,6 +87,39 @@ describe('PolicyAgentInstaller Test Suite', function () {
         }, tr);
     });
 
+    // --- Registry pre-signed download-URL token masking ---
+    // The registry download_url carries a live storage credential in its query
+    // string and tool-lib logs the URL at INFO. Assert every token component is
+    // registered as a secret (so the agent masks it) while benign params stay
+    // visible.
+    it('registry download token masking: sensitive query params are registered as secrets', async () => {
+        const tp = path.join(__dirname, 'RegistryDownloadTokenMasked.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+            const maskedTokens = [
+                'AWSSIGNATUREtoken1111',
+                'AWSCREDENTIALtoken2222',
+                'AWSSECURITYtoken3333',
+                'GOOGSIGNATUREtoken4444',
+                'GOOGCREDENTIALtoken5555',
+                'AZURESIGtoken6666',
+            ];
+            for (const token of maskedTokens) {
+                assert(
+                    tr.stdout.includes('##vso[task.setsecret]' + token),
+                    `expected ##vso[task.setsecret] for token ${token}. stdout: ${tr.stdout}`,
+                );
+            }
+            assert(!tr.stdout.includes('##vso[task.setsecret]20260703T000000Z'),
+                'benign X-Amz-Date must not be registered as a secret');
+            assert(!tr.stdout.includes('##vso[task.setsecret]host'),
+                'benign X-Amz-SignedHeaders must not be registered as a secret');
+        }, tr);
+    });
+
     // --- Failure cases ---
     expectFailure('InsecureUrlReject');
     expectFailure('Sha256Fail');

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -1,0 +1,81 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// The registry download_url carries a live storage credential in its query
+// string, and tool-lib logs the URL at INFO (fully redacting only Azure
+// `sig=`). Assert every sensitive token component is registered as a secret
+// (so the agent masks it) while benign params stay visible. Mirrors
+// TerraformInstaller's RegistryDownloadTokenMasked.ts regression test.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'sentinel');
+tr.setInput('version', '0.40.0');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'sentinel');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+const AWS_SIGNATURE = 'AWSSIGNATUREtoken1111';        // X-Amz-Signature       -> masked
+const AWS_CREDENTIAL = 'AWSCREDENTIALtoken2222';      // X-Amz-Credential      -> masked
+const AWS_SECURITY_TOKEN = 'AWSSECURITYtoken3333';    // X-Amz-Security-Token  -> masked
+const GOOG_SIGNATURE = 'GOOGSIGNATUREtoken4444';      // X-Goog-Signature      -> masked
+const GOOG_CREDENTIAL = 'GOOGCREDENTIALtoken5555';    // X-Goog-Credential     -> masked
+const AZURE_SIG = 'AZURESIGtoken6666';                // sig (Azure SAS)       -> masked
+const BENIGN_DATE = '20260703T000000Z';               // X-Amz-Date            -> NOT masked
+const BENIGN_SIGNED_HEADERS = 'host';                 // X-Amz-SignedHeaders   -> NOT masked
+
+const PRESIGNED_URL =
+  'https://storage.example.com/signed/sentinel_0.40.0_linux_amd64.zip' +
+  '?X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+  `&X-Amz-Credential=${AWS_CREDENTIAL}` +
+  `&X-Amz-Date=${BENIGN_DATE}` +
+  '&X-Amz-Expires=900' +
+  `&X-Amz-SignedHeaders=${BENIGN_SIGNED_HEADERS}` +
+  `&X-Amz-Security-Token=${AWS_SECURITY_TOKEN}` +
+  `&X-Amz-Signature=${AWS_SIGNATURE}` +
+  `&X-Goog-Credential=${GOOG_CREDENTIAL}` +
+  `&X-Goog-Signature=${GOOG_SIGNATURE}` +
+  `&sig=${AZURE_SIG}`;
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    if (url === 'https://registry.example.com/terraform/binaries/sentinel/versions/0.40.0/linux/amd64') {
+      return { download_url: PRESIGNED_URL, sha256: EXPECTED_SHA256 };
+    }
+    throw new Error('Unexpected fetchJson URL: ' + url);
+  },
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { throw new Error('registry must not use GPG'); } });
+
+tr.registerMock('fs', {
+  chmodSync: () => { },
+  readFileSync: () => Buffer.from('fake-zip')
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => '/tmp/sentinel.zip',
+  extractZip: async () => '/tmp/sentinel-extracted',
+  cacheDir: async () => '/tmp/sentinel-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/sentinel-cached': ['/tmp/sentinel-cached/sentinel'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -10,6 +10,7 @@ import { fetchJson, fetchText, fetchTextAllow404 } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
+import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage } from './url-secret-redaction';
 
 const isWindows = os.type().match(/^Win/);
 
@@ -228,7 +229,33 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
     }
 
     const ext = agent === "sentinel" ? ".zip" : (isWindows ? ".exe" : "");
-    const filePath = await downloadTo(data.download_url, `${agent}-${version}-${uuidV4()}${ext}`);
+    const fileName = `${agent}-${version}-${uuidV4()}${ext}`;
+    // The pre-signed download_url carries a live, read-scoped storage credential in
+    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
+    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
+    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
+    // normal registry run. Register each token component as a secret FIRST so the
+    // agent masks it in tool-lib's log line (and in any failure message).
+    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
+    for (const secret of urlTokenSecrets) {
+        tasks.setSecret(secret);
+    }
+    let filePath: string;
+    try {
+        filePath = await tools.downloadTool(data.download_url, fileName);
+    } catch (exception) {
+        // download_url is a pre-signed URL whose query string carries the signing
+        // token; drop the whole query (redactUrl) and scrub the raw URL out of the
+        // tool-lib exception text so the live credential never reaches the build
+        // log via the failure message.
+        const safeUrl = redactUrl(data.download_url);
+        const safeMsg = scrubSecretsFromMessage(
+            String(exception instanceof Error ? exception.message : exception),
+            data.download_url,
+            urlTokenSecrets,
+        );
+        throw new Error(tasks.loc("PolicyAgentDownloadFailed", safeUrl, safeMsg));
+    }
 
     if (data.sha256) {
         await verifySha256(filePath, data.sha256);

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/url-secret-redaction.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/url-secret-redaction.ts
@@ -1,0 +1,79 @@
+/**
+ * Registry-provided pre-signed download URLs (Azure blob SAS, AWS S3 presigned,
+ * GCS signed URL) carry a live, short-TTL storage credential in their query
+ * string. azure-pipelines-tool-lib's downloadTool logs the URL at INFO and only
+ * auto-redacts Azure `sig=`, so AWS `X-Amz-Signature`/`X-Amz-Credential`/
+ * `X-Amz-Security-Token` and GCS `X-Goog-Signature`/`X-Goog-Credential` would
+ * otherwise print unredacted on every normal registry run — and the same token
+ * can leak again if a download failure echoes the raw URL in its message.
+ *
+ * Shared byte-for-byte across all three installer tasks that consume a registry
+ * download_url (guarded by scripts/check-shared-modules.js) so a fix here can
+ * never be applied to one copy and silently missed in the others.
+ */
+
+function isSensitiveQueryParam(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower === 'sig'
+        || lower.includes('signature')
+        || lower.includes('credential')
+        || lower.includes('token');
+}
+
+/**
+ * Extracts the values of every sensitive query-string token in `url`. Values are
+ * returned in the raw form they appear in the URL (still percent-encoded) so they
+ * match the exact substring tool-lib logs at INFO; the decoded form is added too when
+ * it differs, so a consumer that logs the decoded value is masked as well. Used to
+ * setSecret() the tokens before download and to scrub them from any failure message.
+ */
+export function extractUrlTokenSecrets(url: string): string[] {
+    const qIndex = url.indexOf('?');
+    if (qIndex === -1) return [];
+    const query = url.slice(qIndex + 1).split('#')[0];
+    const secrets: string[] = [];
+    for (const pair of query.split('&')) {
+        const eq = pair.indexOf('=');
+        if (eq === -1) continue;
+        const name = pair.slice(0, eq);
+        const rawValue = pair.slice(eq + 1);
+        if (!rawValue || !isSensitiveQueryParam(name)) continue;
+        secrets.push(rawValue);
+        let decoded: string;
+        try { decoded = decodeURIComponent(rawValue); } catch { decoded = rawValue; }
+        if (decoded !== rawValue) secrets.push(decoded);
+    }
+    return secrets;
+}
+
+/**
+ * Strips the ENTIRE query string (which can carry a pre-signed signature/token —
+ * Azure `sig`, AWS `X-Amz-Signature`/`X-Amz-Credential`/`X-Amz-Security-Token`,
+ * GCS `X-Goog-Signature`/`X-Goog-Credential`) from a URL for safe logging. The whole
+ * query is dropped rather than redacting known parameter names one at a time, so an
+ * unforeseen token parameter can never leak through the error path.
+ */
+export function redactUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        return u.origin + u.pathname + (u.search ? '?<redacted>' : '');
+    } catch {
+        return url.split('?')[0];
+    }
+}
+
+/**
+ * Scrubs a raw download URL and its extracted token secrets out of an error
+ * message string. Used when a download failure's exception text embeds the raw
+ * URL verbatim; scrubbing each known token value too is belt-and-suspenders
+ * against a downstream library (e.g. tool-lib's own partial `sig=` redaction)
+ * embedding a differently-transformed copy of the URL.
+ */
+export function scrubSecretsFromMessage(message: string, url: string, secrets: string[]): string {
+    const safeUrl = redactUrl(url);
+    let safeMessage = message.split(url).join(safeUrl);
+    for (const secret of secrets) {
+        safeMessage = safeMessage.split(secret).join('<redacted>');
+    }
+    return safeMessage;
+}

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "7",
+        "Minor": "8",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -211,6 +211,24 @@ describe('client.createKnowledgeArticle', () => {
 // ===========================================================================
 // servicenow-client — updateKnowledgeArticle (update path)
 // ===========================================================================
+// ===========================================================================
+// servicenow-client — getArticle / articleId path encoding (#449)
+// ===========================================================================
+describe('client.getArticle', () => {
+    it('#449: encodeURIComponent-encodes an articleId containing a path-manipulation character', async () => {
+        // Without encoding, an articleId of 'a/b' would splice an extra path
+        // segment into the REST URL. nock matches the literal outgoing path, so
+        // this only passes if the client sends the percent-encoded segment.
+        const article = { sys_id: 'a/b', number: 'KB0099', short_description: 'T', workflow_state: 'draft' };
+        nock(BASE_URL)
+            .get('/api/now/table/kb_knowledge/a%2Fb')
+            .reply(200, { result: article });
+
+        const found = await client.getArticle(INSTANCE, HEADERS, 'a/b');
+        assert.strictEqual(found.sys_id, 'a/b');
+    });
+});
+
 describe('client.updateKnowledgeArticle', () => {
     it('GETs existing article then PATCHes with updated fields', async () => {
         const existingArticle = {
@@ -537,6 +555,41 @@ describe('htmlValidate.validateHtmlContent', () => {
             () => htmlValidate.validateHtmlContent(html, false),
             /javascript:.*URIs are not allowed/,
         );
+    });
+
+    it('throws on a javascript: URI obfuscated with an HTML-entity-encoded control char (#446)', () => {
+        // Browsers strip ASCII tab/newline/CR before parsing a URL scheme, so a
+        // naive trim()+startsWith('javascript:') check would miss "jav&#9;ascript:".
+        const cases = ['jav&#9;ascript:alert(1)', 'jav&#10;ascript:alert(1)', 'jav&#13;ascript:alert(1)', 'jav&Tab;ascript:alert(1)', '&#1;javascript:alert(1)'];
+        for (const payload of cases) {
+            const html = `<html><body><a href="${payload}">x</a></body></html>`;
+            assert.throws(
+                () => htmlValidate.validateHtmlContent(html, false),
+                /javascript:.*URIs are not allowed/,
+                `expected a throw for payload: ${payload}`,
+            );
+        }
+    });
+
+    it('throws on a <base> element when force=false', () => {
+        const html = '<html><head><base href="//evil.example.com/"></head><body><p>x</p></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /<base> elements and <meta http-equiv="refresh">/,
+        );
+    });
+
+    it('throws on a javascript: <meta http-equiv="refresh"> when force=false', () => {
+        const html = '<html><head><meta http-equiv="refresh" content="0;url=javascript:alert(1)"></head><body><p>x</p></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /<base> elements and <meta http-equiv="refresh">/,
+        );
+    });
+
+    it('does not throw on a benign <meta> tag', () => {
+        const html = '<html><head><meta charset="utf-8"></head><body><p>x</p></body></html>';
+        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, false));
     });
 
     it('throws on a non-image data: URI when force=false', () => {
@@ -956,6 +1009,38 @@ describe('manifest.emitArticleOutput / findKbArticleJson', () => {
         process.chdir(tmpDir());
         try {
             assert.strictEqual(manifest.findKbArticleJson(), null);
+        } finally {
+            process.chdir(cwd);
+        }
+    });
+
+    it('#449: ignores a non-matching *.json file even if it has an article_id key', () => {
+        // findKbArticleJson must only consider filenames matching this task's own
+        // legacy-writer convention (KB<number>.json / article_info.json) — not any
+        // arbitrary *.json an earlier build step could have dropped in cwd.
+        const cwd = process.cwd();
+        const dir = tmpDir();
+        process.chdir(dir);
+        try {
+            fs.writeFileSync('rogue.json', JSON.stringify({ article_id: 'rogue-sys-id' }));
+            assert.strictEqual(manifest.findKbArticleJson(), null, 'a non-KB-named json file must be ignored');
+        } finally {
+            process.chdir(cwd);
+        }
+    });
+
+    it('#449: picks the most recently modified match when multiple KB article json files exist', () => {
+        const cwd = process.cwd();
+        const dir = tmpDir();
+        process.chdir(dir);
+        try {
+            fs.writeFileSync('KB0001.json', JSON.stringify({ article_id: 'older-sys-id' }));
+            const olderTime = new Date(Date.now() - 60_000);
+            fs.utimesSync('KB0001.json', olderTime, olderTime);
+            fs.writeFileSync('KB0002.json', JSON.stringify({ article_id: 'newer-sys-id' }));
+            const found = manifest.findKbArticleJson();
+            assert.ok(found);
+            assert.strictEqual(found!['article_id'], 'newer-sys-id');
         } finally {
             process.chdir(cwd);
         }

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
@@ -2,6 +2,21 @@ import * as fs from 'fs';
 import { load } from 'cheerio';
 
 /**
+ * Normalizes an attribute value before a URI-scheme check. Browsers (per the
+ * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
+ * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can
+ * be bypassed with an HTML-entity-encoded control char INSIDE the scheme (e.g.
+ * `jav&#9;ascript:`) — `.trim()` only removes leading/trailing whitespace, so
+ * the interior tab survives the check but is stripped by the browser at parse
+ * time, yielding a working `javascript:` URI. Stripping every ASCII control
+ * character (U+0000–U+001F, U+007F) from anywhere in the string — not just
+ * the edges — before lower-casing closes this bypass.
+ */
+function normalizeUriForSchemeCheck(value: string): string {
+    return value.replace(/[\u0000-\u001F\u007F]/g, '').trim().toLowerCase();
+}
+
+/**
  * Validate HTML content for common issues.
  * Throws if invalid and force is false; warns (console) if force is true.
  */
@@ -53,6 +68,26 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
         console.warn(`[WARN] HTML validation: ${msg}`);
     }
 
+    // Reject <base> (redirects every relative URL in the document) and a
+    // <meta http-equiv="refresh"> that redirects to a javascript:/vbscript: URI
+    // — active-content vectors the href/src attribute check below never sees.
+    let baseOrMetaRefreshFound = false;
+    $('base').each(() => { baseOrMetaRefreshFound = true; });
+    $('meta').each((_, el) => {
+        const httpEquiv = normalizeUriForSchemeCheck(String($(el).attr('http-equiv') ?? ''));
+        const content = normalizeUriForSchemeCheck(String($(el).attr('content') ?? ''));
+        if (httpEquiv === 'refresh' && (content.includes('javascript:') || content.includes('vbscript:'))) {
+            baseOrMetaRefreshFound = true;
+        }
+    });
+    if (baseOrMetaRefreshFound) {
+        const msg = '<base> elements and <meta http-equiv="refresh"> redirects to javascript:/vbscript: are not allowed in KB articles';
+        if (!force) {
+            throw new Error(msg);
+        }
+        console.warn(`[WARN] HTML validation: ${msg}`);
+    }
+
     // Reject inline event-handler attributes (onerror=, onload=, onclick=, …)
     // and javascript:/vbscript:/non-image data: URIs — stored-XSS vectors the
     // external <script src> check above does not cover.
@@ -62,7 +97,7 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
         const attribs = $(el).attr() ?? {};
         for (const name of Object.keys(attribs)) {
             const lname = name.toLowerCase();
-            const value = String(attribs[name]).trim().toLowerCase();
+            const value = normalizeUriForSchemeCheck(String(attribs[name]));
             if (lname.startsWith('on')) {
                 eventHandlerFound = true;
             } else if (

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
@@ -92,28 +92,53 @@ export function emitArticleOutput(
 }
 
 /**
+ * Matches only the filenames this task's own legacy `outputArticleInfoToJson`
+ * writes: `KB<number>.json` (ServiceNow KB article numbers, e.g. KB0001234) or
+ * the `article_info.json` fallback used when the article has no number yet.
+ */
+const KB_ARTICLE_JSON_NAME_RE = /^(KB\S*|article_info)\.json$/i;
+
+/**
  * Find a KB article JSON file in the current working directory.
  * Returns parsed data if a file with `article_id` is found, null otherwise.
+ *
+ * Only filenames matching the exact convention this task's own legacy writer
+ * uses (KB_ARTICLE_JSON_NAME_RE) are considered — an earlier, unrelated build
+ * step could otherwise drop an arbitrary *.json file into the working
+ * directory (e.g. a stray manifest, lockfile-adjacent artifact, or a
+ * maliciously-placed file) and, with no filename pinning, have it picked up
+ * as the KB article identity source (a confused-deputy risk: this function
+ * feeds directly into which ServiceNow article gets updated). When more than
+ * one matching file is present, the most recently modified one is used (not
+ * directory-listing order, which is filesystem-dependent and not meaningful).
  */
 export function findKbArticleJson(): Record<string, unknown> | null {
     let jsonFiles: string[];
     try {
-        jsonFiles = fs.readdirSync('.').filter(f => f.endsWith('.json'));
+        jsonFiles = fs.readdirSync('.').filter(f => KB_ARTICLE_JSON_NAME_RE.test(f));
     } catch {
         return null;
     }
+    const candidates: { filename: string; mtimeMs: number; data: Record<string, unknown> }[] = [];
     for (const filename of jsonFiles) {
         try {
             const data = JSON.parse(fs.readFileSync(filename, 'utf-8'));
             if (data['article_id']) {
-                console.log(`Found KB article JSON file: ${filename}`);
-                return data as Record<string, unknown>;
+                candidates.push({ filename, mtimeMs: fs.statSync(filename).mtimeMs, data });
             }
         } catch {
             continue;
         }
     }
-    return null;
+    if (candidates.length === 0) {
+        return null;
+    }
+    if (candidates.length > 1) {
+        console.warn(`Warning: multiple KB article JSON files found (${candidates.map(c => c.filename).join(', ')}); using the most recently modified.`);
+    }
+    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    console.log(`Found KB article JSON file: ${candidates[0].filename}`);
+    return candidates[0].data;
 }
 
 /**

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -42,7 +42,9 @@ export async function getKnowledgeBases(instance: string, headers: Record<string
 
 /** Retrieve a single knowledge article by sys_id. */
 export async function getArticle(instance: string, headers: Record<string, string>, articleId: string): Promise<KbArticle> {
-    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${articleId}`;
+    // encodeURIComponent guards the path segment: an unencoded articleId containing
+    // '/', '?', or '#' could otherwise alter the effective REST path/query.
+    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
     const response = await snRequest('GET', url, { headers });
     const result = response.data.result;
     if (!result || typeof result !== 'object' || Array.isArray(result)) {
@@ -129,7 +131,9 @@ export async function updateKnowledgeArticle(
     workflowState?: string,
     sourceKey?: string,
 ): Promise<KbArticle> {
-    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${articleId}`;
+    // encodeURIComponent guards the path segment: an unencoded articleId containing
+    // '/', '?', or '#' could otherwise alter the effective REST path/query.
+    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
     const existing = await getArticle(instance, headers, articleId);
 
     // Extract kb_id (reference fields can be objects or plain strings)
@@ -184,7 +188,9 @@ export async function updateArticleBody(
     articleId: string,
     text: string,
 ): Promise<void> {
-    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${articleId}`;
+    // encodeURIComponent guards the path segment: an unencoded articleId containing
+    // '/', '?', or '#' could otherwise alter the effective REST path/query.
+    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
     await snRequest('PATCH', url, { headers, body: { text } });
 }
 
@@ -199,7 +205,9 @@ export async function changeWorkflowState(
     workflowState: string,
 ): Promise<KbArticle> {
     if (workflowState === 'publish') {
-        const publishUrl = `${baseUrl(instance)}/api/now/table/kb_knowledge/${articleId}/publish`;
+        // encodeURIComponent guards the path segment: an unencoded articleId containing
+        // '/', '?', or '#' could otherwise alter the effective REST path/query.
+        const publishUrl = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}/publish`;
         try {
             console.log('Attempting to publish article using workflow action...');
             const response = await snRequest('POST', publishUrl, { headers, body: {} });
@@ -219,7 +227,9 @@ export async function changeWorkflowState(
         publish: 'published',
     };
 
-    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${articleId}`;
+    // encodeURIComponent guards the path segment: an unencoded articleId containing
+    // '/', '?', or '#' could otherwise alter the effective REST path/query.
+    const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
     const response = await snRequest('PATCH', url, {
         headers,
         body: { workflow_state: STATE_VALUE_MAP[workflowState] ?? workflowState },

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "4",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
@@ -1,22 +1,22 @@
 export interface TerraformDocsConfig {
-  /** The picklist formatter option (e.g. "markdown-table", "json"). */
-  formatter: string;
-  /** Directory terraform-docs scans; emitted last as the positional argument. */
-  modulePath: string;
-  /** Optional path to a .terraform-docs.yml configuration file (--config). */
-  configFile?: string;
-  /** Optional output file to write the generated documentation to (--output-file). */
-  outputFile?: string;
-  /** How to write the output file: "inject" or "replace" (--output-mode). */
-  outputMode?: string;
-  /** Fail if the output file is out of date rather than writing it (--output-check). */
-  outputCheck?: boolean;
-  /** Sort criteria: "name", "required", or "type" (--sort-by). */
-  sortBy?: string;
-  /** Recurse into submodules (--recursive). */
-  recursive?: boolean;
-  /** Submodule directory to recurse into (--recursive-path). */
-  recursivePath?: string;
+    /** The picklist formatter option (e.g. "markdown-table", "json"). */
+    formatter: string;
+    /** Directory terraform-docs scans; emitted last as the positional argument. */
+    modulePath: string;
+    /** Optional path to a .terraform-docs.yml configuration file (--config). */
+    configFile?: string;
+    /** Optional output file to write the generated documentation to (--output-file). */
+    outputFile?: string;
+    /** How to write the output file: "inject" or "replace" (--output-mode). */
+    outputMode?: string;
+    /** Fail if the output file is out of date rather than writing it (--output-check). */
+    outputCheck?: boolean;
+    /** Sort criteria: "name", "required", or "type" (--sort-by). */
+    sortBy?: string;
+    /** Recurse into submodules (--recursive). */
+    recursive?: boolean;
+    /** Submodule directory to recurse into (--recursive-path). */
+    recursivePath?: string;
 }
 
 /**
@@ -25,31 +25,31 @@ export interface TerraformDocsConfig {
  * fast with a clear error rather than being passed through to the CLI.
  */
 const FORMATTER_SUBCOMMANDS: Record<string, string[]> = {
-  'markdown-table': ['markdown', 'table'],
-  'markdown-document': ['markdown', 'document'],
-  'json': ['json'],
-  'yaml': ['yaml'],
-  'toml': ['toml'],
-  'pretty': ['pretty'],
-  'asciidoc-table': ['asciidoc', 'table'],
-  'asciidoc-document': ['asciidoc', 'document'],
-  'tfvars-hcl': ['tfvars', 'hcl'],
-  'tfvars-json': ['tfvars', 'json'],
+    'markdown-table': ['markdown', 'table'],
+    'markdown-document': ['markdown', 'document'],
+    'json': ['json'],
+    'yaml': ['yaml'],
+    'toml': ['toml'],
+    'pretty': ['pretty'],
+    'asciidoc-table': ['asciidoc', 'table'],
+    'asciidoc-document': ['asciidoc', 'document'],
+    'tfvars-hcl': ['tfvars', 'hcl'],
+    'tfvars-json': ['tfvars', 'json'],
 };
 
 /** Resolves a picklist formatter option to its terraform-docs subcommand tokens. */
 export function resolveFormatter(formatter: string): string[] {
-  const subcommand = FORMATTER_SUBCOMMANDS[formatter];
-  if (!subcommand) {
-    throw new Error(`Unsupported terraform-docs formatter: ${formatter}`);
-  }
-  return [...subcommand];
+    const subcommand = FORMATTER_SUBCOMMANDS[formatter];
+    if (!subcommand) {
+        throw new Error(`Unsupported terraform-docs formatter: ${formatter}`);
+    }
+    return [...subcommand];
 }
 
 /** Minimal `fs.Stats` surface used to classify a candidate config-file path. */
 export interface StatLike {
-  isFile(): boolean;
-  isDirectory(): boolean;
+    isFile(): boolean;
+    isDirectory(): boolean;
 }
 
 /** The `fs.statSync`-shaped dependency `sanitizeConfigFile` needs (injected for testability). */
@@ -80,34 +80,34 @@ export type StatSyncFn = (p: string) => StatLike;
  * function is strictly to reject non-file inputs.
  */
 export function sanitizeConfigFile(raw: string | undefined | null, statSync: StatSyncFn): string | undefined {
-  if (raw === undefined || raw === null) {
-    return undefined;
-  }
+    if (raw === undefined || raw === null) {
+        return undefined;
+    }
 
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) {
-    return undefined;
-  }
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+        return undefined;
+    }
 
-  let stat: StatLike;
-  try {
-    stat = statSync(trimmed);
-  } catch {
-    // Non-existent / unstat-able path. The agent's empty-filePath -> working
-    // directory resolution always yields an existing directory, so a path that
-    // cannot be stat'd can only be a genuinely user-supplied (mistyped) value.
-    throw new Error(`terraform-docs config file not found: ${trimmed}`);
-  }
+    let stat: StatLike;
+    try {
+        stat = statSync(trimmed);
+    } catch {
+        // Non-existent / unstat-able path. The agent's empty-filePath -> working
+        // directory resolution always yields an existing directory, so a path that
+        // cannot be stat'd can only be a genuinely user-supplied (mistyped) value.
+        throw new Error(`terraform-docs config file not found: ${trimmed}`);
+    }
 
-  if (stat.isDirectory()) {
-    return undefined;
-  }
+    if (stat.isDirectory()) {
+        return undefined;
+    }
 
-  if (!stat.isFile()) {
-    throw new Error(`terraform-docs config file is not a regular file: ${trimmed}`);
-  }
+    if (!stat.isFile()) {
+        throw new Error(`terraform-docs config file is not a regular file: ${trimmed}`);
+    }
 
-  return trimmed;
+    return trimmed;
 }
 
 /**
@@ -116,30 +116,30 @@ export function sanitizeConfigFile(raw: string | undefined | null, statSync: Sta
  * is emitted last as the positional argument terraform-docs scans.
  */
 export function buildTerraformDocsArgs(config: TerraformDocsConfig): string[] {
-  const args = resolveFormatter(config.formatter);
+    const args = resolveFormatter(config.formatter);
 
-  if (config.configFile) {
-    args.push('--config', config.configFile);
-  }
-  if (config.outputFile) {
-    args.push('--output-file', config.outputFile);
-    if (config.outputMode) {
-      args.push('--output-mode', config.outputMode);
+    if (config.configFile) {
+        args.push('--config', config.configFile);
     }
-  }
-  if (config.outputCheck) {
-    args.push('--output-check');
-  }
-  if (config.sortBy && config.sortBy !== 'default') {
-    args.push('--sort-by', config.sortBy);
-  }
-  if (config.recursive) {
-    args.push('--recursive');
-    if (config.recursivePath) {
-      args.push('--recursive-path', config.recursivePath);
+    if (config.outputFile) {
+        args.push('--output-file', config.outputFile);
+        if (config.outputMode) {
+            args.push('--output-mode', config.outputMode);
+        }
     }
-  }
+    if (config.outputCheck) {
+        args.push('--output-check');
+    }
+    if (config.sortBy && config.sortBy !== 'default') {
+        args.push('--sort-by', config.sortBy);
+    }
+    if (config.recursive) {
+        args.push('--recursive');
+        if (config.recursivePath) {
+            args.push('--recursive-path', config.recursivePath);
+        }
+    }
 
-  args.push(config.modulePath && config.modulePath.length > 0 ? config.modulePath : '.');
-  return args;
+    args.push(config.modulePath && config.modulePath.length > 0 ? config.modulePath : '.');
+    return args;
 }

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
@@ -5,54 +5,54 @@ import path = require('path');
 import { buildTerraformDocsArgs, sanitizeConfigFile, TerraformDocsConfig } from './args-builder';
 
 async function run() {
-  tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
+    tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
 
-  try {
-    const config: TerraformDocsConfig = {
-      formatter: tasks.getInput('formatter', true)!,
-      modulePath: tasks.getPathInput('modulePath', false, false) || '.',
-      // Azure Pipelines resolves an unset optional `filePath` input to the agent
-      // working directory, so `configFile` must be validated (not trusted) before
-      // it is forwarded as `--config`; a resolved directory means "not provided".
-      configFile: sanitizeConfigFile(tasks.getPathInput('configFile', false, false), (p) => fs.statSync(p)),
-      outputFile: tasks.getInput('outputFile', false),
-      outputMode: tasks.getInput('outputMode', false),
-      outputCheck: tasks.getBoolInput('outputCheck', false),
-      sortBy: tasks.getInput('sortBy', false),
-      recursive: tasks.getBoolInput('recursive', false),
-      recursivePath: tasks.getInput('recursivePath', false),
-    };
+    try {
+        const config: TerraformDocsConfig = {
+            formatter: tasks.getInput('formatter', true)!,
+            modulePath: tasks.getPathInput('modulePath', false, false) || '.',
+            // Azure Pipelines resolves an unset optional `filePath` input to the agent
+            // working directory, so `configFile` must be validated (not trusted) before
+            // it is forwarded as `--config`; a resolved directory means "not provided".
+            configFile: sanitizeConfigFile(tasks.getPathInput('configFile', false, false), (p) => fs.statSync(p)),
+            outputFile: tasks.getInput('outputFile', false),
+            outputMode: tasks.getInput('outputMode', false),
+            outputCheck: tasks.getBoolInput('outputCheck', false),
+            sortBy: tasks.getInput('sortBy', false),
+            recursive: tasks.getBoolInput('recursive', false),
+            recursivePath: tasks.getInput('recursivePath', false),
+        };
 
-    const toolPath = tasks.which('terraform-docs', true);
-    const toolRunner: ToolRunner = tasks.tool(toolPath);
+        const toolPath = tasks.which('terraform-docs', true);
+        const toolRunner: ToolRunner = tasks.tool(toolPath);
 
-    for (const arg of buildTerraformDocsArgs(config)) {
-      toolRunner.arg(arg);
+        for (const arg of buildTerraformDocsArgs(config)) {
+            toolRunner.arg(arg);
+        }
+
+        const additionalArgs = tasks.getInput('additionalArgs', false);
+        if (additionalArgs) {
+            toolRunner.line(additionalArgs);
+        }
+
+        // ignoreReturnCode lets us surface a precise message. terraform-docs exits
+        // non-zero on a genuine error and, with --output-check, when the target file
+        // is out of date — both should fail the task.
+        const exitCode = await toolRunner.execAsync(<IExecOptions>{ ignoreReturnCode: true });
+        if (exitCode !== 0) {
+            throw new Error(tasks.loc('TerraformDocsFailed', exitCode));
+        }
+
+        if (config.outputFile) {
+            const generated = path.join(config.modulePath, config.outputFile);
+            tasks.setVariable('generatedFilePath', generated, false, true);
+            console.log(tasks.loc('GeneratedFile', generated));
+        }
+
+        tasks.setResult(tasks.TaskResult.Succeeded, '');
+    } catch (error) {
+        tasks.setResult(tasks.TaskResult.Failed, error instanceof Error ? error.message : String(error));
     }
-
-    const additionalArgs = tasks.getInput('additionalArgs', false);
-    if (additionalArgs) {
-      toolRunner.line(additionalArgs);
-    }
-
-    // ignoreReturnCode lets us surface a precise message. terraform-docs exits
-    // non-zero on a genuine error and, with --output-check, when the target file
-    // is out of date — both should fail the task.
-    const exitCode = await toolRunner.execAsync(<IExecOptions>{ ignoreReturnCode: true });
-    if (exitCode !== 0) {
-      throw new Error(tasks.loc('TerraformDocsFailed', exitCode));
-    }
-
-    if (config.outputFile) {
-      const generated = path.join(config.modulePath, config.outputFile);
-      tasks.setVariable('generatedFilePath', generated, false, true);
-      console.log(tasks.loc('GeneratedFile', generated));
-    }
-
-    tasks.setResult(tasks.TaskResult.Succeeded, '');
-  } catch (error) {
-    tasks.setResult(tasks.TaskResult.Failed, error instanceof Error ? error.message : String(error));
-  }
 }
 
 void run();

--- a/Tasks/TerraformDocs/TerraformDocsV1/task.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "2",
+    "Minor": "3",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
@@ -82,10 +82,44 @@ describe('TerraformDocsInstaller Test Suite', function () {
     }, tr);
   });
 
+  // --- Registry pre-signed download-URL token masking ---
+  // The registry download_url carries a live storage credential in its query
+  // string and tool-lib logs the URL at INFO. Assert every token component is
+  // registered as a secret (so the agent masks it) while benign params stay
+  // visible.
+  it('registry download token masking: sensitive query params are registered as secrets', async () => {
+    const tp = path.join(__dirname, 'RegistryDownloadTokenMasked.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    await tr.runAsync();
+    runValidations(() => {
+      assert(tr.succeeded, 'task should have succeeded');
+      assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+      const maskedTokens = [
+        'AWSSIGNATUREtoken1111',
+        'AWSCREDENTIALtoken2222',
+        'AWSSECURITYtoken3333',
+        'GOOGSIGNATUREtoken4444',
+        'GOOGCREDENTIALtoken5555',
+        'AZURESIGtoken6666',
+      ];
+      for (const token of maskedTokens) {
+        assert(
+          tr.stdout.includes('##vso[task.setsecret]' + token),
+          `expected ##vso[task.setsecret] for token ${token}. stdout: ${tr.stdout}`,
+        );
+      }
+      assert(!tr.stdout.includes('##vso[task.setsecret]20260703T000000Z'),
+        'benign X-Amz-Date must not be registered as a secret');
+      assert(!tr.stdout.includes('##vso[task.setsecret]host'),
+        'benign X-Amz-SignedHeaders must not be registered as a secret');
+    }, tr);
+  });
+
   // --- Failure cases ---
   expectFailure('InsecureUrlReject');
   expectFailure('RegistryInsecureUrl');
   expectFailure('Sha256Fail');
   expectFailure('InvalidVersionFail');
   expectFailure('RegistryEmptySha256RequireChecksum');
+  expectFailure('MirrorChecksumFetch5xxFail');
 });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorChecksumFetch5xxFail.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorChecksumFetch5xxFail.ts
@@ -1,0 +1,52 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('version', '0.24.0');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://artifacts.example.com/terraform-docs');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+// A NON-404 mirror .sha256sum fetch failure (e.g. a 5xx after http-client retries)
+// must be FATAL, not treated as "checksum absent". fetchTextAllow404 returns null
+// ONLY for a genuine 404; here it throws, so the install must fail closed rather
+// than silently skipping verification. Mirrors TerraformInstaller's
+// MirrorChecksumFetch5xxFail.ts / PolicyAgentInstaller's MirrorSentinel5xxFail.ts.
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('Mirror path should not fetch json: ' + url); },
+  fetchTextAllow404: async () => {
+    throw new Error('HTTP 503 fetching .sha256sum (server error, exhausted retries)');
+  }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('fs', {
+  chmodSync: () => { },
+  readFileSync: () => Buffer.from('fake-archive')
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => 'deadbeef' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => '/tmp/terraform-docs-download.tar.gz',
+  extractTar: async () => '/tmp/terraform-docs-extracted',
+  extractZip: async () => { throw new Error('extractZip should not be called on Linux'); },
+  cacheDir: async () => '/tmp/terraform-docs-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/terraform-docs-cached': ['/tmp/terraform-docs-cached/terraform-docs'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -1,0 +1,80 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// The registry download_url carries a live storage credential in its query
+// string, and tool-lib logs the URL at INFO (fully redacting only Azure
+// `sig=`). Assert every sensitive token component is registered as a secret
+// (so the agent masks it) while benign params stay visible. Mirrors
+// TerraformInstaller's RegistryDownloadTokenMasked.ts regression test.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('version', '0.24.0');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform-docs');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+const AWS_SIGNATURE = 'AWSSIGNATUREtoken1111';        // X-Amz-Signature       -> masked
+const AWS_CREDENTIAL = 'AWSCREDENTIALtoken2222';      // X-Amz-Credential      -> masked
+const AWS_SECURITY_TOKEN = 'AWSSECURITYtoken3333';    // X-Amz-Security-Token  -> masked
+const GOOG_SIGNATURE = 'GOOGSIGNATUREtoken4444';      // X-Goog-Signature      -> masked
+const GOOG_CREDENTIAL = 'GOOGCREDENTIALtoken5555';    // X-Goog-Credential     -> masked
+const AZURE_SIG = 'AZURESIGtoken6666';                // sig (Azure SAS)       -> masked
+const BENIGN_DATE = '20260703T000000Z';               // X-Amz-Date            -> NOT masked
+const BENIGN_SIGNED_HEADERS = 'host';                 // X-Amz-SignedHeaders   -> NOT masked
+
+const PRESIGNED_URL =
+  'https://storage.example.com/signed/terraform-docs_0.24.0_linux_amd64.tar.gz' +
+  '?X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+  `&X-Amz-Credential=${AWS_CREDENTIAL}` +
+  `&X-Amz-Date=${BENIGN_DATE}` +
+  '&X-Amz-Expires=900' +
+  `&X-Amz-SignedHeaders=${BENIGN_SIGNED_HEADERS}` +
+  `&X-Amz-Security-Token=${AWS_SECURITY_TOKEN}` +
+  `&X-Amz-Signature=${AWS_SIGNATURE}` +
+  `&X-Goog-Credential=${GOOG_CREDENTIAL}` +
+  `&X-Goog-Signature=${GOOG_SIGNATURE}` +
+  `&sig=${AZURE_SIG}`;
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    if (url.includes('/terraform/binaries/terraform-docs/versions/0.24.0/linux/amd64')) {
+      return { download_url: PRESIGNED_URL, sha256: EXPECTED_SHA256 };
+    }
+    throw new Error('Unexpected fetchJson URL: ' + url);
+  },
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('fs', {
+  chmodSync: () => { },
+  readFileSync: () => Buffer.from('fake-archive')
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => '/tmp/terraform-docs-download.tar.gz',
+  extractTar: async () => '/tmp/terraform-docs-extracted',
+  extractZip: async () => { throw new Error('extractZip should not be called on Linux'); },
+  cacheDir: async () => '/tmp/terraform-docs-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/terraform-docs-cached': ['/tmp/terraform-docs-cached/terraform-docs'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -9,6 +9,7 @@ import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchTextAllow404 } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
+import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage } from './url-secret-redaction';
 
 const toolName = "terraform-docs";
 const isWindows = os.type().match(/^Win/);
@@ -167,7 +168,33 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
         }
     }
 
-    const filePath = await downloadTo(data.download_url, `terraform-docs-${version}-${uuidV4()}.${getArchiveExtension()}`);
+    const fileName = `terraform-docs-${version}-${uuidV4()}.${getArchiveExtension()}`;
+    // The pre-signed download_url carries a live, read-scoped storage credential in
+    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
+    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
+    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
+    // normal registry run. Register each token component as a secret FIRST so the
+    // agent masks it in tool-lib's log line (and in any failure message).
+    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
+    for (const secret of urlTokenSecrets) {
+        tasks.setSecret(secret);
+    }
+    let filePath: string;
+    try {
+        filePath = await tools.downloadTool(data.download_url, fileName);
+    } catch (exception) {
+        // download_url is a pre-signed URL whose query string carries the signing
+        // token; drop the whole query (redactUrl) and scrub the raw URL out of the
+        // tool-lib exception text so the live credential never reaches the build
+        // log via the failure message.
+        const safeUrl = redactUrl(data.download_url);
+        const safeMsg = scrubSecretsFromMessage(
+            String(exception instanceof Error ? exception.message : exception),
+            data.download_url,
+            urlTokenSecrets,
+        );
+        throw new Error(tasks.loc("TerraformDocsDownloadFailed", safeUrl, safeMsg));
+    }
 
     if (data.sha256) {
         await verifySha256(filePath, data.sha256);

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/url-secret-redaction.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/url-secret-redaction.ts
@@ -1,0 +1,79 @@
+/**
+ * Registry-provided pre-signed download URLs (Azure blob SAS, AWS S3 presigned,
+ * GCS signed URL) carry a live, short-TTL storage credential in their query
+ * string. azure-pipelines-tool-lib's downloadTool logs the URL at INFO and only
+ * auto-redacts Azure `sig=`, so AWS `X-Amz-Signature`/`X-Amz-Credential`/
+ * `X-Amz-Security-Token` and GCS `X-Goog-Signature`/`X-Goog-Credential` would
+ * otherwise print unredacted on every normal registry run — and the same token
+ * can leak again if a download failure echoes the raw URL in its message.
+ *
+ * Shared byte-for-byte across all three installer tasks that consume a registry
+ * download_url (guarded by scripts/check-shared-modules.js) so a fix here can
+ * never be applied to one copy and silently missed in the others.
+ */
+
+function isSensitiveQueryParam(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower === 'sig'
+        || lower.includes('signature')
+        || lower.includes('credential')
+        || lower.includes('token');
+}
+
+/**
+ * Extracts the values of every sensitive query-string token in `url`. Values are
+ * returned in the raw form they appear in the URL (still percent-encoded) so they
+ * match the exact substring tool-lib logs at INFO; the decoded form is added too when
+ * it differs, so a consumer that logs the decoded value is masked as well. Used to
+ * setSecret() the tokens before download and to scrub them from any failure message.
+ */
+export function extractUrlTokenSecrets(url: string): string[] {
+    const qIndex = url.indexOf('?');
+    if (qIndex === -1) return [];
+    const query = url.slice(qIndex + 1).split('#')[0];
+    const secrets: string[] = [];
+    for (const pair of query.split('&')) {
+        const eq = pair.indexOf('=');
+        if (eq === -1) continue;
+        const name = pair.slice(0, eq);
+        const rawValue = pair.slice(eq + 1);
+        if (!rawValue || !isSensitiveQueryParam(name)) continue;
+        secrets.push(rawValue);
+        let decoded: string;
+        try { decoded = decodeURIComponent(rawValue); } catch { decoded = rawValue; }
+        if (decoded !== rawValue) secrets.push(decoded);
+    }
+    return secrets;
+}
+
+/**
+ * Strips the ENTIRE query string (which can carry a pre-signed signature/token —
+ * Azure `sig`, AWS `X-Amz-Signature`/`X-Amz-Credential`/`X-Amz-Security-Token`,
+ * GCS `X-Goog-Signature`/`X-Goog-Credential`) from a URL for safe logging. The whole
+ * query is dropped rather than redacting known parameter names one at a time, so an
+ * unforeseen token parameter can never leak through the error path.
+ */
+export function redactUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        return u.origin + u.pathname + (u.search ? '?<redacted>' : '');
+    } catch {
+        return url.split('?')[0];
+    }
+}
+
+/**
+ * Scrubs a raw download URL and its extracted token secrets out of an error
+ * message string. Used when a download failure's exception text embeds the raw
+ * URL verbatim; scrubbing each known token value too is belt-and-suspenders
+ * against a downstream library (e.g. tool-lib's own partial `sig=` redaction)
+ * embedding a differently-transformed copy of the URL.
+ */
+export function scrubSecretsFromMessage(message: string, url: string, secrets: string[]): string {
+    const safeUrl = redactUrl(url);
+    let safeMessage = message.split(url).join(safeUrl);
+    for (const secret of secrets) {
+        safeMessage = safeMessage.split(secret).join('<redacted>');
+    }
+    return safeMessage;
+}

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "3",
+    "Minor": "4",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -11,60 +11,11 @@ import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';
+import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage } from './url-secret-redaction';
 
 const terraformToolName = "terraform";
 const tofuToolName = "tofu";
 const isWindows = os.type().match(/^Win/);
-
-function isSensitiveQueryParam(name: string): boolean {
-    const lower = name.toLowerCase();
-    return lower === 'sig'
-        || lower.includes('signature')
-        || lower.includes('credential')
-        || lower.includes('token');
-}
-
-/**
- * Extracts the values of every sensitive query-string token in `url`. Values are
- * returned in the raw form they appear in the URL (still percent-encoded) so they
- * match the exact substring tool-lib logs at INFO; the decoded form is added too when
- * it differs, so a consumer that logs the decoded value is masked as well. Used to
- * setSecret() the tokens before download and to scrub them from any failure message.
- */
-function extractUrlTokenSecrets(url: string): string[] {
-    const qIndex = url.indexOf('?');
-    if (qIndex === -1) return [];
-    const query = url.slice(qIndex + 1).split('#')[0];
-    const secrets: string[] = [];
-    for (const pair of query.split('&')) {
-        const eq = pair.indexOf('=');
-        if (eq === -1) continue;
-        const name = pair.slice(0, eq);
-        const rawValue = pair.slice(eq + 1);
-        if (!rawValue || !isSensitiveQueryParam(name)) continue;
-        secrets.push(rawValue);
-        let decoded: string;
-        try { decoded = decodeURIComponent(rawValue); } catch { decoded = rawValue; }
-        if (decoded !== rawValue) secrets.push(decoded);
-    }
-    return secrets;
-}
-
-/**
- * Strips the ENTIRE query string (which can carry a pre-signed signature/token —
- * Azure `sig`, AWS `X-Amz-Signature`/`X-Amz-Credential`/`X-Amz-Security-Token`,
- * GCS `X-Goog-Signature`/`X-Goog-Credential`) from a URL for safe logging. The whole
- * query is dropped rather than redacting known parameter names one at a time, so an
- * unforeseen token parameter can never leak through the error path.
- */
-function redactUrl(url: string): string {
-    try {
-        const u = new URL(url);
-        return u.origin + u.pathname + (u.search ? '?<redacted>' : '');
-    } catch {
-        return url.split('?')[0];
-    }
-}
 
 export async function downloadTerraform(inputVersion: string): Promise<string> {
     const binary = tasks.getInput("binary") || "terraform";
@@ -259,13 +210,11 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
         // tool-lib exception text so the live credential never reaches the build
         // log via the failure message.
         const safeUrl = redactUrl(data.download_url);
-        let safeMsg = String(exception instanceof Error ? exception.message : exception).split(data.download_url).join(safeUrl);
-        // Belt-and-suspenders: tool-lib may embed a URL it partially transformed
-        // (its own `sig=` redaction) that the exact-URL replace above misses, so
-        // also scrub each known token value out of the message.
-        for (const secret of urlTokenSecrets) {
-            safeMsg = safeMsg.split(secret).join('<redacted>');
-        }
+        const safeMsg = scrubSecretsFromMessage(
+            String(exception instanceof Error ? exception.message : exception),
+            data.download_url,
+            urlTokenSecrets,
+        );
         throw new Error(tasks.loc("TerraformDownloadFailed", safeUrl, safeMsg));
     }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/url-secret-redaction.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/url-secret-redaction.ts
@@ -1,0 +1,79 @@
+/**
+ * Registry-provided pre-signed download URLs (Azure blob SAS, AWS S3 presigned,
+ * GCS signed URL) carry a live, short-TTL storage credential in their query
+ * string. azure-pipelines-tool-lib's downloadTool logs the URL at INFO and only
+ * auto-redacts Azure `sig=`, so AWS `X-Amz-Signature`/`X-Amz-Credential`/
+ * `X-Amz-Security-Token` and GCS `X-Goog-Signature`/`X-Goog-Credential` would
+ * otherwise print unredacted on every normal registry run — and the same token
+ * can leak again if a download failure echoes the raw URL in its message.
+ *
+ * Shared byte-for-byte across all three installer tasks that consume a registry
+ * download_url (guarded by scripts/check-shared-modules.js) so a fix here can
+ * never be applied to one copy and silently missed in the others.
+ */
+
+function isSensitiveQueryParam(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower === 'sig'
+        || lower.includes('signature')
+        || lower.includes('credential')
+        || lower.includes('token');
+}
+
+/**
+ * Extracts the values of every sensitive query-string token in `url`. Values are
+ * returned in the raw form they appear in the URL (still percent-encoded) so they
+ * match the exact substring tool-lib logs at INFO; the decoded form is added too when
+ * it differs, so a consumer that logs the decoded value is masked as well. Used to
+ * setSecret() the tokens before download and to scrub them from any failure message.
+ */
+export function extractUrlTokenSecrets(url: string): string[] {
+    const qIndex = url.indexOf('?');
+    if (qIndex === -1) return [];
+    const query = url.slice(qIndex + 1).split('#')[0];
+    const secrets: string[] = [];
+    for (const pair of query.split('&')) {
+        const eq = pair.indexOf('=');
+        if (eq === -1) continue;
+        const name = pair.slice(0, eq);
+        const rawValue = pair.slice(eq + 1);
+        if (!rawValue || !isSensitiveQueryParam(name)) continue;
+        secrets.push(rawValue);
+        let decoded: string;
+        try { decoded = decodeURIComponent(rawValue); } catch { decoded = rawValue; }
+        if (decoded !== rawValue) secrets.push(decoded);
+    }
+    return secrets;
+}
+
+/**
+ * Strips the ENTIRE query string (which can carry a pre-signed signature/token —
+ * Azure `sig`, AWS `X-Amz-Signature`/`X-Amz-Credential`/`X-Amz-Security-Token`,
+ * GCS `X-Goog-Signature`/`X-Goog-Credential`) from a URL for safe logging. The whole
+ * query is dropped rather than redacting known parameter names one at a time, so an
+ * unforeseen token parameter can never leak through the error path.
+ */
+export function redactUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        return u.origin + u.pathname + (u.search ? '?<redacted>' : '');
+    } catch {
+        return url.split('?')[0];
+    }
+}
+
+/**
+ * Scrubs a raw download URL and its extracted token secrets out of an error
+ * message string. Used when a download failure's exception text embeds the raw
+ * URL verbatim; scrubbing each known token value too is belt-and-suspenders
+ * against a downstream library (e.g. tool-lib's own partial `sig=` redaction)
+ * embedding a differently-transformed copy of the URL.
+ */
+export function scrubSecretsFromMessage(message: string, url: string, secrets: string[]): string {
+    const safeUrl = redactUrl(url);
+    let safeMessage = message.split(url).join(safeUrl);
+    for (const secret of secrets) {
+        safeMessage = safeMessage.split(secret).join('<redacted>');
+    }
+    return safeMessage;
+}

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "231",
+        "Minor": "232",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -75,6 +75,7 @@ describe('TerraformPolicyCheck Test Suite', function () {
     expectFailure('SentinelHardFail');
     expectSuccess('SentinelAdvisoryWarn');
     expectSuccess('SentinelSoftOverride');
+    expectFailure('SentinelUnrecognizedExitFail');
 
     // --- Policy source ---
     expectSuccess('GitSourceClone');

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SentinelUnrecognizedExitFail.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SentinelUnrecognizedExitFail.ts
@@ -1,0 +1,39 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+import fs = require('fs');
+
+// #448: Sentinel's documented exit codes are 0 (pass), 1/2 (policy failed), 3/9
+// (runtime error, already handled). An unrecognized code (e.g. 137 = SIGKILL, an
+// OOM-killed process) must NOT silently fall through to a policy pass — assert
+// the task fails closed instead.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const testDir = path.join(os.tmpdir(), 'tpc-sentinel-unrecognized-exit');
+fs.rmSync(testDir, { recursive: true, force: true });
+const policyDir = path.join(testDir, 'policies');
+fs.mkdirSync(policyDir, { recursive: true });
+fs.writeFileSync(path.join(policyDir, 'deny-public.sentinel'), 'main = rule { true }\n');
+const planFile = path.join(testDir, 'plan.json');
+fs.writeFileSync(planFile, '{}');
+
+tr.setInput('engine', 'sentinel');
+tr.setInput('inputFile', planFile);
+tr.setInput('policySource', 'path');
+tr.setInput('policyPath', policyDir);
+tr.setInput('defaultEnforcementLevel', 'soft-mandatory');
+tr.setInput('publishTestResults', 'false');
+
+const sentinelPath = '/usr/bin/sentinel';
+const a: ma.TaskLibAnswers = {
+  which: { sentinel: sentinelPath },
+  checkPath: { [sentinelPath]: true },
+  exec: {
+    // 137 = SIGKILL (e.g. OOM-killed); not one of Sentinel's documented codes.
+    [`${sentinelPath} apply`]: { code: 137, stdout: '' }
+  }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
@@ -54,6 +54,18 @@ export async function runSentinel(
         throw new Error(`Sentinel returned a non-policy error (exit code ${code}). Output:\n${stdout.slice(0, 2000)}`);
     }
 
+    // Sentinel's documented exit codes are 0 (pass), 1 (policy failed), 2 (undefined
+    // result), 3 (runtime error, handled above), and 9 (other error, handled above).
+    // Any other code — e.g. 126/127 (not executable / not found), 137/139
+    // (SIGKILL/SIGSEGV), an OOM-killed process, or a future Sentinel exit code this
+    // task does not yet recognize — must NOT be silently treated as a pass: without
+    // this check it falls through to `policyFailed = false` below and the policy
+    // gate reports `passed: true` on an abnormal process outcome. Fail closed
+    // instead, mirroring opa-engine's exhaustive `code !== 0` check.
+    if (code !== 0 && code !== 1 && code !== 2) {
+        throw new Error(`Sentinel exited with an unrecognized code (${code}); refusing to treat this as a policy pass. Output:\n${stdout.slice(0, 2000)}`);
+    }
+
     const policyFailed = code === 1 || code === 2;
     const cases = parseCases(stdout, level);
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "6",
+        "Minor": "7",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -24,7 +24,8 @@
     "GCP",
     "OCI",
     "Release",
-    "DevOps"
+    "DevOps",
+    "ServiceNow"
   ],
   "branding": {
     "color": "#FFFFFF",

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -77,6 +77,22 @@ const FAMILIES = [
             'bool-input.ts',
         ],
     },
+    {
+        // Registry-download credential masking: extracts and setSecret()s any
+        // pre-signed-URL query-string token before download, and scrubs the raw
+        // URL/tokens out of a download failure message. A drift here previously let
+        // two of the three installers leak a live storage credential to the build
+        // log (2026-07 re-audit, finding "registry pre-signed URL token leak") while
+        // the third had already fixed it — keep byte-identical across all three.
+        dirs: [
+            'Tasks/TerraformInstaller/TerraformInstallerV1/src',
+            'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src',
+            'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src',
+        ],
+        modules: [
+            'url-secret-redaction.ts',
+        ],
+    },
 ];
 
 // These two families are deliberately NOT merged into one shared client, even


### PR DESCRIPTION
Fixes the 6 P0-P3 findings from the 5th blind re-audit (2026-07-07), in priority order, all verified with PoCs/regression tests.

## P0 — [#446](https://github.com/sethbacon/azure-pipelines-terraform/issues/446) KB stored XSS (PoC-confirmed)
`sanitizeRenderedHtml` (Markdown2Html) and `validateHtmlContent` (PublishKbArticle) both checked a URI scheme with `value.trim().toLowerCase().startsWith('javascript:'...)`. `.trim()` only strips leading/trailing whitespace, so an HTML-entity-encoded control char **inside** the scheme (`jav&#9;ascript:`, also `&#10;`/`&#13;`/`&Tab;`/leading `&#1;`) survives the check but is stripped by a browser's URL parser at click time — executing `javascript:` in a KB reader's session. Confirmed with a working PoC against both layers before the fix. Fixed by stripping all ASCII control chars before the scheme check in both layers, plus rejecting `<base>` and a `javascript:`/`vbscript:` `<meta http-equiv=refresh>`. New abuse-case tests in both tasks.

## P0 — [#447](https://github.com/sethbacon/azure-pipelines-terraform/issues/447) Registry pre-signed URL token leak
`PolicyAgentInstaller` and `TerraformDocsInstaller` passed the registry `download_url` (query string can carry a live AWS/GCS/Azure storage token) straight into `tools.downloadTool()` (logs at INFO) and into thrown errors, with no masking — `TerraformInstaller` fixed this class of issue previously but the fix was never backported. Extracted the masking helpers into a new shared, parity-gated module (`url-secret-redaction.ts`, in `scripts/check-shared-modules.js`) and wired all three installers to it. New masking regression test in each of the two fixed installers.

## P1 — [#448](https://github.com/sethbacon/azure-pipelines-terraform/issues/448) Sentinel fail-open on unrecognized exit codes
`sentinel-engine.ts` only handled exit codes `{0,1,2,3,9}`; any other code (126/127, 137/139 SIGKILL/SIGSEGV, a future Sentinel code) fell through to `policyFailed=false`, silently reporting a policy **pass**. Now fails closed on any code outside `{0,1,2,3,9}`, matching `opa-engine.ts`'s exhaustive check. New regression test with exit code 137.

## P2 — [#449](https://github.com/sethbacon/azure-pipelines-terraform/issues/449) KB article identity hardening
- `findKbArticleJson()` scanned every `*.json` in the working directory — restricted to this task's own legacy-writer naming convention (`KB<number>.json` / `article_info.json`), and picks the most-recently-modified match instead of directory-listing order.
- `articleId` is now `encodeURIComponent`-encoded at every REST URL build site in `servicenow-client.ts`.
- New tests for both.

## P2 — [#450](https://github.com/sethbacon/azure-pipelines-terraform/issues/450) CI/test coverage gaps
- Added `npm audit --audit-level=high` to the one CI job that installs the **root** toolchain (`tfx-cli`, `webpack`, `cyclonedx-npm`, `jest` — all devDependencies, so the per-task `--omit=dev` gates never covered them). Verified locally: currently passes (only one pre-existing `moderate` finding).
- Added the `MirrorChecksumFetch5xxFail` regression test to `TerraformDocsInstaller` (the installer left out of the prior two-installer fix), asserting a 5xx checksum-fetch is fatal, not conflated with a genuine 404.

## P3 — [#451](https://github.com/sethbacon/azure-pipelines-terraform/issues/451) Hygiene
- Reindented `TerraformDocs` (the terraform-docs **runner**, sibling of the already-fixed installer) to 4-space.
- `dependency-review-action` `fail-on-severity` lowered from `high` to `moderate`, matching the npm audit gates.
- Added a `ServiceNow` tag to `azure-devops-extension.json` for Marketplace discoverability.
- Generalized `CONTRIBUTING.md`'s "Initial Setup" (previously listed only 3 of 11 task dirs) and pointed at the already-complete Testing section.

## Validation
- Shared-module parity (`check-shared-modules.js`), version consistency (`check-versions.js`), and the mandatory per-task Minor-bump gate (`check-minor-bumps.js`, v1.8.5→HEAD) all pass.
- Lint + full test suite green for all 7 touched tasks: TerraformInstaller (68), PolicyAgentInstaller (58), TerraformDocsInstaller (49), TerraformPolicyCheck (25), TerraformDocs (32), Markdown2Html (55), PublishKbArticle (92) — 379 tests total, including ~15 new regression tests added by this PR.
- Minor bumped for all 7 tasks whose `src/` changed (TerraformInstaller 231→232, PolicyAgentInstaller 7→8, TerraformDocsInstaller 3→4, TerraformPolicyCheck 6→7, TerraformDocs 2→3, Markdown2Html 2→3, PublishKbArticle 3→4).

Closes #446, closes #447, closes #448, closes #449, closes #450, closes #451
