### PR TITLE
fix(PublishKbArticle): resolve article id via sourceKey then KB*.json before create

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -1184,4 +1184,15 @@ describe('PublishKbArticle full-task: instance SSRF guard', () => {
             assert.strictEqual(tr.errorIssues.length, 0, `should have no error issues: ${tr.errorIssues}`);
         }, tr);
     });
+
+    it('SourceKeyMissFallsBackToJson — a source-key miss falls through to the KB*.json lookup instead of creating a duplicate', async () => {
+        const tp = nodePath.join(__dirname, 'SourceKeyMissFallsBackToJson.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            assert.ok(/json-art-999/.test(tr.stdout), `plan should target the article resolved from JSON fallback: ${tr.stdout}`);
+            assert.ok(!/CREATE new article/.test(tr.stdout), `a source-key miss must not plan a create when a KB*.json exists: ${tr.stdout}`);
+        }, tr);
+    });
 });

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/SourceKeyMissFallsBackToJson.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/SourceKeyMissFallsBackToJson.ts
@@ -1,0 +1,48 @@
+// Full-task test: when a `sourceKey` is provided but no article matches the
+// wiki-source sentinel (findArticleBySourceKey → null), resolution must FALL
+// THROUGH to the legacy KB*.json lookup rather than short-circuiting to a
+// create. This proves adopting sourceKey stays backward-compatible with modules
+// still tracked by a KB*.json file (no duplicate article is planned).
+//
+// Runs in dry-run mode so no write is performed; the mocked servicenow-client
+// returns the existing article for the resolved id so the plan can be built.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('instance', 'my-valid-instance');
+tr.setInput('authType', 'basic');
+tr.setInput('username', 'svc-user');
+tr.setInput('password', 'svc-pass');
+tr.setInput('sourceKey', 'existing-module-key');
+tr.setInput('workflowState', 'draft');
+tr.setInput('dryRun', 'true');
+tr.setInput('skipJsonLookup', 'false');
+tr.setInput('force', 'false');
+tr.setInput('uploadImages', 'false');
+
+// Source-key lookup MISSES; getArticle returns the article resolved from the
+// JSON fallback so the dry-run plan can report its current state.
+tr.registerMock('./servicenow-client', {
+  getKnowledgeBases: async () => { throw new Error('NETWORK_CALLED: getKnowledgeBases'); },
+  getArticle: async () => ({ sys_id: 'json-art-999', workflow_state: 'draft' }),
+  createKnowledgeArticle: async () => { throw new Error('NETWORK_CALLED: createKnowledgeArticle'); },
+  updateKnowledgeArticle: async () => { throw new Error('NETWORK_CALLED: updateKnowledgeArticle'); },
+  changeWorkflowState: async () => { throw new Error('NETWORK_CALLED: changeWorkflowState'); },
+  findArticleBySourceKey: async () => null,
+  updateArticleBody: async () => { throw new Error('NETWORK_CALLED: updateArticleBody'); },
+});
+
+// Legacy JSON fallback returns an existing article id.
+tr.registerMock('./manifest', {
+  findKbArticleJson: () => ({ article_id: 'json-art-999' }),
+  readFrontMatterKey: () => { throw new Error('readFrontMatterKey should not be called'); },
+  emitArticleOutput: () => { throw new Error('emitArticleOutput should not be called in dry-run'); },
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
@@ -139,21 +139,28 @@ async function run() {
         }
 
         // -----------------------------------------------------------------
-        // Resolve article ID
+        // Resolve article ID in priority order: explicit input, then the stable
+        // source-key sentinel, then the legacy KB*.json file; otherwise create.
+        //
+        // The source-key lookup FALLS THROUGH to the JSON lookup on a miss (rather
+        // than short-circuiting to create). This keeps sourceKey backward-compatible
+        // with modules still tracked by a KB*.json file: an existing article created
+        // before the sentinel existed is found via the JSON file and updated in place
+        // (self-healing its wiki-source sentinel) instead of a duplicate being created.
         // -----------------------------------------------------------------
         let articleId: string | undefined = articleIdInput;
 
-        if (!articleId) {
-            if (sourceKey) {
-                const found = await findArticleBySourceKey(instance, headers, sourceKey, kbId);
-                articleId = found || undefined;
-            } else if (!skipJsonLookup) {
-                console.log('No article-id provided. Looking for KB article JSON file...');
-                const jsonData = findKbArticleJson();
-                if (jsonData && jsonData['article_id']) {
-                    articleId = jsonData['article_id'] as string;
-                    console.log(`Using article ID from JSON file: ${articleId}`);
-                }
+        if (!articleId && sourceKey) {
+            const found = await findArticleBySourceKey(instance, headers, sourceKey, kbId);
+            articleId = found || undefined;
+        }
+
+        if (!articleId && !skipJsonLookup) {
+            console.log('No article-id resolved yet. Looking for KB article JSON file...');
+            const jsonData = findKbArticleJson();
+            if (jsonData && jsonData['article_id']) {
+                articleId = jsonData['article_id'] as string;
+                console.log(`Using article ID from JSON file: ${articleId}`);
             }
         }
 


### PR DESCRIPTION
## What & why

The ServiceNow KB publish flow wasn't creating/publishing an article for **new** modules: the release stage only knew how to find an existing article via a `KB*.json` file, so a brand-new module (no such file) printed *"nothing to publish"* and skipped. The fix is to drive find/create/publish off the stable `sourceKey` (`wiki-source: <key>` sentinel) — but adopting `sourceKey` naively would create a **duplicate draft** for existing modules still tracked by a `KB*.json` file, because article-id resolution was previously *either* sourceKey *or* JSON (never both).

## Change

`index.ts` now resolves the target article id as a **chain** instead of either/or:

`articleId input → sourceKey sentinel → KB*.json → else create`

A `sourceKey` miss now **falls through** to the legacy `KB*.json` lookup, so an existing article is found (and its `wiki-source` sentinel self-healed on the update) instead of a duplicate being created. A brand-new module still creates on a genuine miss.

## Scope

This is the task-side enabler. The pipeline templates that pass `sourceKey: <moduleName>` (build "Draft KB Article" + release "Publish KB Article") live in the ADO `terraform-pipeline-templates` repo and are changed separately.

## Testing

- New full-task test `SourceKeyMissFallsBackToJson` proves a sourceKey miss resolves the article from `KB*.json` and plans an update, not a create.
- `npm test` — **93 passing**; `npm run test:coverage` gate passes.
- No `task.json` bump needed — `main` already has this task at `1.4.0`.
