### PR TITLE
fix: publish KB via PATCH; drop dead /publish action

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -446,47 +446,24 @@ describe('client.findOrCreateCategory', () => {
 });
 
 // ===========================================================================
-// servicenow-client — changeWorkflowState (publish endpoint + fallback)
+// servicenow-client — changeWorkflowState (direct PATCH)
 // ===========================================================================
 describe('client.changeWorkflowState', () => {
-    it('uses /publish endpoint on success and returns fetched article', async () => {
+    it('publishes via a direct PATCH of workflow_state=published (no /publish action)', async () => {
         const articleId = 'pub_art_001';
-        const resultArticle = {
-            sys_id: articleId,
-            number: 'KB0040',
-            workflow_state: 'published',
-        };
-
+        let capturedBody: Record<string, unknown> = {};
+        // Only the PATCH is mocked. The Table API has no /publish sub-resource, so if the code
+        // attempted POST .../publish, nock would fail the test as an unmatched request.
         nock(BASE_URL)
-            .post(`/api/now/table/kb_knowledge/${articleId}/publish`)
-            .reply(200, {});
-
-        nock(BASE_URL)
-            .get(`/api/now/table/kb_knowledge/${articleId}`)
-            .reply(200, { result: resultArticle });
+            .patch(`/api/now/table/kb_knowledge/${articleId}`, (body: Record<string, unknown>) => {
+                capturedBody = body;
+                return true;
+            })
+            .reply(200, { result: { sys_id: articleId, number: 'KB0040', workflow_state: 'published' } });
 
         const article = await client.changeWorkflowState(INSTANCE, HEADERS, articleId, 'publish');
         assert.strictEqual(article.workflow_state, 'published');
-    });
-
-    it('falls back to PATCH when /publish endpoint fails', async () => {
-        const articleId = 'pub_art_002';
-        const resultArticle = {
-            sys_id: articleId,
-            number: 'KB0041',
-            workflow_state: 'published',
-        };
-
-        nock(BASE_URL)
-            .post(`/api/now/table/kb_knowledge/${articleId}/publish`)
-            .reply(500, { error: 'Internal Server Error' });
-
-        nock(BASE_URL)
-            .patch(`/api/now/table/kb_knowledge/${articleId}`)
-            .reply(200, { result: resultArticle });
-
-        const article = await client.changeWorkflowState(INSTANCE, HEADERS, articleId, 'publish');
-        assert.strictEqual(article.workflow_state, 'published');
+        assert.strictEqual(capturedBody['workflow_state'], 'published');
     });
 
     it('uses PATCH directly for non-publish states', async () => {

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -195,8 +195,12 @@ export async function updateArticleBody(
 }
 
 /**
- * Change workflow state using the /publish endpoint first (for publish),
- * falling back to a standard PATCH on failure.
+ * Set the article's workflow state via the Table API.
+ *
+ * Publishing is done by patching workflow_state directly. ServiceNow's Table API has no
+ * "/publish" action sub-resource — POST .../kb_knowledge/{id}/publish returns HTTP 400
+ * "Requested URI does not represent any resource" on every instance — so the PATCH is the
+ * supported mechanism, not a fallback.
  */
 export async function changeWorkflowState(
     instance: string,
@@ -204,23 +208,6 @@ export async function changeWorkflowState(
     articleId: string,
     workflowState: string,
 ): Promise<KbArticle> {
-    if (workflowState === 'publish') {
-        // encodeURIComponent guards the path segment: an unencoded articleId containing
-        // '/', '?', or '#' could otherwise alter the effective REST path/query.
-        const publishUrl = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}/publish`;
-        try {
-            console.log('Attempting to publish article using workflow action...');
-            const response = await snRequest('POST', publishUrl, { headers, body: {} });
-            if ([200, 201, 204].includes(response.status)) {
-                console.log('Article published successfully using workflow action.');
-                return await getArticle(instance, headers, articleId);
-            }
-        } catch (e: unknown) {
-            const detail = e instanceof Error ? e.message : String(e);
-            console.log(`Workflow action failed (${detail}). Falling back to standard update...`);
-        }
-    }
-
     const STATE_VALUE_MAP: Record<string, string> = {
         draft: 'draft',
         review: 'review',

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "4",
+        "Minor": "5",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
## What

`PublishKbArticle` set a KB article to *published* by first attempting a "workflow action" `POST /api/now/table/kb_knowledge/{sys_id}/publish`, then falling back to a `PATCH` of `workflow_state`. In practice the first call **always** fails:

```
POST /api/now/table/kb_knowledge/{id}/publish -> 400
{"error":{"message":"Requested URI does not represent any resource"}}
```

## Why

`/api/now/table/` is ServiceNow's **Table API** namespace, which only addresses records at `/{table}/{sys_id}` — it has **no `/publish` action sub-resource** (and you can't mount one there; Scripted REST APIs live under `/api/{scope}/…`). So the workflow-action attempt returns 400 on every instance and the task always falls back to the `PATCH`, which is the actual, supported way to set `workflow_state=published`.

## Change

- Remove the guaranteed-to-fail `/publish` attempt; publish via the `PATCH` directly (same effective outcome, no noisy 400 in every release log).
- Update the `changeWorkflowState` tests accordingly (publish now asserts a single direct `PATCH`; not mocking `/publish` means a stray call would fail the test).
- Bump `PublishKbArticleV1` to `1.5.0`.

## Tests

Full task suite passes (92/92); ESLint clean.
