### PR TITLE
refactor: decompose PublishKbArticle run() and track servicenow-http.ts

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
@@ -15,102 +15,235 @@ import { DryRunPlan, PlannedAction, formatDryRunReport } from './dry-run';
 import { processArticleImages } from './attachments';
 import { updateArticleBody } from './servicenow-client';
 
+interface ResolvedAuth {
+    instance: string;
+    headers: Record<string, string>;
+}
+
+/**
+ * Resolve the ServiceNow instance and auth headers from a service connection
+ * and/or inline inputs (inline inputs override/supplement the connection),
+ * validate the instance name against URL injection, and obtain the OAuth or
+ * Basic auth headers.
+ */
+async function resolveAuth(): Promise<ResolvedAuth> {
+    // -----------------------------------------------------------------
+    // Resolve instance and auth from service connection or inline inputs
+    // -----------------------------------------------------------------
+    let instance = '';
+    let authType = '';
+    let clientId: string | undefined;
+    let clientSecret: string | undefined;
+    let username: string | undefined;
+    let password: string | undefined;
+
+    const serviceConnection = tasks.getInput('serviceConnection', false);
+    if (serviceConnection) {
+        const rawUrl = tasks.getEndpointUrl(serviceConnection, false) || '';
+        // Extract instance name from URL like https://myinstance.service-now.com
+        const urlMatch = rawUrl.match(/https?:\/\/([^.]+)\.service-now\.com/i);
+        instance = urlMatch ? urlMatch[1] : rawUrl;
+
+        const scheme = (tasks.getEndpointAuthorizationScheme(serviceConnection, false) || '').toLowerCase();
+        if (scheme === 'usernamepassword' || scheme === 'basic') {
+            authType = 'basic';
+            username = tasks.getEndpointAuthorizationParameter(serviceConnection, 'username', false) || undefined;
+            password = tasks.getEndpointAuthorizationParameter(serviceConnection, 'password', false) || undefined;
+        } else {
+            authType = 'oauth';
+            clientId = tasks.getEndpointAuthorizationParameter(serviceConnection, 'clientId', false) || undefined;
+            clientSecret = tasks.getEndpointAuthorizationParameter(serviceConnection, 'clientSecret', false) || undefined;
+        }
+    }
+
+    // Inline inputs override / supplement service connection
+    instance = tasks.getInput('instance', false) || instance;
+    authType = tasks.getInput('authType', false) || authType;
+    clientId = tasks.getInput('clientId', false) || clientId;
+    clientSecret = tasks.getInput('clientSecret', false) || clientSecret;
+    username = tasks.getInput('username', false) || username;
+    password = tasks.getInput('password', false) || password;
+
+    if (!instance) {
+        throw new Error('ServiceNow instance is required (set "instance" input or provide a service connection).');
+    }
+    // Guard against URL injection: instance is interpolated into
+    // https://<instance>.service-now.com, which carries the OAuth secret.
+    if (!/^[a-z0-9-]+$/i.test(instance)) {
+        throw new Error(
+            `Invalid ServiceNow instance '${instance}'. Expected the instance name only ` +
+            `(letters, digits, hyphens), e.g. 'mycompany' for mycompany.service-now.com.`,
+        );
+    }
+    if (!authType) {
+        throw new Error('authType is required.');
+    }
+
+    // -----------------------------------------------------------------
+    // Obtain auth headers
+    // -----------------------------------------------------------------
+    let headers: Record<string, string>;
+    if (authType === 'oauth') {
+        if (!clientId || !clientSecret) {
+            throw new Error('OAuth authentication requires clientId and clientSecret.');
+        }
+        const token = await getOAuthToken(instance, clientId, clientSecret);
+        headers = getAuthHeaders('oauth', { accessToken: token });
+    } else {
+        if (!username || !password) {
+            throw new Error('Basic authentication requires username and password.');
+        }
+        tasks.setSecret(password);
+        headers = getAuthHeaders('basic', { username, password });
+    }
+
+    return { instance, headers };
+}
+
+interface ActionPlan {
+    kbId?: string;
+    title?: string;
+    htmlFile?: string;
+    author?: string;
+    category?: string;
+    subcategory?: string;
+    workflowState: string;
+    sourceKey?: string;
+    force: boolean;
+    articleContent?: string;
+    articleId?: string;
+    plannedAction: PlannedAction;
+    workflowOnly: boolean;
+}
+
+/**
+ * Read the article-related inputs, read/validate the HTML file (if any),
+ * resolve the source key (front-matter override), and resolve which article
+ * this run targets — explicit `articleId` input, then the stable source-key
+ * sentinel, then the legacy KB*.json file; otherwise create — plus whether the
+ * resulting action is a create, a full update, or a workflow-state-only change.
+ *
+ * The source-key lookup FALLS THROUGH to the JSON lookup on a miss (rather
+ * than short-circuiting to create). This keeps sourceKey backward-compatible
+ * with modules still tracked by a KB*.json file: an existing article created
+ * before the sentinel existed is found via the JSON file and updated in place
+ * (self-healing its wiki-source sentinel) instead of a duplicate being created.
+ */
+async function planAction(instance: string, headers: Record<string, string>, kbId: string | undefined): Promise<ActionPlan> {
+    const articleIdInput = tasks.getInput('articleId', false) || undefined;
+    const title = tasks.getInput('title', false) || undefined;
+    const htmlFile = tasks.getInput('htmlFile', false) || undefined;
+    const author = tasks.getInput('author', false) || undefined;
+    const category = tasks.getInput('category', false) || undefined;
+    const subcategory = tasks.getInput('subcategory', false) || undefined;
+    const workflowState = tasks.getInput('workflowState', false) || 'draft';
+    let sourceKey = tasks.getInput('sourceKey', false) || undefined;
+    const readKeyFrom = tasks.getInput('readKeyFrom', false) || undefined;
+    const force = tasks.getBoolInput('force', false);
+    const skipJsonLookup = tasks.getBoolInput('skipJsonLookup', false);
+
+    let articleContent: string | undefined;
+    if (htmlFile) {
+        articleContent = readHtmlFile(htmlFile);
+        validateHtmlContent(articleContent, force);
+    }
+
+    if (readKeyFrom) {
+        sourceKey = readFrontMatterKey(readKeyFrom);
+        console.log(`Source key from front-matter '${readKeyFrom}': ${sourceKey}`);
+    }
+
+    let articleId: string | undefined = articleIdInput;
+
+    if (!articleId && sourceKey) {
+        const found = await findArticleBySourceKey(instance, headers, sourceKey, kbId);
+        articleId = found || undefined;
+    }
+
+    if (!articleId && !skipJsonLookup) {
+        console.log('No article-id resolved yet. Looking for KB article JSON file...');
+        const jsonData = findKbArticleJson();
+        if (jsonData && jsonData['article_id']) {
+            articleId = jsonData['article_id'] as string;
+            console.log(`Using article ID from JSON file: ${articleId}`);
+        }
+    }
+
+    // Determine the action that would be taken (shared by dry-run and execute).
+    const workflowOnly = Boolean(articleId) && Boolean(workflowState) &&
+        !title && !articleContent && !category && !author;
+    const plannedAction: PlannedAction = !articleId
+        ? 'create'
+        : workflowOnly ? 'workflow-only' : 'update';
+
+    return {
+        kbId, title, htmlFile, author, category, subcategory, workflowState,
+        sourceKey, force, articleContent, articleId, plannedAction, workflowOnly,
+    };
+}
+
+/**
+ * Perform the actual ServiceNow write for a resolved plan: change the workflow
+ * state only, update the article's full content, or (when no article was
+ * resolved) validate the create-required fields and create a new article.
+ */
+async function executeCreateOrUpdate(
+    instance: string,
+    headers: Record<string, string>,
+    plan: ActionPlan,
+): Promise<Record<string, unknown>> {
+    const { kbId, articleId, workflowOnly, title, articleContent, author, category, subcategory, workflowState, sourceKey } = plan;
+    let article: Record<string, unknown>;
+
+    if (articleId) {
+        console.log(`Updating knowledge article with ID '${articleId}'...`);
+
+        if (workflowOnly) {
+            console.log(`Changing workflow state to '${workflowState}'...`);
+            article = await changeWorkflowState(instance, headers, articleId, workflowState) as unknown as Record<string, unknown>;
+        } else {
+            article = await updateKnowledgeArticle(
+                instance, headers, articleId,
+                title, articleContent, author,
+                category, subcategory, workflowState, sourceKey,
+            ) as unknown as Record<string, unknown>;
+        }
+        console.log('Knowledge article updated successfully!');
+    } else {
+        // Create path — validate required fields
+        if (!kbId) {
+            throw new Error('Knowledge base ID (kbId) is required for creating an article.');
+        }
+        if (!title) {
+            throw new Error('Article title is required for creating an article.');
+        }
+        if (!articleContent) {
+            throw new Error('Article content is required (set htmlFile input).');
+        }
+        if (!author) {
+            throw new Error('Author is required for creating an article.');
+        }
+
+        console.log(`Creating new knowledge article '${title}'...`);
+        article = await createKnowledgeArticle(
+            instance, headers, kbId, title, articleContent, author,
+            category, subcategory, workflowState, sourceKey,
+        ) as unknown as Record<string, unknown>;
+        console.log('Knowledge article created successfully!');
+    }
+
+    return article;
+}
+
 async function run() {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
     try {
-        // -----------------------------------------------------------------
-        // Resolve instance and auth from service connection or inline inputs
-        // -----------------------------------------------------------------
-        let instance = '';
-        let authType = '';
-        let clientId: string | undefined;
-        let clientSecret: string | undefined;
-        let username: string | undefined;
-        let password: string | undefined;
-
-        const serviceConnection = tasks.getInput('serviceConnection', false);
-        if (serviceConnection) {
-            const rawUrl = tasks.getEndpointUrl(serviceConnection, false) || '';
-            // Extract instance name from URL like https://myinstance.service-now.com
-            const urlMatch = rawUrl.match(/https?:\/\/([^.]+)\.service-now\.com/i);
-            instance = urlMatch ? urlMatch[1] : rawUrl;
-
-            const scheme = (tasks.getEndpointAuthorizationScheme(serviceConnection, false) || '').toLowerCase();
-            if (scheme === 'usernamepassword' || scheme === 'basic') {
-                authType = 'basic';
-                username = tasks.getEndpointAuthorizationParameter(serviceConnection, 'username', false) || undefined;
-                password = tasks.getEndpointAuthorizationParameter(serviceConnection, 'password', false) || undefined;
-            } else {
-                authType = 'oauth';
-                clientId = tasks.getEndpointAuthorizationParameter(serviceConnection, 'clientId', false) || undefined;
-                clientSecret = tasks.getEndpointAuthorizationParameter(serviceConnection, 'clientSecret', false) || undefined;
-            }
-        }
-
-        // Inline inputs override / supplement service connection
-        instance = tasks.getInput('instance', false) || instance;
-        authType = tasks.getInput('authType', false) || authType;
-        clientId = tasks.getInput('clientId', false) || clientId;
-        clientSecret = tasks.getInput('clientSecret', false) || clientSecret;
-        username = tasks.getInput('username', false) || username;
-        password = tasks.getInput('password', false) || password;
-
-        if (!instance) {
-            throw new Error('ServiceNow instance is required (set "instance" input or provide a service connection).');
-        }
-        // Guard against URL injection: instance is interpolated into
-        // https://<instance>.service-now.com, which carries the OAuth secret.
-        if (!/^[a-z0-9-]+$/i.test(instance)) {
-            throw new Error(
-                `Invalid ServiceNow instance '${instance}'. Expected the instance name only ` +
-                `(letters, digits, hyphens), e.g. 'mycompany' for mycompany.service-now.com.`,
-            );
-        }
-        if (!authType) {
-            throw new Error('authType is required.');
-        }
-
-        // -----------------------------------------------------------------
-        // Obtain auth headers
-        // -----------------------------------------------------------------
-        let headers: Record<string, string>;
-        if (authType === 'oauth') {
-            if (!clientId || !clientSecret) {
-                throw new Error('OAuth authentication requires clientId and clientSecret.');
-            }
-            const token = await getOAuthToken(instance, clientId, clientSecret);
-            headers = getAuthHeaders('oauth', { accessToken: token });
-        } else {
-            if (!username || !password) {
-                throw new Error('Basic authentication requires username and password.');
-            }
-            tasks.setSecret(password);
-            headers = getAuthHeaders('basic', { username, password });
-        }
-
-        // -----------------------------------------------------------------
-        // Read remaining inputs
-        // -----------------------------------------------------------------
-        const kbId = tasks.getInput('kbId', false) || undefined;
-        const articleIdInput = tasks.getInput('articleId', false) || undefined;
-        const title = tasks.getInput('title', false) || undefined;
-        const htmlFile = tasks.getInput('htmlFile', false) || undefined;
-        const author = tasks.getInput('author', false) || undefined;
-        const category = tasks.getInput('category', false) || undefined;
-        const subcategory = tasks.getInput('subcategory', false) || undefined;
-        const workflowState = tasks.getInput('workflowState', false) || 'draft';
-        let sourceKey = tasks.getInput('sourceKey', false) || undefined;
-        const readKeyFrom = tasks.getInput('readKeyFrom', false) || undefined;
-        const emitManifest = tasks.getInput('emitManifest', false) || undefined;
-        const force = tasks.getBoolInput('force', false);
-        const skipJsonLookup = tasks.getBoolInput('skipJsonLookup', false);
-        const dryRun = tasks.getBoolInput('dryRun', false);
-        const uploadImages = tasks.getBoolInput('uploadImages', false);
-        const imageBaseDir = tasks.getInput('imageBaseDir', false) || undefined;
+        const { instance, headers } = await resolveAuth();
 
         // -----------------------------------------------------------------
         // List KB mode
         // -----------------------------------------------------------------
+        const kbId = tasks.getInput('kbId', false) || undefined;
         if (kbId === 'list') {
             const kbs = await getKnowledgeBases(instance, headers);
             console.log('Available Knowledge Bases:');
@@ -121,55 +254,13 @@ async function run() {
             return;
         }
 
-        // -----------------------------------------------------------------
-        // Read HTML content
-        // -----------------------------------------------------------------
-        let articleContent: string | undefined;
-        if (htmlFile) {
-            articleContent = readHtmlFile(htmlFile);
-            validateHtmlContent(articleContent, force);
-        }
+        const emitManifest = tasks.getInput('emitManifest', false) || undefined;
+        const dryRun = tasks.getBoolInput('dryRun', false);
+        const uploadImages = tasks.getBoolInput('uploadImages', false);
+        const imageBaseDir = tasks.getInput('imageBaseDir', false) || undefined;
 
-        // -----------------------------------------------------------------
-        // Resolve source key
-        // -----------------------------------------------------------------
-        if (readKeyFrom) {
-            sourceKey = readFrontMatterKey(readKeyFrom);
-            console.log(`Source key from front-matter '${readKeyFrom}': ${sourceKey}`);
-        }
-
-        // -----------------------------------------------------------------
-        // Resolve article ID in priority order: explicit input, then the stable
-        // source-key sentinel, then the legacy KB*.json file; otherwise create.
-        //
-        // The source-key lookup FALLS THROUGH to the JSON lookup on a miss (rather
-        // than short-circuiting to create). This keeps sourceKey backward-compatible
-        // with modules still tracked by a KB*.json file: an existing article created
-        // before the sentinel existed is found via the JSON file and updated in place
-        // (self-healing its wiki-source sentinel) instead of a duplicate being created.
-        // -----------------------------------------------------------------
-        let articleId: string | undefined = articleIdInput;
-
-        if (!articleId && sourceKey) {
-            const found = await findArticleBySourceKey(instance, headers, sourceKey, kbId);
-            articleId = found || undefined;
-        }
-
-        if (!articleId && !skipJsonLookup) {
-            console.log('No article-id resolved yet. Looking for KB article JSON file...');
-            const jsonData = findKbArticleJson();
-            if (jsonData && jsonData['article_id']) {
-                articleId = jsonData['article_id'] as string;
-                console.log(`Using article ID from JSON file: ${articleId}`);
-            }
-        }
-
-        // Determine the action that would be taken (shared by dry-run and execute).
-        const workflowOnly = Boolean(articleId) && Boolean(workflowState) &&
-            !title && !articleContent && !category && !author;
-        const plannedAction: PlannedAction = !articleId
-            ? 'create'
-            : workflowOnly ? 'workflow-only' : 'update';
+        const plan = await planAction(instance, headers, kbId);
+        const { title, htmlFile, author, category, subcategory, workflowState, sourceKey, force, articleContent, articleId, plannedAction } = plan;
 
         // -----------------------------------------------------------------
         // Dry-run: report the plan and exit without any write.
@@ -202,7 +293,7 @@ async function run() {
                 }
             }
 
-            const plan: DryRunPlan = {
+            const dryRunPlan: DryRunPlan = {
                 action: plannedAction,
                 instance,
                 kbId,
@@ -218,7 +309,7 @@ async function run() {
                 sourceKeyMatched: sourceKey ? Boolean(articleId) : undefined,
             };
 
-            console.log(formatDryRunReport(plan));
+            console.log(formatDryRunReport(dryRunPlan));
             tasks.setResult(tasks.TaskResult.Succeeded, 'Dry run complete — no changes made.');
             return;
         }
@@ -226,44 +317,7 @@ async function run() {
         // -----------------------------------------------------------------
         // Execute: update or create
         // -----------------------------------------------------------------
-        let article: Record<string, unknown>;
-
-        if (articleId) {
-            console.log(`Updating knowledge article with ID '${articleId}'...`);
-
-            if (workflowOnly) {
-                console.log(`Changing workflow state to '${workflowState}'...`);
-                article = await changeWorkflowState(instance, headers, articleId, workflowState) as unknown as Record<string, unknown>;
-            } else {
-                article = await updateKnowledgeArticle(
-                    instance, headers, articleId,
-                    title, articleContent, author,
-                    category, subcategory, workflowState, sourceKey,
-                ) as unknown as Record<string, unknown>;
-            }
-            console.log('Knowledge article updated successfully!');
-        } else {
-            // Create path — validate required fields
-            if (!kbId) {
-                throw new Error('Knowledge base ID (kbId) is required for creating an article.');
-            }
-            if (!title) {
-                throw new Error('Article title is required for creating an article.');
-            }
-            if (!articleContent) {
-                throw new Error('Article content is required (set htmlFile input).');
-            }
-            if (!author) {
-                throw new Error('Author is required for creating an article.');
-            }
-
-            console.log(`Creating new knowledge article '${title}'...`);
-            article = await createKnowledgeArticle(
-                instance, headers, kbId, title, articleContent, author,
-                category, subcategory, workflowState, sourceKey,
-            ) as unknown as Record<string, unknown>;
-            console.log('Knowledge article created successfully!');
-        }
+        const article = await executeCreateOrUpdate(instance, headers, plan);
 
         console.log(`Article Number: ${article['number']}`);
         console.log(`Article ID: ${article['sys_id']}`);

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
@@ -10,6 +10,15 @@
  *
  * Like axios (which this replaces), a non-2xx response REJECTS: several call
  * sites rely on that to fall back or return null.
+ *
+ * This is a third, independently-maintained credential-bearing transport
+ * alongside Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts
+ * (shared byte-for-byte with TerraformDriftReport and enforced by
+ * scripts/check-shared-modules.js). It is not merged into that shared client
+ * because this API needs JSON-body encoding, query-string params, and
+ * axios-like non-2xx rejection that the other client's callers don't — see the
+ * tracking note in check-shared-modules.js for what must stay in sync by hand
+ * (https-only guard, request timeout, response size cap).
  */
 
 import * as https from 'https';

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -104,6 +104,19 @@ const FAMILIES = [
 // end-to-end by this script, which is the property that actually matters;
 // collapsing them into a single abstraction would be a large, risky rewrite
 // of working transport code for no behavior change.
+//
+// A THIRD credential-bearing transport exists outside this script's FAMILIES:
+// Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts. It is not
+// listed above because it has only one copy (nothing to byte-compare), but it
+// intentionally mirrors the same hardening as the family above — an https-only
+// guard, a DEFAULT_REQUEST_TIMEOUT_MS socket timeout, and the same 10MB
+// MAX_RESPONSE_BYTES response cap (see truncate()/truncateBody()). It stays a
+// separate module rather than reusing https-client.ts because its call sites
+// need JSON-body encoding, query-string params, and axios-like non-2xx
+// rejection that the module-publish/drift-report clients don't. This comment
+// is the tracking mechanism for it: a future hardening change to the timeout,
+// response cap, or https-only guard in https-client.ts should be evaluated for
+// servicenow-http.ts too, even though CI cannot enforce byte-identity here.
 
 // Normalize line endings so a CRLF checkout never reads as drift; the bytes that
 // matter (the key material, the verification logic) are still compared exactly.


### PR DESCRIPTION
## Summary
- Extract `resolveAuth()` / `planAction()` / `executeCreateOrUpdate()` out of PublishKbArticleV1's ~300-line `run()`, each with a single responsibility and a documented return shape. Behavior is unchanged.
- Document `servicenow-http.ts` in `check-shared-modules.js` as a third, independently-tracked credential-bearing transport family alongside `https-client.ts`, and cross-reference it from `servicenow-http.ts`'s own header comment, so a future hardening change to one is remembered for the other even though there's no second copy to byte-compare.

## Testing
- `npm test` in `Tasks/PublishKbArticle/PublishKbArticleV1`: 92 passing (unchanged behavior)
- `npm run lint`: clean
- `node scripts/check-shared-modules.js` / `node scripts/check-versions.js`: pass

Addresses ar1 and ar2 from the 2026-07-06 blind security re-audit.

Closes #397