### PR TITLE
test(tab): raise plan-tab coverage gate + doc trust/SARIF-viewer gaps

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -104,7 +104,7 @@
             "defaultValue": "true",
             "required": false,
             "visibleRule": "policyAgent = opa || downloadSource = mirror",
-            "helpMarkDown": "When enabled, fail if a SHA256 checksum is not available for the requested version/platform."
+            "helpMarkDown": "When enabled, fail if a SHA256 checksum is not available for the requested version/platform. Note: OPA (and any mirror source) publishes no GPG/cosign signature here, so this checksum is a same-origin transport-integrity check, not independent-authenticity verification (see SECURITY.md)."
         }
     ],
     "restrictions": {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -82,7 +82,7 @@
       "label": "Require checksum verification",
       "defaultValue": "true",
       "required": false,
-      "helpMarkDown": "When enabled (default), fail if a SHA256 checksum is not available for the requested version/platform. Disable only for mirrors or registries that do not publish checksums."
+      "helpMarkDown": "When enabled (default), fail if a SHA256 checksum is not available for the requested version/platform. Note: terraform-docs publishes no GPG/cosign signature, so this checksum is a same-origin transport-integrity check, not independent-authenticity verification (see SECURITY.md). Disable only for mirrors or registries that do not publish checksums."
     }
   ],
   "restrictions": {

--- a/docs/yaml-examples.md
+++ b/docs/yaml-examples.md
@@ -864,6 +864,13 @@ violations and exposes its path via the `sarifFilePath` output variable. When
 a build artifact to surface policy findings in SARIF-aware tooling; the JUnit
 report (published by default) remains the zero-setup path for the **Tests** tab.
 
+> **SARIF has no native Azure DevOps viewer.** The file above is only actionable
+> once published (e.g. as the `CodeAnalysisLogs` artifact shown above) and read by
+> a SARIF-aware Marketplace extension or an external sink (GitHub code scanning, a
+> SIEM) — the same caveat noted under `PipelineTerraformDriftReport@1`'s own SARIF
+> section below, which emits the same SARIF shape from the same `sarifFilePath`
+> output variable name.
+
 ---
 
 ## PipelineTerraformDriftReport@1

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,18 @@ module.exports = {
     ],
     coverageThreshold: {
         global: {
-            statements: 70,
-            branches: 58,
-            functions: 42,
-            lines: 70,
+            // Raised from 70/58/42/70 after adding tests for the previously-untested
+            // render branches (loading/error/empty states, multi-plan <select>,
+            // oversize-plan download link) and loadPlans edge cases (no attachments,
+            // per-attachment fetch failure, top-level failure). Actual coverage is
+            // ~82/81/63/83; a few points of headroom is kept below that so a small,
+            // legitimate code change doesn't fail the gate. The module-level SDK
+            // bootstrap block (SDK.ready().then(...) wiring) stays uncovered by
+            // design — it needs a real DOM (jsdom), see tabContent.test.tsx.
+            statements: 80,
+            branches: 78,
+            functions: 60,
+            lines: 80,
         },
     },
     transform: {

--- a/src/tab/tabContent.test.tsx
+++ b/src/tab/tabContent.test.tsx
@@ -20,6 +20,24 @@ import { getClient } from 'azure-devops-extension-api';
 import { TerraformPlanTab } from './tabContent';
 import { ansiToHtml } from './ansi-to-html';
 
+/**
+ * Creates an unmounted TerraformPlanTab with setState monkey-patched to merge
+ * synchronously into the instance's own state — a real (unmounted) component's
+ * setState is a no-op (there is no updater attached outside a live React tree),
+ * which is why every test that exercises state transitions needs this. An
+ * optional partial state can be applied up front for render-only fixtures.
+ */
+function makeTestableTab(initialState: Record<string, unknown> = {}): TerraformPlanTab {
+  const tab = new TerraformPlanTab({});
+  const inst = tab as unknown as { state: Record<string, unknown> };
+  inst.state = { ...inst.state, ...initialState };
+  (tab as unknown as { setState: (u: unknown) => void }).setState = (update: unknown): void => {
+    const next = typeof update === 'function' ? (update as (s: unknown) => object)(inst.state) : update;
+    inst.state = { ...inst.state, ...(next as object) };
+  };
+  return tab;
+}
+
 describe('TerraformPlanTab', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -40,14 +58,7 @@ describe('TerraformPlanTab', () => {
       text: () => Promise.resolve(rawContent),
     });
 
-    const tab = new TerraformPlanTab({});
-    const inst = tab as unknown as { state: Record<string, unknown> };
-    // The instance is not mounted by a renderer, so apply setState synchronously
-    // in place for the test.
-    (tab as unknown as { setState: (u: unknown) => void }).setState = (update: unknown): void => {
-      const next = typeof update === 'function' ? (update as (s: unknown) => object)(inst.state) : update;
-      inst.state = { ...inst.state, ...(next as object) };
-    };
+    const tab = makeTestableTab();
 
     await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
 
@@ -59,5 +70,115 @@ describe('TerraformPlanTab', () => {
     expect(html).toContain(ansiToHtml(rawContent));
     expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
     expect(html).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('renders a loading indicator before any plans have been fetched', () => {
+    const tab = makeTestableTab();
+    const html = renderToStaticMarkup(tab.render());
+    expect(html).toContain('Loading terraform plans...');
+  });
+
+  it('renders an error message when loading the attachments failed', () => {
+    const tab = makeTestableTab({ loading: false, error: 'boom' });
+    const html = renderToStaticMarkup(tab.render());
+    expect(html).toContain('Error: boom');
+  });
+
+  it('renders an empty-state message when the build published no plans', () => {
+    const tab = makeTestableTab({ loading: false, error: null, plans: [] });
+    const html = renderToStaticMarkup(tab.render());
+    expect(html).toContain('No terraform plans have been published for this pipeline run.');
+  });
+
+  it('renders a <select> plan picker for multiple plans, and onPlanSelect updates the selected index', () => {
+    const tab = makeTestableTab({
+      loading: false,
+      error: null,
+      plans: [
+        { name: 'plan-a.txt', content: 'aaa' },
+        { name: 'plan-b.txt', content: 'bbb' },
+      ],
+      selectedIndex: 0,
+    });
+
+    const html = renderToStaticMarkup(tab.render());
+    expect(html).toContain('<select');
+    expect(html).toContain('plan-a.txt');
+    expect(html).toContain('plan-b.txt');
+
+    (tab as unknown as { onPlanSelect: (e: unknown) => void }).onPlanSelect({ target: { value: '1' } });
+    expect((tab as unknown as { state: { selectedIndex: number } }).state.selectedIndex).toBe(1);
+  });
+
+  it('renders a download link instead of inline output when plan content exceeds the render-size cap', () => {
+    const oversized = 'x'.repeat(2 * 1024 * 1024 + 1);
+    const tab = makeTestableTab({
+      loading: false,
+      error: null,
+      plans: [{ name: 'huge-plan.txt', content: oversized }],
+      selectedIndex: 0,
+    });
+
+    const html = renderToStaticMarkup(tab.render());
+    expect(html).toContain('too large to render inline');
+    expect(html).toContain('Download raw output');
+    expect(html).not.toContain('dangerouslySetInnerHTML');
+  });
+
+  it('loadPlans sets an empty plans list and stops loading when the build has no attachments', async () => {
+    (getClient as jest.Mock).mockReturnValue({
+      getAttachments: jest.fn().mockResolvedValue([]),
+    });
+
+    const tab = makeTestableTab();
+    await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
+
+    const state = (tab as unknown as { state: { plans: unknown[]; loading: boolean } }).state;
+    expect(state.plans).toEqual([]);
+    expect(state.loading).toBe(false);
+  });
+
+  it('loadPlans skips an attachment whose download throws and one that returns a non-OK response, keeping only the successful download', async () => {
+    (getClient as jest.Mock).mockReturnValue({
+      getAttachments: jest.fn().mockResolvedValue([
+        { name: 'network-error.txt', _links: { self: { href: 'https://example.test/a' } } },
+        { name: 'not-found.txt', _links: { self: { href: 'https://example.test/b' } } },
+        { name: 'ok.txt', _links: { self: { href: 'https://example.test/c' } } },
+      ]),
+    });
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { /* silence expected log */ });
+
+    (global as unknown as { fetch: jest.Mock }).fetch = jest.fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ ok: false, text: () => Promise.resolve('') })
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('plan output') });
+
+    const tab = makeTestableTab();
+    await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
+
+    const state = (tab as unknown as { state: { plans: Array<{ name: string }>; loading: boolean } }).state;
+    expect(state.plans).toHaveLength(1);
+    expect(state.plans[0].name).toBe('ok.txt');
+    expect(state.loading).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to download attachment network-error.txt:'),
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('loadPlans sets an error state when fetching the attachment list itself fails', async () => {
+    (getClient as jest.Mock).mockReturnValue({
+      getAttachments: jest.fn().mockRejectedValue(new Error('attachments API unavailable')),
+    });
+
+    const tab = makeTestableTab();
+    await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
+
+    const state = (tab as unknown as { state: { error: string | null; loading: boolean } }).state;
+    expect(state.error).toBe('attachments API unavailable');
+    expect(state.loading).toBe(false);
   });
 });

--- a/src/tab/tsconfig.json
+++ b/src/tab/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "amd",
         "moduleResolution": "node",
+        "ignoreDeprecations": "5.0",
         "target": "es6",
         "jsx": "react",
         "lib": [


### PR DESCRIPTION
## Summary
- Add jest tests for previously-untested `tabContent.tsx` render branches (loading/error/empty states, multi-plan `<select>`, oversize-plan download link) and `loadPlans` edge cases (no attachments, per-attachment fetch failure, top-level failure).
- Raise `coverageThreshold` from 70/58/42/70 to 80/78/60/80 to match the new ~82/81/63/83 actual coverage (headroom kept below actual). The module-level SDK bootstrap block stays uncovered by design — it needs jsdom.
- Note in the OPA/terraform-docs installer `task.json` `helpMarkDown` that `requireChecksum` is a same-origin transport-integrity check, not independent signature verification (`overview.md` already had this; `task.json` is the other Marketplace-facing surface).
- Explicitly document that Azure DevOps has no native SARIF viewer for both `PipelineTerraformPolicyCheck@1` and `PipelineTerraformDriftReport@1`'s SARIF output, cross-referencing each other.
- Fix an unrelated TS5103/deprecation error in `src/tab/tsconfig.json` (`module=amd`/`moduleResolution=node10` deprecated ahead of TS 7.0); `ignoreDeprecations: \"5.0\"` is the value the pinned TypeScript 5.9.3 actually accepts (verified with `tsc --noEmit`).

## Testing
- `npx jest --config jest.config.js --coverage`: 29 passing, thresholds met
- `npx tsc --noEmit -p src/tab/tsconfig.json`: clean
- `node scripts/check-versions.js`: pass

Addresses t2, ec1, and ec3 from the 2026-07-06 blind security re-audit.

Closes #400