### PR TITLE
chore(PublishKbArticle): bump Minor to 1.6.0 for the run() refactor

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "5",
+        "Minor": "6",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
## Summary
PR #459 changed `Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts` and `src/servicenow-http.ts` (merged) but did not bump the task's `Minor` version. Per CLAUDE.md's Release Process, ADO agents cache tasks by `Major.Minor` and won't pick up the new code until `Minor` increments — this would have shipped release 1.9.2 with agents still serving the cached 1.5.0 `PublishKbArticleV1` code.

Bumps `Tasks/PublishKbArticle/PublishKbArticleV1/task.json`: `1.5.0` -> `1.6.0` (Patch reset to 0 per convention).

## Testing
- `node scripts/check-minor-bumps.js` (the same check wired into `release.yml`'s `guard` job): now passes (was failing against `v1.9.1`)
- `node scripts/check-versions.js`: pass
- `npm test` in `PublishKbArticleV1`: 92 passing

Should merge before release-please's open release PR (#462, 1.9.2) to avoid shipping an un-bumped task.