### PR TITLE
security: contain unredacted terraform output -json file

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformTask/TerraformTaskV5/Strings/resources.resjson/en-US/resources.resjson
@@ -20,6 +20,8 @@
   "loc.input.help.outputTo": "choose output to file or console.  ",
   "loc.input.label.filename": "Output filename",
   "loc.input.help.filename": "Path (relative to the working directory) of the file to write the command output to. Used when Output to is set to file for the show and custom commands.",
+  "loc.input.label.cleanupOutputFile": "Delete the output JSON file at task end",
+  "loc.input.help.cleanupOutputFile": "Delete the JSON file written by the output command (containing every output's real value, including any marked sensitive) when this step finishes. It is retained by default so downstream steps can read it via the `jsonOutputVariablesPath` output variable -- enable this if the step only needs the auto-set `TF_OUT_*` pipeline variables and not the file itself, especially on a self-hosted agent whose working directory is not wiped between jobs.",
   "loc.input.label.outputFormat": "Output format",
   "loc.input.help.outputFormat": "choose format of console ouput for show cmd.",
   "loc.input.label.environmentServiceNameAzureRM": "Azure subscription",

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
 
 // Direct unit tests for OCI WIF token-exchange URL validation & transport.
 import './OciTokenExchangeL0';
@@ -37,7 +39,14 @@ describe('Terraform Test Suite', function () {
         delete process.env.NODE_OPTIONS
     });
 
-    after(() => { });
+    after(() => {
+        // show/output/custom (file mode) now write real files with restricted
+        // permissions via writeCommandOutputFile() instead of the previously
+        // no-op-under-test tasks.writeFile() -- clean up the scratch directory
+        // those scenarios create so repeated local `npm test` runs don't
+        // accumulate real files on disk.
+        fs.rmSync('DummyWorkingDirectory', { recursive: true, force: true });
+    });
 
     /* terraform init tests */
 
@@ -1935,6 +1944,57 @@ describe('Terraform Test Suite', function () {
                 'the control-character value must never reach a ##vso[task.setvariable] line');
             assert(tr.stdout.includes('##vso[task.setvariable variable=TF_OUT_safe_output'), 'the well-formed sibling output should still be set');
         }, tr);
+    });
+
+    it('aws output warns when a sensitive output is written to the JSON file', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputSensitiveWarning.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(
+                tr.warningIssues.some((w) => w.includes('sensitive output') && w.includes('db_password')),
+                'should warn about the sensitive output. warnings: ' + tr.warningIssues
+            );
+        }, tr);
+    });
+
+    it('aws output with cleanupOutputFile=true removes the JSON file after the step finishes', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputCleanupRemovesFile.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        const workingDirectory = path.join(os.tmpdir(), 'tf-output-cleanup-test');
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            const remaining = fs.existsSync(workingDirectory) ? fs.readdirSync(workingDirectory) : [];
+            assert.strictEqual(remaining.length, 0, `expected the output JSON file to be cleaned up, found: ${remaining.join(', ')}`);
+        }, tr);
+        fs.rmSync(workingDirectory, { recursive: true, force: true });
+    });
+
+    it('aws output retains the JSON file by default (for downstream steps) with restrictive permissions', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputFileRetainedByDefault.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        const workingDirectory = path.join(os.tmpdir(), 'tf-output-retain-test');
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            const files = fs.existsSync(workingDirectory) ? fs.readdirSync(workingDirectory) : [];
+            assert.strictEqual(files.length, 1, `expected exactly one retained output file, found: ${files.join(', ')}`);
+            const filePath = path.join(workingDirectory, files[0]);
+            assert(fs.existsSync(filePath), 'the output JSON file should still exist for downstream steps to read');
+            if (process.platform !== 'win32') {
+                const mode = fs.statSync(filePath).mode & 0o777;
+                assert.strictEqual(mode, 0o600, `expected mode 0600, got ${mode.toString(8)}`);
+            }
+        }, tr);
+        fs.rmSync(workingDirectory, { recursive: true, force: true });
     });
 
     /* terraform custom tests */

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputCleanupRemovesFile.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputCleanupRemovesFile.ts
@@ -1,0 +1,44 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// Real, existing working directory -- cleanupOutputFile=true only has an
+// observable effect if the file actually got written to disk first (via
+// writeCommandOutputFile()'s real, no-longer-mocked-away fs.writeFileSync).
+// Uses ParentCommandHandler (via runViaParentHandler) rather than calling
+// the handler method directly, since cleanupTempFiles() only runs from
+// ParentCommandHandler.execute()'s finally block.
+const workingDirectory = path.join(os.tmpdir(), 'tf-output-cleanup-test');
+fs.rmSync(workingDirectory, { recursive: true, force: true });
+fs.mkdirSync(workingDirectory, { recursive: true });
+
+let tp = path.join(__dirname, './AWSOutputCleanupRemovesFileL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('cleanupOutputFile', 'true');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"test_output\": { \"value\": \"hello\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputCleanupRemovesFileL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputCleanupRemovesFileL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../test-l0-helpers';
+
+runViaParentHandler('AWSOutputCleanupRemovesFileL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputFileRetainedByDefault.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputFileRetainedByDefault.ts
@@ -1,0 +1,42 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// Regression guard for the default (cleanupOutputFile unset/false) path: the
+// JSON file must remain on disk for downstream steps to read via
+// `jsonOutputVariablesPath`, and must be written with restrictive (0600)
+// permissions rather than the default umask.
+const workingDirectory = path.join(os.tmpdir(), 'tf-output-retain-test');
+fs.rmSync(workingDirectory, { recursive: true, force: true });
+fs.mkdirSync(workingDirectory, { recursive: true });
+
+let tp = path.join(__dirname, './AWSOutputFileRetainedByDefaultL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', workingDirectory);
+// cleanupOutputFile intentionally left unset -- must default to false.
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"test_output\": { \"value\": \"hello\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputFileRetainedByDefaultL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputFileRetainedByDefaultL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'output', 'AWSOutputFileRetainedByDefaultL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveWarning.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveWarning.ts
@@ -1,0 +1,36 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// `terraform output -json` emits every output's real value in cleartext,
+// including ones declared `sensitive = true` (only the human-readable console
+// format is redacted). warnIfSensitiveOutputFile() must surface a warning
+// naming the sensitive output so it isn't casually published as a build
+// artifact.
+let tp = path.join(__dirname, './AWSOutputSensitiveWarningL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"db_password\": { \"value\": \"hunter2\", \"sensitive\": true }, \"safe_output\": { \"value\": \"hello\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveWarningL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveWarningL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'output', 'AWSOutputSensitiveWarningL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -2,6 +2,7 @@ import { TerraformToolHandler, ITerraformToolHandler, getBinaryName, resolveTool
 import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformBaseCommandInitializer, TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import { getSecureVarFileArgs, SecureFileLoader } from './secure-file-loader';
+import { writeSecretFile } from './secure-temp';
 import tasks = require('azure-pipelines-task-lib/task');
 import path = require('path');
 import { randomUUID as uuidV4 } from 'crypto';
@@ -225,6 +226,19 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     /**
+     * Writes a terraform command's captured stdout (show/output/custom -- any
+     * of which can carry unredacted `sensitive = true` values, most notably
+     * `terraform output -json`) to disk with restrictive 0600 permissions
+     * instead of the default umask. The parent directory is created first
+     * since `show`/`custom` accept a caller-supplied, possibly-nested
+     * `filename`.
+     */
+    private writeCommandOutputFile(filePath: string, content: string): void {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        writeSecretFile(filePath, content);
+    }
+
+    /**
      * Regex patterns anchored to typical `terraform providers` output format.
      * Matches lines like: `provider[registry.terraform.io/hashicorp/aws]`
      */
@@ -351,7 +365,7 @@ export abstract class BaseTerraformCommandHandler {
                 cwd: showCommand.workingDirectory,
             });
 
-            tasks.writeFile(showFilePath, commandOutput.stdout);
+            this.writeCommandOutputFile(showFilePath, commandOutput.stdout);
             tasks.setVariable('showFilePath', showFilePath, false, true);
 
             // Detect destroy changes in JSON plan output
@@ -378,8 +392,13 @@ export abstract class BaseTerraformCommandHandler {
             cwd: outputCommand.workingDirectory,
         });
 
-        tasks.writeFile(jsonOutputVariablesFilePath, commandOutput.stdout);
+        this.writeCommandOutputFile(jsonOutputVariablesFilePath, commandOutput.stdout);
         tasks.setVariable('jsonOutputVariablesPath', jsonOutputVariablesFilePath, false, true);
+        this.warnIfSensitiveOutputFile(commandOutput.stdout, jsonOutputVariablesFilePath);
+
+        if (tasks.getBoolInput('cleanupOutputFile', false)) {
+            this.tempFiles.push(jsonOutputVariablesFilePath);
+        }
 
         // Auto-set pipeline variables from terraform output
         this.setOutputVariables(commandOutput.stdout);
@@ -459,7 +478,7 @@ export abstract class BaseTerraformCommandHandler {
                 cwd: customCommand.workingDirectory
             });
 
-            tasks.writeFile(customFilePath, commandOutput.stdout);
+            this.writeCommandOutputFile(customFilePath, commandOutput.stdout);
             tasks.setVariable('customFilePath', customFilePath, false, true);
             return commandOutput.code;
         }
@@ -786,6 +805,36 @@ export abstract class BaseTerraformCommandHandler {
             }
         } catch (error) {
             tasks.warning(`Could not parse terraform plan for sensitive-output detection; the sensitive-value safety warning did not run: ${String(error)}`);
+        }
+    }
+
+    /**
+     * `terraform output -json` emits every output's real value in cleartext,
+     * including ones declared `sensitive = true` in configuration (Terraform
+     * only redacts the human-readable console format, not `-json`). Warn
+     * loudly when that's the case so the file written by
+     * writeCommandOutputFile() -- restrictive permissions notwithstanding --
+     * doesn't get casually published as a build artifact or left for a
+     * downstream step to mishandle.
+     */
+    private warnIfSensitiveOutputFile(jsonOutput: string, filePath: string): void {
+        try {
+            const outputs = JSON.parse(jsonOutput);
+            if (!outputs || typeof outputs !== 'object') return;
+
+            const sensitiveKeys = Object.entries(outputs)
+                .filter(([, def]) => (def as { sensitive?: boolean }).sensitive === true)
+                .map(([key]) => key);
+
+            if (sensitiveKeys.length > 0) {
+                tasks.warning(
+                    `${filePath} contains ${sensitiveKeys.length} sensitive output(s) in cleartext (${sensitiveKeys.join(', ')}). ` +
+                    `Ensure this file is not published as a pipeline artifact. Set 'cleanupOutputFile' to remove it automatically ` +
+                    `at the end of this step if downstream steps don't need to read it from disk.`
+                );
+            }
+        } catch (error) {
+            tasks.debug(`Could not parse terraform output as JSON for sensitive-output detection: ${error}`);
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "276",
+        "Minor": "277",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",
@@ -424,6 +424,15 @@
             "visibleRule": "outputTo = file",
             "required": true,
             "helpMarkDown": "Path (relative to the working directory) of the file to write the command output to. Used when Output to is set to file for the show and custom commands."
+        },
+        {
+            "name": "cleanupOutputFile",
+            "type": "boolean",
+            "label": "Delete the output JSON file at task end",
+            "defaultValue": "false",
+            "required": false,
+            "visibleRule": "command = output",
+            "helpMarkDown": "Delete the JSON file written by the output command (containing every output's real value, including any marked sensitive) when this step finishes. It is retained by default so downstream steps can read it via the `jsonOutputVariablesPath` output variable -- enable this if the step only needs the auto-set `TF_OUT_*` pipeline variables and not the file itself, especially on a self-hosted agent whose working directory is not wiped between jobs."
         },
         {
             "name": "environmentServiceNameAzureRM",


### PR DESCRIPTION
## Summary

	erraform output -json (and show/custom in file mode) wrote command output to a default-permission working-directory file that was never cleaned up and carried no runtime warning -- even though outputs marked sensitive = true are emitted in full cleartext by -json (only the human-readable console format is redacted).

Addresses the **High** finding in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) (Credential and Secret Handling domain, P0 in the prioritized roadmap): `base-terraform-command-handler.ts:376-385`.

## Changes

- Write the output/show/custom result files with restrictive 0600 permissions via the existing writeSecretFile() helper (already used for OIDC/GCP/OCI credential temp files elsewhere in this task) instead of 	asks.writeFile().
- Add warnIfSensitiveOutputFile(), called from output(), which warns when the JSON file contains any output marked sensitive -- mirroring the warning show() already emits for sensitive plan attributes, but for the output-command's flat JSON shape.
- Add an opt-in cleanupOutputFile task input (default alse, matching TerraformDriftReport's existing cleanupSummaryFile precedent) so pipelines that only need the auto-set TF_OUT_* pipeline variables can have the file removed at the end of the step. Left off by default since jsonOutputVariablesPath is meant for downstream steps to read (unconditional cleanup would delete it before any later step could use it -- confirmed this is how cleanupTempFiles() is wired, in the same task invocation's inally).
- Bump TerraformTaskV5 	ask.json Minor 276->277 per CLAUDE.md's mandatory security-fix rule.

## Regression risk considered

Switching from 	asks.writeFile() (a documented no-op under this repo's mock-test harness) to a real s.writeFileSync-backed write meant existing tests using the fictional workingDirectory: 'DummyWorkingDirectory' would now perform a **real** file write for the first time. Handled by:
- A new writeCommandOutputFile() helper that mkdirSync(..., {recursive:true})s the parent directory first.
- Fixing Tests/L0.ts's previously no-op fter() hook to actually clean up the scratch directory.
- 3 new test scenarios (AWSOutputSensitiveWarning, AWSOutputCleanupRemovesFile, AWSOutputFileRetainedByDefault) using real, isolated temp directories that verify: the warning fires, the opt-in cleanup actually removes the file via the real ParentCommandHandler -> cleanupTempFiles() path, and -- critically -- that the file is **still retained by default** with 0600 permissions (proving no regression to the primary downstream-consumption use case).

Full suite: **267 passing, 0 failing** (
pm test in Tasks/TerraformTask/TerraformTaskV5). Reviewed by an adversarial pass focused on regressions, mock-vs-real-fs behavior, and security completeness before opening this PR.