### PR TITLE
fix: add bounded retry to DriftReport callback and PublishKbArticle ServiceNow calls

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -20,7 +20,7 @@ import { formatDryRunReport, DryRunPlan } from '../src/dry-run';
 import { extractLocalImageRefs, rewriteImageSrcs } from '../src/image-rewrite';
 import { processArticleImages, syncImageAttachment, contentTypeFor, fileSha256 } from '../src/attachments';
 import * as manifest from '../src/manifest';
-import { snRequest } from '../src/servicenow-http';
+import { snRequest, withRetry } from '../src/servicenow-http';
 
 const INSTANCE = 'testinstance';
 const BASE_URL = `https://${INSTANCE}.service-now.com`;
@@ -147,6 +147,64 @@ describe('auth.basicAuthHeader', () => {
             capturedSecrets.includes('mypassword'),
             'tasks.setSecret should be called with the password',
         );
+    });
+});
+
+// ===========================================================================
+// servicenow-http — withRetry
+// ===========================================================================
+describe('servicenow-http.withRetry', () => {
+    it('retries a bounded number of times on a 5xx then succeeds', async () => {
+        nock(BASE_URL)
+            .post('/api/now/table/kb_knowledge')
+            .reply(503, { error: 'busy' })
+            .post('/api/now/table/kb_knowledge')
+            .reply(201, { result: { sys_id: 'retried_id', number: 'KB0099', workflow_state: 'draft' } });
+
+        const logs: string[] = [];
+        const resp = await withRetry(
+            () => snRequest('POST', `${BASE_URL}/api/now/table/kb_knowledge`, { headers: HEADERS, body: {} }),
+            { retries: 2, baseDelayMs: 1, log: (m) => logs.push(m) },
+        );
+        assert.strictEqual((resp.data.result as { sys_id: string }).sys_id, 'retried_id');
+        assert.strictEqual(logs.length, 1, 'should log exactly one retry attempt');
+    });
+
+    it('does not retry a 4xx -- fails on the first attempt', async () => {
+        let calls = 0;
+        nock(BASE_URL)
+            .post('/api/now/table/kb_knowledge')
+            .reply(() => {
+                calls++;
+                return [400, { error: 'bad request' }];
+            });
+
+        const logs: string[] = [];
+        await assert.rejects(
+            withRetry(
+                () => snRequest('POST', `${BASE_URL}/api/now/table/kb_knowledge`, { headers: HEADERS, body: {} }),
+                { retries: 2, baseDelayMs: 1, log: (m) => logs.push(m) },
+            ),
+            /failed with status 400/,
+        );
+        assert.strictEqual(calls, 1, 'a 4xx must not be retried');
+        assert.strictEqual(logs.length, 0);
+    });
+
+    it('retries on a pure transport failure (no response received)', async () => {
+        nock(BASE_URL)
+            .post('/api/now/table/kb_knowledge')
+            .replyWithError('socket hang up')
+            .post('/api/now/table/kb_knowledge')
+            .reply(201, { result: { sys_id: 'ok_after_transport_retry', number: 'KB0100', workflow_state: 'draft' } });
+
+        const logs: string[] = [];
+        const resp = await withRetry(
+            () => snRequest('POST', `${BASE_URL}/api/now/table/kb_knowledge`, { headers: HEADERS, body: {} }),
+            { retries: 2, baseDelayMs: 1, log: (m) => logs.push(m) },
+        );
+        assert.strictEqual((resp.data.result as { sys_id: string }).sys_id, 'ok_after_transport_retry');
+        assert.strictEqual(logs.length, 1);
     });
 });
 

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/attachments.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/attachments.ts
@@ -15,7 +15,7 @@
  * account can POST and DELETE attachments; the REST file endpoint serves the bytes.
  */
 
-import { snRequest } from './servicenow-http';
+import { snRequest, withRetry } from './servicenow-http';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
@@ -64,10 +64,12 @@ export async function uploadAttachment(
     };
     if (headers['Authorization']) uploadHeaders['Authorization'] = headers['Authorization'];
 
-    const response = await snRequest('POST', url, {
+    const response = await withRetry(() => snRequest('POST', url, {
         headers: uploadHeaders,
         params: { table_name: 'kb_knowledge', table_sys_id: articleId, file_name: fileName },
         body: data,
+    }), {
+        log: (message) => console.log(`[WARN] ${message}`),
     });
     return (response.data.result as { sys_id: string }).sys_id;
 }

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -1,4 +1,4 @@
-import { snRequest } from './servicenow-http';
+import { snRequest, withRetry } from './servicenow-http';
 
 const WORKFLOW_STATE_MAP: Record<string, string> = {
     draft: 'draft',
@@ -114,7 +114,9 @@ export async function createKnowledgeArticle(
         payload['kb_category'] = kbCategoryId;
     }
 
-    const response = await snRequest('POST', url, { headers, body: payload });
+    const response = await withRetry(() => snRequest('POST', url, { headers, body: payload }), {
+        log: (message) => console.log(`[WARN] ${message}`),
+    });
     return response.data.result as KbArticle;
 }
 
@@ -174,7 +176,9 @@ export async function updateKnowledgeArticle(
         throw new Error('No fields provided for update.');
     }
 
-    const response = await snRequest('PATCH', url, { headers, body: payload });
+    const response = await withRetry(() => snRequest('PATCH', url, { headers, body: payload }), {
+        log: (message) => console.log(`[WARN] ${message}`),
+    });
     return response.data.result as KbArticle;
 }
 
@@ -191,7 +195,9 @@ export async function updateArticleBody(
     // encodeURIComponent guards the path segment: an unencoded articleId containing
     // '/', '?', or '#' could otherwise alter the effective REST path/query.
     const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
-    await snRequest('PATCH', url, { headers, body: { text } });
+    await withRetry(() => snRequest('PATCH', url, { headers, body: { text } }), {
+        log: (message) => console.log(`[WARN] ${message}`),
+    });
 }
 
 /**
@@ -217,9 +223,11 @@ export async function changeWorkflowState(
     // encodeURIComponent guards the path segment: an unencoded articleId containing
     // '/', '?', or '#' could otherwise alter the effective REST path/query.
     const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
-    const response = await snRequest('PATCH', url, {
+    const response = await withRetry(() => snRequest('PATCH', url, {
         headers,
         body: { workflow_state: STATE_VALUE_MAP[workflowState] ?? workflowState },
+    }), {
+        log: (message) => console.log(`[WARN] ${message}`),
     });
     return response.data.result as KbArticle;
 }

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
@@ -42,6 +42,19 @@ export interface SnResponse {
     data: Record<string, unknown>;
 }
 
+/**
+ * Thrown for a non-2xx ServiceNow response (as opposed to a pure transport
+ * failure -- connection error, timeout, or the response-size guard, which
+ * throw a plain Error with no `status`). Lets withRetry() distinguish "the
+ * server responded with an error" from "no response was ever received".
+ */
+export class ServiceNowHttpError extends Error {
+    constructor(message: string, public readonly status: number) {
+        super(message);
+        this.name = 'ServiceNowHttpError';
+    }
+}
+
 function encodeBody(body: SnRequestOptions['body']): Buffer | undefined {
     if (body === undefined) {
         return undefined;
@@ -137,8 +150,9 @@ export function snRequest(
                         }
                     }
                     if (status < 200 || status >= 300) {
-                        reject(new Error(
+                        reject(new ServiceNowHttpError(
                             `ServiceNow request ${method} ${parsed.pathname} failed with status ${status}: ${truncate(raw)}`,
+                            status,
                         ));
                         return;
                     }
@@ -157,4 +171,35 @@ export function snRequest(
         }
         req.end();
     });
+}
+
+/**
+ * Wraps a mutating ServiceNow call (create/update/publish/upload) with bounded
+ * exponential-backoff retry on TRANSIENT failures only: a thrown transport
+ * error (no response ever received -- connection reset, timeout, response-size
+ * guard) or a captured 5xx status. A captured 4xx (bad request, auth failure,
+ * not-found, validation error, etc.) is never retried -- retrying an unchanged
+ * request wouldn't produce a different 4xx. Mirrors this repo's established
+ * mutating-call retry convention (TerraformModulePublish's retryHttp).
+ */
+export async function withRetry<T>(
+    call: () => Promise<T>,
+    opts: { retries?: number; baseDelayMs?: number; log?: (message: string) => void } = {},
+): Promise<T> {
+    const retries = opts.retries ?? 3;
+    const baseDelayMs = opts.baseDelayMs ?? 500;
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return await call();
+        } catch (err) {
+            const status = err instanceof ServiceNowHttpError ? err.status : undefined;
+            const retryable = status === undefined || status >= 500;
+            if (!retryable || attempt >= retries) {
+                throw err;
+            }
+            const reason = err instanceof Error ? err.message : String(err);
+            opts.log?.(`Transient ServiceNow request failure (${reason}); retrying (${attempt + 1}/${retries}).`);
+            await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+        }
+    }
 }

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "6",
+        "Minor": "7",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackFails.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackFails.ts
@@ -30,6 +30,7 @@ tr.setInput('rejectUnauthorized', 'true');
 // Stub the callback transport to return a non-2xx status so the task fails.
 tr.registerMock('./callback', {
     postJson: async () => ({ status: 500, body: 'internal error' }),
+    postJsonWithRetry: async () => ({ status: 500, body: 'internal error' }),
     truncateBody: (body: string) => body,
     resolveRejectUnauthorized,
 });

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackPartial.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackPartial.ts
@@ -28,6 +28,7 @@ tr.setInput('callbackUrl', 'https://tsm.example.com/drift');
 // Stub the callback transport: it must NOT be invoked on this path.
 tr.registerMock('./callback', {
     postJson: async () => ({ status: 200, body: '{}' }),
+    postJsonWithRetry: async () => ({ status: 200, body: '{}' }),
     truncateBody: (body: string) => body,
 });
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackSuccess.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackSuccess.ts
@@ -30,6 +30,7 @@ tr.setInput('rejectUnauthorized', 'true');
 // Stub the callback transport so no real network request is made.
 tr.registerMock('./callback', {
     postJson: async () => ({ status: 200, body: '{}' }),
+    postJsonWithRetry: async () => ({ status: 200, body: '{}' }),
     truncateBody: (body: string) => body,
     resolveRejectUnauthorized,
 });

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackTlsOff.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCallbackTlsOff.ts
@@ -30,6 +30,7 @@ tr.setInput('rejectUnauthorized', 'false');
 
 tr.registerMock('./callback', {
     postJson: async () => ({ status: 200, body: '{}' }),
+    postJsonWithRetry: async () => ({ status: 200, body: '{}' }),
     truncateBody: (body: string) => body,
     resolveRejectUnauthorized,
 });

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as net from 'net';
 import * as https from 'https';
-import { postJson, truncateBody } from '../src/callback';
+import { postJson, postJsonWithRetry, truncateBody } from '../src/callback';
 import { createHttpsClient } from '../src/https-client';
 import { TLS_CERT, TLS_KEY } from './loopback-tls';
 
@@ -74,6 +74,55 @@ describe('TerraformDriftReport callback transport', function () {
         const out = truncateBody(long);
         assert.ok(out.length < long.length, 'long body should be truncated');
         assert.ok(out.endsWith('… (truncated)'), 'should mark truncation');
+    });
+
+    it('postJsonWithRetry retries a bounded number of times on pure transport failures then throws', async () => {
+        // A closed port guarantees ECONNREFUSED -- a pure transport failure with
+        // no response ever received, the only case this retry policy covers.
+        const probe = net.createServer();
+        await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve));
+        const port = (probe.address() as net.AddressInfo).port;
+        await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+        const logs: string[] = [];
+        await assert.rejects(
+            postJsonWithRetry(
+                `https://127.0.0.1:${port}/drift`,
+                { 'X-TSM-Callback-Token': 't' },
+                '{}',
+                true,
+                undefined,
+                { retries: 2, baseDelayMs: 5, log: (m) => logs.push(m) },
+            ),
+        );
+        assert.strictEqual(logs.length, 2, `expected exactly 2 retry attempts logged, got: ${logs.length}`);
+    });
+
+    it('postJsonWithRetry does not retry a received 5xx response (one-shot token safety)', async () => {
+        let requestCount = 0;
+        const server = https.createServer({ cert: TLS_CERT, key: TLS_KEY }, (req, res) => {
+            requestCount++;
+            res.statusCode = 503;
+            res.end('{"error":"unavailable"}');
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        try {
+            const logs: string[] = [];
+            const resp = await postJsonWithRetry(
+                `https://127.0.0.1:${port}/drift`,
+                { 'X-TSM-Callback-Token': 't' },
+                '{}',
+                false,
+                undefined,
+                { retries: 2, baseDelayMs: 5, log: (m) => logs.push(m) },
+            );
+            assert.strictEqual(resp.status, 503);
+            assert.strictEqual(requestCount, 1, 'a received 5xx must not be retried (one-shot callback token safety)');
+            assert.strictEqual(logs.length, 0, 'no retry should have been logged');
+        } finally {
+            server.close();
+        }
     });
 });
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts
@@ -36,3 +36,39 @@ export function postJson(
         body,
     );
 }
+
+/**
+ * Retries postJson on a bounded number of pure TRANSPORT failures only (a
+ * thrown error -- connection refused/reset, TLS failure, socket timeout, or
+ * the response-size guard). A received HTTP response, including a 5xx, is
+ * returned immediately and never retried: the callback token is one-shot, so
+ * if the server received and validated the request but its response was
+ * lost in transit, a retry could be rejected as a replay of an
+ * already-consumed token -- indistinguishable, from the client's side, from
+ * "the callback simply hasn't landed yet". A pure transport failure carries
+ * no such ambiguity: no response was ever received, so the server cannot
+ * have consumed the token.
+ */
+export async function postJsonWithRetry(
+    url: string,
+    headers: Record<string, string>,
+    body: string,
+    rejectUnauthorized = true,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+    opts: { retries?: number; baseDelayMs?: number; log?: (message: string) => void } = {},
+): Promise<HttpResponse> {
+    const retries = opts.retries ?? 3;
+    const baseDelayMs = opts.baseDelayMs ?? 500;
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return await postJson(url, headers, body, rejectUnauthorized, timeoutMs);
+        } catch (err) {
+            if (attempt >= retries) {
+                throw err;
+            }
+            const reason = err instanceof Error ? err.message : String(err);
+            opts.log?.(`Drift callback transport failure (${reason}); retrying (${attempt + 1}/${retries}).`);
+            await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+        }
+    }
+}

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -4,7 +4,7 @@ import fs = require('fs');
 import os = require('os');
 import { randomUUID } from 'crypto';
 import { summarize, moduleCallsPlan, Plan } from 'terraform-drift-contract';
-import { postJson, truncateBody, resolveRejectUnauthorized } from './callback';
+import { postJsonWithRetry, truncateBody, resolveRejectUnauthorized } from './callback';
 import { writeSarif } from './sarif';
 
 // Reads `.terraform/modules/modules.json` verbatim for the callback's
@@ -98,11 +98,13 @@ async function run(): Promise<void> {
                     'endpoint fronted by a private CA the agent does not trust.',
                 );
             }
-            const resp = await postJson(
+            const resp = await postJsonWithRetry(
                 callbackUrl,
                 { 'X-TSM-Callback-Token': callbackToken },
                 JSON.stringify(body),
                 rejectUnauthorized,
+                undefined,
+                { log: (message) => tasks.warning(message) },
             );
             if (resp.status < 200 || resp.status >= 300) {
                 throw new Error(`Drift callback failed (HTTP ${resp.status}): ${truncateBody(resp.body)}`);

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "7",
+    "Minor": "8",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
## Summary

Closes the regressed portion of issue #395 (finding e1): the shared installer `http-client.ts` already retries, but TerraformDriftReport's TSM callback POST and PublishKbArticle's ServiceNow create/update/upload calls did not, despite #395's closing PR fixing the sibling items (hcp-publisher.ts / private-publisher.ts) in TerraformModulePublish.

Addresses the P1 regressed finding in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) / [.audit/terraform-ext-delta-2026-07-12.md](.audit/terraform-ext-delta-2026-07-12.md) (findings #29 and #31).

## Changes

**TerraformDriftReport** (`callback.ts`): added `postJsonWithRetry()`, which retries **only** on a thrown transport failure (connection reset, timeout, the response-size guard) -- never on a *received* HTTP response, including 5xx. The `callbackToken` input is documented as one-shot: if the server received and validated the request but the response was lost in transit, a retry could be rejected as a replay of an already-consumed token. A pure transport failure carries no such ambiguity, since the server never responded at all.

**PublishKbArticle** (`servicenow-http.ts`): added a `ServiceNowHttpError` class that carries the response status, and a generic `withRetry()` helper that retries transport failures and captured 5xx responses (no one-shot-token constraint on this API) but never a captured 4xx. Applied to the actual mutating calls: `createKnowledgeArticle`, `updateKnowledgeArticle`, `updateArticleBody`, `changeWorkflowState` (`servicenow-client.ts`), and `uploadAttachment` (`attachments.ts`).

Both bumped Minor per the mandatory task-cache rule (DriftReport 7->8, PublishKbArticle 6->7).

## Regression risk considered

- Switching `index.ts`'s callback call from `postJson` to `postJsonWithRetry` broke 4 existing DriftReport test scenarios whose `tr.registerMock('./callback', {...})` mocks only declared the old `postJson` key -- `registerMock` isn't type-checked against the real module shape, so this surfaced as a runtime `"...postJsonWithRetry is not a function"` rather than a compile error. Fixed by adding the new key to all 4 mocks (`DriftReportCallbackFails/Partial/Success/TlsOff.ts`); confirmed via a repo-wide search that no other test mocks of either changed module are stale.
- New tests added for both retry helpers proving: transport failures retry (bounded, with backoff), a received 5xx/one-shot-response is returned immediately without retry (DriftReport), a received 5xx *does* retry then succeeds (PublishKbArticle, no token constraint), and a 4xx never retries (PublishKbArticle).
- Test backoff delays are overridden to a few ms so the suites stay fast.

Full suites: **DriftReport 19 passing/0 failing**, **PublishKbArticle 95 passing/0 failing**. Reviewed by an adversarial pass focused on retry-safety reasoning (verifying the underlying HTTP clients truly never reject on a received response), stale-mock detection, and backoff timing before opening this PR.
