### PR TITLE
ci: pass --ignore-scripts explicitly to every npm ci invocation

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -79,7 +79,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -107,7 +107,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -135,7 +135,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -163,7 +163,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -191,7 +191,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -219,7 +219,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -247,7 +247,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -275,7 +275,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -303,7 +303,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -331,7 +331,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high
       - name: Lint
@@ -352,7 +352,7 @@ jobs:
         with:
           node-version: "24"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Audit root tooling (tfx-cli, webpack, cyclonedx-npm, jest, …)
         # The root package.json has no "dependencies" — everything here
         # (tfx-cli used by the marketplace publish job, webpack, cyclonedx-npm,


### PR DESCRIPTION
Fixes the regressed portion of issue #413: the root `.npmrc`'s `ignore-scripts=true` does not reach any of the 11 per-task matrix jobs (or the tab job) in `unit-test.yml`, because npm's local-prefix config resolution stops at each task's own `package.json` subdirectory -- it never walks up to the repo root to find the root `.npmrc`.

Adds `--ignore-scripts` directly to all 12 `npm ci` invocations, matching the pattern this repo's own `release.yml` already uses successfully (it never relied on the root .npmrc alone). Verified no task's `package.json` defines `preinstall`/`postinstall`/`prepare` scripts, consistent with the root `.npmrc`'s own comment that this is behaviour-neutral across the repo.

Addresses the P1 regressed finding (medium) in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) / [.audit/terraform-ext-delta-2026-07-12.md](.audit/terraform-ext-delta-2026-07-12.md) (finding #18), originally issue #413.

No source code changes -- pure CI config. Validated the edited YAML parses cleanly with js-yaml.
