### PR TITLE
security: scope PublishKbArticle force input to only the content-loss heuristic

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,11 @@ Every task's job in `unit-test.yml` runs `npm audit --omit=dev --audit-level=hig
 
 **The moderate/low-severity gap is covered by the weekly OSV scan, not the PR gate.** `weekly-security.yml`'s `osv-scan` job runs `google/osv-scanner-action` with no severity filter — it reports vulnerabilities of every severity, including the moderate/low findings `npm audit --audit-level=high` intentionally passes over. That step is `continue-on-error: true` so a finding doesn't fail the scheduled run itself, but a failing scan still automatically files a tracked GitHub issue (the `Create issue on new vulnerabilities` step, labeled `security, dependencies`, linking back to the run) — this is the triage mechanism, run weekly rather than gating every PR.
 
+## Optional-feature residual risk: PublishKbArticle's `force` input
+
+`force` (opt-in, **default false**) only downgrades one heuristic in `html-validate.ts`'s `validateHtmlContent()` — a parsing-fidelity check (does the parsed output retain at least 50% of the input's length) that can have legitimate false positives on unusual-but-safe markdown-to-HTML output — from a hard failure to a warning. Every stored-XSS-relevant check in the same function (external/inline `<script>` elements, inline event-handler attributes, `<base>`/meta-refresh redirects, `javascript:`/`vbscript:`/non-image `data:` URIs, including control-character-obfuscated variants) always fails the task regardless of `force`. This was not always the case: prior to this fix, `force` disabled the entire validation gate, including the XSS-relevant checks — see the resolved history in CHANGELOG.md for the original stored-XSS finding.
+
+
 ## Preferred Languages
 
 English preferred.

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -495,9 +495,12 @@ describe('htmlValidate.validateHtmlContent', () => {
         );
     });
 
-    it('does not throw on external script when force=true', () => {
+    it('throws on external script even when force=true (#446: force no longer bypasses XSS checks)', () => {
         const html = '<html><body><script src="https://cdn.example.com/lib.js"></script></body></html>';
-        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /External script sources are not allowed/,
+        );
     });
 
     it('throws on an inline <script> element when force=false', () => {
@@ -508,9 +511,12 @@ describe('htmlValidate.validateHtmlContent', () => {
         );
     });
 
-    it('does not throw on an inline <script> when force=true', () => {
+    it('throws on an inline <script> even when force=true (#446: force no longer bypasses XSS checks)', () => {
         const html = '<html><body><script>alert(1)</script></body></html>';
-        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /Inline <script> elements are not allowed/,
+        );
     });
 
     it('throws on an inline event-handler attribute (onerror) when force=false', () => {
@@ -521,9 +527,12 @@ describe('htmlValidate.validateHtmlContent', () => {
         );
     });
 
-    it('does not throw on an inline event-handler when force=true', () => {
+    it('throws on an inline event-handler even when force=true (#446: force no longer bypasses XSS checks)', () => {
         const html = '<html><body><img src="x" onerror="alert(1)"></body></html>';
-        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /event-handler attributes .* are not allowed/,
+        );
     });
 
     it('throws on a javascript: URI when force=false', () => {
@@ -582,22 +591,44 @@ describe('htmlValidate.validateHtmlContent', () => {
         assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, false));
     });
 
-    it('does not throw on a dangerous URI when force=true', () => {
-        const html = '<html><body><a href="javascript:alert(1)">x</a></body></html>';
-        assert.doesNotThrow(() => htmlValidate.validateHtmlContent(html, true));
+    it('throws on a <base> element even when force=true (#446: force no longer bypasses XSS checks)', () => {
+        const html = '<html><head><base href="//evil.example.com/"></head><body><p>x</p></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /<base> elements and <meta http-equiv="refresh">/,
+        );
     });
 
-    it('throws on content loss when force=false', () => {
-        // Construct input that will lose significant content after cheerio parse.
-        // cheerio wraps fragments in html/head/body which adds bytes, so this
-        // heuristic fires only for content that genuinely gets stripped.
-        // We simulate by passing a very long string of unclosed tags that cheerio collapses.
-        const badHtml = '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<' +
-            'invalid garbage content that is mostly angle brackets and gets stripped>>>>>>>>>>>>>>' +
-            'x'.repeat(1000);
-        // This may or may not trigger the heuristic depending on cheerio version;
-        // for external scripts the heuristic is more reliable.  We test what we can.
-        // Just verify the function runs without an unhandled exception on weird input.
+    it('throws on a javascript: <meta http-equiv="refresh"> even when force=true (#446: force no longer bypasses XSS checks)', () => {
+        const html = '<html><head><meta http-equiv="refresh" content="0;url=javascript:alert(1)"></head><body><p>x</p></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /<base> elements and <meta http-equiv="refresh">/,
+        );
+    });
+
+    it('throws on a dangerous URI even when force=true (#446: force no longer bypasses XSS checks)', () => {
+        const html = '<html><body><a href="javascript:alert(1)">x</a></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /javascript:.*URIs are not allowed/,
+        );
+    });
+
+    it('throws on content loss when force=false (#38: was previously mislabeled -- asserted doesNotThrow with force=true)', () => {
+        // A DOCTYPE's public-identifier padding is discarded on serialization
+        // (cheerio/dom-serializer always emits a bare "<!doctype html>"),
+        // reliably producing >50% content loss without relying on parser-version-
+        // specific tag-soup behavior.
+        const badHtml = `<!DOCTYPE html PUBLIC "${'x'.repeat(3000)}"><html><body><p>hi</p></body></html>`;
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(badHtml, false),
+            /significant content loss/,
+        );
+    });
+
+    it('warns instead of throwing on content loss when force=true (the one heuristic force still covers)', () => {
+        const badHtml = `<!DOCTYPE html PUBLIC "${'x'.repeat(3000)}"><html><body><p>hi</p></body></html>`;
         assert.doesNotThrow(() => htmlValidate.validateHtmlContent(badHtml, true));
     });
 });

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
@@ -18,7 +18,16 @@ function normalizeUriForSchemeCheck(value: string): string {
 
 /**
  * Validate HTML content for common issues.
- * Throws if invalid and force is false; warns (console) if force is true.
+ *
+ * `force` ONLY downgrades the content-loss heuristic below (a false-positive-
+ * prone parsing-fidelity check, not a security control) from a throw to a
+ * warning. Every other check here is a stored-XSS/active-content defense
+ * (external/inline `<script>`, inline event handlers, `<base>`/meta-refresh
+ * redirects, javascript:/vbscript:/non-image data: URIs) and always throws
+ * regardless of `force` -- these are deterministic invariants with no
+ * legitimate false-positive case, unlike the content-loss heuristic, so
+ * letting `force` bypass them would let a KB author (or a compromised
+ * upstream markdown source) simply opt out of XSS protection entirely.
  */
 export function validateHtmlContent(html: string, force: boolean = false): void {
     const $ = load(html);
@@ -43,11 +52,7 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
     });
 
     if (externalScriptFound) {
-        const msg = 'External script sources are not allowed in KB articles';
-        if (!force) {
-            throw new Error(msg);
-        }
-        console.warn(`[WARN] HTML validation: ${msg}`);
+        throw new Error('External script sources are not allowed in KB articles');
     }
 
     // Reject inline <script> elements: even without a remote src, inline script
@@ -61,11 +66,7 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
     });
 
     if (inlineScriptFound) {
-        const msg = 'Inline <script> elements are not allowed in KB articles';
-        if (!force) {
-            throw new Error(msg);
-        }
-        console.warn(`[WARN] HTML validation: ${msg}`);
+        throw new Error('Inline <script> elements are not allowed in KB articles');
     }
 
     // Reject <base> (redirects every relative URL in the document) and a
@@ -81,11 +82,7 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
         }
     });
     if (baseOrMetaRefreshFound) {
-        const msg = '<base> elements and <meta http-equiv="refresh"> redirects to javascript:/vbscript: are not allowed in KB articles';
-        if (!force) {
-            throw new Error(msg);
-        }
-        console.warn(`[WARN] HTML validation: ${msg}`);
+        throw new Error('<base> elements and <meta http-equiv="refresh"> redirects to javascript:/vbscript: are not allowed in KB articles');
     }
 
     // Reject inline event-handler attributes (onerror=, onload=, onclick=, …)
@@ -110,19 +107,11 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
     });
 
     if (eventHandlerFound) {
-        const msg = 'Inline event-handler attributes (on*) are not allowed in KB articles';
-        if (!force) {
-            throw new Error(msg);
-        }
-        console.warn(`[WARN] HTML validation: ${msg}`);
+        throw new Error('Inline event-handler attributes (on*) are not allowed in KB articles');
     }
 
     if (dangerousUriFound) {
-        const msg = 'javascript:, vbscript: and non-image data: URIs are not allowed in KB articles';
-        if (!force) {
-            throw new Error(msg);
-        }
-        console.warn(`[WARN] HTML validation: ${msg}`);
+        throw new Error('javascript:, vbscript: and non-image data: URIs are not allowed in KB articles');
     }
 }
 

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -184,7 +184,7 @@
             "label": "Force",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "Continue processing even if HTML validation fails."
+            "helpMarkDown": "Continue processing (as a warning instead of a failure) when HTML validation flags likely content loss from a parsing/syntax issue. Security-relevant checks (script tags, inline event handlers, javascript:/vbscript:/data: URIs, <base>/meta-refresh redirects) are never affected by this input and always fail the task -- see SECURITY.md."
         },
         {
             "name": "skipJsonLookup",


### PR DESCRIPTION
## Summary

Fixes the regressed followup from issue #446 (P0 stored-XSS): `force` previously downgraded the **entire** HTML validation gate in `html-validate.ts` to a warning, including the actual XSS-relevant checks -- not just the content-loss parsing-fidelity heuristic. `#446`'s own body recommended marking `force` as security-sensitive; the audit found the gate itself was scoped too broadly.

Addresses finding #16 in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) / [.audit/terraform-ext-delta-2026-07-12.md](.audit/terraform-ext-delta-2026-07-12.md).

## Changes

`force` now only affects the **content-loss heuristic** (a false-positive-prone parsing-fidelity check with no security relevance). Every other check -- external/inline `<script>` tags, `<base>`/meta-refresh redirects, inline event-handler attributes, `javascript:`/`vbscript:`/non-image `data:` URIs (including the control-char-obfuscated variants #446 already fixed) -- now **always throws regardless of `force`**. A KB author can no longer opt out of XSS protection by setting `force: true`.

Also:
- Updated `task.json`'s `force` help text and added a `SECURITY.md` residual-risk entry documenting the new (narrow) scope, per #446's own recommended followup.
- Fixed audit finding #38: a test titled *"throws on content loss when force=false"* actually passed `force=true` and asserted `doesNotThrow` (lcov-proven zero executions of the real throw branch). Replaced with a real `force=false`/throws case (a padded DOCTYPE public-identifier reliably triggers the heuristic, since `dom-serializer` normalizes it away on output) plus a companion `force=true`/warns-only case.
- Updated the tests that previously asserted `force=true` suppressed the XSS checks to assert they still throw, and added the same coverage for `<base>`, meta-refresh, and dangerous-URI paths.

## Breaking change (intentional)

This is an intentional breaking behavior change for any pipeline that relied on `force: true` to tolerate KB content containing scripts/event handlers/dangerous URIs -- flagged in `task.json` help text and `SECURITY.md`.

**Note on Minor version:** PublishKbArticle's `task.json` Minor is already bumped in PR #465 (retry hardening, same task, currently open). Not re-bumped here to avoid a guaranteed merge conflict on the same line -- whichever of the two PRs merges first satisfies the mandatory pre-release Minor-bump gate (`check-minor-bumps.js` compares against the last release tag, not merge order between these two PRs).

## Verification

Full suite: **95 passing, 0 failing**. Reviewed by an adversarial pass focused on: confirming every non-content-loss check throws unconditionally with no leftover `force` gate, confirming the DOCTYPE-padding test triggers the heuristic for the right reason (not flakily), and checking for stale docs/other tests assuming the old behavior. It found one test-symmetry gap (a missing explicit meta-refresh+`force=true` case, since that path shares the `<base>` branch) -- added.
