### PR TITLE
test: restore parent-handler.ts to the coverage gate

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/.nycrc.json
@@ -11,8 +11,7 @@
     "exclude": [
         "src/**/*.d.ts",
         "src/**/*.map",
-        "src/index.js",
-        "src/parent-handler.js"
+        "src/index.js"
     ],
     "check-coverage": true,
     "lines": 85,


### PR DESCRIPTION
Fixes the regressed disposition from issue #310: `parent-handler.js` was excluded from TerraformTaskV5's `.nycrc.json` alongside `index.js` on the stated justification that both are non-logic entry files. That holds for `index.js` (thin CLI wiring) but not for `parent-handler.ts`, which contains real logic -- cross-cloud backend-detection dispatch (`injectCrossCloudBackendCredentials`), the provider/backend handler factory (`createHandler`), and credential cleanup on both normal completion and SIGTERM/SIGINT/uncaughtException (`cleanupAllHandlers`/`emergencyCleanup`).

Addresses the P1 regressed finding (low) in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) / [.audit/terraform-ext-delta-2026-07-12.md](.audit/terraform-ext-delta-2026-07-12.md) (finding #42).

## Change

Removed `src/parent-handler.js` from the `.nycrc.json` exclude list; kept `src/index.js` excluded.

## Verification

Existing tests (`CrossCloudInjectionL0`, `EmergencyCleanupNoHandlerL0`, plus the full mock-run suite) already exercise `parent-handler.ts`, so no new tests were required. Ran `npm run test:coverage` before opening this PR:

- Aggregate (the actual gate): lines 90.29% / functions 85.33% / branches 76.04% -- comfortably above the configured thresholds (85 / 80 / 71).
- `parent-handler.js` individually: 91.07% lines / 93.33% functions / 62.85% branches (uncovered: lines 124, 134-138) -- branch coverage is below the aggregate threshold for this one file, but the gate is evaluated in aggregate, not per-file, so this doesn't fail the build.
- 264 passing, 0 failing.

No source code changes -- pure coverage-gate config.
