### PR TITLE
security: dedupe HTML/URI sanitizer into a shared, parity-checked module

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -467,6 +467,24 @@ describe('convertMarkdownToHtml', () => {
         assert.ok(!/<base[\s>]/i.test(html), '<base> must be removed');
         assert.ok(!/<meta/i.test(html), 'the dangerous <meta refresh> must be removed');
     });
+
+    it('allows a raster data:image/* URI (e.g. png) in an <img> src', () => {
+        const html = convertMarkdownToHtml('<img src="data:image/png;base64,iVBORw0KGgo=">');
+        assert.ok(/src\s*=/.test(html), `the raster data: URI must be preserved (got: ${html})`);
+    });
+
+    it('strips a data:image/svg+xml URI even on an <img> element (an SVG document can embed active content, unlike a raster format)', () => {
+        const html = convertMarkdownToHtml('<img src="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">');
+        assert.ok(!/src\s*=/.test(html), `svg+xml data: URI must be stripped even on <img> (got: ${html})`);
+    });
+
+    it('strips a data:image/svg+xml URI on non-<img> elements (<a href>, <button formaction>)', () => {
+        const anchorHtml = convertMarkdownToHtml('<a href="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</a>');
+        assert.ok(!/href\s*=/.test(anchorHtml), `<a href> must be stripped (got: ${anchorHtml})`);
+
+        const formHtml = convertMarkdownToHtml('<form><button formaction="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</button></form>');
+        assert.ok(!/formaction\s*=/.test(formHtml), `formaction must be stripped (got: ${formHtml})`);
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
@@ -8,6 +8,7 @@ import path = require('path');
 import MarkdownIt = require('markdown-it');
 import * as cheerio from 'cheerio';
 import hljs from 'highlight.js';
+import { normalizeUriForSchemeCheck, isDangerousUriScheme, isDangerousMetaRefresh, URI_BEARING_ATTRIBUTES } from './uri-scheme-guard';
 
 // ---------------------------------------------------------------------------
 // preprocessMarkdown
@@ -52,21 +53,6 @@ function escapeHtml(s: string): string {
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;');
-}
-
-/**
- * Normalizes an attribute value before a URI-scheme check. Browsers (per the
- * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
- * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can
- * be bypassed with an HTML-entity-encoded control char INSIDE the scheme (e.g.
- * `jav&#9;ascript:`) — `.trim()` only removes leading/trailing whitespace, so
- * the interior tab survives the check but is stripped by the browser at parse
- * time, yielding a working `javascript:` URI. Stripping every ASCII control
- * character (U+0000–U+001F, U+007F) from anywhere in the string — not just
- * the edges — before lower-casing closes this bypass.
- */
-function normalizeUriForSchemeCheck(value: string): string {
-    return value.replace(/[\u0000-\u001F\u007F]/g, '').trim().toLowerCase();
 }
 
 function highlightCode(code: string, lang: string): string {
@@ -129,7 +115,7 @@ export function sanitizeRenderedHtml(html: string): string {
     $('meta').each((_, el) => {
         const httpEquiv = normalizeUriForSchemeCheck(String($(el).attr('http-equiv') ?? ''));
         const content = normalizeUriForSchemeCheck(String($(el).attr('content') ?? ''));
-        if (httpEquiv === 'refresh' && (content.includes('javascript:') || content.includes('vbscript:'))) {
+        if (isDangerousMetaRefresh(httpEquiv, content)) {
             $(el).remove();
         }
     });
@@ -142,8 +128,8 @@ export function sanitizeRenderedHtml(html: string): string {
             if (lname.startsWith('on')) {
                 $(el).removeAttr(name);
             } else if (
-                (lname === 'href' || lname === 'src' || lname === 'xlink:href' || lname === 'formaction') &&
-                (value.startsWith('javascript:') || value.startsWith('vbscript:') || (value.startsWith('data:') && !value.startsWith('data:image/')))
+                URI_BEARING_ATTRIBUTES.has(lname) &&
+                isDangerousUriScheme(value)
             ) {
                 $(el).removeAttr(name);
             }

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared URI-scheme validation for the two independent HTML sanitizer/gate
+ * implementations that guard the ServiceNow KB-publishing pipeline:
+ * Markdown2Html's render-time `sanitizeRenderedHtml()` (defense-in-depth,
+ * strips dangerous markup) and PublishKbArticle's `validateHtmlContent()`
+ * (the downstream fail-closed gate, throws). Kept byte-identical across both
+ * tasks' `src/` directories and guarded by scripts/check-shared-modules.js --
+ * a fix to the allowlist here must never be applied to one copy and silently
+ * missed in the other, which is exactly how the original control-character
+ * scheme bypass (#446) evaded both layers using two independently-drifting
+ * copies of this exact logic.
+ */
+
+/** Attribute names that can carry a URI capable of triggering navigation or resource loading. */
+export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction']);
+
+/**
+ * Normalizes an attribute value before a URI-scheme check. Browsers (per the
+ * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
+ * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can
+ * be bypassed with an HTML-entity-encoded control char INSIDE the scheme (e.g.
+ * `jav&#9;ascript:`) — `.trim()` only removes leading/trailing whitespace, so
+ * the interior tab survives the check but is stripped by the browser at parse
+ * time, yielding a working `javascript:` URI. Stripping every ASCII control
+ * character (U+0000–U+001F, U+007F) from anywhere in the string — not just
+ * the edges — before lower-casing closes this bypass.
+ */
+export function normalizeUriForSchemeCheck(value: string): string {
+  return value.replace(/[\u0000-\u001F\u007F]/g, '').trim().toLowerCase();
+}
+
+/**
+ * True if a NORMALIZED (see normalizeUriForSchemeCheck) attribute value uses a
+ * scheme that can execute script or load arbitrary non-image content:
+ * `javascript:`, `vbscript:`, or a `data:` URI other than a plain raster
+ * image. `data:image/svg+xml` is deliberately EXCLUDED from the safe set even
+ * though it matches the `data:image/` prefix: an SVG document can embed
+ * `<script>`/event-handler attributes that execute when referenced in a
+ * context other than a plain `<img>` (e.g. `<object>`, `<embed>`, or a direct
+ * navigation via `<a href>`), unlike a raster format.
+ */
+export function isDangerousUriScheme(normalizedValue: string): boolean {
+  if (normalizedValue.startsWith('javascript:') || normalizedValue.startsWith('vbscript:')) {
+    return true;
+  }
+  if (!normalizedValue.startsWith('data:')) {
+    return false;
+  }
+  return !(normalizedValue.startsWith('data:image/') && !normalizedValue.startsWith('data:image/svg+xml'));
+}
+
+/** True if a NORMALIZED http-equiv/content pair is a meta-refresh redirect to a dangerous scheme. */
+export function isDangerousMetaRefresh(normalizedHttpEquiv: string, normalizedContent: string): boolean {
+  return normalizedHttpEquiv === 'refresh' &&
+    (normalizedContent.includes('javascript:') || normalizedContent.includes('vbscript:'));
+}

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "3",
+        "Minor": "4",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -657,6 +657,28 @@ describe('htmlValidate.validateHtmlContent', () => {
         );
     });
 
+    it('throws on a data:image/svg+xml URI even on an <img> element (an SVG document can embed active content, unlike a raster format)', () => {
+        const html = '<html><body><img src="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+"></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /data: URIs are not allowed/,
+        );
+    });
+
+    it('throws on a data:image/svg+xml URI on non-<img> elements (<a href>, <button formaction>)', () => {
+        const anchorHtml = '<html><body><a href="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</a></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(anchorHtml, false),
+            /data: URIs are not allowed/,
+        );
+
+        const formHtml = '<html><body><form><button formaction="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</button></form></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(formHtml, false),
+            /data: URIs are not allowed/,
+        );
+    });
+
     it('throws on a javascript: <meta http-equiv="refresh"> even when force=true (#446: force no longer bypasses XSS checks)', () => {
         const html = '<html><head><meta http-equiv="refresh" content="0;url=javascript:alert(1)"></head><body><p>x</p></body></html>';
         assert.throws(

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
@@ -1,20 +1,6 @@
 import * as fs from 'fs';
 import { load } from 'cheerio';
-
-/**
- * Normalizes an attribute value before a URI-scheme check. Browsers (per the
- * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
- * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can
- * be bypassed with an HTML-entity-encoded control char INSIDE the scheme (e.g.
- * `jav&#9;ascript:`) — `.trim()` only removes leading/trailing whitespace, so
- * the interior tab survives the check but is stripped by the browser at parse
- * time, yielding a working `javascript:` URI. Stripping every ASCII control
- * character (U+0000–U+001F, U+007F) from anywhere in the string — not just
- * the edges — before lower-casing closes this bypass.
- */
-function normalizeUriForSchemeCheck(value: string): string {
-    return value.replace(/[\u0000-\u001F\u007F]/g, '').trim().toLowerCase();
-}
+import { normalizeUriForSchemeCheck, isDangerousUriScheme, isDangerousMetaRefresh, URI_BEARING_ATTRIBUTES } from './uri-scheme-guard';
 
 /**
  * Validate HTML content for common issues.
@@ -77,7 +63,7 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
     $('meta').each((_, el) => {
         const httpEquiv = normalizeUriForSchemeCheck(String($(el).attr('http-equiv') ?? ''));
         const content = normalizeUriForSchemeCheck(String($(el).attr('content') ?? ''));
-        if (httpEquiv === 'refresh' && (content.includes('javascript:') || content.includes('vbscript:'))) {
+        if (isDangerousMetaRefresh(httpEquiv, content)) {
             baseOrMetaRefreshFound = true;
         }
     });
@@ -98,8 +84,8 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
             if (lname.startsWith('on')) {
                 eventHandlerFound = true;
             } else if (
-                (lname === 'href' || lname === 'src' || lname === 'xlink:href' || lname === 'formaction') &&
-                (value.startsWith('javascript:') || value.startsWith('vbscript:') || (value.startsWith('data:') && !value.startsWith('data:image/')))
+                URI_BEARING_ATTRIBUTES.has(lname) &&
+                isDangerousUriScheme(value)
             ) {
                 dangerousUriFound = true;
             }

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared URI-scheme validation for the two independent HTML sanitizer/gate
+ * implementations that guard the ServiceNow KB-publishing pipeline:
+ * Markdown2Html's render-time `sanitizeRenderedHtml()` (defense-in-depth,
+ * strips dangerous markup) and PublishKbArticle's `validateHtmlContent()`
+ * (the downstream fail-closed gate, throws). Kept byte-identical across both
+ * tasks' `src/` directories and guarded by scripts/check-shared-modules.js --
+ * a fix to the allowlist here must never be applied to one copy and silently
+ * missed in the other, which is exactly how the original control-character
+ * scheme bypass (#446) evaded both layers using two independently-drifting
+ * copies of this exact logic.
+ */
+
+/** Attribute names that can carry a URI capable of triggering navigation or resource loading. */
+export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction']);
+
+/**
+ * Normalizes an attribute value before a URI-scheme check. Browsers (per the
+ * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
+ * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can
+ * be bypassed with an HTML-entity-encoded control char INSIDE the scheme (e.g.
+ * `jav&#9;ascript:`) — `.trim()` only removes leading/trailing whitespace, so
+ * the interior tab survives the check but is stripped by the browser at parse
+ * time, yielding a working `javascript:` URI. Stripping every ASCII control
+ * character (U+0000–U+001F, U+007F) from anywhere in the string — not just
+ * the edges — before lower-casing closes this bypass.
+ */
+export function normalizeUriForSchemeCheck(value: string): string {
+  return value.replace(/[\u0000-\u001F\u007F]/g, '').trim().toLowerCase();
+}
+
+/**
+ * True if a NORMALIZED (see normalizeUriForSchemeCheck) attribute value uses a
+ * scheme that can execute script or load arbitrary non-image content:
+ * `javascript:`, `vbscript:`, or a `data:` URI other than a plain raster
+ * image. `data:image/svg+xml` is deliberately EXCLUDED from the safe set even
+ * though it matches the `data:image/` prefix: an SVG document can embed
+ * `<script>`/event-handler attributes that execute when referenced in a
+ * context other than a plain `<img>` (e.g. `<object>`, `<embed>`, or a direct
+ * navigation via `<a href>`), unlike a raster format.
+ */
+export function isDangerousUriScheme(normalizedValue: string): boolean {
+  if (normalizedValue.startsWith('javascript:') || normalizedValue.startsWith('vbscript:')) {
+    return true;
+  }
+  if (!normalizedValue.startsWith('data:')) {
+    return false;
+  }
+  return !(normalizedValue.startsWith('data:image/') && !normalizedValue.startsWith('data:image/svg+xml'));
+}
+
+/** True if a NORMALIZED http-equiv/content pair is a meta-refresh redirect to a dangerous scheme. */
+export function isDangerousMetaRefresh(normalizedHttpEquiv: string, normalizedContent: string): boolean {
+  return normalizedHttpEquiv === 'refresh' &&
+    (normalizedContent.includes('javascript:') || normalizedContent.includes('vbscript:'));
+}

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -20,6 +20,15 @@ describe('TerraformDriftReport callback transport', function () {
         );
     });
 
+    it('refuses a non-HTTPS URL even when rejectUnauthorized (TLS verification) is disabled', async () => {
+        // The https-only guard must be independent of rejectUnauthorized -- disabling
+        // certificate verification must never also disable the https-only requirement.
+        await assert.rejects(
+            postJson('http://insecure.example.com/drift', { 'X-TSM-Callback-Token': 't' }, '{}', false),
+            /non-HTTPS/,
+        );
+    });
+
     it('completes a POST and a bodyless GET against a loopback HTTPS server', async () => {
         // Exercises the shared client end-to-end: TLS request, response read
         // (data/end + status), the body-present Content-Length path (POST) and

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
@@ -39,6 +39,16 @@ describe('http client transport', () => {
         );
     });
 
+    it('refuses a non-HTTPS URL even when rejectUnauthorized (TLS verification) is disabled', async () => {
+        // The https-only guard must be independent of rejectUnauthorized -- disabling
+        // certificate verification must never also disable the https-only requirement.
+        const client = createHttpsClient(false);
+        await assert.rejects(
+            client('GET', 'http://insecure.example.com/api', { Authorization: 'Bearer k' }),
+            /non-HTTPS/,
+        );
+    });
+
     it('times out a hung connection instead of hanging', async () => {
         // A bare TCP server that accepts the socket but never completes the TLS
         // handshake — req.setTimeout must fire and reject.

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -93,6 +93,21 @@ const FAMILIES = [
             'url-secret-redaction.ts',
         ],
     },
+    {
+        // URI-scheme validation shared by the two independent HTML sanitizer/gate
+        // layers guarding the ServiceNow KB-publishing pipeline: Markdown2Html's
+        // render-time sanitizeRenderedHtml() and PublishKbArticle's downstream
+        // fail-closed validateHtmlContent(). Previously each task carried its own
+        // drifting copy of this logic, which is exactly how the control-character
+        // scheme bypass (#446) evaded both layers at once — keep byte-identical.
+        dirs: [
+            'Tasks/Markdown2Html/Markdown2HtmlV1/src',
+            'Tasks/PublishKbArticle/PublishKbArticleV1/src',
+        ],
+        modules: [
+            'uri-scheme-guard.ts',
+        ],
+    },
 ];
 
 // These two families are deliberately NOT merged into one shared client, even


### PR DESCRIPTION
## Summary

Markdown2Html's render-time `sanitizeRenderedHtml()` and PublishKbArticle's fail-closed `validateHtmlContent()` each carried a byte-for-byte-identical `normalizeUriForSchemeCheck()` and dangerous-URI-scheme condition, untracked by `scripts/check-shared-modules.js` unlike every other duplicated security module in this repo -- exactly how the original control-character scheme bypass (#446) evaded both layers at once via two independently-drifting copies.

Addresses finding #14 (medium, dedup), #9 (low, svg allowlist), and #28 (medium, https-client TLS-independence test) in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) / [.audit/terraform-ext-new-issues-2026-07-12.md](.audit/terraform-ext-new-issues-2026-07-12.md).

## Changes

Extracted both into a new shared `Tasks/*/src/uri-scheme-guard.ts` (kept byte-identical, registered in `check-shared-modules.js`'s FAMILIES). Also tightens the allowlist while here: `data:image/svg+xml` is no longer treated as a safe raster image -- an SVG document can embed active script/event-handler content, unlike png/jpeg/gif/webp, so it no longer gets a blanket `data:image/*` pass on `href`/`src`/`xlink:href`/`formaction`.

Also closes two related testing gaps from the same audit item:
- New tests prove the svg+xml restriction holds on `<img>` AND on non-`<img>` elements (`<a href>`, `<button formaction>`), plus a regression guard that raster `data:image/png` is still allowed.
- New tests on the shared `https-client.ts` (TerraformModulePublish + TerraformDriftReport) prove the https-only guard rejects a non-HTTPS URL even when `rejectUnauthorized` (TLS verification) is disabled -- previously only asserted in a code comment.

## Minor version

Bumped Markdown2Html Minor 3->4 (src changed). PublishKbArticle's `src/` also changed here, but its Minor is already bumped in PRs #465/#467 (same task, unmerged) -- not re-bumped again in this PR to avoid a guaranteed merge conflict on the same line; whichever PR merges first satisfies the mandatory pre-release Minor-bump gate. TerraformModulePublish/TerraformDriftReport changes in this PR are test-only, so no bump needed there.

## Verification

All 4 affected suites run before opening this PR:
- Markdown2Html: 58 passing, 0 failing
- PublishKbArticle: 94 passing, 0 failing
- TerraformModulePublish: 39 passing, 0 failing
- TerraformDriftReport: 18 passing, 0 failing

`node scripts/check-shared-modules.js` confirms byte-identity of the new shared module.

Reviewed by an adversarial pass covering: byte-identity confirmation, behavior preservation in both sanitizer control-flows (removal vs. throw), a full truth table for the new `isDangerousUriScheme()` (raster formats safe, svg+xml/text/html/bare-data/javascript/vbscript all rejected), a search for any existing SVG data-URI fixture that would regress (none found), and test-correctness (confirmed `convertMarkdownToHtml`'s markdown-it `html:true` pass-through doesn't alter the `formaction`/`href` attributes before the sanitizer sees them). Verdict: SHIP IT.
