### PR TITLE
test: cover PublishKbArticle real write/upload/list-KB paths

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -1173,3 +1173,116 @@ describe('PublishKbArticle full-task: instance SSRF guard', () => {
         }, tr);
     });
 });
+
+// ===========================================================================
+// PublishKbArticle full-task: real (non-dry-run) execution paths
+//
+// Every scenario above hardcodes dryRun=true (or reaches an early return
+// before dryRun is even checked). executeCreateOrUpdate()'s real POST/PATCH
+// branches, the image-upload phase, kbId='list' mode, and the
+// serviceConnection-derived OAuth wiring in resolveAuth() were therefore
+// never exercised by any test -- a regression in any of them would be caught
+// by neither a test nor the coverage gate (#25/#36).
+// ===========================================================================
+describe('PublishKbArticle full-task: real (non-dry-run) execution paths', () => {
+    before(() => {
+        (ttm.MockTestRunner.prototype as unknown as { getNodePath: () => string }).getNodePath = function () {
+            return process.execPath;
+        };
+    });
+
+    function runValidations(validator: () => void, tr: ttm.MockTestRunner) {
+        try {
+            validator();
+        } catch (error) {
+            console.log('STDERR', tr.stderr);
+            console.log('STDOUT', tr.stdout);
+            throw error;
+        }
+    }
+
+    it('RealCreateSucceeds — dryRun=false with no articleId performs a real create', async () => {
+        const tp = nodePath.join(__dirname, 'RealCreateSucceeds.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            assert.ok(
+                tr.stdout.includes('##[MOCK] createKnowledgeArticle called with instance=my-valid-instance kbId=kb-123 title=Brand New Article author=jdoe'),
+                `createKnowledgeArticle should receive the task inputs correctly threaded through: ${tr.stdout}`,
+            );
+            assert.ok(
+                tr.stdout.includes('##vso[task.setvariable variable=kbArticleId;isOutput=true;issecret=false;]new-sys-id'),
+                `kbArticleId output variable should be set from the created article: ${tr.stdout}`,
+            );
+            assert.ok(tr.stdout.includes('Article Number: KB0099'), `should log the created article number: ${tr.stdout}`);
+        }, tr);
+    });
+
+    it('RealUpdateSucceeds — dryRun=false with an existing articleId + content performs a real update', async () => {
+        const tp = nodePath.join(__dirname, 'RealUpdateSucceeds.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            assert.ok(
+                tr.stdout.includes('##[MOCK] updateKnowledgeArticle called with instance=my-valid-instance articleId=existing-art-id title=Updated Title'),
+                `updateKnowledgeArticle should receive the task inputs correctly threaded through: ${tr.stdout}`,
+            );
+            assert.ok(
+                tr.stdout.includes('##vso[task.setvariable variable=kbArticleId;isOutput=true;issecret=false;]existing-art-id'),
+                `kbArticleId output variable should be set from the updated article: ${tr.stdout}`,
+            );
+            assert.ok(tr.stdout.includes('Article Number: KB0050'), `should log the updated article number: ${tr.stdout}`);
+        }, tr);
+    });
+
+    it('RealWorkflowOnlySucceeds — dryRun=false with only workflowState performs a real workflow-state change', async () => {
+        const tp = nodePath.join(__dirname, 'RealWorkflowOnlySucceeds.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            assert.ok(
+                tr.stdout.includes('##vso[task.setvariable variable=kbWorkflowState;isOutput=true;issecret=false;]published'),
+                `kbWorkflowState output variable should reflect the new state: ${tr.stdout}`,
+            );
+            assert.ok(tr.stdout.includes("Changing workflow state to 'publish'"), `should log the workflow-only path was taken: ${tr.stdout}`);
+        }, tr);
+    });
+
+    it('RealUploadImagesSucceeds — uploadImages=true runs the image-upload phase and rewrites the body', async () => {
+        const tp = nodePath.join(__dirname, 'RealUploadImagesSucceeds.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            assert.ok(tr.stdout.includes('Rewrote 1 image reference(s) to ServiceNow attachments'), `should log the image-upload result: ${tr.stdout}`);
+            assert.ok(tr.stdout.includes('##[MOCK] updateArticleBody called with text:'), `updateArticleBody should have been called with the rewritten body: ${tr.stdout}`);
+        }, tr);
+    });
+
+    it('RealListKbSucceeds — kbId=list lists knowledge bases and returns before any create/update logic', async () => {
+        const tp = nodePath.join(__dirname, 'RealListKbSucceeds.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            assert.ok(tr.stdout.includes('IT Knowledge Base'), `should list the mocked knowledge base: ${tr.stdout}`);
+            assert.ok(tr.stdout.includes('kb-sys-1'), `should include the KB sys_id: ${tr.stdout}`);
+        }, tr);
+    });
+
+    it('RealServiceConnectionOAuthSucceeds — auth resolved via serviceConnection (OAuth scheme) instead of inline inputs', async () => {
+        const tp = nodePath.join(__dirname, 'RealServiceConnectionOAuthSucceeds.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            assert.ok(
+                tr.stdout.includes('##[MOCK] getOAuthToken called with instance=sc-instance clientId=sc-client-id clientSecret=sc-client-secret'),
+                `resolveAuth should have derived instance/clientId/clientSecret from the service connection endpoint: ${tr.stdout}`,
+            );
+        }, tr);
+    });
+});

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealCreateSucceeds.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealCreateSucceeds.ts
@@ -1,0 +1,43 @@
+// Full-task test: dryRun=false, no existing articleId -> real CREATE path
+// (executeCreateOrUpdate's createKnowledgeArticle branch). This branch was
+// previously 100% untested -- every existing full-task scenario hardcoded
+// dryRun=true.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-real-create-'));
+const htmlFile = path.join(dir, 'article.html');
+fs.writeFileSync(htmlFile, '<p>Real create content</p>');
+
+tr.setInput('instance', 'my-valid-instance');
+tr.setInput('authType', 'basic');
+tr.setInput('username', 'svc-user');
+tr.setInput('password', 'svc-pass');
+tr.setInput('kbId', 'kb-123');
+tr.setInput('title', 'Brand New Article');
+tr.setInput('htmlFile', htmlFile);
+tr.setInput('author', 'jdoe');
+tr.setInput('workflowState', 'draft');
+tr.setInput('dryRun', 'false');
+tr.setInput('skipJsonLookup', 'true');
+tr.setInput('force', 'false');
+tr.setInput('uploadImages', 'false');
+tr.setInput('emitManifest', path.join(dir, 'manifest.json'));
+
+tr.registerMock('./servicenow-client', {
+  createKnowledgeArticle: async (instance: string, _headers: unknown, kbId: string, title: string, content: string, author: string) => {
+    console.log(`##[MOCK] createKnowledgeArticle called with instance=${instance} kbId=${kbId} title=${title} author=${author} contentLen=${content.length}`);
+    return { sys_id: 'new-sys-id', number: 'KB0099', workflow_state: 'draft' };
+  },
+  getKnowledgeBases: async () => [],
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealListKbSucceeds.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealListKbSucceeds.ts
@@ -1,0 +1,23 @@
+// Full-task test: kbId='list' -> the list-KB-mode branch (getKnowledgeBases),
+// which returns before any dry-run/create/update logic. Previously never
+// exercised by any test.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('instance', 'my-valid-instance');
+tr.setInput('authType', 'basic');
+tr.setInput('username', 'svc-user');
+tr.setInput('password', 'svc-pass');
+tr.setInput('kbId', 'list');
+
+tr.registerMock('./servicenow-client', {
+  getKnowledgeBases: async () => [{ title: 'IT Knowledge Base', sys_id: 'kb-sys-1' }],
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealServiceConnectionOAuthSucceeds.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealServiceConnectionOAuthSucceeds.ts
@@ -1,0 +1,48 @@
+// Full-task test: auth resolved via a serviceConnection (not inline
+// username/password/clientId/clientSecret inputs) using the OAuth branch --
+// exercises resolveAuth()'s getEndpointUrl/getEndpointAuthorizationScheme/
+// getEndpointAuthorizationParameter wiring, previously untested (every
+// existing full-task scenario used inline basic-auth inputs only).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-real-sc-oauth-'));
+
+tr.setInput('serviceConnection', 'MyKbConnection');
+tr.setInput('articleId', 'existing-art-id');
+tr.setInput('workflowState', 'publish');
+tr.setInput('dryRun', 'false');
+tr.setInput('skipJsonLookup', 'true');
+tr.setInput('force', 'false');
+tr.setInput('uploadImages', 'false');
+tr.setInput('emitManifest', path.join(dir, 'manifest.json'));
+
+process.env['ENDPOINT_URL_MyKbConnection'] = 'https://sc-instance.service-now.com';
+process.env['ENDPOINT_AUTH_SCHEME_MyKbConnection'] = 'OAuth2';
+process.env['ENDPOINT_AUTH_PARAMETER_MyKbConnection_CLIENTID'] = 'sc-client-id';
+process.env['ENDPOINT_AUTH_PARAMETER_MyKbConnection_CLIENTSECRET'] = 'sc-client-secret';
+
+tr.registerMock('./auth', {
+  getOAuthToken: async (instance: string, clientId: string, clientSecret: string) => {
+    console.log(`##[MOCK] getOAuthToken called with instance=${instance} clientId=${clientId} clientSecret=${clientSecret}`);
+    return 'mock-oauth-access-token';
+  },
+  getAuthHeaders: (type: string, opts: { accessToken?: string }) => ({
+    Authorization: `Bearer ${opts.accessToken}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  }),
+});
+tr.registerMock('./servicenow-client', {
+  changeWorkflowState: async () => ({ sys_id: 'existing-art-id', number: 'KB0053', workflow_state: 'published' }),
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealUpdateSucceeds.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealUpdateSucceeds.ts
@@ -1,0 +1,38 @@
+// Full-task test: dryRun=false, existing articleId + title/content -> real
+// UPDATE path (executeCreateOrUpdate's updateKnowledgeArticle branch).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-real-update-'));
+const htmlFile = path.join(dir, 'article.html');
+fs.writeFileSync(htmlFile, '<p>Real update content</p>');
+
+tr.setInput('instance', 'my-valid-instance');
+tr.setInput('authType', 'basic');
+tr.setInput('username', 'svc-user');
+tr.setInput('password', 'svc-pass');
+tr.setInput('articleId', 'existing-art-id');
+tr.setInput('title', 'Updated Title');
+tr.setInput('htmlFile', htmlFile);
+tr.setInput('dryRun', 'false');
+tr.setInput('skipJsonLookup', 'true');
+tr.setInput('force', 'false');
+tr.setInput('uploadImages', 'false');
+tr.setInput('emitManifest', path.join(dir, 'manifest.json'));
+
+tr.registerMock('./servicenow-client', {
+  updateKnowledgeArticle: async (instance: string, _headers: unknown, articleId: string, title: string) => {
+    console.log(`##[MOCK] updateKnowledgeArticle called with instance=${instance} articleId=${articleId} title=${title}`);
+    return { sys_id: 'existing-art-id', number: 'KB0050', workflow_state: 'draft' };
+  },
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealUploadImagesSucceeds.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealUploadImagesSucceeds.ts
@@ -1,0 +1,47 @@
+// Full-task test: dryRun=false + uploadImages=true -> the image-upload phase
+// (processArticleImages + updateArticleBody) runs after a successful update.
+// Previously never exercised by any test (every scenario hardcoded
+// uploadImages=false).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-real-upload-images-'));
+const htmlFile = path.join(dir, 'article.html');
+fs.writeFileSync(htmlFile, '<p>Body with an image</p><img src="pic.png">');
+
+tr.setInput('instance', 'my-valid-instance');
+tr.setInput('authType', 'basic');
+tr.setInput('username', 'svc-user');
+tr.setInput('password', 'svc-pass');
+tr.setInput('articleId', 'existing-art-id');
+tr.setInput('title', 'Article With Image');
+tr.setInput('htmlFile', htmlFile);
+tr.setInput('dryRun', 'false');
+tr.setInput('skipJsonLookup', 'true');
+tr.setInput('force', 'false');
+tr.setInput('uploadImages', 'true');
+tr.setInput('emitManifest', path.join(dir, 'manifest.json'));
+
+tr.registerMock('./servicenow-client', {
+  updateKnowledgeArticle: async () => ({ sys_id: 'existing-art-id', number: 'KB0052', workflow_state: 'draft' }),
+  updateArticleBody: async (_instance: string, _headers: unknown, _sysId: string, text: string) => {
+    console.log(`##[MOCK] updateArticleBody called with text: ${text}`);
+  },
+});
+tr.registerMock('./attachments', {
+  processArticleImages: async () => ({
+    html: '<p>Body with an image</p><img src="sys_attachment.do?sys_id=att-1">',
+    uploaded: 1,
+    missing: [],
+  }),
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealWorkflowOnlySucceeds.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RealWorkflowOnlySucceeds.ts
@@ -1,0 +1,33 @@
+// Full-task test: dryRun=false, existing articleId + ONLY workflowState (no
+// title/content/category/author) -> real WORKFLOW-ONLY path
+// (executeCreateOrUpdate's changeWorkflowState branch).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-real-workflow-only-'));
+
+tr.setInput('instance', 'my-valid-instance');
+tr.setInput('authType', 'basic');
+tr.setInput('username', 'svc-user');
+tr.setInput('password', 'svc-pass');
+tr.setInput('articleId', 'existing-art-id');
+tr.setInput('workflowState', 'publish');
+tr.setInput('dryRun', 'false');
+tr.setInput('skipJsonLookup', 'true');
+tr.setInput('force', 'false');
+tr.setInput('uploadImages', 'false');
+tr.setInput('emitManifest', path.join(dir, 'manifest.json'));
+
+tr.registerMock('./servicenow-client', {
+  changeWorkflowState: async () => ({ sys_id: 'existing-art-id', number: 'KB0051', workflow_state: 'published' }),
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();


### PR DESCRIPTION
## Summary

Every existing full-task mock-run scenario hardcoded `dryRun=true` (or reached an early return before `dryRun` was even checked), so `index.ts`'s real create/update/workflow-only POST/PATCH branches (`executeCreateOrUpdate`), the image-upload phase, `kbId=list` mode, and the `serviceConnection`-derived OAuth wiring in `resolveAuth()` were never exercised by any test or the coverage gate.

Addresses the P1 finding (medium, findings #25/#36) in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) -- the testing sub-point of the sanitizer-dedup roadmap item (the dedup itself landed in #470).

## Changes

Added 6 new full-task scenarios (`dryRun=false`): `RealCreateSucceeds`, `RealUpdateSucceeds`, `RealWorkflowOnlySucceeds`, `RealUploadImagesSucceeds`, `RealListKbSucceeds`, `RealServiceConnectionOAuthSucceeds`. Each mocks only the ServiceNow-facing modules (`servicenow-client`/`attachments`/`auth`) so no real network call is made, while exercising `index.ts`'s own input-parsing, branch-selection, and output-variable logic for real.

## Regression risk considered

- The create/update tests capture and assert on the mocked functions' **actual arguments** (not just their return values), verifying `index.ts` genuinely threads `instance`/`kbId`/`title`/`author` correctly rather than merely returning whatever a fixed mock provides. This was added after an adversarial review flagged the initial versions as accepting-any-arguments tautologies.
- All 6 scenarios set `emitManifest` to a temp file: without it, a real create/update triggers the legacy `outputArticleInfoToJson()` write, which drops a `KB<number>.json` file directly into the task's working directory. An initial run of these exact tests (before this fix) left 5 such files in the repo root -- caught, cleaned up, and fixed by pointing `emitManifest` at a temp path before committing.

## Verification

**98 passing, 0 failing.** Reviewed by an adversarial pass covering: tautology risk (mocks ignoring arguments), whether `RealWorkflowOnlySucceeds`'s input combination genuinely produces the `workflow-only` branch per `planAction()`'s actual condition, whether the `serviceConnection` env var convention (`ENDPOINT_URL_*`/`ENDPOINT_AUTH_SCHEME_*`/`ENDPOINT_AUTH_PARAMETER_*_*`) matches `azure-pipelines-task-lib`'s real implementation, and whether `console.log` inside a `registerMock`-provided function is reliably captured into `MockTestRunner`'s `tr.stdout` (confirmed empirically across two full test runs, not flaky).
