### PR TITLE
security: cap installer http-client.ts response body size at 10MB

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
@@ -26,6 +26,20 @@ const MAX_REDIRECTS = 5;
 const RETRY_ATTEMPTS = 3;
 const RETRY_BASE_MS = 200;
 
+/**
+ * Upper bound on a response body buffered in memory. Node's built-in fetch()
+ * has no default limit on response.json()/.text()/.arrayBuffer() -- they
+ * buffer until stream end or process OOM, so a compromised/malicious endpoint
+ * behind a registryUrl/mirrorUrl input could otherwise exhaust agent memory.
+ * Mirrors the 10MB cap already enforced by the credential-bearing
+ * https-client.ts/servicenow-http.ts families (see the "why two module
+ * families" note in check-shared-modules.js). The actual Terraform/OpenTofu
+ * binary download does not go through this client -- it uses
+ * azure-pipelines-tool-lib's downloadTool(), which streams to a temp file --
+ * so this only bounds the small metadata/checksum/signature payloads that do.
+ */
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
 /** Error carrying whether the failure is worth retrying (transient) vs deterministic (4xx / insecure URL). */
 class HttpError extends Error {
     constructor(message: string, readonly retryable: boolean) {
@@ -134,12 +148,43 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
     throw lastErr;
 }
 
+/**
+ * Reads a fetch Response body into memory with a hard byte-count guard,
+ * cancelling the stream rather than buffering an unbounded/oversized response.
+ */
+async function readBoundedArrayBuffer(response: Response, url: string): Promise<ArrayBuffer> {
+    if (!response.body) {
+        return response.arrayBuffer();
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > MAX_RESPONSE_BYTES) {
+            await reader.cancel(`Response exceeded ${MAX_RESPONSE_BYTES} bytes.`).catch(() => { /* best-effort */ });
+            throw new HttpError(`Response from ${url} exceeded ${MAX_RESPONSE_BYTES} bytes.`, false);
+        }
+        chunks.push(value);
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        out.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return out.buffer;
+}
+
 export function fetchJson<T>(url: string): Promise<T> {
     return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
             throw new HttpError(tasks.loc("RegistryRequestFailed", url, response.status), response.status >= 500);
         }
-        return (await response.json()) as T;
+        const buf = await readBoundedArrayBuffer(response, url);
+        return JSON.parse(Buffer.from(buf).toString('utf8')) as T;
     }));
 }
 
@@ -150,7 +195,8 @@ export function fetchText(url: string): Promise<string> {
         }
         // The returned promise is awaited inside fetchWithTimeout's guard, so the
         // body read stays bounded by the timeout without a redundant await here.
-        return response.text();
+        const buf = await readBoundedArrayBuffer(response, url);
+        return Buffer.from(buf).toString('utf8');
     }));
 }
 
@@ -166,7 +212,8 @@ export function fetchTextAllow404(url: string): Promise<string | null> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return response.text();
+        const buf = await readBoundedArrayBuffer(response, url);
+        return Buffer.from(buf).toString('utf8');
     }));
 }
 
@@ -175,7 +222,7 @@ export function fetchBuffer(url: string): Promise<Uint8Array> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return new Uint8Array(await response.arrayBuffer());
+        return new Uint8Array(await readBoundedArrayBuffer(response, url));
     }));
 }
 
@@ -191,6 +238,6 @@ export function fetchBufferAllow404(url: string): Promise<Uint8Array | null> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return new Uint8Array(await response.arrayBuffer());
+        return new Uint8Array(await readBoundedArrayBuffer(response, url));
     }));
 }

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "8",
+        "Minor": "9",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
@@ -26,6 +26,20 @@ const MAX_REDIRECTS = 5;
 const RETRY_ATTEMPTS = 3;
 const RETRY_BASE_MS = 200;
 
+/**
+ * Upper bound on a response body buffered in memory. Node's built-in fetch()
+ * has no default limit on response.json()/.text()/.arrayBuffer() -- they
+ * buffer until stream end or process OOM, so a compromised/malicious endpoint
+ * behind a registryUrl/mirrorUrl input could otherwise exhaust agent memory.
+ * Mirrors the 10MB cap already enforced by the credential-bearing
+ * https-client.ts/servicenow-http.ts families (see the "why two module
+ * families" note in check-shared-modules.js). The actual Terraform/OpenTofu
+ * binary download does not go through this client -- it uses
+ * azure-pipelines-tool-lib's downloadTool(), which streams to a temp file --
+ * so this only bounds the small metadata/checksum/signature payloads that do.
+ */
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
 /** Error carrying whether the failure is worth retrying (transient) vs deterministic (4xx / insecure URL). */
 class HttpError extends Error {
     constructor(message: string, readonly retryable: boolean) {
@@ -134,12 +148,43 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
     throw lastErr;
 }
 
+/**
+ * Reads a fetch Response body into memory with a hard byte-count guard,
+ * cancelling the stream rather than buffering an unbounded/oversized response.
+ */
+async function readBoundedArrayBuffer(response: Response, url: string): Promise<ArrayBuffer> {
+    if (!response.body) {
+        return response.arrayBuffer();
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > MAX_RESPONSE_BYTES) {
+            await reader.cancel(`Response exceeded ${MAX_RESPONSE_BYTES} bytes.`).catch(() => { /* best-effort */ });
+            throw new HttpError(`Response from ${url} exceeded ${MAX_RESPONSE_BYTES} bytes.`, false);
+        }
+        chunks.push(value);
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        out.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return out.buffer;
+}
+
 export function fetchJson<T>(url: string): Promise<T> {
     return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
             throw new HttpError(tasks.loc("RegistryRequestFailed", url, response.status), response.status >= 500);
         }
-        return (await response.json()) as T;
+        const buf = await readBoundedArrayBuffer(response, url);
+        return JSON.parse(Buffer.from(buf).toString('utf8')) as T;
     }));
 }
 
@@ -150,7 +195,8 @@ export function fetchText(url: string): Promise<string> {
         }
         // The returned promise is awaited inside fetchWithTimeout's guard, so the
         // body read stays bounded by the timeout without a redundant await here.
-        return response.text();
+        const buf = await readBoundedArrayBuffer(response, url);
+        return Buffer.from(buf).toString('utf8');
     }));
 }
 
@@ -166,7 +212,8 @@ export function fetchTextAllow404(url: string): Promise<string | null> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return response.text();
+        const buf = await readBoundedArrayBuffer(response, url);
+        return Buffer.from(buf).toString('utf8');
     }));
 }
 
@@ -175,7 +222,7 @@ export function fetchBuffer(url: string): Promise<Uint8Array> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return new Uint8Array(await response.arrayBuffer());
+        return new Uint8Array(await readBoundedArrayBuffer(response, url));
     }));
 }
 
@@ -191,6 +238,6 @@ export function fetchBufferAllow404(url: string): Promise<Uint8Array | null> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return new Uint8Array(await response.arrayBuffer());
+        return new Uint8Array(await readBoundedArrayBuffer(response, url));
     }));
 }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "4",
+    "Minor": "5",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
@@ -245,4 +245,32 @@ describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
         await fetchJson('https://api.example.com/v');
         assert.ok(seenInit && 'dispatcher' in seenInit, 'proxy dispatcher should be set');
     });
+
+    it('rejects a response exceeding the response-size guard instead of buffering it unbounded', async () => {
+        // 11 x 1MB chunks = 11MB, over the 10MB cap. A compromised/malicious
+        // registryUrl/mirrorUrl endpoint must not be able to exhaust agent
+        // memory via an oversized response.
+        const chunkSize = 1024 * 1024;
+        const chunkCount = 11;
+        globalThis.fetch = (async () => {
+            const stream = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    for (let i = 0; i < chunkCount; i++) {
+                        controller.enqueue(new Uint8Array(chunkSize));
+                    }
+                    controller.close();
+                },
+            });
+            return new Response(stream, { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        await assert.rejects(fetchText('https://files.example.com/huge'), /exceeded 10485760 bytes/);
+    });
+
+    it('accepts a response at exactly the response-size guard boundary', async () => {
+        const exactly10Mb = 10 * 1024 * 1024;
+        globalThis.fetch = (async () =>
+            new Response(new Uint8Array(exactly10Mb), { status: 200 })) as unknown as typeof globalThis.fetch;
+        const buf = await fetchBuffer('https://files.example.com/at-limit');
+        assert.strictEqual(buf.byteLength, exactly10Mb);
+    });
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
@@ -26,6 +26,20 @@ const MAX_REDIRECTS = 5;
 const RETRY_ATTEMPTS = 3;
 const RETRY_BASE_MS = 200;
 
+/**
+ * Upper bound on a response body buffered in memory. Node's built-in fetch()
+ * has no default limit on response.json()/.text()/.arrayBuffer() -- they
+ * buffer until stream end or process OOM, so a compromised/malicious endpoint
+ * behind a registryUrl/mirrorUrl input could otherwise exhaust agent memory.
+ * Mirrors the 10MB cap already enforced by the credential-bearing
+ * https-client.ts/servicenow-http.ts families (see the "why two module
+ * families" note in check-shared-modules.js). The actual Terraform/OpenTofu
+ * binary download does not go through this client -- it uses
+ * azure-pipelines-tool-lib's downloadTool(), which streams to a temp file --
+ * so this only bounds the small metadata/checksum/signature payloads that do.
+ */
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
 /** Error carrying whether the failure is worth retrying (transient) vs deterministic (4xx / insecure URL). */
 class HttpError extends Error {
     constructor(message: string, readonly retryable: boolean) {
@@ -134,12 +148,43 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
     throw lastErr;
 }
 
+/**
+ * Reads a fetch Response body into memory with a hard byte-count guard,
+ * cancelling the stream rather than buffering an unbounded/oversized response.
+ */
+async function readBoundedArrayBuffer(response: Response, url: string): Promise<ArrayBuffer> {
+    if (!response.body) {
+        return response.arrayBuffer();
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > MAX_RESPONSE_BYTES) {
+            await reader.cancel(`Response exceeded ${MAX_RESPONSE_BYTES} bytes.`).catch(() => { /* best-effort */ });
+            throw new HttpError(`Response from ${url} exceeded ${MAX_RESPONSE_BYTES} bytes.`, false);
+        }
+        chunks.push(value);
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        out.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return out.buffer;
+}
+
 export function fetchJson<T>(url: string): Promise<T> {
     return withRetry(() => fetchWithTimeout(url, METADATA_TIMEOUT_MS, async (response) => {
         if (!response.ok) {
             throw new HttpError(tasks.loc("RegistryRequestFailed", url, response.status), response.status >= 500);
         }
-        return (await response.json()) as T;
+        const buf = await readBoundedArrayBuffer(response, url);
+        return JSON.parse(Buffer.from(buf).toString('utf8')) as T;
     }));
 }
 
@@ -150,7 +195,8 @@ export function fetchText(url: string): Promise<string> {
         }
         // The returned promise is awaited inside fetchWithTimeout's guard, so the
         // body read stays bounded by the timeout without a redundant await here.
-        return response.text();
+        const buf = await readBoundedArrayBuffer(response, url);
+        return Buffer.from(buf).toString('utf8');
     }));
 }
 
@@ -166,7 +212,8 @@ export function fetchTextAllow404(url: string): Promise<string | null> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return response.text();
+        const buf = await readBoundedArrayBuffer(response, url);
+        return Buffer.from(buf).toString('utf8');
     }));
 }
 
@@ -175,7 +222,7 @@ export function fetchBuffer(url: string): Promise<Uint8Array> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return new Uint8Array(await response.arrayBuffer());
+        return new Uint8Array(await readBoundedArrayBuffer(response, url));
     }));
 }
 
@@ -191,6 +238,6 @@ export function fetchBufferAllow404(url: string): Promise<Uint8Array | null> {
         if (!response.ok) {
             throw new HttpError(`Failed to fetch ${url}: HTTP ${response.status}`, response.status >= 500);
         }
-        return new Uint8Array(await response.arrayBuffer());
+        return new Uint8Array(await readBoundedArrayBuffer(response, url));
     }));
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "232",
+        "Minor": "233",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
## Summary

The shared `http-client.ts` (byte-identical across TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller) had no response-body size cap, unlike the credential-bearing `https-client.ts`/`servicenow-http.ts` families (10MB cap). Node's built-in `fetch()`'s `.json()/.text()/.arrayBuffer()` buffer an entire response with no limit -- a compromised or malicious endpoint behind a `registryUrl`/`mirrorUrl` input could exhaust agent memory. The actual Terraform/OpenTofu binary download does not go through this client (it streams to a temp file via `azure-pipelines-tool-lib`'s `downloadTool()`); this only bounds the small metadata/checksum/signature payloads that do.

Addresses the P2 finding (medium) in [.audit/terraform-ext-audit-2026-07-12.md](.audit/terraform-ext-audit-2026-07-12.md) / [.audit/terraform-ext-new-issues-2026-07-12.md](.audit/terraform-ext-new-issues-2026-07-12.md) (draft #21).

## Changes

Added a `readBoundedArrayBuffer()` helper that manually reads the response body stream chunk-by-chunk via `getReader()`, cancelling and throwing (as a non-retryable `HttpError`) once the running total exceeds `MAX_RESPONSE_BYTES` (10MB), instead of calling `response.json()/.text()/.arrayBuffer()` directly. Applied identically to all 3 copies; parity confirmed via `scripts/check-shared-modules.js`.

Added 2 new tests in TerraformInstaller's `HttpClientL0.ts` (not duplicated to the sibling tasks' `Tests/`, which aren't parity-checked): an 11MB response is rejected with the expected message, and a response at exactly the 10MB boundary is still accepted.

## Minor version

Bumped for all 3 tasks: TerraformInstaller 232->233, PolicyAgentInstaller 8->9, TerraformDocsInstaller 4->5.

## Verification

All 3 suites run before opening this PR: **TerraformInstaller 70 passing, PolicyAgentInstaller 58 passing, TerraformDocsInstaller 49 passing -- 0 failing.**

Reviewed by an adversarial pass covering: boundary correctness (a chunk that would push the total over the cap is never added to the accumulated buffer), resource cleanup on `reader.cancel()`, confirming the size-guard rejection is `retryable: false` (not wastefully retried), `JSON.parse` equivalence to the old `response.json()`, and independent re-confirmation of byte-identity across the 3 copies. Verdict: SHIP IT.
