### PR TITLE
security: reject terragrunt binaryName and escape Sentinel policy names in generated HCL

### DIFF
--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/HclEscapeL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/HclEscapeL0.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import { hcl } from '../src/sentinel-engine';
+
+// Direct unit tests for the hcl() escaping helper used when embedding both source
+// paths and Sentinel policy names (derived from .sentinel file basenames) into the
+// generated sentinel.hcl's double-quoted string labels/values -- e.g.
+// `policy "<name>" { source = "<path>" ... }`. Policy names are NOT restricted to
+// identifier syntax (unlike sentinelImportName): legitimate filenames commonly use
+// dashes (e.g. require-tags.sentinel, deny-public.sentinel -- both used by other
+// fixtures in this suite), so only the characters that are actually unsafe inside
+// an HCL quoted string (backslash and double-quote) need escaping.
+describe('hcl() escaping for policy names and paths', () => {
+    it('passes common filename characters through unchanged', () => {
+        assert.strictEqual(hcl('require-tags'), 'require-tags');
+        assert.strictEqual(hcl('deny-public'), 'deny-public');
+        assert.strictEqual(hcl('policy_v2.1'), 'policy_v2.1');
+    });
+
+    it('escapes an embedded double-quote so it cannot close the HCL string', () => {
+        const escaped = hcl('evil" { source = "x" }\npolicy "injected');
+        assert.strictEqual(escaped, 'evil\\" { source = \\"x\\" }\npolicy \\"injected');
+        // Re-embedding the escaped value in a quoted HCL string yields exactly one
+        // opening and one closing (unescaped) quote -- the crafted quotes inside no
+        // longer terminate the string early.
+        const rebuilt = `policy "${escaped}" {`;
+        const unescapedQuoteCount = (rebuilt.match(/(?<!\\)"/g) || []).length;
+        assert.strictEqual(unescapedQuoteCount, 2);
+    });
+
+    it('escapes an embedded backslash', () => {
+        assert.strictEqual(hcl('a\\b'), 'a\\\\b');
+    });
+});

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import './ResultsL0';
 // Direct unit tests for sentinel import-name validation (HCL injection guard).
 import './SentinelImportNameL0';
+import './HclEscapeL0';
 
 describe('TerraformPolicyCheck Test Suite', function () {
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
@@ -145,8 +145,18 @@ function generateConfig(policyDir: string, inputFile: string, level: string, tem
     lines.push(`}`);
     lines.push('');
     for (const policyFile of policies) {
+        // The policy name (derived from the .sentinel file's basename) is a plain
+        // quoted HCL string label here, not an identifier reference used elsewhere
+        // in policy code like the import name above -- legitimate filenames commonly
+        // use dashes (e.g. require-tags.sentinel), so it must not be restricted to
+        // identifier syntax. `hcl()` escaping is sufficient to keep it inside the
+        // string: a literal embedded newline is not a silent injection vector either
+        // way, since HCL's quoted-string grammar hard-fails to parse ("Invalid
+        // multi-line string") rather than treating it as a request to close the
+        // string. Reachable when policySource=gitUrl points at a shared/third-party
+        // policy repo whose filenames aren't fully trusted.
         const name = path.basename(policyFile, '.sentinel');
-        lines.push(`policy "${name}" {`);
+        lines.push(`policy "${hcl(name)}" {`);
         lines.push(`  source = "${hcl(policyFile)}"`);
         lines.push(`  enforcement_level = "${level}"`);
         lines.push(`}`);
@@ -161,8 +171,8 @@ function generateConfig(policyDir: string, inputFile: string, level: string, tem
     return configDir;
 }
 
-/** Escapes a path for embedding in an HCL double-quoted string. */
-function hcl(value: string): string {
+/** Escapes a value (path or policy name) for embedding in an HCL double-quoted string. */
+export function hcl(value: string): string {
     return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "7",
+        "Minor": "8",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/BinaryNameAllowlistL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/BinaryNameAllowlistL0.ts
@@ -1,0 +1,39 @@
+import * as assert from 'assert';
+import { getBinaryName } from '../src/terraform';
+
+/**
+ * Direct unit tests for getBinaryName's allowlist (#52/terragrunt): binaryName
+ * was previously accepted with zero implementation, silently disabling
+ * cross-cloud backend-credential injection (backend-detection.ts never finds
+ * .terraform/terraform.tfstate at the plain working directory under
+ * terragrunt, which nests it under .terragrunt-cache/<hash>/<hash>/).
+ */
+describe('getBinaryName allowlist', () => {
+    function fakeTasks(input: string | undefined): typeof import('azure-pipelines-task-lib/task') {
+        return {
+            getInput: () => input,
+        } as unknown as typeof import('azure-pipelines-task-lib/task');
+    }
+
+    it('defaults to terraform when binaryName is not set', () => {
+        assert.strictEqual(getBinaryName(fakeTasks(undefined)), 'terraform');
+    });
+
+    it('accepts tofu', () => {
+        assert.strictEqual(getBinaryName(fakeTasks('tofu')), 'tofu');
+    });
+
+    it('rejects terragrunt with a clear error instead of silently disabling cross-cloud backend detection', () => {
+        assert.throws(
+            () => getBinaryName(fakeTasks('terragrunt')),
+            /Invalid binaryName 'terragrunt'/,
+        );
+    });
+
+    it('rejects an arbitrary unrecognized binary name', () => {
+        assert.throws(
+            () => getBinaryName(fakeTasks('some-other-binary')),
+            /Invalid binaryName 'some-other-binary'/,
+        );
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -29,6 +29,8 @@ import './CrossCloudBackendCredentialTests/AzureConfigureBackendCredentialsL0';
 import './CrossCloudBackendCredentialTests/AwsConfigureBackendCredentialsL0';
 import './CrossCloudBackendCredentialTests/GcpConfigureBackendCredentialsL0';
 import './CrossCloudBackendCredentialTests/HcpOciGenericConfigureBackendCredentialsL0';
+// Direct unit tests for the binaryName allowlist (terraform/tofu only).
+import './BinaryNameAllowlistL0';
 
 describe('Terraform Test Suite', function () {
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
@@ -3,7 +3,15 @@ import path = require('path');
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner'
 import { TerraformBaseCommandInitializer } from './terraform-commands'
 
-const ALLOWED_BINARY_NAMES = ["terraform", "tofu", "terragrunt"];
+// terragrunt is deliberately excluded: backend-detection.ts hardcodes reading
+// <workingDirectory>/.terraform/terraform.tfstate to decide cross-cloud
+// backend-credential injection, but terragrunt runs terraform inside a nested
+// .terragrunt-cache/<hash>/<hash>/ directory, so that file never exists at the
+// plain working directory under terragrunt -- cross-cloud backend-credential
+// injection would silently no-op (only a debug-level log, no visible warning)
+// rather than fail loudly. Reject it explicitly here until real terragrunt
+// support (argument/path handling, backend detection) is implemented.
+const ALLOWED_BINARY_NAMES = ["terraform", "tofu"];
 
 export function getBinaryName(tasks: typeof import('azure-pipelines-task-lib/task')): string {
     const name = tasks.getInput("binaryName", false) || "terraform";


### PR DESCRIPTION
## Summary

Two related P2 hardening items from the audit's roadmap:

1. **TerraformTaskV5** — `binaryName` no longer silently accepts `terragrunt`.
2. **TerraformPolicyCheckV1** — Sentinel policy names are now safely escaped when embedded in the generated `sentinel.hcl`.

## 1. Reject `terragrunt` binaryName loudly

`ALLOWED_BINARY_NAMES` accepted `terraform`, `tofu`, and `terragrunt`, but `terragrunt` has zero actual implementation in this task. `backend-detection.ts` hardcodes reading `<workingDirectory>/.terraform/terraform.tfstate` to decide whether to inject cross-cloud backend credentials, but terragrunt runs terraform inside a nested `.terragrunt-cache/<hash>/<hash>/` directory — so that file never exists at the plain working directory under terragrunt. The practical effect was that cross-cloud backend-credential injection would silently no-op (only a debug-level log, no visible warning) instead of failing loudly, which could look like a working setup that's actually not authenticating cross-cloud state access at all.

`ALLOWED_BINARY_NAMES` is now `["terraform", "tofu"]`. Setting `binaryName: terragrunt` now throws a clear `Invalid binaryName 'terragrunt'. Allowed values: terraform, tofu` error immediately instead of silently disabling a feature. (`task.json`'s pickList already only exposed `terraform`/`tofu` in the UI — this closes the gap where a YAML pipeline author could bypass the pickList by setting the value directly.)

Added `Tests/BinaryNameAllowlistL0.ts` — 4 direct unit tests via a `fakeTasks()` stub (no mock-run harness needed since `getBinaryName(tasks)` takes the tasks module as a parameter): default `terraform`, accepts `tofu`, rejects `terragrunt` with the clear error, rejects an arbitrary unrecognized value.

## 2. Escape Sentinel policy names in generated HCL

`generateConfig()` builds a `sentinel.hcl` wiring each `*.sentinel` policy file in at a chosen enforcement level. The policy name (derived from each file's basename) was interpolated **unescaped** into `policy "<name>" {`. This is reachable when `policySource=gitUrl` points at a shared/third-party policy repo whose filenames aren't fully trusted — a crafted filename containing a double-quote could break out of the HCL string and inject additional config/attributes.

Fixed by exporting the pre-existing `hcl()` escape helper (already used for `source = "<path>"` values two lines below) and applying it to the policy name too: `policy "${hcl(name)}" {`.

### Self-caught correction (before this went to adversarial review)

My first attempt restricted policy names to strict HCL-identifier syntax, mirroring the existing `validateSentinelImportName` validation for the `sentinelImportName` task input. Running the test suite immediately showed this was wrong: it broke the `SentinelPassPath` fixture, which legitimately uses `require-tags.sentinel` (a kebab-case filename). Grepping further, `deny-public.sentinel` is used in two more fixtures (`SentinelHardFail`, `SentinelUnrecognizedExitFail`) — those didn't surface the regression because they *expect* the task to fail anyway (it still "failed", just for the wrong reason).

The correct fix: `sentinelImportName` is later referenced as a bare unquoted identifier in policy code (`tfplan.resource_changes`), so restricting it to identifier syntax is correct for that field — but the policy `name` is purely a quoted HCL string label, never referenced as a bare identifier elsewhere, so kebab-case and other non-identifier characters are completely legitimate and only need the same backslash/quote escaping already used for paths. An embedded literal newline in the name isn't a silent bypass either way, since HCL's quoted-string grammar hard-fails to parse rather than treating it as a request to close the string early.

Added `Tests/HclEscapeL0.ts` (replacing my initial, incorrect `SentinelPolicyNameL0.ts`) testing the `hcl()` escaping directly: common filename characters (including dashes) pass through unchanged, a crafted quote-injection payload is safely escaped (verified by rebuilding the HCL line and counting exactly 2 unescaped quotes), and embedded backslashes are escaped.

## Version bump

- `TerraformPolicyCheckV1/task.json` Minor `7` → `8` (first change to its `src/` this session).
- `TerraformTaskV5/task.json` Minor was already bumped `276` → `277` in PR #464 (still unmerged); not re-bumped here to avoid a guaranteed merge conflict when both land.

## Verification

- `TerraformTaskV5`: **268 passing / 0 failing** (was 264 baseline + 4 new).
- `TerraformPolicyCheckV1`: **28 passing / 0 failing** (was 25 baseline + 3 new).
- Dispatched an adversarial subagent review covering: `hcl()` escape-order correctness (backslash before quote, preventing double-escape bugs), embedded-newline/HCL-parse-failure behavior, call-site completeness (grepped for any other unescaped interpolation in `sentinel-engine.ts`), terragrunt-removal consistency across docs/tests/task.json, and test-quality (non-tautological). Verdict: **SHIP IT**. One suggested follow-up (a "stale" CHANGELOG.md mention of terragrunt) was investigated and declined — that file is auto-generated by `release-please` from conventional commits and must not be hand-edited; the flagged section is a correct historical record of an already-published release.
