### PR TITLE
docs: fix nonexistent task id TerraformTaskV5@5 in WIF/private-testing setup guides

### DIFF
--- a/docs/setup/aws-wif-setup.md
+++ b/docs/setup/aws-wif-setup.md
@@ -70,7 +70,7 @@ Replace `<ACCOUNT_ID>`, `<ORG_ID>`, `<ORG_NAME>`, `<PROJECT_NAME>`, and `<SERVIC
 In your Azure Pipeline YAML, add the Terraform task with the WIF auth scheme:
 
 ```yaml
-- task: TerraformTaskV5@5
+- task: PipelineTerraformTask@5
   inputs:
     provider: 'aws'
     command: 'plan'

--- a/docs/setup/gcp-wif-setup.md
+++ b/docs/setup/gcp-wif-setup.md
@@ -117,7 +117,7 @@ You will need these values for the pipeline task configuration:
 ## Step 7: Configure the Pipeline Task
 
 ```yaml
-- task: TerraformTaskV5@5
+- task: PipelineTerraformTask@5
   inputs:
     provider: 'gcp'
     command: 'plan'

--- a/docs/setup/private-testing.md
+++ b/docs/setup/private-testing.md
@@ -96,7 +96,7 @@ Alternatively, install directly from the publisher portal:
 In a pipeline, reference the task by its version:
 
 ```yaml
-- task: TerraformTaskV5@5
+- task: PipelineTerraformTask@5
   inputs:
     provider: 'azurerm'
     command: 'validate'


### PR DESCRIPTION
## Summary

All three of this repo's WIF (Workload Identity Federation) and private-testing setup guides referenced a task id that doesn't exist: `TerraformTaskV5@5`. This fork's actual `task.json` name is `PipelineTerraformTask` (confirmed via `Tasks/TerraformTask/TerraformTaskV5/task.json`'s `name` field), so a pipeline author copy-pasting any of these snippets would get an `Unable to find task` failure at pipeline-parse time.

- `docs/setup/aws-wif-setup.md:73`
- `docs/setup/gcp-wif-setup.md:120`
- `docs/setup/private-testing.md:99`

Every other doc in the repo (`README.md`, `overview.md`, `yaml-examples.md`, `docs/troubleshooting.md`, `docs/migration-from-ms-devlabs.md`) already correctly uses `PipelineTerraformTask@5` — confirmed via a repo-wide grep before and after this change.

These are the only end-to-end guides for the security-preferred WIF (no static credentials) auth flow, so despite being a doc-only fix the breakage was high-impact: anyone following the recommended, most-secure setup path would hit an immediate wall.

## Change

Simple 1-line-per-file fix: `- task: TerraformTaskV5@5` → `- task: PipelineTerraformTask@5` in all three files. No other changes.

## Verification

- Repo-wide grep for `TerraformTaskV5@` after the fix returns zero hits outside the `.audit/` report files (which document the original finding and are left as historical record).
- Repo-wide grep for `PipelineTerraformTask@` confirms all 9 files that reference the task now use the correct id consistently.
