### PR TITLE
security: mask derived secrets (OAuth clientSecret, Basic base64 header) and add isSecret to 4 token inputs

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -119,6 +119,19 @@ describe('auth.getOAuthToken', () => {
         );
     });
 
+    it('calls tasks.setSecret on the clientSecret input itself, not just the returned token', async () => {
+        nock(BASE_URL)
+            .post('/oauth_token.do')
+            .reply(200, { access_token: 'irrelevant_token' });
+
+        await auth.getOAuthToken(INSTANCE, 'cid', 'super-secret-client-value');
+        assert.ok(
+            capturedSecrets.includes('super-secret-client-value'),
+            'tasks.setSecret should be called with the clientSecret input, so it is masked even if it leaks ' +
+            'before the token exchange completes (e.g. in a request-body log or an unhandled error)',
+        );
+    });
+
     it('throws on HTTP error', async () => {
         nock(BASE_URL)
             .post('/oauth_token.do')
@@ -147,6 +160,18 @@ describe('auth.basicAuthHeader', () => {
             capturedSecrets.includes('mypassword'),
             'tasks.setSecret should be called with the password',
         );
+    });
+
+    it('also calls tasks.setSecret on the base64-encoded credentials, not just the raw password', () => {
+        const header = auth.basicAuthHeader('carol', 'anotherpassword');
+        const encoded = Buffer.from('carol:anotherpassword').toString('base64');
+        assert.ok(
+            capturedSecrets.includes(encoded),
+            'tasks.setSecret should also be called with the base64-encoded credentials, since ADO log ' +
+            'masking matches literal registered strings and the encoded header value is a different ' +
+            'string than the raw password',
+        );
+        assert.strictEqual(header, `Basic ${encoded}`);
     });
 });
 

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/auth.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/auth.ts
@@ -3,9 +3,11 @@ import { snRequest } from './servicenow-http';
 
 /**
  * Obtain an OAuth token from ServiceNow using client credentials grant.
- * Masks the token via tasks.setSecret before returning it.
+ * Masks clientSecret immediately (it's user input, not yet registered by the
+ * caller) and the returned token via tasks.setSecret.
  */
 export async function getOAuthToken(instance: string, clientId: string, clientSecret: string): Promise<string> {
+    tasks.setSecret(clientSecret);
     const url = `https://${instance}.service-now.com/oauth_token.do`;
     const params = new URLSearchParams({
         grant_type: 'client_credentials',
@@ -28,11 +30,15 @@ export async function getOAuthToken(instance: string, clientId: string, clientSe
 
 /**
  * Build a Basic auth header value from username and password.
- * Masks the password via tasks.setSecret before encoding.
+ * Masks the password via tasks.setSecret before encoding, and separately masks
+ * the base64-encoded credentials themselves -- ADO's log masking matches
+ * literal registered strings, so the encoded form needs its own registration
+ * even though the plain password is already masked.
  */
 export function basicAuthHeader(user: string, pass: string): string {
     tasks.setSecret(pass);
     const credentials = Buffer.from(`${user}:${pass}`).toString('base64');
+    tasks.setSecret(credentials);
     return `Basic ${credentials}`;
 }
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -66,6 +66,7 @@
       "type": "string",
       "label": "TSM callback token",
       "required": false,
+      "isSecret": true,
       "helpMarkDown": "Per-run one-shot TSM callback token, sent as the X-TSM-Callback-Token header."
     },
     {

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "6",
+        "Minor": "7",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",
@@ -98,6 +98,7 @@
             "groupName": "private",
             "defaultValue": "",
             "required": false,
+            "isSecret": true,
             "helpMarkDown": "Registry API key with modules:write scope. Pass a secret pipeline variable, e.g. $(tfregistry-api-key)."
         },
         {
@@ -170,6 +171,7 @@
             "groupName": "hcp",
             "defaultValue": "",
             "required": false,
+            "isSecret": true,
             "helpMarkDown": "HCP Terraform team or user API token. Pass a secret pipeline variable."
         },
         {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -123,6 +123,7 @@
             "label": "Repo access token",
             "defaultValue": "",
             "required": false,
+            "isSecret": true,
             "groupName": "policySource",
             "visibleRule": "policySource = gitUrl",
             "helpMarkDown": "Optional token for a private repo. Pass a pipeline secret variable; it is injected via http.extraheader and never written to the clone URL or logs."


### PR DESCRIPTION
## Summary

Addresses the P3 audit finding on secrets-masking asymmetries: two code-level gaps where a *derived* form of a secret wasn't masked even though the raw value was, plus 4 task.json inputs that hold sensitive values but weren't flagged `isSecret: true`.

## 1. OAuth `clientSecret` wasn't masked before use

`getOAuthToken()` in `Tasks/PublishKbArticle/PublishKbArticleV1/src/auth.ts` masked the *returned* `access_token` via `tasks.setSecret()`, but never masked the `clientSecret` input itself before sending it in the token-exchange POST body. If that request ever failed in a way that surfaced request details, or a future debug log dumped the request, `clientSecret` would leak unmasked in pipeline logs.

Fixed by calling `tasks.setSecret(clientSecret)` at the top of the function.

## 2. Basic-auth base64 header wasn't masked

`basicAuthHeader()` masked the raw `password` via `tasks.setSecret(pass)`, but not the base64-encoded `credentials` string actually sent as the `Authorization: Basic <credentials>` header value. ADO's log masking matches literal registered strings — the encoded form is a different string from the raw password and needs its own registration to be masked if it ever appears in a log.

Fixed by also calling `tasks.setSecret(credentials)` right after building the base64 string.

Added 2 new tests in `Tests/L0.ts` asserting both values now appear in the spied `tasks.setSecret` calls, using the file's existing `capturedSecrets` spy harness.

## 3. Missing `isSecret: true` on 4 task.json inputs

- `TerraformDriftReport/task.json` — `callbackToken`
- `TerraformModulePublish/task.json` — `apiKey`, `hcpToken`
- `TerraformPolicyCheck/task.json` — `policyRepoToken`

These inputs hold sensitive values (a one-shot callback token, a registry API key, an HCP API token, and a private-repo access token) but relied solely on each task's own code to mask them, not on the ADO agent's built-in handling for `isSecret`-flagged inputs (which the agent also uses for password-style rendering in the UI). Placement mirrors the existing `isSecret: true` convention already used for `PublishKbArticle`'s `clientSecret`/`password` inputs.

## Version bumps

- `TerraformModulePublish/task.json` Minor `6` → `7` (first change to it this session).
- `TerraformDriftReport`, `TerraformPolicyCheck`, and `PublishKbArticle` task.json were **not** bumped here — each was already bumped in another still-unmerged PR this session (#465 for DriftReport and PublishKbArticle, #473 for PolicyCheck). Re-bumping here would guarantee a merge conflict when those land.

## Verification

- `PublishKbArticle`: **94 passing / 0 failing** (92 baseline + 2 new).
- `TerraformModulePublish`: 38/0, `TerraformDriftReport`: 17/0, `TerraformPolicyCheck`: 25/0 (all unchanged — task.json-only edits, no test count change expected).
- Dispatched an adversarial subagent review covering: whether masking both the raw and derived form is correct/necessary (yes — `tasks.setSecret()` is idempotent, and ADO masking is literal-string based), whether the 4 task.json inputs' consuming code has any OTHER unmasked derived form (checked — `policyRepoToken`'s consumer already independently masks a derived form defensively), a repo-wide grep for the same `Buffer.from(...).toString('base64')` pattern elsewhere (none found unmasked), JSON validity, and confirmation that the 3 skipped Minor bumps are genuinely already claimed by other unmerged PRs. Verdict: **SHIP IT**. One pre-existing, out-of-scope cosmetic note: `index.ts` already calls `tasks.setSecret(password)` once before `basicAuthHeader()` calls it again internally — both calls predate this change, are harmless/idempotent, and are left as-is.
