### PR TITLE
security: escape mirrorUrl in generated HCL and guard listArticleAttachments query

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -18,7 +18,7 @@ import * as htmlValidate from '../src/html-validate';
 import * as client from '../src/servicenow-client';
 import { formatDryRunReport, DryRunPlan } from '../src/dry-run';
 import { extractLocalImageRefs, rewriteImageSrcs } from '../src/image-rewrite';
-import { processArticleImages, syncImageAttachment, contentTypeFor, fileSha256 } from '../src/attachments';
+import { processArticleImages, syncImageAttachment, contentTypeFor, fileSha256, listArticleAttachments } from '../src/attachments';
 import * as manifest from '../src/manifest';
 import { snRequest } from '../src/servicenow-http';
 
@@ -85,6 +85,14 @@ describe('servicenow-client sysparm_query injection guard', () => {
 
     it('findArticleBySourceKey rejects a kbId containing ^', async () => {
         await assert.rejects(() => client.findArticleBySourceKey(INSTANCE, HEADERS, 'cleankey', 'kb^1'), GUARD_MSG);
+    });
+
+    it('listArticleAttachments rejects an articleId containing ^ (encoded-query control char)', async () => {
+        await assert.rejects(() => listArticleAttachments(INSTANCE, HEADERS, 'id^ORtable_sys_id=1'), GUARD_MSG);
+    });
+
+    it('listArticleAttachments rejects an articleId containing a newline', async () => {
+        await assert.rejects(() => listArticleAttachments(INSTANCE, HEADERS, 'id\nvalue'), GUARD_MSG);
     });
 
     it('allows clean values through the guard (mocked HTTP returns no match)', async () => {

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/attachments.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/attachments.ts
@@ -19,7 +19,7 @@ import { snRequest } from './servicenow-http';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { baseUrl } from './servicenow-client';
+import { baseUrl, assertQueryValueSafe } from './servicenow-client';
 import { extractLocalImageRefs, rewriteImageSrcs } from './image-rewrite';
 
 export interface SnAttachment {
@@ -36,6 +36,7 @@ export async function listArticleAttachments(
     headers: Record<string, string>,
     articleId: string,
 ): Promise<SnAttachment[]> {
+    assertQueryValueSafe(articleId, 'article id');
     const url = `${baseUrl(instance)}/api/now/attachment`;
     const params = {
         sysparm_query: `table_name=kb_knowledge^table_sys_id=${articleId}`,

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -269,7 +269,7 @@ export async function createCategory(
  * document-derived value (e.g. a markdown front-matter sourceKey) cannot inject query
  * clauses that redirect the lookup onto an unrelated record.
  */
-function assertQueryValueSafe(value: string, field: string): void {
+export function assertQueryValueSafe(value: string, field: string): void {
     if (/[\^\r\n]/.test(value)) {
         throw new Error(`Invalid ${field}: values used in a ServiceNow query must not contain '^' or newline characters.`);
     }

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/Tests/L0.ts
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/Tests/L0.ts
@@ -215,6 +215,30 @@ describe('config-generator', () => {
                 `expected escaped backslashes, got: ${result}`
             );
         });
+
+        it('should escape double quotes and newlines in mirrorUrl to prevent HCL injection', () => {
+            // validateMirrorUrl() checks the parsed URL, but generateProviderInstallationConfig
+            // interpolates the raw string -- a crafted value could still carry a literal quote
+            // through to this point (e.g. from a different validation path, or future callers
+            // that skip validateMirrorUrl). It must never be interpolated unescaped.
+            const malicious = 'https://registry.example.com/evil"\n}\nprovider_installation "injected" {\n  x = "*';
+            const config: ProviderMirrorConfig = {
+                mirrorUrl: malicious,
+                allowDirectFallback: false,
+                directExcludePatterns: [],
+                directIncludePatterns: [],
+            };
+
+            const result = generateProviderInstallationConfig(config);
+
+            assert.ok(!result.includes(`"${malicious}/"`), 'mirrorUrl must not be interpolated unescaped');
+            assert.ok(result.includes('\\"'), 'embedded quote in mirrorUrl must be escaped');
+            assert.ok(result.includes('\\n'), 'embedded newline in mirrorUrl must be escaped');
+
+            // The url assignment must remain a single well-formed HCL line.
+            const urlLineMatch = result.match(/^\s*url = ".*"$/m);
+            assert.ok(urlLineMatch, 'url assignment must remain a single well-formed line');
+        });
     });
 });
 

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/config-generator.ts
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/config-generator.ts
@@ -24,9 +24,13 @@ export function validateMirrorUrl(url: string): void {
 
 /**
  * Escape a value for safe interpolation inside a double-quoted HCL string
- * literal. Without this, an include/exclude pattern containing a `"` or a
- * newline could break out of the quoted string and inject arbitrary HCL into
- * the generated .terraformrc.
+ * literal. Without this, a mirror URL or include/exclude pattern containing a
+ * `"` or a newline could break out of the quoted string and inject arbitrary
+ * HCL into the generated .terraformrc. mirrorUrl is validated as a genuine
+ * HTTPS URL via `new URL()` before reaching here, but that validation checks
+ * the parsed representation, not the raw string that's actually interpolated
+ * -- escaping it too is cheap defense-in-depth against a URL string crafted to
+ * carry a literal quote/newline through validation.
  */
 function escapeHclString(value: string): string {
     return value
@@ -42,7 +46,7 @@ export function generateProviderInstallationConfig(config: ProviderMirrorConfig)
 
     let hcl = 'provider_installation {\n';
     hcl += '  network_mirror {\n';
-    hcl += `    url = "${mirrorUrl}/"\n`;
+    hcl += `    url = "${escapeHclString(mirrorUrl)}/"\n`;
     hcl += '  }\n';
 
     if (config.allowDirectFallback) {

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "6",
+        "Minor": "7",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
## Summary

Addresses the last P3 audit finding in the "remaining injection hardening" bucket: two more interpolation sites that were missing the escaping/validation already used elsewhere in the same file.

## 1. `mirrorUrl` wasn't escaped in generated HCL

`generateProviderInstallationConfig()` (TerraformProviderMirror) already escaped `directIncludePatterns`/`directExcludePatterns` via `escapeHclString()` before interpolating them into the generated `.terraformrc`, but `mirrorUrl` was interpolated raw into `url = "${mirrorUrl}/"`.

`validateMirrorUrl()` checks that the value parses as a genuine HTTPS URL via `new URL()`, but that validates the *parsed* representation and discards it — the original raw string (which can still carry a literal quote/newline that survived URL parsing) is what actually flows into the HCL.

Fixed by wrapping `mirrorUrl` with the same `escapeHclString()` helper: `url = "${escapeHclString(mirrorUrl)}/"`. Added a test proving a crafted `mirrorUrl` containing a quote+newline payload is safely escaped rather than breaking out of the quoted string, mirroring the existing include/exclude-pattern injection test in the same file.

## 2. `listArticleAttachments` was missing the query-injection guard

`listArticleAttachments(articleId)` (PublishKbArticle) built a ServiceNow encoded-query string (`table_name=kb_knowledge^table_sys_id=${articleId}`) by directly interpolating `articleId`, without the `assertQueryValueSafe()` guard that every other `sysparm_query`-building function in `servicenow-client.ts` already uses (`findOrCreateCategory`, `getKbCategories`, `findArticleBySourceKey`).

ServiceNow encoded queries use `^` as a clause delimiter with no escaping mechanism, so a crafted `articleId` containing `^` could inject an additional clause (e.g. `^ORtable_sys_id=<other>`) and redirect the lookup to an unrelated record.

Fixed by exporting `assertQueryValueSafe` from `servicenow-client.ts` and calling it at the top of `listArticleAttachments()`. Added 2 tests proving it now rejects an `articleId` containing `^` or a newline, following the existing `GUARD_MSG` pattern already in `Tests/L0.ts`.

**`uploadAttachment()`'s `articleId` does NOT need the same guard** — investigated and confirmed during review: it passes `articleId` as a flat, independently URL-encoded query parameter (`table_sys_id`), not as part of a hand-built `^`-delimited `sysparm_query` string, so there's no combined-string parsing step for a crafted value to break out of.

## Version bump

- `TerraformProviderMirror/task.json` Minor `6` → `7` (first change to it this session; confirmed via `git log --all` that no other unmerged branch already claims this bump).
- `PublishKbArticle/task.json` is **not** bumped here — already bumped in PR #465 (unmerged); re-bumping would guarantee a merge conflict when that lands.

## Verification

- `PublishKbArticle`: **94 passing / 0 failing** (92 baseline + 2 new).
- `TerraformProviderMirror`: **17 passing / 0 failing** (16 baseline + 1 new).
- Dispatched an adversarial subagent review covering: whether the escape closes the injection vector without double-escaping or affecting legitimate URLs (confirmed), whether `articleId`'s actual source is attacker-influenceable in practice and whether `uploadAttachment`'s different parameter-passing mechanism is genuinely safe as-is (confirmed, with full data-flow tracing), and test quality (confirmed meaningful, not tautological). Verdict: **SHIP IT**. One subagent suggestion (re-bump `PublishKbArticle`'s Minor for "consistency" with the ProviderMirror bump) was independently verified and declined — `git log --all` confirms PR #465 already claims that exact bump; the subagent reviewing only this diff had no visibility into that other unmerged PR.
