### PR TITLE
security: error-handling cleanup and TerraformTaskV5 proxy configuration parity

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,15 +9,15 @@ These packages are compiled into one or more shipped task bundles. Each is distr
 a permissive OSI license; full license texts ship in each package's distribution and are
 available at the linked repositories.
 
-| Package                  | Bundled into                                                                         | License           |
-| ------------------------ | ------------------------------------------------------------------------------------ | ----------------- |
-| markdown-it              | Markdown2Html                                                                        | MIT               |
-| highlight.js             | Markdown2Html                                                                        | BSD-3-Clause      |
-| js-yaml                  | Markdown2Html (front matter)                                                         | MIT               |
-| cheerio                  | Markdown2Html, PublishKbArticle (HTML sanitize/validate)                             | MIT               |
-| openpgp                  | TerraformInstaller, PolicyAgentInstaller (GPG signature verification)                | LGPL-3.0-or-later |
-| undici                   | TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller (HTTP/proxy client) | MIT               |
-| terraform-drift-contract | TerraformDriftReport (drift-summary contract)                                        | Apache-2.0        |
+| Package                  | Bundled into                                                                                          | License           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------- |
+| markdown-it              | Markdown2Html                                                                                         | MIT               |
+| highlight.js             | Markdown2Html                                                                                         | BSD-3-Clause      |
+| js-yaml                  | Markdown2Html (front matter)                                                                          | MIT               |
+| cheerio                  | Markdown2Html, PublishKbArticle (HTML sanitize/validate)                                              | MIT               |
+| openpgp                  | TerraformInstaller, PolicyAgentInstaller (GPG signature verification)                                 | LGPL-3.0-or-later |
+| undici                   | TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller, TerraformTaskV5 (HTTP/proxy client) | MIT               |
+| terraform-drift-contract | TerraformDriftReport (drift-summary contract)                                                         | Apache-2.0        |
 
 > Maintained manually: when adding or removing a bundled runtime dependency, update this
 > table. (A generated SPDX/license report is a tracked future improvement.)

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -823,6 +823,25 @@ describe('syncImageAttachment', () => {
         );
         assert.strictEqual(id, 'fresh_att');
     });
+
+    it('does not delete the old attachment when the replacement upload fails (non-atomic swap, upload-first)', async () => {
+        nock(BASE_URL)
+            .post('/api/now/attachment/file')
+            .query(true)
+            .reply(400, { error: { message: 'bad request' } });
+        // Registered but must NEVER be triggered -- if syncImageAttachment still
+        // deleted before uploading (the old order), this interceptor would be
+        // consumed and .isDone() would report true.
+        const deleteScope = nock(BASE_URL).delete('/api/now/attachment/old_att').reply(204);
+
+        await assert.rejects(
+            () => syncImageAttachment(
+                INSTANCE, HEADERS, 'art1', tmpFile, 'pic.png',
+                [{ sys_id: 'old_att', file_name: 'pic.png', hash: 'DIFFERENT' }],
+            ),
+        );
+        assert.strictEqual(deleteScope.isDone(), false, 'the old attachment must not be deleted when the upload fails');
+    });
 });
 
 // ===========================================================================

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/attachments.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/attachments.ts
@@ -118,18 +118,24 @@ export async function syncImageAttachment(
     const localHash = fileSha256(filePath);
     const match = existing.find((a) => a.file_name === fileName);
 
-    if (match) {
-        if (match.hash && match.hash === localHash) {
-            // Identical content already attached — reuse.
-            return match.sys_id;
-        }
-        // Same name, different content — replace.
-        await deleteAttachment(instance, headers, match.sys_id);
+    if (match && match.hash && match.hash === localHash) {
+        // Identical content already attached — reuse.
+        return match.sys_id;
     }
 
-    return uploadAttachment(
+    // Upload the replacement first, and only delete the old attachment (if any)
+    // after the upload succeeds. Deleting first (the previous order) left no
+    // rollback path if the subsequent upload failed -- self-healing either way
+    // on the next pipeline re-run (the article is re-resolved by sourceKey and
+    // the local source file is never touched), but this avoids a window where
+    // the image is briefly missing from the article.
+    const newId = await uploadAttachment(
         instance, headers, articleId, filePath, fileName, contentTypeFor(fileName),
     );
+    if (match) {
+        await deleteAttachment(instance, headers, match.sys_id);
+    }
+    return newId;
 }
 
 export interface ProcessImagesResult {

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
@@ -470,4 +470,30 @@ describe('index orchestrator (setSecret masking + publisher routing)', () => {
             throw error;
         }
     });
+
+    it('decouples the per-request socket timeout from the user-configurable timeoutSeconds poll deadline', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'SocketTimeoutDecoupledFromPollDeadline.js'));
+        await tr.runAsync();
+        try {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            const match = tr.stdout.match(/CREATE_HTTPS_CLIENT_ARGS:(\[.*\])/);
+            assert.ok(match, 'createHttpsClient should have logged its call args');
+            const args = JSON.parse(match![1]);
+            // JSON.stringify serializes an `undefined` array element as `null`, so the
+            // round-tripped value here is `null`, not `undefined` -- the actual runtime
+            // call still passes a true `undefined` (confirmed: createHttpsClient's own
+            // `timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS` default parameter only applies
+            // when the argument is omitted/undefined, and https-client.ts's tests
+            // separately confirm createHttpsClient(true) uses that default).
+            assert.strictEqual(
+                args[1],
+                null,
+                `createHttpsClient's socket-timeout arg must not be forwarded from timeoutSeconds (999) -- got ${JSON.stringify(args)}`,
+            );
+        } catch (error) {
+            console.log('STDERR', tr.stderr);
+            console.log('STDOUT', tr.stdout);
+            throw error;
+        }
+    });
 });

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/SocketTimeoutDecoupledFromPollDeadline.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/SocketTimeoutDecoupledFromPollDeadline.ts
@@ -1,0 +1,50 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Proves timeoutSeconds is NOT forwarded as the per-request socket timeout
+// (audit finding: it previously doubled as both the poll deadline and the
+// socket timeout via createHttpsClient(..., timeoutSeconds * 1000), so a large
+// user-configured wait-for-publish deadline also let any single stuck request
+// hang for that same long duration instead of failing fast). Uses a large,
+// distinctive timeoutSeconds (999) so a regression back to the old
+// `timeoutSeconds * 1000` behavior would be unambiguous in the logged args.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('registryType', 'private');
+tr.setInput('namespace', 'aceo');
+tr.setInput('name', 'networking-vpc');
+tr.setInput('provider', 'aws');
+tr.setInput('version', '1.0.0');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('apiKey', 'super-secret-api-key');
+tr.setInput('skipTlsVerify', 'false');
+tr.setInput('waitForPublish', 'true');
+tr.setInput('timeoutSeconds', '999');
+
+// Stub the HTTPS transport, logging the exact args it was called with so the
+// parent test process (which spawns this file as a child) can inspect them.
+tr.registerMock('./http', {
+    createHttpsClient: (rejectUnauthorized: unknown, timeoutMs: unknown) => {
+        console.log(`CREATE_HTTPS_CLIENT_ARGS:${JSON.stringify([rejectUnauthorized, timeoutMs])}`);
+        return () => Promise.resolve({ status: 200, body: '{}' });
+    },
+});
+
+tr.registerMock('./private-publisher', {
+    PrivateRegistryPublisher: class {
+        publish() {
+            return Promise.resolve({ published: true, message: 'Sync triggered for version 1.0.0.' });
+        }
+    },
+});
+
+tr.registerMock('./hcp-publisher', {
+    HcpPublisher: class {
+        publish() {
+            return Promise.resolve({ published: true, message: 'should not be called' });
+        }
+    },
+});
+
+tr.run();

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
@@ -45,7 +45,13 @@ function buildPublisher(): RegistryPublisher {
         }
         const apiKey = requireInput('apiKey');
         tasks.setSecret(apiKey);
-        return new PrivateRegistryPublisher(createHttpsClient(!skipTlsVerify, timeoutSeconds * 1000), {
+        // createHttpsClient uses its own fixed default per-request socket timeout
+        // here (not timeoutSeconds) -- timeoutSeconds is the user-configurable
+        // overall wait-for-publish poll deadline below; reusing it as the socket
+        // timeout would let a single stuck request hang for that same long
+        // duration instead of failing fast, defeating the polling loop's
+        // fast-fail-and-retry cadence.
+        return new PrivateRegistryPublisher(createHttpsClient(!skipTlsVerify), {
             ...coordinates,
             registryUrl: requireInput('registryUrl'),
             apiKey,
@@ -64,7 +70,9 @@ function buildPublisher(): RegistryPublisher {
     if (registryType === 'hcp') {
         const token = requireInput('hcpToken');
         tasks.setSecret(token);
-        return new HcpPublisher(createHttpsClient(true, timeoutSeconds * 1000), {
+        // See the private-registry branch above: the socket timeout is
+        // intentionally decoupled from timeoutSeconds (the poll deadline).
+        return new HcpPublisher(createHttpsClient(true), {
             ...coordinates,
             address: tasks.getInput('hcpAddress', false) || 'https://app.terraform.io',
             token,

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
@@ -48,7 +48,12 @@ export async function resolvePolicyDir(tempDirs: string[]): Promise<string> {
     const subdir = tasks.getInput('policyRepoSubdir');
     const token = tasks.getInput('policyRepoToken');
 
-    const cloneDir = path.join(os.tmpdir(), `policy-repo-${uuidV4()}`);
+    // Agent.TempDirectory is auto-purged by the ADO agent at job end, which
+    // backstops cleanup even if the process is killed (e.g. a cancelled build)
+    // before the try/finally in index.ts can run fs.rmSync -- os.tmpdir() has
+    // no such guarantee and would otherwise need its own SIGTERM/SIGINT
+    // handler to avoid leaking a clone on cancellation.
+    const cloneDir = path.join(tasks.getVariable('Agent.TempDirectory') || os.tmpdir(), `policy-repo-${uuidV4()}`);
     await cloneRepo(url, ref, token, cloneDir);
     tempDirs.push(cloneDir);
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -6,6 +6,8 @@ import * as path from 'path';
 import './OciTokenExchangeL0';
 // Direct unit tests for the OIDC ID-token generator (WIF fallback).
 import './IdTokenGeneratorL0';
+// Direct unit tests for the agent HTTP proxy configuration helper.
+import './ProxyConfigL0';
 // Direct unit tests for the secure var-file loader.
 import './SecureFileLoaderL0';
 // Direct unit tests for post-hoc chmod on third-party secure-file downloads.

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciTokenExchangeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciTokenExchangeL0.ts
@@ -91,6 +91,21 @@ describe('OCI token exchange — URL validation & transport', function () {
         await assert.rejects(exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey), /missing access_token/);
     });
 
+    it('throws a clear, truncated error on a non-JSON 200 response instead of a raw SyntaxError', async () => {
+        globalThis.fetch = (async () =>
+            new Response('<html>captive portal</html>', { status: 200 })) as unknown as typeof globalThis.fetch;
+        await assert.rejects(
+            exchangeOidcForUpst('jwt', VALID_DOMAIN, 'client', publicKey),
+            (err: unknown) => {
+                assert.ok(err instanceof Error, 'should throw an Error');
+                assert.ok(!(err instanceof SyntaxError), 'must not be a raw unwrapped SyntaxError');
+                assert.match(err.message, /OCI token exchange returned a non-JSON response/);
+                assert.ok(err.message.includes('captive portal'), 'should include the (truncated) response body');
+                return true;
+            },
+        );
+    });
+
     it('throws on a non-OK response', async () => {
         globalThis.fetch = (async () =>
             new Response('bad request', { status: 400, statusText: 'Bad Request' })) as unknown as typeof globalThis.fetch;

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ProxyConfigL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ProxyConfigL0.ts
@@ -1,0 +1,66 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import assert = require('assert');
+import tasks = require('azure-pipelines-task-lib/task');
+import { buildProxyFetchOptions } from '../src/proxy-config';
+
+/**
+ * Direct unit tests for buildProxyFetchOptions(), mirroring the equivalent
+ * buildFetchOptions() tests in the installer tasks' shared http-client.ts
+ * (Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts).
+ * Self-hosted agents that require an HTTP proxy for outbound internet access
+ * typically require it for ANY external HTTPS call, so the OIDC token
+ * exchange and OCI Identity Domains calls need the same proxy awareness the
+ * installer tasks already have.
+ */
+describe('buildProxyFetchOptions', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch the shared task-lib module
+  const t = tasks as any;
+  const origProxy = t.getHttpProxyConfiguration;
+  const origSetSecret = t.setSecret;
+
+  beforeEach(() => {
+    t.getHttpProxyConfiguration = origProxy;
+    t.setSecret = origSetSecret;
+  });
+  afterEach(() => {
+    t.getHttpProxyConfiguration = origProxy;
+    t.setSecret = origSetSecret;
+  });
+
+  it('returns an empty object when no proxy is configured', () => {
+    t.getHttpProxyConfiguration = () => undefined;
+    assert.deepStrictEqual(buildProxyFetchOptions(), {});
+  });
+
+  it('attaches an undici ProxyAgent dispatcher when a proxy is configured', () => {
+    t.getHttpProxyConfiguration = () => ({
+      proxyUrl: 'http://proxy.example.com:8080',
+      proxyUsername: '',
+      proxyPassword: '',
+    });
+    const options = buildProxyFetchOptions();
+    assert.ok('dispatcher' in options, 'proxy dispatcher should be set');
+  });
+
+  it('embeds credentials in the proxy URL and masks the password as a secret', () => {
+    const setSecretCalls: string[] = [];
+    t.setSecret = (v: string) => setSecretCalls.push(v);
+    t.getHttpProxyConfiguration = () => ({
+      proxyUrl: 'http://proxy.example.com:8080',
+      proxyUsername: 'user',
+      proxyPassword: 'p@ss',
+    });
+    const options = buildProxyFetchOptions();
+    assert.ok('dispatcher' in options, 'proxy dispatcher should be set');
+    assert.ok(setSecretCalls.includes('p@ss'), 'proxy password should be registered as a secret');
+  });
+
+  it('throws a clear error on a malformed proxy URL instead of an unhandled TypeError', () => {
+    t.getHttpProxyConfiguration = () => ({
+      proxyUrl: 'not a url',
+      proxyUsername: 'user',
+      proxyPassword: 'p@ss',
+    });
+    assert.throws(() => buildProxyFetchOptions(), /Invalid proxy URL/);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -12,7 +12,8 @@
         "azure-devops-node-api": "^12.0.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-artifacts-common": "^2.225.0",
-        "azure-pipelines-tasks-securefiles-common": "^2.272.0"
+        "azure-pipelines-tasks-securefiles-common": "^2.272.0",
+        "undici": "^6.27.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -5639,6 +5640,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -20,7 +20,8 @@
     "azure-devops-node-api": "^12.0.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-artifacts-common": "^2.225.0",
-    "azure-pipelines-tasks-securefiles-common": "^2.272.0"
+    "azure-pipelines-tasks-securefiles-common": "^2.272.0",
+    "undici": "^6.27.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",

--- a/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
@@ -1,4 +1,5 @@
 import tasks = require("azure-pipelines-task-lib/task");
+import { buildProxyFetchOptions } from './proxy-config';
 
 export async function generateIdToken(serviceConnectionID: string): Promise<string> {
     const tokenGenerator = new TokenGenerator();
@@ -89,7 +90,8 @@ export class TokenGenerator {
                     },
                     signal: controller.signal,
                     // This token exchange has no legitimate redirect.
-                    redirect: 'error'
+                    redirect: 'error',
+                    ...buildProxyFetchOptions(),
                 });
             } catch (error) {
                 if (error instanceof Error && error.name === 'AbortError') {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
@@ -135,7 +135,17 @@ export async function exchangeOidcForUpst(
 
         // Read the success body while the abort timer is still armed, so a server
         // that sends headers then stalls the body is still bounded by the timeout.
-        const result = await response.json() as { access_token?: string; token?: string };
+        // Parsed manually (rather than response.json()) so a non-JSON body -- e.g.
+        // a misconfigured gateway or captive portal answering 200 with HTML --
+        // surfaces as a clear, truncated error instead of a raw SyntaxError,
+        // mirroring module-publish/http.ts's parseJson().
+        const bodyText = await response.text();
+        let result: { access_token?: string; token?: string };
+        try {
+            result = JSON.parse(bodyText) as { access_token?: string; token?: string };
+        } catch {
+            throw new Error(`OCI token exchange returned a non-JSON response: ${truncateBody(bodyText)}`);
+        }
         const upst = result.access_token || result.token;
         if (!upst) {
             throw new Error('OCI token exchange response missing access_token/token field.');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
@@ -1,5 +1,6 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import crypto = require('crypto');
+import { buildProxyFetchOptions } from './proxy-config';
 
 /**
  * Bound a remote response body before it is interpolated into a thrown error,
@@ -108,6 +109,7 @@ export async function exchangeOidcForUpst(
                 // Never follow a redirect: a 3xx could forward the OIDC bearer JWT
                 // (preserved with the POST body) to a different, unvalidated origin.
                 redirect: 'manual',
+                ...buildProxyFetchOptions(),
             });
         } catch (error) {
             if (error instanceof Error && error.name === 'AbortError') {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/proxy-config.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/proxy-config.ts
@@ -1,0 +1,39 @@
+import tasks = require('azure-pipelines-task-lib/task');
+import { ProxyAgent } from 'undici';
+
+/**
+ * Builds fetch() RequestInit options that route the request through the
+ * agent's configured HTTP proxy (Agent.ProxyUrl / Agent.ProxyUsername /
+ * Agent.ProxyPassword), if one is set. Mirrors the equivalent
+ * buildFetchOptions() helper in the installer tasks' shared http-client.ts —
+ * self-hosted agents that require a proxy for outbound internet access
+ * typically require it for ANY external HTTPS call, including the OIDC
+ * token-exchange and OCI Identity Domains calls this task makes via fetch().
+ * Returns an empty object when no proxy is configured, so callers can always
+ * spread the result into their own RequestInit unconditionally.
+ */
+export function buildProxyFetchOptions(): RequestInit {
+  const proxy = tasks.getHttpProxyConfiguration();
+  if (!proxy) return {};
+
+  let proxyUrl = proxy.proxyUrl;
+  if (proxy.proxyUsername) {
+    if (proxy.proxyPassword) {
+      tasks.setSecret(proxy.proxyPassword);
+    }
+    let url: URL;
+    try {
+      url = new URL(proxy.proxyUrl);
+    } catch (err) {
+      throw new Error(`Invalid proxy URL configured on the agent: ${err instanceof Error ? err.message : err}`);
+    }
+    url.username = proxy.proxyUsername;
+    url.password = proxy.proxyPassword ?? "";
+    proxyUrl = url.toString();
+  }
+
+  return {
+    // @ts-expect-error Node.js fetch accepts undici dispatcher
+    dispatcher: new ProxyAgent(proxyUrl),
+  };
+}


### PR DESCRIPTION
## Summary

Addresses the final P3 audit batch: 4 independent, low-severity error-handling hardening items, plus the tractable half of a medium-severity reliability finding (proxy configuration parity).

## 1. TerraformPolicyCheck — temp-dir cancellation safety

The git-clone temp directory for `policySource=gitUrl` used `os.tmpdir()`, which has no cleanup guarantee if the process is killed (e.g. a cancelled build) before the existing `try`/`finally` can run `fs.rmSync` — Node's default disposition for an unhandled SIGTERM/SIGINT is immediate termination without unwinding to `finally`.

Fixed by preferring `Agent.TempDirectory` (which the ADO agent auto-purges at job end) with an `os.tmpdir()` fallback, matching the identical pattern already used in `TerraformDriftReport`, `TerraformProviderMirror`, and `TerraformTaskV5`'s dedicated `temp-dir.ts` helper. `sentinel-engine.ts`'s separate `os.tmpdir()` usage (for its generated config dir) is intentionally left untouched — it's synchronous and already cleaned up in its own `finally` block, not subject to the same cancellation race.

## 2. PublishKbArticle — non-atomic image-attachment swap

`syncImageAttachment()` deleted the existing ServiceNow attachment *before* uploading the replacement, with no rollback if the upload failed afterward — a transient failure left the article's image temporarily missing.

Fixed by uploading the replacement first and only deleting the old attachment after the upload succeeds. Added a test proving the old attachment is **not** deleted when the upload fails, using nock's `.isDone()` tracking on a registered-but-never-triggered DELETE interceptor (a much stronger check than just asserting the function rejects, which would have passed even under the old, buggy ordering for the wrong reason).

## 3. TerraformModulePublish — decoupled socket timeout from poll deadline

The `timeoutSeconds` input doubled as both the overall wait-for-publish poll deadline **and**, via `createHttpsClient(..., timeoutSeconds * 1000)`, the per-HTTP-request socket timeout. A user who set a large `timeoutSeconds` to allow a long wait for HCP/registry processing inadvertently also let any single stuck request hang for that same long duration before failing, defeating the polling loop's fast-fail-and-retry cadence.

Fixed by dropping the second argument entirely, relying on `createHttpsClient`'s own fixed `DEFAULT_REQUEST_TIMEOUT_MS` (100s) default instead. Added a test that captures `createHttpsClient`'s actual call args via a stubbed transport (logged to stdout across the mock-test child-process boundary) and confirms the socket-timeout arg is never forwarded from a distinctive `timeoutSeconds` value (999).

## 4. TerraformTaskV5 — wrapped OCI token-exchange JSON parse

`await response.json()` was not wrapped in try/catch, unlike module-publish's `parseJson()` helper — if OCI's Identity Domains endpoint returns HTTP 200 with a non-JSON body (e.g. a misconfigured gateway or captive portal), a raw unwrapped `SyntaxError` surfaced instead of a clear, actionable message.

Fixed by reading the body as text and manually `JSON.parse`-ing it inside a try/catch that rethrows a clear, truncated error, mirroring `module-publish/http.ts`'s `parseJson()`. Added a test constructing a real non-JSON `Response` and confirming the thrown error is not a raw `SyntaxError` and includes the expected message + truncated body content.

## 5. TerraformTaskV5 — agent HTTP proxy configuration for fetch()-based transports

A separate, medium-severity finding: `tasks.getHttpProxyConfiguration()` + an `undici` `ProxyAgent` dispatcher is wired up only in the 3 installer tasks' shared `http-client.ts`. A self-hosted agent that requires a proxy for outbound internet access typically requires it for **any** external HTTPS call — `docs/troubleshooting.md` already has a dedicated section confirming this is a real, supported deployment scenario — but TerraformTaskV5's OIDC id-token generator and OCI token-exchange calls issued raw `fetch()` requests with no proxy awareness.

Addressed the tractable half of this finding: added a `proxy-config.ts` module exporting `buildProxyFetchOptions()`, faithfully porting the installer's private `buildFetchOptions()` helper, and wired it into `oci-token-exchange.ts` and `id-token-generator.ts` (both already use native `fetch()`, so they can directly reuse the same `undici` `ProxyAgent`-as-`dispatcher` mechanism). Added `undici` as a new TerraformTaskV5 dependency (already used at the same version by the 3 installer tasks) and a dedicated test file mirroring the installer's proxy test pattern.

**Deliberately deferred**: the other transports named in the same finding (`TerraformModulePublish`/`TerraformDriftReport`'s `https-client.ts`, `PublishKbArticle`'s `servicenow-http.ts`) use Node's native `https.request()`, not `fetch()` — they'd need a fundamentally different proxy mechanism (an `https-proxy-agent`-style tunneling `https.Agent`, or a larger migration to `fetch()`+`undici`) and were extensively hardened earlier this session (TLS enforcement, response-size caps, timeout handling). Recommending this as a separate, dedicated follow-up rather than rushing it into this change.

## Version bump

No Minor bumps in this PR — all 4 touched tasks already have their Minor claimed as bumped in other still-unmerged PRs this session:

- TerraformPolicyCheck → PR #473
- PublishKbArticle → PR #465
- TerraformModulePublish → PR #475
- TerraformTaskV5 → PR #464

Confirmed via `git log --all --oneline -- <task>/task.json` for each. Re-bumping here would guarantee a merge conflict when those land.

## Verification

- `TerraformPolicyCheck`: 25 passing / 0 failing (unchanged — 1-line `os.tmpdir()` fallback).
- `PublishKbArticle`: **93 passing / 0 failing** (92 baseline + 1 new).
- `TerraformModulePublish`: **39 passing / 0 failing** (38 baseline + 1 new).
- `TerraformTaskV5`: **269 passing / 0 failing** (264 baseline + 1 new for the JSON-parse fix + 4 new for the proxy-config addition).
- `npm install` added `undici` cleanly with no new `npm audit` findings (the only 2 moderate findings present are pre-existing, unrelated transitive deps of `@typescript-eslint/typescript-estree` and `azure-pipelines-task-lib` itself).
- Dispatched two rounds of adversarial subagent review (one for the 4 error-handling fixes, one for the proxy-config addition). Both verdicts: **SHIP IT**. Confirmed: the proxy-config port is faithful line-by-line to the installer's pattern, no option-key collisions at either `fetch()` call site, the new tests are meaningful and properly isolated, and `proxy-config.ts` correctly should **not** be registered in `check-shared-modules.js` (single copy, same precedent already established for `servicenow-http.ts`). One theoretical residual noted and accepted as-is in fix #2: if the upload succeeds but the *subsequent* delete of the old attachment fails, two same-named attachments briefly coexist — self-healing on the next re-run via hash-match reuse, matching the audit's own severity framing.
