### PR TITLE
refactor: dedup multiline-input parsing in TerraformTaskV5

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -12,13 +12,31 @@ import os = require('os');
 export const RESOURCE_ADDRESS_RE = /^[a-zA-Z_][\w\-]*(\[[^\]]+\])?(\.[a-zA-Z_][\w\-]*(\[[^\]]+\])?)*$/;
 
 /**
+ * Splits a multi-line task input into trimmed, non-empty lines -- the common
+ * core of this task's several multi-line-input parsers (var-file paths, target
+ * addresses, -var tokens, -backend-config args). Each line is kept whole (never
+ * further split) so a value containing spaces -- a path on a Windows agent, or
+ * a quoted index key like `module.x["a b"]` -- survives as one token.
+ * `skipComments` additionally drops lines starting with `#`, matching the
+ * `-var`/`-backend-config` inputs' existing support for comment lines; the
+ * var-file/target-address inputs never supported that and keep it disabled so
+ * behavior here is unchanged from before this helper existed.
+ */
+export function splitNonEmptyLines(input: string | undefined, opts: { skipComments?: boolean } = {}): string[] {
+    if (!input) return [];
+    return input
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => l && !(opts.skipComments && l.startsWith('#')));
+}
+
+/**
  * Splits a multi-line `varFile` input into `-var-file=<path>` tokens, one per
  * non-empty line. Each path is kept whole so it can be passed as a single argv
  * entry — paths containing spaces (common on Windows agents) must not be split.
  */
 export function parseVarFileTokens(varFile: string | undefined): string[] {
-    if (!varFile) return [];
-    return varFile.split('\n').map(l => l.trim()).filter(l => l).map(f => `-var-file=${f}`);
+    return splitNonEmptyLines(varFile).map(f => `-var-file=${f}`);
 }
 
 /**
@@ -27,8 +45,7 @@ export function parseVarFileTokens(varFile: string | undefined): string[] {
  * (e.g. `module.x["a b"]`), so each is kept as a single argv entry.
  */
 export function parseTargetTokens(targetResources: string | undefined): string[] {
-    if (!targetResources) return [];
-    const lines = targetResources.split('\n').map(l => l.trim()).filter(l => l);
+    const lines = splitNonEmptyLines(targetResources);
     for (const address of lines) {
         if (!RESOURCE_ADDRESS_RE.test(address)) {
             throw new Error(`Invalid target address '${address}': must be a valid Terraform resource address`);
@@ -176,12 +193,9 @@ export abstract class BaseTerraformCommandHandler {
         const variables = tasks.getInput("terraformVariables", false);
         if (!variables) return;
 
-        for (const line of variables.split('\n')) {
-            const trimmed = line.trim();
-            if (trimmed && !trimmed.startsWith('#')) {
-                terraformTool.arg('-var');
-                terraformTool.arg(trimmed);
-            }
+        for (const trimmed of splitNonEmptyLines(variables, { skipComments: true })) {
+            terraformTool.arg('-var');
+            terraformTool.arg(trimmed);
         }
     }
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
@@ -1,7 +1,7 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformAuthorizationCommandInitializer } from './terraform-commands';
-import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
+import { BaseTerraformCommandHandler, splitNonEmptyLines } from './base-terraform-command-handler';
 
 export class TerraformCommandHandlerGeneric extends BaseTerraformCommandHandler {
     constructor() {
@@ -16,13 +16,8 @@ export class TerraformCommandHandlerGeneric extends BaseTerraformCommandHandler 
         }
 
         const configArgs = tasks.getInput("backendConfigArgs", false);
-        if (configArgs) {
-            for (const line of configArgs.split('\n')) {
-                const trimmed = line.trim();
-                if (trimmed && !trimmed.startsWith('#')) {
-                    terraformToolRunner.arg(`-backend-config=${trimmed}`);
-                }
-            }
+        for (const trimmed of splitNonEmptyLines(configArgs, { skipComments: true })) {
+            terraformToolRunner.arg(`-backend-config=${trimmed}`);
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses an info-severity code-quality audit finding: three near-identical (not byte-identical) split/trim/filter-blank[/skip-`#`] implementations for parsing multiline task inputs existed within `TerraformTaskV5`. Each was only a few lines, so functional risk was minimal, but the duplication was real.

## Change

Extracted a single `splitNonEmptyLines(input, { skipComments })` helper covering the common core (split, trim, filter blank lines, optionally drop `#`-prefixed comment lines) and switched all four call sites to use it:

- `parseVarFileTokens` (`base-terraform-command-handler.ts`)
- `parseTargetTokens` (`base-terraform-command-handler.ts`)
- `appendTerraformVariables`'s inline loop (`base-terraform-command-handler.ts`)
- `TerraformCommandHandlerGeneric.handleBackend`'s inline loop (`generic-terraform-command-handler.ts`)

**Pure refactor, zero behavior change**: `parseVarFileTokens`/`parseTargetTokens` never supported comment lines and still don't (`skipComments` left `false` there); `appendTerraformVariables` and `handleBackend`'s `backendConfigArgs` loop already supported comment lines and still do (`skipComments: true` there), matching each site's exact prior behavior.

`TerraformProviderMirrorV1`'s own small `parseMultiLineInput` (`index.ts`) is deliberately left as-is: it's a separate task/package, has no comment-skip requirement, and is already a clean, single-purpose helper — not worth forcing a cross-task shared-module extraction for this small amount of logic.

## Verification

**264 passing / 0 failing**, unchanged from baseline. Existing tests directly exercise the preserved behavior:
- `CommandArgsL0.ts` for `parseVarFileTokens`/`parseTargetTokens` (blank-line filtering, whitespace trimming, space-containing values kept as single tokens).
- `AzureImportSuccessWithVars.ts`'s `'env=staging\n# comment line\nregion=eastus'` fixture for `appendTerraformVariables`'s comment-skip behavior.
- `GenericInitSuccess.ts` for `handleBackend`'s multiline `backendConfigArgs` parsing.

No new tests added — this is a pure, behavior-preserving refactor with strong pre-existing coverage already proving correctness at every call site.
