### PR TITLE
security: fix Markdown2Html/PublishKbArticle XSS gaps and ServiceNow response validation (audit #12, #13/#446, #29/#372, #19/#396)

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -99,11 +99,66 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --add-label "stale-security-patch" || true
 
+  # ── Marketplace environment protection verification ───
+  # Verifies the `marketplace` GitHub Environment (which gates publish-marketplace
+  # in release.yml) has at least one required reviewer configured. This closes the
+  # verifiability gap from audit finding #19/#396: the "must have at least one
+  # required reviewer" policy (CLAUDE.md) was previously asserted only in prose,
+  # with no repository-visible or CI-checked source of truth, so silent removal
+  # or misconfiguration of the rule would go undetected.
+  verify-marketplace-environment-protection:
+    name: Verify marketplace environment protection
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check required reviewers on the marketplace environment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const ENVIRONMENT = 'marketplace';
+            let env;
+            try {
+              const response = await github.request('GET /repos/{owner}/{repo}/environments/{environment_name}', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment_name: ENVIRONMENT,
+              });
+              env = response.data;
+            } catch (err) {
+              if (err.status === 404) {
+                core.setFailed(`The '${ENVIRONMENT}' GitHub Environment does not exist — publish-marketplace in release.yml references an environment with no protection rules at all.`);
+                return;
+              }
+              // Reading environment protection rules only requires ordinary repo
+              // read access (unlike branch-protection/admin endpoints, which
+              // GITHUB_TOKEN cannot satisfy — see the legitify job above). A
+              // failure here is unexpected; surface it distinctly from a real
+              // policy gap so the two aren't confused.
+              core.warning(`Could not verify the '${ENVIRONMENT}' environment's protection rules (HTTP ${err.status ?? 'unknown'}): ${err.message}. Verify manually via Settings -> Environments.`);
+              return;
+            }
+
+            const rules = env.protection_rules ?? [];
+            const requiredReviewersRule = rules.find((rule) => rule.type === 'required_reviewers');
+            const hasRequiredReviewers = Boolean(requiredReviewersRule && Array.isArray(requiredReviewersRule.reviewers) && requiredReviewersRule.reviewers.length > 0);
+
+            if (!hasRequiredReviewers) {
+              core.setFailed(
+                `The '${ENVIRONMENT}' GitHub Environment has no required-reviewer protection rule configured. ` +
+                `CLAUDE.md documents this as mandatory ("must have at least one required reviewer") for every VS Marketplace publish. ` +
+                `Configure it under Settings -> Environments -> ${ENVIRONMENT} -> Required reviewers.`
+              );
+              return;
+            }
+
+            core.info(`OK: '${ENVIRONMENT}' environment has ${requiredReviewersRule.reviewers.length} required reviewer(s) configured.`);
+
   # ── Notify on failure ─────────────────────────────────
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
-    needs: [ci, osv-scan, stale-dependabot]
+    needs: [ci, osv-scan, stale-dependabot, verify-marketplace-environment-protection]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -130,11 +130,12 @@ jobs:
                 core.setFailed(`The '${ENVIRONMENT}' GitHub Environment does not exist — publish-marketplace in release.yml references an environment with no protection rules at all.`);
                 return;
               }
-              // Reading environment protection rules only requires ordinary repo
-              // read access (unlike branch-protection/admin endpoints, which
-              // GITHUB_TOKEN cannot satisfy — see the legitify job above). A
-              // failure here is unexpected; surface it distinctly from a real
-              // policy gap so the two aren't confused.
+              // Confirmed against GitHub's REST API docs: reading environment
+              // protection rules only requires ordinary repo read access (unlike
+              // branch-protection/admin-settings endpoints, which need the
+              // `administration` permission -- a scope GITHUB_TOKEN cannot grant
+              // at all). A failure here is therefore unexpected; surface it
+              // distinctly from a real policy gap so the two aren't confused.
               core.warning(`Could not verify the '${ENVIRONMENT}' environment's protection rules (HTTP ${err.status ?? 'unknown'}): ${err.message}. Verify manually via Settings -> Environments.`);
               return;
             }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 
 As of PR #218, `release.yml` publishes via **GitHub OIDC federated to Microsoft Entra** — there is no stored `TFX_PAT`. The publish job (under the `marketplace` environment, `id-token: write`) signs in with `azure/login` using the two `AZDO_PUBLISH_*` variables, exchanges the OIDC token for a short-lived Entra access token, and passes it to `tfx extension publish`. The Entra app needs a federated credential with subject `repo:sethbacon/azure-pipelines-terraform:environment:marketplace`.
 
-The `marketplace` environment (Settings → Environments) must have at least one required reviewer so every VS Marketplace publish gets human approval.
+The `marketplace` environment (Settings → Environments) must have at least one required reviewer so every VS Marketplace publish gets human approval. This is verified automatically by the `verify-marketplace-environment-protection` job in `weekly-security.yml`, which fails the scheduled run (filing an issue) if the required-reviewer rule is missing, removed, or the environment itself no longer exists.
 
 ## Publisher Registration
 

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -330,6 +330,18 @@ describe('buildToc', () => {
         assert.ok(!/<img[\s>]/i.test(toc), `TOC must not contain a live <img> element (got: ${toc})`);
         assert.ok(toc.includes('&lt;img'), `TOC should contain the re-escaped heading text (got: ${toc})`);
     });
+
+    it('escapes an author-supplied raw heading id, closing an href attribute-breakout (#12 follow-up)', () => {
+        // markdown-it runs with html:true, so a heading can carry its own raw `id`
+        // attribute straight from the source markdown/HTML. cheerio's .attr('id')
+        // decodes it the same way .text() decodes heading content -- an id
+        // containing a literal double-quote would otherwise break out of the
+        // TOC's href="#..." attribute and inject live markup.
+        const html = '<h1 id=\'a"><iframe srcdoc="x"></iframe><a href="b\'>Heading</h1>';
+        const { toc } = buildToc(html);
+        assert.ok(!/<iframe[\s>]/i.test(toc), `TOC must not contain a live <iframe> element (got: ${toc})`);
+        assert.ok(toc.includes('&quot;'), `TOC should contain the re-escaped id value (got: ${toc})`);
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -513,8 +525,8 @@ describe('convertMarkdownToHtml', () => {
         assert.ok(!/<animate[\s/>]/i.test(html), `<animate> must be removed (got: ${html})`);
     });
 
-    it('removes animateTransform, animateMotion and set elements alongside animate', () => {
-        for (const tag of ['animateTransform', 'animateMotion', 'set']) {
+    it('removes animateTransform, animateMotion, animateColor and set elements alongside animate', () => {
+        for (const tag of ['animateTransform', 'animateMotion', 'animateColor', 'set']) {
             const html = convertMarkdownToHtml(`<svg><${tag} attributeName="href" to="javascript:alert(1)"/></svg>`);
             assert.ok(!new RegExp(`<${tag}[\\s/>]`, 'i').test(html), `<${tag}> must be removed (got: ${html})`);
         }
@@ -675,6 +687,31 @@ describe('processFrontMatterDriven', () => {
         assert.ok(/Table of Contents/i.test(html), 'expected a generated TOC');
         assert.ok(html.includes('file-divider'), 'expected the hr separator between includes');
         assert.ok(html.includes('<section id='), 'expected section-anchor wrappers');
+    });
+
+    it('escapes an ampersand in a section-anchor id (#12 follow-up: sectionId is interpolated unescaped)', async () => {
+        // '"'/'<'/'>' are illegal in Windows filenames (this repo's own CI matrix
+        // runs Windows), so '&' is used here to stay cross-platform while still
+        // proving escapeHtml() runs on the path-derived sectionId before it is
+        // interpolated into an HTML attribute that skips sanitizeRenderedHtml.
+        const dir = writeTmpDir({
+            'main.md': [
+                '---',
+                'includes:',
+                '  - Q&A.md',
+                'include-options:',
+                '  section-anchors: true',
+                '---',
+                '# Intro',
+                '',
+            ].join('\n'),
+            'Q&A.md': '# Part\n\nContent.\n',
+        });
+        const out = path.join(dir, 'out.html');
+        await processFrontMatterDriven(path.join(dir, 'main.md'), out);
+        const html = fs.readFileSync(out, 'utf8');
+        assert.ok(!html.includes('id="q&a-md"'), `raw ampersand in the section id must be escaped (got: ${html})`);
+        assert.ok(html.includes('id="q&amp;a-md"'), `expected the escaped section id to appear (got: ${html})`);
     });
 
     it('derives the title from the first h1 when front matter has none', async () => {

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -518,6 +518,17 @@ describe('convertMarkdownToHtml', () => {
         assert.ok(!/action\s*=/.test(html), `no action= attribute should survive (got: ${html})`);
     });
 
+    it('removes iframe/object/embed/noscript via the shared DANGEROUS_TAGS filter (final-review regression check)', () => {
+        // sanitizeRenderedHtml's removal mechanism for these elements was
+        // refactored from a plain CSS selector to the shared DANGEROUS_TAGS
+        // tagName-filter (so PublishKbArticle's gate could reuse the exact same
+        // set) -- confirm the refactor didn't change render-time behavior.
+        for (const tag of ['iframe', 'object', 'embed', 'noscript']) {
+            const html = convertMarkdownToHtml(`Before\n\n<${tag}>x</${tag}>\n\nAfter`);
+            assert.ok(!new RegExp(`<${tag}[\\s>]`, 'i').test(html), `<${tag}> must be removed (got: ${html})`);
+        }
+    });
+
     it('removes SVG SMIL animation elements that can dynamically assign a javascript: URI (#446 follow-up)', () => {
         const html = convertMarkdownToHtml(
             '<svg><a href="#safe"><animate attributeName="href" to="javascript:alert(1)"/>x</a></svg>',

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -319,6 +319,17 @@ describe('buildToc', () => {
         assert.ok(modified.includes('id="title"'));
         assert.ok(modified.includes('id="sub"'));
     });
+
+    it('escapes heading text in TOC entries, closing a decode-then-reinject XSS gap (#12)', () => {
+        // A heading whose rendered HTML already has the tag ENCODED (e.g. because
+        // it came from a markdown code span, which sanitizeRenderedHtml sees only
+        // as inert escaped text) still decodes back to live markup via cheerio's
+        // .text() -- buildToc must re-escape it before building the TOC <li>.
+        const html = '<h1>&lt;img src=x onerror=alert(1)&gt;</h1><p>text</p>';
+        const { toc } = buildToc(html);
+        assert.ok(!/<img[\s>]/i.test(toc), `TOC must not contain a live <img> element (got: ${toc})`);
+        assert.ok(toc.includes('&lt;img'), `TOC should contain the re-escaped heading text (got: ${toc})`);
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -482,8 +493,31 @@ describe('convertMarkdownToHtml', () => {
         const anchorHtml = convertMarkdownToHtml('<a href="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</a>');
         assert.ok(!/href\s*=/.test(anchorHtml), `<a href> must be stripped (got: ${anchorHtml})`);
 
-        const formHtml = convertMarkdownToHtml('<form><button formaction="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</button></form>');
+        // Not wrapped in <form>: this specifically tests the formaction attribute
+        // check (a standalone <button> is valid HTML), independent of the separate
+        // wholesale <form>-element removal covered below.
+        const formHtml = convertMarkdownToHtml('<button formaction="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</button>');
         assert.ok(!/formaction\s*=/.test(formHtml), `formaction must be stripped (got: ${formHtml})`);
+    });
+
+    it('removes <form> elements outright, closing the action="javascript:..." bypass (#446 follow-up)', () => {
+        const html = convertMarkdownToHtml('Before\n\n<form action="javascript:alert(1)"><button>Submit</button></form>\n\nAfter');
+        assert.ok(!/<form[\s>]/i.test(html), `<form> must be removed entirely (got: ${html})`);
+        assert.ok(!/action\s*=/.test(html), `no action= attribute should survive (got: ${html})`);
+    });
+
+    it('removes SVG SMIL animation elements that can dynamically assign a javascript: URI (#446 follow-up)', () => {
+        const html = convertMarkdownToHtml(
+            '<svg><a href="#safe"><animate attributeName="href" to="javascript:alert(1)"/>x</a></svg>',
+        );
+        assert.ok(!/<animate[\s/>]/i.test(html), `<animate> must be removed (got: ${html})`);
+    });
+
+    it('removes animateTransform, animateMotion and set elements alongside animate', () => {
+        for (const tag of ['animateTransform', 'animateMotion', 'set']) {
+            const html = convertMarkdownToHtml(`<svg><${tag} attributeName="href" to="javascript:alert(1)"/></svg>`);
+            assert.ok(!new RegExp(`<${tag}[\\s/>]`, 'i').test(html), `<${tag}> must be removed (got: ${html})`);
+        }
     });
 });
 
@@ -578,6 +612,22 @@ describe('processFileList', () => {
         const out = path.join(dir, 'nested', 'deep', 'out.html');
         await processFileList([path.join(dir, 'a.md')], out);
         assert.ok(fs.existsSync(out), 'expected the nested output file to be written');
+    });
+
+    it('escapes an ampersand in a filename in both the TOC entry and the file-title heading (#12)', async () => {
+        // '<'/'>' are illegal in Windows filenames, so this uses '&' -- still
+        // enough to prove escapeHtml() runs on the operator/contributor-supplied
+        // filename before it is interpolated into HTML that skips sanitizeRenderedHtml.
+        const dir = writeTmpDir({ 'Q&A.md': '# Alpha\n\nOne.\n', 'b.md': '# Beta\n\nTwo.\n' });
+        const out = path.join(dir, 'out.html');
+        await processFileList(
+            [path.join(dir, 'Q&A.md'), path.join(dir, 'b.md')],
+            out,
+            { addSections: true },
+        );
+        const html = fs.readFileSync(out, 'utf8');
+        assert.ok(!html.includes('>Q&A<'), `raw ampersand must be escaped (got: ${html})`);
+        assert.ok(html.includes('Q&amp;A'), `expected the escaped filename to appear (got: ${html})`);
     });
 
     it('throws when an input file cannot be converted', async () => {

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/converter.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/converter.ts
@@ -123,7 +123,10 @@ export async function processFrontMatterDriven(
 
         const sectionId = sectionIds.get(incPath);
         if (sectionAnchors && sectionId) {
-            contentBlocks.push(`<section id="${sectionId}">`);
+            // pathToSectionId only replaces '/', '\' and '.' -- a relative include
+            // path containing '"' (illegal in Windows filenames, but valid on
+            // Linux/macOS agents) would otherwise break out of this attribute (#12).
+            contentBlocks.push(`<section id="${escapeHtml(sectionId)}">`);
             contentBlocks.push(incHtml);
             contentBlocks.push('</section>');
         } else {

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/converter.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/converter.ts
@@ -14,6 +14,7 @@ import {
     buildToc,
     rewriteMdLinks,
     pathToSectionId,
+    escapeHtml,
 } from './render';
 import { generateHtmlDocument } from './document';
 
@@ -171,7 +172,10 @@ export async function processFileList(
         for (let i = 0; i < inputFiles.length; i++) {
             const fileName = path.basename(inputFiles[i]);
             const fileId = `file-${i + 1}`;
-            toc.push(`<li><a href="#${fileId}">${fileName}</a></li>`);
+            // fileId is always the safe, machine-generated `file-N`; fileName is an
+            // operator/contributor-supplied filename and must be escaped -- this TOC
+            // entry is never passed through sanitizeRenderedHtml (#12).
+            toc.push(`<li><a href="#${fileId}">${escapeHtml(fileName)}</a></li>`);
             fileTitles.push({ id: fileId, name: fileName });
         }
         toc.push('</ul>', '</div>');
@@ -190,7 +194,8 @@ export async function processFileList(
 
         if (addSections) {
             const { id: fileId, name: fileName } = fileTitles[i] ?? { id: `file-${i + 1}`, name: path.basename(filePath) };
-            contentBlocks.push(`<h2 id="${fileId}" class="file-title">${fileName}</h2>`);
+            // fileName is escaped for the same reason as the TOC entry above (#12).
+            contentBlocks.push(`<h2 id="${fileId}" class="file-title">${escapeHtml(fileName)}</h2>`);
         }
 
         const htmlContent = convertMarkdownToHtml(markdownContent);

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
@@ -104,17 +104,19 @@ export function convertMarkdownToHtml(text: string): string {
  */
 export function sanitizeRenderedHtml(html: string): string {
     const $ = cheerio.load(html, { xmlMode: false });
-    // Remove executable / embedding elements outright.
-    $('script, iframe, object, embed, noscript').remove();
-    // <form> has no legitimate use in a KB article fragment, and an
-    // action="javascript:..." attribute is otherwise a blocklist-fragile
-    // per-attribute check (#446 follow-up). SVG SMIL animation elements
-    // (animate/animateColor/animateTransform/animateMotion/set) can
-    // dynamically assign a javascript: URI into a referenced attribute (e.g.
-    // an <a>'s href) at runtime via their to/from/values attributes, a vector
-    // a static attribute-value scan cannot catch -- drop them outright too.
-    // DANGEROUS_TAGS is the shared, byte-identity-gated set (uri-scheme-guard.ts)
-    // also used by PublishKbArticle's validateHtmlContent gate.
+    // Remove executable / embedding elements (script/iframe/object/embed/
+    // noscript) outright. <form> has no legitimate use in a KB article
+    // fragment, and an action="javascript:..." attribute is otherwise a
+    // blocklist-fragile per-attribute check (#446 follow-up). SVG SMIL
+    // animation elements (animate/animateColor/animateTransform/
+    // animateMotion/set) can dynamically assign a javascript: URI into a
+    // referenced attribute (e.g. an <a>'s href) at runtime via their
+    // to/from/values attributes, a vector a static attribute-value scan
+    // cannot catch -- drop them outright too. DANGEROUS_TAGS is the shared,
+    // byte-identity-gated set (uri-scheme-guard.ts) also used by
+    // PublishKbArticle's validateHtmlContent gate -- keeping this single set
+    // shared (rather than a separately-hand-typed CSS selector here) is what
+    // keeps the two layers from drifting on which elements are dangerous.
     $('*').filter((_, el) => DANGEROUS_TAGS.has(($(el).prop('tagName') ?? '').toLowerCase())).remove();
     // <base> can redirect every relative URL in the document; not needed in a
     // KB article fragment, so drop it outright rather than trying to validate it.

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
@@ -8,7 +8,7 @@ import path = require('path');
 import MarkdownIt = require('markdown-it');
 import * as cheerio from 'cheerio';
 import hljs from 'highlight.js';
-import { normalizeUriForSchemeCheck, isDangerousUriScheme, isDangerousMetaRefresh, URI_BEARING_ATTRIBUTES } from './uri-scheme-guard';
+import { normalizeUriForSchemeCheck, isDangerousUriScheme, isDangerousMetaRefresh, URI_BEARING_ATTRIBUTES, DANGEROUS_TAGS } from './uri-scheme-guard';
 
 // ---------------------------------------------------------------------------
 // preprocessMarkdown
@@ -109,16 +109,12 @@ export function sanitizeRenderedHtml(html: string): string {
     // <form> has no legitimate use in a KB article fragment, and an
     // action="javascript:..." attribute is otherwise a blocklist-fragile
     // per-attribute check (#446 follow-up). SVG SMIL animation elements
-    // (animate/animateTransform/animateMotion/set) can dynamically assign a
-    // javascript: URI into a referenced attribute (e.g. an <a>'s href) at
-    // runtime via their to/from/values attributes, a vector a static
-    // attribute-value scan cannot catch -- drop them outright too. Matched by
-    // tagName rather than a CSS tag selector: per the HTML5 foreign-content
-    // parsing algorithm, cheerio/parse5 preserves the SVG spec's camelCase
-    // spelling for animateTransform/animateMotion (unlike ordinary HTML tags,
-    // which are lower-cased), and a css-select tag selector does not match
-    // these foreign-namespaced nodes by name in either case (verified empirically).
-    const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatetransform', 'animatemotion', 'set']);
+    // (animate/animateColor/animateTransform/animateMotion/set) can
+    // dynamically assign a javascript: URI into a referenced attribute (e.g.
+    // an <a>'s href) at runtime via their to/from/values attributes, a vector
+    // a static attribute-value scan cannot catch -- drop them outright too.
+    // DANGEROUS_TAGS is the shared, byte-identity-gated set (uri-scheme-guard.ts)
+    // also used by PublishKbArticle's validateHtmlContent gate.
     $('*').filter((_, el) => DANGEROUS_TAGS.has(($(el).prop('tagName') ?? '').toLowerCase())).remove();
     // <base> can redirect every relative URL in the document; not needed in a
     // KB article fragment, so drop it outright rather than trying to validate it.
@@ -229,12 +225,17 @@ export function buildToc(html: string): TocResult {
         const tagName = $el.prop('tagName') ?? '';
         const level = parseInt(tagName.slice(1), 10);
         const indent = '  '.repeat(level - 1);
-        // hid is a slug ([\w-]+ only, see above) so it is always attribute-safe;
-        // text is the raw heading content and MUST be escaped -- this TOC block is
-        // built from html that has ALREADY been through sanitizeRenderedHtml, so an
-        // unescaped heading (e.g. from a code span containing a tag) would
-        // reintroduce live markup after the sanitizer already ran (#12).
-        tocItems.push(`${indent}<li><a href="#${hid}">${escapeHtml(text)}</a></li>`);
+        // hid is EITHER a computed slug ([\w-]+ only, attribute-safe) OR an
+        // author-supplied raw `id` attribute from the source HTML (markdown-it
+        // runs with html:true, so a heading like `<h2 id='a"><iframe ...'>` is
+        // possible) -- cheerio's .attr('id') decodes it just like .text() decodes
+        // heading content, so it is NOT safe to assume attribute-clean. Escaping
+        // it here closes an href="#..." attribute-breakout that a raw id would
+        // otherwise reopen; text is the raw heading content and separately MUST be
+        // escaped for the same reason -- this TOC block is built from html that
+        // has ALREADY been through sanitizeRenderedHtml, so either unescaped value
+        // would reintroduce live markup after the sanitizer already ran (#12).
+        tocItems.push(`${indent}<li><a href="#${escapeHtml(hid)}">${escapeHtml(text)}</a></li>`);
     }
 
     const toc =

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/render.ts
@@ -47,7 +47,7 @@ export function preprocessMarkdown(text: string): string {
  * <pre><code class="hljs ...">…</code></pre>. Falls back to escaped plain text
  * when the language is unknown or highlighting throws.
  */
-function escapeHtml(s: string): string {
+export function escapeHtml(s: string): string {
     return s
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -106,6 +106,20 @@ export function sanitizeRenderedHtml(html: string): string {
     const $ = cheerio.load(html, { xmlMode: false });
     // Remove executable / embedding elements outright.
     $('script, iframe, object, embed, noscript').remove();
+    // <form> has no legitimate use in a KB article fragment, and an
+    // action="javascript:..." attribute is otherwise a blocklist-fragile
+    // per-attribute check (#446 follow-up). SVG SMIL animation elements
+    // (animate/animateTransform/animateMotion/set) can dynamically assign a
+    // javascript: URI into a referenced attribute (e.g. an <a>'s href) at
+    // runtime via their to/from/values attributes, a vector a static
+    // attribute-value scan cannot catch -- drop them outright too. Matched by
+    // tagName rather than a CSS tag selector: per the HTML5 foreign-content
+    // parsing algorithm, cheerio/parse5 preserves the SVG spec's camelCase
+    // spelling for animateTransform/animateMotion (unlike ordinary HTML tags,
+    // which are lower-cased), and a css-select tag selector does not match
+    // these foreign-namespaced nodes by name in either case (verified empirically).
+    const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatetransform', 'animatemotion', 'set']);
+    $('*').filter((_, el) => DANGEROUS_TAGS.has(($(el).prop('tagName') ?? '').toLowerCase())).remove();
     // <base> can redirect every relative URL in the document; not needed in a
     // KB article fragment, so drop it outright rather than trying to validate it.
     $('base').remove();
@@ -215,7 +229,12 @@ export function buildToc(html: string): TocResult {
         const tagName = $el.prop('tagName') ?? '';
         const level = parseInt(tagName.slice(1), 10);
         const indent = '  '.repeat(level - 1);
-        tocItems.push(`${indent}<li><a href="#${hid}">${text}</a></li>`);
+        // hid is a slug ([\w-]+ only, see above) so it is always attribute-safe;
+        // text is the raw heading content and MUST be escaped -- this TOC block is
+        // built from html that has ALREADY been through sanitizeRenderedHtml, so an
+        // unescaped heading (e.g. from a code span containing a tag) would
+        // reintroduce live markup after the sanitizer already ran (#12).
+        tocItems.push(`${indent}<li><a href="#${hid}">${escapeHtml(text)}</a></li>`);
     }
 
     const toc =

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
@@ -15,6 +15,23 @@
 export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction', 'action']);
 
 /**
+ * Element (tag) names rejected outright by both layers: <form> has no
+ * legitimate use in a KB article fragment and an action="javascript:..."
+ * attribute is otherwise a blocklist-fragile per-attribute check (#446
+ * follow-up); the SVG SMIL animation elements (animate/animateColor/
+ * animateTransform/animateMotion/set) can dynamically assign a javascript:
+ * URI into a referenced attribute (e.g. an <a>'s href) at RUNTIME via their
+ * to/from/values attributes, a vector the static attribute-value scan above
+ * cannot catch. Lower-cased tag names -- match by comparing a lower-cased
+ * tagName, NOT a CSS tag selector: per the HTML5 foreign-content parsing
+ * algorithm, cheerio/parse5 preserves the SVG spec's camelCase spelling for
+ * animateColor/animateTransform/animateMotion (unlike ordinary HTML tags,
+ * which are lower-cased), and a css-select tag selector does not match these
+ * foreign-namespaced nodes by name in either case (verified empirically).
+ */
+export const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatecolor', 'animatetransform', 'animatemotion', 'set']);
+
+/**
  * Normalizes an attribute value before a URI-scheme check. Browsers (per the
  * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
  * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
@@ -15,21 +15,28 @@
 export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction', 'action']);
 
 /**
- * Element (tag) names rejected outright by both layers: <form> has no
- * legitimate use in a KB article fragment and an action="javascript:..."
- * attribute is otherwise a blocklist-fragile per-attribute check (#446
- * follow-up); the SVG SMIL animation elements (animate/animateColor/
- * animateTransform/animateMotion/set) can dynamically assign a javascript:
- * URI into a referenced attribute (e.g. an <a>'s href) at RUNTIME via their
- * to/from/values attributes, a vector the static attribute-value scan above
- * cannot catch. Lower-cased tag names -- match by comparing a lower-cased
- * tagName, NOT a CSS tag selector: per the HTML5 foreign-content parsing
- * algorithm, cheerio/parse5 preserves the SVG spec's camelCase spelling for
- * animateColor/animateTransform/animateMotion (unlike ordinary HTML tags,
- * which are lower-cased), and a css-select tag selector does not match these
- * foreign-namespaced nodes by name in either case (verified empirically).
+ * Element (tag) names rejected outright by both layers: <script>/<iframe>/
+ * <object>/<embed>/<noscript> are executable/embedding elements with no
+ * legitimate use in a KB article fragment; <form> likewise has none, and an
+ * action="javascript:..." attribute is otherwise a blocklist-fragile
+ * per-attribute check (#446 follow-up); the SVG SMIL animation elements
+ * (animate/animateColor/animateTransform/animateMotion/set) can dynamically
+ * assign a javascript: URI into a referenced attribute (e.g. an <a>'s href)
+ * at RUNTIME via their to/from/values attributes, a vector the static
+ * attribute-value scan above cannot catch. Lower-cased tag names -- match by
+ * comparing a lower-cased tagName, NOT a CSS tag selector: per the HTML5
+ * foreign-content parsing algorithm, cheerio/parse5 preserves the SVG spec's
+ * camelCase spelling for animateColor/animateTransform/animateMotion (unlike
+ * ordinary HTML tags, which are lower-cased), and a css-select tag selector
+ * does not match these foreign-namespaced nodes by name in either case
+ * (verified empirically). Before this set covered iframe/object/embed/
+ * noscript, PublishKbArticle's validateHtmlContent() gate never rejected them
+ * at all -- only Markdown2Html's render-time sanitizer stripped them -- so
+ * HTML supplied directly via the htmlFile input (bypassing Markdown2Html
+ * entirely) could carry a live <iframe srcdoc="..."> or <object data="...">
+ * straight past the fail-closed gate.
  */
-export const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatecolor', 'animatetransform', 'animatemotion', 'set']);
+export const DANGEROUS_TAGS = new Set(['script', 'iframe', 'object', 'embed', 'noscript', 'form', 'animate', 'animatecolor', 'animatetransform', 'animatemotion', 'set']);
 
 /**
  * Normalizes an attribute value before a URI-scheme check. Browsers (per the

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/uri-scheme-guard.ts
@@ -12,7 +12,7 @@
  */
 
 /** Attribute names that can carry a URI capable of triggering navigation or resource loading. */
-export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction']);
+export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction', 'action']);
 
 /**
  * Normalizes an attribute value before a URI-scheme check. Browsers (per the

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "4",
+        "Minor": "5",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Strings/resources.resjson/en-US/resources.resjson
@@ -11,6 +11,7 @@
   "loc.messages.ExternalScriptNotAllowed": "External script sources are not allowed in KB articles",
   "loc.messages.InlineScriptNotAllowed": "Inline <script> elements are not allowed in KB articles",
   "loc.messages.BaseOrMetaRefreshNotAllowed": "<base> elements and <meta http-equiv=\"refresh\"> redirects to javascript:/vbscript: are not allowed in KB articles",
+  "loc.messages.FormOrSvgAnimationNotAllowed": "<form> elements and SVG SMIL animation elements (animate/animateTransform/animateMotion/set) are not allowed in KB articles",
   "loc.messages.EventHandlerNotAllowed": "Inline event-handler attributes (on*) are not allowed in KB articles",
   "loc.messages.DangerousUriNotAllowed": "javascript:, vbscript: and non-image data: URIs are not allowed in KB articles",
   "loc.messages.HtmlFileNotFound": "File '%s' not found.",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Strings/resources.resjson/en-US/resources.resjson
@@ -11,7 +11,7 @@
   "loc.messages.ExternalScriptNotAllowed": "External script sources are not allowed in KB articles",
   "loc.messages.InlineScriptNotAllowed": "Inline <script> elements are not allowed in KB articles",
   "loc.messages.BaseOrMetaRefreshNotAllowed": "<base> elements and <meta http-equiv=\"refresh\"> redirects to javascript:/vbscript: are not allowed in KB articles",
-  "loc.messages.FormOrSvgAnimationNotAllowed": "<form> elements and SVG SMIL animation elements (animate/animateTransform/animateMotion/set) are not allowed in KB articles",
+  "loc.messages.FormOrSvgAnimationNotAllowed": "<iframe>/<object>/<embed>/<noscript>, <form>, and SVG SMIL animation elements (animate/animateTransform/animateMotion/set) are not allowed in KB articles",
   "loc.messages.EventHandlerNotAllowed": "Inline event-handler attributes (on*) are not allowed in KB articles",
   "loc.messages.DangerousUriNotAllowed": "javascript:, vbscript: and non-image data: URIs are not allowed in KB articles",
   "loc.messages.HtmlFileNotFound": "File '%s' not found.",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -297,6 +297,21 @@ describe('client.createKnowledgeArticle', () => {
         );
         assert.strictEqual(capturedBody['workflow_state'], 'published');
     });
+
+    it('#372/#29: throws a clear error instead of a generic TypeError when a 2xx response is not a JSON article object', async () => {
+        // Mirrors servicenow-http.ts's documented fallback: a non-JSON 2xx body
+        // (e.g. a corporate proxy/WAF returning an HTML page) parses to `data = {}`,
+        // so `result` is undefined -- this must be a clear ArticleNotObject error,
+        // not an unguarded `undefined.sys_id` crash further up the call chain.
+        nock(BASE_URL)
+            .post('/api/now/table/kb_knowledge')
+            .reply(200, '<html>Not the ServiceNow API you expected</html>');
+
+        await assert.rejects(
+            () => client.createKnowledgeArticle(INSTANCE, HEADERS, 'kb123', 'Title', '<p>HTML</p>', 'author'),
+            /no article object in "result"|ArticleNotObject/,
+        );
+    });
 });
 
 // ===========================================================================
@@ -317,6 +332,17 @@ describe('client.getArticle', () => {
 
         const found = await client.getArticle(INSTANCE, HEADERS, 'a/b');
         assert.strictEqual(found.sys_id, 'a/b');
+    });
+
+    it('#372/#29: throws a clear error instead of a generic TypeError when a 2xx response is not a JSON article object', async () => {
+        nock(BASE_URL)
+            .get('/api/now/table/kb_knowledge/art_missing')
+            .reply(200, '<html>Not the ServiceNow API you expected</html>');
+
+        await assert.rejects(
+            () => client.getArticle(INSTANCE, HEADERS, 'art_missing'),
+            /no article object in "result"|ArticleNotObject/,
+        );
     });
 });
 
@@ -397,6 +423,27 @@ describe('client.updateKnowledgeArticle', () => {
             undefined, undefined, undefined, 'key1',
         );
         assert.strictEqual(patchedBody['meta_description'], 'wiki-source: key1');
+    });
+
+    it('#372/#29: throws a clear error instead of a generic TypeError when a 2xx PATCH response is not a JSON article object', async () => {
+        const existingArticle = {
+            sys_id: 'art_004',
+            number: 'KB0013',
+            short_description: 'Title',
+            workflow_state: 'draft',
+            kb_knowledge_base: 'kb123',
+        };
+        nock(BASE_URL)
+            .get('/api/now/table/kb_knowledge/art_004')
+            .reply(200, { result: existingArticle });
+        nock(BASE_URL)
+            .patch('/api/now/table/kb_knowledge/art_004')
+            .reply(200, '<html>Not the ServiceNow API you expected</html>');
+
+        await assert.rejects(
+            () => client.updateKnowledgeArticle(INSTANCE, HEADERS, 'art_004', 'New Title'),
+            /no article object in "result"|ArticleNotObject/,
+        );
     });
 });
 
@@ -566,6 +613,18 @@ describe('client.changeWorkflowState', () => {
         const article = await client.changeWorkflowState(INSTANCE, HEADERS, articleId, 'draft');
         assert.strictEqual(article.workflow_state, 'draft');
     });
+
+    it('#372/#29: throws a clear error instead of a generic TypeError when a 2xx response is not a JSON article object', async () => {
+        const articleId = 'pub_art_002';
+        nock(BASE_URL)
+            .patch(`/api/now/table/kb_knowledge/${articleId}`)
+            .reply(200, '<html>Not the ServiceNow API you expected</html>');
+
+        await assert.rejects(
+            () => client.changeWorkflowState(INSTANCE, HEADERS, articleId, 'publish'),
+            /no article object in "result"|ArticleNotObject/,
+        );
+    });
 });
 
 // ===========================================================================
@@ -690,6 +749,41 @@ describe('htmlValidate.validateHtmlContent', () => {
         );
     });
 
+    it('throws on a <form> element when force=false (#446 follow-up: form action="javascript:..." blocklist gap)', () => {
+        const html = '<html><body><form action="javascript:alert(1)"><button>Submit</button></form></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /<form> elements and SVG SMIL animation elements|FormOrSvgAnimationNotAllowed/,
+        );
+    });
+
+    it('throws on a <form> element even when force=true (#446: force no longer bypasses XSS checks)', () => {
+        const html = '<html><body><form action="https://example.com/submit"><button>Submit</button></form></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /<form> elements and SVG SMIL animation elements|FormOrSvgAnimationNotAllowed/,
+        );
+    });
+
+    it('throws on an SVG SMIL <animate> element that could reassign href to a javascript: URI (#446 follow-up)', () => {
+        const html = '<html><body><svg><a href="#safe"><animate attributeName="href" to="javascript:alert(1)"/>x</a></svg></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /<form> elements and SVG SMIL animation elements|FormOrSvgAnimationNotAllowed/,
+        );
+    });
+
+    it('throws on animateTransform, animateMotion and set elements alongside animate', () => {
+        for (const tag of ['animateTransform', 'animateMotion', 'set']) {
+            const html = `<html><body><svg><${tag} attributeName="href" to="javascript:alert(1)"/></svg></body></html>`;
+            assert.throws(
+                () => htmlValidate.validateHtmlContent(html, false),
+                /<form> elements and SVG SMIL animation elements|FormOrSvgAnimationNotAllowed/,
+                `expected a throw for <${tag}>`,
+            );
+        }
+    });
+
     it('throws on a data:image/svg+xml URI even on an <img> element (an SVG document can embed active content, unlike a raster format)', () => {
         const html = '<html><body><img src="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+"></body></html>';
         assert.throws(
@@ -705,7 +799,10 @@ describe('htmlValidate.validateHtmlContent', () => {
             /data: URIs are not allowed|DangerousUriNotAllowed/,
         );
 
-        const formHtml = '<html><body><form><button formaction="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</button></form></body></html>';
+        // Not wrapped in <form>: this specifically tests the formaction
+        // attribute check (a standalone <button> is valid HTML), independent
+        // of the separate <form>-element rejection covered above.
+        const formHtml = '<html><body><button formaction="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">x</button></body></html>';
         assert.throws(
             () => htmlValidate.validateHtmlContent(formHtml, false),
             /data: URIs are not allowed|DangerousUriNotAllowed/,

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -788,6 +788,40 @@ describe('htmlValidate.validateHtmlContent', () => {
         );
     });
 
+    it('throws on an <iframe srcdoc="..."> that was never checked (final review: the gate never rejected iframe/object/embed/noscript before)', () => {
+        // Untrusted HTML supplied directly via the htmlFile input bypasses
+        // Markdown2Html's render-time sanitizer entirely -- this fail-closed
+        // gate must reject iframe/object/embed/noscript on its own, not rely on
+        // the upstream sanitizer having already stripped them.
+        const html = '<html><body><iframe srcdoc="<img src=x onerror=alert(1)>"></iframe></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, false),
+            /<iframe>\/<object>\/<embed>\/<noscript>|FormOrSvgAnimationNotAllowed/,
+        );
+    });
+
+    it('throws on <object>/<embed>/<noscript> elements alongside iframe', () => {
+        for (const html of [
+            '<html><body><object data="javascript:alert(1)"></object></body></html>',
+            '<html><body><embed src="javascript:alert(1)"></embed></body></html>',
+            '<html><body><noscript><img src=x onerror=alert(1)></noscript></body></html>',
+        ]) {
+            assert.throws(
+                () => htmlValidate.validateHtmlContent(html, false),
+                /<iframe>\/<object>\/<embed>\/<noscript>|FormOrSvgAnimationNotAllowed/,
+                `expected a throw for: ${html}`,
+            );
+        }
+    });
+
+    it('throws on an <iframe> even when force=true (#446: force no longer bypasses XSS checks)', () => {
+        const html = '<html><body><iframe srcdoc="<img src=x onerror=alert(1)>"></iframe></body></html>';
+        assert.throws(
+            () => htmlValidate.validateHtmlContent(html, true),
+            /<iframe>\/<object>\/<embed>\/<noscript>|FormOrSvgAnimationNotAllowed/,
+        );
+    });
+
     it('throws on a <form> element when force=false (#446 follow-up: form action="javascript:..." blocklist gap)', () => {
         const html = '<html><body><form action="javascript:alert(1)"><button>Submit</button></form></body></html>';
         assert.throws(

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -489,6 +489,45 @@ describe('client.findArticleBySourceKey', () => {
             /Key collision|SourceKeyCollision/,
         );
     });
+
+    it('#372/#29 follow-up: returns null (not a TypeError) when a 2xx response is not a JSON array', async () => {
+        // servicenow-http.ts defaults a non-JSON 2xx body to `data = {}` -- an
+        // object, not an array. The old `(result || [])` cast kept the truthy
+        // object and crashed on results[0]; Array.isArray must reject it to [].
+        nock(BASE_URL)
+            .get('/api/now/table/kb_knowledge')
+            .query(true)
+            .reply(200, '<html>Not the ServiceNow API you expected</html>');
+
+        const id = await client.findArticleBySourceKey(INSTANCE, HEADERS, 'my-key');
+        assert.strictEqual(id, null);
+    });
+});
+
+// ===========================================================================
+// servicenow-client — getKbCategories
+// ===========================================================================
+describe('client.getKbCategories', () => {
+    it('returns the category list', async () => {
+        nock(BASE_URL)
+            .get('/api/now/table/kb_category')
+            .query(true)
+            .reply(200, { result: [{ sys_id: 'cat1', label: 'General' }] });
+
+        const categories = await client.getKbCategories(INSTANCE, HEADERS, 'kb123');
+        assert.strictEqual(categories.length, 1);
+        assert.strictEqual(categories[0].label, 'General');
+    });
+
+    it('returns an empty array (not a crash) when a 2xx response is not a JSON array', async () => {
+        nock(BASE_URL)
+            .get('/api/now/table/kb_category')
+            .query(true)
+            .reply(200, '<html>Not the ServiceNow API you expected</html>');
+
+        const categories = await client.getKbCategories(INSTANCE, HEADERS, 'kb123');
+        assert.deepStrictEqual(categories, []);
+    });
 });
 
 // ===========================================================================
@@ -773,8 +812,8 @@ describe('htmlValidate.validateHtmlContent', () => {
         );
     });
 
-    it('throws on animateTransform, animateMotion and set elements alongside animate', () => {
-        for (const tag of ['animateTransform', 'animateMotion', 'set']) {
+    it('throws on animateTransform, animateMotion, animateColor and set elements alongside animate', () => {
+        for (const tag of ['animateTransform', 'animateMotion', 'animateColor', 'set']) {
             const html = `<html><body><svg><${tag} attributeName="href" to="javascript:alert(1)"/></svg></body></html>`;
             assert.throws(
                 () => htmlValidate.validateHtmlContent(html, false),

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
@@ -72,6 +72,28 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
         throw new Error(tasks.loc('BaseOrMetaRefreshNotAllowed'));
     }
 
+    // Reject <form> (no legitimate use in a KB article; an action="javascript:..."
+    // attribute is otherwise a blocklist-fragile per-element check) and SVG SMIL
+    // animation elements (animate/animateTransform/animateMotion/set), which can
+    // dynamically assign a javascript: URI into a referenced attribute (e.g. an
+    // <a>'s href) via their to/from/values attributes at runtime — a vector the
+    // static attribute-value scan below never sees (#446 follow-up). Matched by
+    // tagName rather than a CSS tag selector: per the HTML5 foreign-content
+    // parsing algorithm, cheerio/parse5 preserves the SVG spec's camelCase
+    // spelling for animateTransform/animateMotion (unlike ordinary HTML tags,
+    // which are lower-cased), and a css-select tag selector does not match
+    // these foreign-namespaced nodes by name in either case (verified empirically).
+    const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatetransform', 'animatemotion', 'set']);
+    let formOrSvgAnimationFound = false;
+    $('*').each((_, el) => {
+        if (DANGEROUS_TAGS.has(($(el).prop('tagName') ?? '').toLowerCase())) {
+            formOrSvgAnimationFound = true;
+        }
+    });
+    if (formOrSvgAnimationFound) {
+        throw new Error(tasks.loc('FormOrSvgAnimationNotAllowed'));
+    }
+
     // Reject inline event-handler attributes (onerror=, onload=, onclick=, …)
     // and javascript:/vbscript:/non-image data: URIs — stored-XSS vectors the
     // external <script src> check above does not cover.

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
@@ -72,21 +72,28 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
         throw new Error(tasks.loc('BaseOrMetaRefreshNotAllowed'));
     }
 
-    // Reject <form> (no legitimate use in a KB article; an action="javascript:..."
-    // attribute is otherwise a blocklist-fragile per-element check) and SVG SMIL
-    // animation elements (animate/animateColor/animateTransform/animateMotion/set),
-    // which can dynamically assign a javascript: URI into a referenced attribute
-    // (e.g. an <a>'s href) via their to/from/values attributes at runtime — a
-    // vector the static attribute-value scan below never sees (#446 follow-up).
-    // DANGEROUS_TAGS is the shared, byte-identity-gated set (uri-scheme-guard.ts)
-    // also used by Markdown2Html's render-time sanitizeRenderedHtml.
-    let formOrSvgAnimationFound = false;
+    // Reject executable/embedding elements (<iframe>/<object>/<embed>/
+    // <noscript> -- the <script> checks above already cover <script>),
+    // <form> (no legitimate use in a KB article; an action="javascript:..."
+    // attribute is otherwise a blocklist-fragile per-element check), and SVG
+    // SMIL animation elements (animate/animateColor/animateTransform/
+    // animateMotion/set), which can dynamically assign a javascript: URI into
+    // a referenced attribute (e.g. an <a>'s href) via their to/from/values
+    // attributes at runtime — a vector the static attribute-value scan below
+    // never sees (#446 follow-up). Before iframe/object/embed/noscript were
+    // added here, this fail-closed gate never rejected them at all -- only
+    // Markdown2Html's render-time sanitizer stripped them -- so HTML supplied
+    // directly via the htmlFile input (bypassing Markdown2Html entirely)
+    // could carry a live <iframe srcdoc="..."> past the gate. DANGEROUS_TAGS
+    // is the shared, byte-identity-gated set (uri-scheme-guard.ts) also used
+    // by Markdown2Html's render-time sanitizeRenderedHtml.
+    let dangerousTagFound = false;
     $('*').each((_, el) => {
         if (DANGEROUS_TAGS.has(($(el).prop('tagName') ?? '').toLowerCase())) {
-            formOrSvgAnimationFound = true;
+            dangerousTagFound = true;
         }
     });
-    if (formOrSvgAnimationFound) {
+    if (dangerousTagFound) {
         throw new Error(tasks.loc('FormOrSvgAnimationNotAllowed'));
     }
 

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/html-validate.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { load } from 'cheerio';
-import { normalizeUriForSchemeCheck, isDangerousUriScheme, isDangerousMetaRefresh, URI_BEARING_ATTRIBUTES } from './uri-scheme-guard';
+import { normalizeUriForSchemeCheck, isDangerousUriScheme, isDangerousMetaRefresh, URI_BEARING_ATTRIBUTES, DANGEROUS_TAGS } from './uri-scheme-guard';
 import tasks = require('azure-pipelines-task-lib/task');
 
 /**
@@ -74,16 +74,12 @@ export function validateHtmlContent(html: string, force: boolean = false): void 
 
     // Reject <form> (no legitimate use in a KB article; an action="javascript:..."
     // attribute is otherwise a blocklist-fragile per-element check) and SVG SMIL
-    // animation elements (animate/animateTransform/animateMotion/set), which can
-    // dynamically assign a javascript: URI into a referenced attribute (e.g. an
-    // <a>'s href) via their to/from/values attributes at runtime — a vector the
-    // static attribute-value scan below never sees (#446 follow-up). Matched by
-    // tagName rather than a CSS tag selector: per the HTML5 foreign-content
-    // parsing algorithm, cheerio/parse5 preserves the SVG spec's camelCase
-    // spelling for animateTransform/animateMotion (unlike ordinary HTML tags,
-    // which are lower-cased), and a css-select tag selector does not match
-    // these foreign-namespaced nodes by name in either case (verified empirically).
-    const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatetransform', 'animatemotion', 'set']);
+    // animation elements (animate/animateColor/animateTransform/animateMotion/set),
+    // which can dynamically assign a javascript: URI into a referenced attribute
+    // (e.g. an <a>'s href) via their to/from/values attributes at runtime — a
+    // vector the static attribute-value scan below never sees (#446 follow-up).
+    // DANGEROUS_TAGS is the shared, byte-identity-gated set (uri-scheme-guard.ts)
+    // also used by Markdown2Html's render-time sanitizeRenderedHtml.
     let formOrSvgAnimationFound = false;
     $('*').each((_, el) => {
         if (DANGEROUS_TAGS.has(($(el).prop('tagName') ?? '').toLowerCase())) {

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -30,6 +30,20 @@ export function baseUrl(instance: string): string {
     return `https://${instance}.service-now.com`;
 }
 
+/**
+ * Validate that a ServiceNow Table API response's `result` is a single record
+ * object (not undefined/null/an array), narrowing it to KbArticle. servicenow-http.ts
+ * silently defaults the parsed body to `{}` when a 2xx response fails JSON.parse
+ * (e.g. a corporate proxy/WAF intercepting the request and returning 200 with an
+ * HTML page), which would otherwise flow through as `undefined` result and crash
+ * the caller with a generic TypeError instead of a clear, actionable diagnostic.
+ */
+function assertArticleResult(result: unknown, context: string): asserts result is KbArticle {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) {
+        throw new Error(tasks.loc('ArticleNotObject', context));
+    }
+}
+
 /** Retrieve all knowledge bases. */
 export async function getKnowledgeBases(instance: string, headers: Record<string, string>): Promise<unknown[]> {
     const url = `${baseUrl(instance)}/api/now/table/kb_knowledge_base`;
@@ -48,10 +62,8 @@ export async function getArticle(instance: string, headers: Record<string, strin
     const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
     const response = await snRequest('GET', url, { headers });
     const result = response.data.result;
-    if (!result || typeof result !== 'object' || Array.isArray(result)) {
-        throw new Error(tasks.loc('ArticleNotObject', articleId));
-    }
-    return result as KbArticle;
+    assertArticleResult(result, articleId);
+    return result;
 }
 
 /**
@@ -118,7 +130,8 @@ export async function createKnowledgeArticle(
     const response = await withRetry(() => snRequest('POST', url, { headers, body: payload }), {
         log: (message) => console.log(`[WARN] ${message}`),
     });
-    return response.data.result as KbArticle;
+    assertArticleResult(response.data.result, title);
+    return response.data.result;
 }
 
 /** Update an existing knowledge base article. */
@@ -180,7 +193,8 @@ export async function updateKnowledgeArticle(
     const response = await withRetry(() => snRequest('PATCH', url, { headers, body: payload }), {
         log: (message) => console.log(`[WARN] ${message}`),
     });
-    return response.data.result as KbArticle;
+    assertArticleResult(response.data.result, articleId);
+    return response.data.result;
 }
 
 /**
@@ -230,7 +244,8 @@ export async function changeWorkflowState(
     }), {
         log: (message) => console.log(`[WARN] ${message}`),
     });
-    return response.data.result as KbArticle;
+    assertArticleResult(response.data.result, articleId);
+    return response.data.result;
 }
 
 /** Retrieve knowledge categories, optionally filtered by KB. */

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -261,7 +261,7 @@ export async function getKbCategories(
         params['sysparm_query'] = `kb_knowledge_base=${kbId}`;
     }
     const response = await snRequest('GET', url, { headers, params });
-    return response.data.result as KbCategory[];
+    return Array.isArray(response.data.result) ? (response.data.result as KbCategory[]) : [];
 }
 
 /** Create a new category (or subcategory) in the given knowledge base. */
@@ -390,7 +390,12 @@ export async function findArticleBySourceKey(
     };
 
     const response = await snRequest('GET', url, { headers, params });
-    const results = (response.data.result || []) as KbArticle[];
+    // Array.isArray guard (not a bare cast): the same 2xx-non-JSON-body fallback
+    // documented on assertArticleResult applies here -- a malformed response's
+    // data defaults to `{}`, which is truthy, so `results || []` alone would keep
+    // the object and crash on `results[0]` (#372/#29 follow-up; matches the
+    // existing pattern in findOrCreateCategory below).
+    const results = Array.isArray(response.data.result) ? (response.data.result as KbArticle[]) : [];
 
     if (results.length === 0) return null;
 

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
@@ -15,6 +15,23 @@
 export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction', 'action']);
 
 /**
+ * Element (tag) names rejected outright by both layers: <form> has no
+ * legitimate use in a KB article fragment and an action="javascript:..."
+ * attribute is otherwise a blocklist-fragile per-attribute check (#446
+ * follow-up); the SVG SMIL animation elements (animate/animateColor/
+ * animateTransform/animateMotion/set) can dynamically assign a javascript:
+ * URI into a referenced attribute (e.g. an <a>'s href) at RUNTIME via their
+ * to/from/values attributes, a vector the static attribute-value scan above
+ * cannot catch. Lower-cased tag names -- match by comparing a lower-cased
+ * tagName, NOT a CSS tag selector: per the HTML5 foreign-content parsing
+ * algorithm, cheerio/parse5 preserves the SVG spec's camelCase spelling for
+ * animateColor/animateTransform/animateMotion (unlike ordinary HTML tags,
+ * which are lower-cased), and a css-select tag selector does not match these
+ * foreign-namespaced nodes by name in either case (verified empirically).
+ */
+export const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatecolor', 'animatetransform', 'animatemotion', 'set']);
+
+/**
  * Normalizes an attribute value before a URI-scheme check. Browsers (per the
  * WHATWG URL spec) strip ASCII tab/newline/CR before parsing a URL's scheme,
  * so a naive `value.trim().toLowerCase().startsWith('javascript:')` check can

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
@@ -15,21 +15,28 @@
 export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction', 'action']);
 
 /**
- * Element (tag) names rejected outright by both layers: <form> has no
- * legitimate use in a KB article fragment and an action="javascript:..."
- * attribute is otherwise a blocklist-fragile per-attribute check (#446
- * follow-up); the SVG SMIL animation elements (animate/animateColor/
- * animateTransform/animateMotion/set) can dynamically assign a javascript:
- * URI into a referenced attribute (e.g. an <a>'s href) at RUNTIME via their
- * to/from/values attributes, a vector the static attribute-value scan above
- * cannot catch. Lower-cased tag names -- match by comparing a lower-cased
- * tagName, NOT a CSS tag selector: per the HTML5 foreign-content parsing
- * algorithm, cheerio/parse5 preserves the SVG spec's camelCase spelling for
- * animateColor/animateTransform/animateMotion (unlike ordinary HTML tags,
- * which are lower-cased), and a css-select tag selector does not match these
- * foreign-namespaced nodes by name in either case (verified empirically).
+ * Element (tag) names rejected outright by both layers: <script>/<iframe>/
+ * <object>/<embed>/<noscript> are executable/embedding elements with no
+ * legitimate use in a KB article fragment; <form> likewise has none, and an
+ * action="javascript:..." attribute is otherwise a blocklist-fragile
+ * per-attribute check (#446 follow-up); the SVG SMIL animation elements
+ * (animate/animateColor/animateTransform/animateMotion/set) can dynamically
+ * assign a javascript: URI into a referenced attribute (e.g. an <a>'s href)
+ * at RUNTIME via their to/from/values attributes, a vector the static
+ * attribute-value scan above cannot catch. Lower-cased tag names -- match by
+ * comparing a lower-cased tagName, NOT a CSS tag selector: per the HTML5
+ * foreign-content parsing algorithm, cheerio/parse5 preserves the SVG spec's
+ * camelCase spelling for animateColor/animateTransform/animateMotion (unlike
+ * ordinary HTML tags, which are lower-cased), and a css-select tag selector
+ * does not match these foreign-namespaced nodes by name in either case
+ * (verified empirically). Before this set covered iframe/object/embed/
+ * noscript, PublishKbArticle's validateHtmlContent() gate never rejected them
+ * at all -- only Markdown2Html's render-time sanitizer stripped them -- so
+ * HTML supplied directly via the htmlFile input (bypassing Markdown2Html
+ * entirely) could carry a live <iframe srcdoc="..."> or <object data="...">
+ * straight past the fail-closed gate.
  */
-export const DANGEROUS_TAGS = new Set(['form', 'animate', 'animatecolor', 'animatetransform', 'animatemotion', 'set']);
+export const DANGEROUS_TAGS = new Set(['script', 'iframe', 'object', 'embed', 'noscript', 'form', 'animate', 'animatecolor', 'animatetransform', 'animatemotion', 'set']);
 
 /**
  * Normalizes an attribute value before a URI-scheme check. Browsers (per the

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/uri-scheme-guard.ts
@@ -12,7 +12,7 @@
  */
 
 /** Attribute names that can carry a URI capable of triggering navigation or resource loading. */
-export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction']);
+export const URI_BEARING_ATTRIBUTES = new Set(['href', 'src', 'xlink:href', 'formaction', 'action']);
 
 /**
  * Normalizes an attribute value before a URI-scheme check. Browsers (per the

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -263,7 +263,7 @@
         "ExternalScriptNotAllowed": "External script sources are not allowed in KB articles",
         "InlineScriptNotAllowed": "Inline <script> elements are not allowed in KB articles",
         "BaseOrMetaRefreshNotAllowed": "<base> elements and <meta http-equiv=\"refresh\"> redirects to javascript:/vbscript: are not allowed in KB articles",
-        "FormOrSvgAnimationNotAllowed": "<form> elements and SVG SMIL animation elements (animate/animateTransform/animateMotion/set) are not allowed in KB articles",
+        "FormOrSvgAnimationNotAllowed": "<iframe>/<object>/<embed>/<noscript>, <form>, and SVG SMIL animation elements (animate/animateTransform/animateMotion/set) are not allowed in KB articles",
         "EventHandlerNotAllowed": "Inline event-handler attributes (on*) are not allowed in KB articles",
         "DangerousUriNotAllowed": "javascript:, vbscript: and non-image data: URIs are not allowed in KB articles",
         "HtmlFileNotFound": "File '%s' not found.",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "7",
+        "Minor": "8",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",
@@ -263,6 +263,7 @@
         "ExternalScriptNotAllowed": "External script sources are not allowed in KB articles",
         "InlineScriptNotAllowed": "Inline <script> elements are not allowed in KB articles",
         "BaseOrMetaRefreshNotAllowed": "<base> elements and <meta http-equiv=\"refresh\"> redirects to javascript:/vbscript: are not allowed in KB articles",
+        "FormOrSvgAnimationNotAllowed": "<form> elements and SVG SMIL animation elements (animate/animateTransform/animateMotion/set) are not allowed in KB articles",
         "EventHandlerNotAllowed": "Inline event-handler attributes (on*) are not allowed in KB articles",
         "DangerousUriNotAllowed": "javascript:, vbscript: and non-image data: URIs are not allowed in KB articles",
         "HtmlFileNotFound": "File '%s' not found.",


### PR DESCRIPTION
## Summary

Fixes 4 findings from the 2026-07-14 blind security/quality audit of `main` (`8823a3e`, release 1.9.4) — one active **HIGH** and three **regressed** findings that had previously been closed as fixed — plus everything two rounds of adversarial re-verification and a final broad security review turned up while working the fix.

### The 4 audit findings

| Finding | Severity | Component | Issue |
| --- | --- | --- | --- |
| Post-sanitizer stored-XSS reinjection (`buildToc`/`processFileList`) | **HIGH** (new) | Markdown2Html | none yet (new) |
| Blocklist sanitizer/gate misses `<form action=javascript:>` + SVG SMIL | Medium (**regressed**) | Markdown2Html + PublishKbArticle | #446 |
| Marketplace environment required-reviewer rule not code-verifiable | Info (**regressed**) | CI/CD | #396 |
| ServiceNow response-shape validation missing on write paths | Low (**regressed**) | PublishKbArticle | #372 |

### What adversarial re-verification (2 rounds + a final Opus 4.8 broad review) found and this PR also closes

- `buildToc`'s TOC anchor `hid` and `processFrontMatterDriven`'s `sectionId` were **also** unescaped before HTML-attribute interpolation (author-supplied heading `id`, or a Linux-only include filename) — same attribute-breakout class as the HIGH finding above, missed in the first pass.
- `animateColor` (a real, spec-recognized SVG SMIL element) was missing from the new SVG-SMIL blocklist.
- The blocklist itself was duplicated inline in two files with no CI parity gate — moved into the existing byte-identity-gated `uri-scheme-guard.ts` shared module (alongside `URI_BEARING_ATTRIBUTES`).
- `findArticleBySourceKey` had the *exact same* unguarded-response-shape crash as the 3 functions the #372 fix targeted — missed in the first pass; fixed the same way, matching the correct pattern already used by its sibling `findOrCreateCategory` in the same file. `getKbCategories` got the same guard for consistency.
- A dangling code comment (introduced by this PR) referenced a `legitify` job that only exists in a sibling repo's workflow, not this one — corrected.
- **Final broad review finding:** PublishKbArticle's fail-closed publish gate (`validateHtmlContent`) never rejected `<iframe>`/`<object>`/`<embed>`/`<noscript>` at all — only Markdown2Html's render-time sanitizer stripped them. Since PublishKbArticle accepts HTML directly via its `htmlFile` input (bypassing Markdown2Html entirely), this was a real gate-bypass for the same stored-XSS class. Closed by unifying the full dangerous-element set into the shared module so the two layers can no longer drift.

## Task version bumps

Per `CLAUDE.md`'s mandatory security-fix rule (ADO caches tasks by `Major.Minor`):

- `Markdown2HtmlV1`: `1.4.0` → `1.5.0`
- `PublishKbArticleV1`: `1.7.0` → `1.8.0`

## Testing

- `Markdown2HtmlV1`: 66 passing, 0 failing (`npm test`)
- `PublishKbArticleV1`: 125 passing, 0 failing (`npm test`)
- `node scripts/check-shared-modules.js` — all shared-module parity checks pass (including the newly-shared `DANGEROUS_TAGS`)
- `node scripts/check-minor-bumps.js v1.9.4 HEAD` — both bumps recognized
- `node scripts/check-versions.js` — all versions consistent
- `npm run lint` clean on both tasks
- `.github/workflows/weekly-security.yml` validated with `python3 -c "import yaml..."` and `actionlint`

## Notes for reviewer

- `#446`, `#396`, and `#372` will be commented on (not closed again / not reopened) once this merges, since they're already closed-as-fixed and this PR documents why the fix regressed and how it's now closed more completely.
- Two lower-severity items surfaced during review were deliberately **left out of scope** (tracked separately, not fixed here): both HTML layers still allow `<style>`/`<link>` (CSS-injection/exfil risk, not script execution), and `servicenow-client.ts`'s `createCategory` still uses an older non-crashing-but-silent response-handling pattern.
