### PR TITLE
security: move TerraformPolicyCheck temp outputs to Agent.TempDirectory and verify token masking

### DIFF
--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitShaCheckout.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitShaCheckout.ts
@@ -13,6 +13,9 @@ const cloneDir = path.join(os.tmpdir(), `policy-repo-${FIXED_UUID}`);
 const testDir = path.join(os.tmpdir(), 'tpc-sha');
 fs.rmSync(testDir, { recursive: true, force: true });
 fs.rmSync(cloneDir, { recursive: true, force: true });
+// The task writes its results file with O_EXCL; with a mocked fixed UUID a
+// leftover from a previous local run would collide, so remove it up front.
+fs.rmSync(path.join(os.tmpdir(), `policy-results-${FIXED_UUID}.txt`), { force: true });
 fs.mkdirSync(testDir, { recursive: true });
 fs.mkdirSync(cloneDir, { recursive: true });
 const planFile = path.join(testDir, 'plan.json');

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitSourceClone.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitSourceClone.ts
@@ -13,6 +13,9 @@ const cloneDir = path.join(os.tmpdir(), `policy-repo-${FIXED_UUID}`);
 const testDir = path.join(os.tmpdir(), 'tpc-git');
 fs.rmSync(testDir, { recursive: true, force: true });
 fs.rmSync(cloneDir, { recursive: true, force: true });
+// The task writes its results file with O_EXCL; with a mocked fixed UUID a
+// leftover from a previous local run would collide, so remove it up front.
+fs.rmSync(path.join(os.tmpdir(), `policy-results-${FIXED_UUID}.txt`), { force: true });
 fs.mkdirSync(testDir, { recursive: true });
 // Pre-create the clone target so the post-clone existence check passes (clone is mocked).
 fs.mkdirSync(cloneDir, { recursive: true });

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -78,10 +78,57 @@ describe('TerraformPolicyCheck Test Suite', function () {
     expectSuccess('SentinelSoftOverride');
     expectFailure('SentinelUnrecognizedExitFail');
 
+    it('SentinelConfigTempDir — generated config and results land in Agent.TempDirectory', async () => {
+        const agentTemp = path.join(os.tmpdir(), 'tpc-sentinel-tempdir', 'agent-temp');
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'SentinelConfigTempDir.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            // The generated sentinel.hcl dir must be created under
+            // Agent.TempDirectory (job-end purged), not bare os.tmpdir()
+            // (issues #503/#505); the cleanup debug line proves where it lived.
+            const configDir = path.join(agentTemp, 'sentinel-config-fixed-tempdir-uuid');
+            assert(
+                tr.stdout.includes(`Cleaned up temp dir: ${configDir}`),
+                `sentinel config dir should be created (and cleaned up) under Agent.TempDirectory; stdout: ${tr.stdout}`,
+            );
+            // The raw-results file must also land under Agent.TempDirectory
+            // (issue #487). It is deliberately NOT deleted at step end — later
+            // steps consume it via the resultsFilePath output variable, and the
+            // agent purges Agent.TempDirectory when the job finishes.
+            const resultsFile = path.join(agentTemp, 'policy-results-fixed-tempdir-uuid.txt');
+            assert(fs.existsSync(resultsFile), `results file should exist under Agent.TempDirectory at ${resultsFile}`);
+            assert(
+                tr.stdout.includes(resultsFile),
+                'resultsFilePath output variable should point at the Agent.TempDirectory file',
+            );
+        }, tr);
+    });
+
     // --- Policy source ---
     expectSuccess('GitSourceClone');
-    expectSuccess('GitShaCheckout');
     expectFailure('InsecureGitUrlReject');
+
+    it('GitShaCheckout — SHA checkout succeeds and masks the policy repo token', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'GitShaCheckout.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+            // Both the raw token and its derived Basic credential must be
+            // registered as secrets so the agent masks them in every log line;
+            // guards against accidental removal of the setSecret calls in
+            // policy-source.ts (issue #510).
+            assert(
+                tr.stdout.includes('##vso[task.setsecret]secrettoken'),
+                'policyRepoToken should be registered as a secret',
+            );
+            assert(
+                tr.stdout.includes(`##vso[task.setsecret]${Buffer.from(':secrettoken').toString('base64')}`),
+                'derived Basic credential should be registered as a secret',
+            );
+        }, tr);
+    });
 
     it('GitRefInjectionReject — a leading-dash ref is rejected before git runs', async () => {
         const tr = new ttm.MockTestRunner(path.join(__dirname, 'GitRefInjectionReject.js'));

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/ResultsL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/ResultsL0.ts
@@ -1,9 +1,9 @@
-import { describe, it } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import assert = require('assert');
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { buildPolicySarif, writeJUnit, writeSarif } from '../src/results';
+import { buildPolicySarif, writeJUnit, writeResultsFile, writeSarif } from '../src/results';
 import { PolicyResult } from '../src/types';
 
 // Direct (parent-process) unit tests for the reporting helpers. The MockTestRunner
@@ -73,6 +73,57 @@ describe('results: SARIF generation', () => {
         const defaulted = writeSarif(result, 'opa');
         assert.ok(defaulted.endsWith('.sarif') && fs.existsSync(defaulted));
         fs.rmSync(defaulted, { force: true });
+    });
+});
+
+describe('results: temp file hygiene', () => {
+    // The writers must land in Agent.TempDirectory (job-end purged by the ADO
+    // agent) rather than bare os.tmpdir(), with owner-only permissions — the raw
+    // engine output can embed plan resource values (see issue #487).
+    let agentTemp: string;
+    let savedAgentTemp: string | undefined;
+
+    beforeEach(() => {
+        savedAgentTemp = process.env['AGENT_TEMPDIRECTORY'];
+        agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'tpc-agent-temp-'));
+        process.env['AGENT_TEMPDIRECTORY'] = agentTemp;
+    });
+
+    afterEach(() => {
+        if (savedAgentTemp === undefined) {
+            delete process.env['AGENT_TEMPDIRECTORY'];
+        } else {
+            process.env['AGENT_TEMPDIRECTORY'] = savedAgentTemp;
+        }
+        fs.rmSync(agentTemp, { recursive: true, force: true });
+    });
+
+    function assertPrivateFileUnderAgentTemp(filePath: string) {
+        assert(
+            filePath.startsWith(agentTemp + path.sep),
+            `file should be under Agent.TempDirectory (${agentTemp}); got: ${filePath}`,
+        );
+        assert.ok(fs.existsSync(filePath), 'file should exist');
+        if (process.platform !== 'win32') {
+            assert.strictEqual(
+                fs.statSync(filePath).mode & 0o777,
+                0o600,
+                'file should be owner-only (0600)',
+            );
+        }
+    }
+
+    it('writeResultsFile writes an owner-only file under Agent.TempDirectory', () => {
+        assertPrivateFileUnderAgentTemp(writeResultsFile('raw engine output'));
+    });
+
+    it('writeJUnit writes an owner-only file under Agent.TempDirectory', () => {
+        assertPrivateFileUnderAgentTemp(writeJUnit([{ name: 'p1', passed: true }], 'opa'));
+    });
+
+    it('writeSarif (default path) writes an owner-only file under Agent.TempDirectory', () => {
+        const result: PolicyResult = { passed: true, violations: [], rawOutput: '', cases: [] };
+        assertPrivateFileUnderAgentTemp(writeSarif(result, 'opa'));
     });
 });
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SentinelConfigTempDir.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SentinelConfigTempDir.ts
@@ -1,0 +1,45 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+import fs = require('fs');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const FIXED_UUID = 'fixed-tempdir-uuid';
+
+const testDir = path.join(os.tmpdir(), 'tpc-sentinel-tempdir');
+fs.rmSync(testDir, { recursive: true, force: true });
+const policyDir = path.join(testDir, 'policies');
+fs.mkdirSync(policyDir, { recursive: true });
+fs.writeFileSync(path.join(policyDir, 'require-tags.sentinel'), 'main = rule { true }\n');
+const planFile = path.join(testDir, 'plan.json');
+fs.writeFileSync(planFile, '{}');
+
+// Simulate the ADO agent's private, job-end-purged temp directory. Both the
+// generated sentinel.hcl config dir and the raw-results file must land here,
+// not in bare os.tmpdir() (issues #487, #503, #505).
+const agentTemp = path.join(testDir, 'agent-temp');
+fs.mkdirSync(agentTemp, { recursive: true });
+process.env['AGENT_TEMPDIRECTORY'] = agentTemp;
+
+tr.registerMock('crypto', { randomUUID: () => FIXED_UUID });
+
+tr.setInput('engine', 'sentinel');
+tr.setInput('inputFile', planFile);
+tr.setInput('policySource', 'path');
+tr.setInput('policyPath', policyDir);
+tr.setInput('defaultEnforcementLevel', 'soft-mandatory');
+tr.setInput('publishTestResults', 'false');
+
+const sentinelPath = '/usr/bin/sentinel';
+const a: ma.TaskLibAnswers = {
+    which: { sentinel: sentinelPath },
+    checkPath: { [sentinelPath]: true },
+    exec: {
+        [`${sentinelPath} apply`]: { code: 0, stdout: 'PASS - require-tags.sentinel\n' }
+    }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/results.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/results.ts
@@ -5,10 +5,32 @@ import fs = require('fs');
 import { randomUUID as uuidV4 } from 'crypto';
 import { PolicyCase, PolicyResult } from './types';
 
+/**
+ * The agent's private temp directory, purged automatically at job end. Raw engine
+ * output (and reports derived from it) can embed Terraform plan resource values,
+ * so it must not land in the shared, never-purged os.tmpdir() (issue #487). The
+ * files written here are deliberately NOT deleted by this task — later pipeline
+ * steps consume them via the resultsFilePath/sarifFilePath output variables; the
+ * job-end purge of Agent.TempDirectory is the cleanup mechanism.
+ */
+function tempDir(): string {
+    return tasks.getVariable('Agent.TempDirectory') || os.tmpdir();
+}
+
+/**
+ * Writes a new owner-only (0600) file. O_EXCL ('wx') fails on a pre-existing
+ * path, defeating a pre-created-symlink hazard; chmod backstops the umask
+ * masking of the writeFileSync mode (mirrors TerraformDriftReport's pattern).
+ */
+function writePrivateFile(filePath: string, content: string): void {
+    fs.writeFileSync(filePath, content, { encoding: 'utf-8', mode: 0o600, flag: 'wx' });
+    try { fs.chmodSync(filePath, 0o600); } catch { /* platforms without POSIX perms */ }
+}
+
 /** Persists raw engine output and returns its path (exposed as resultsFilePath). */
 export function writeResultsFile(rawOutput: string): string {
-    const resultsPath = path.join(os.tmpdir(), `policy-results-${uuidV4()}.txt`);
-    fs.writeFileSync(resultsPath, rawOutput, 'utf-8');
+    const resultsPath = path.join(tempDir(), `policy-results-${uuidV4()}.txt`);
+    writePrivateFile(resultsPath, rawOutput);
     return resultsPath;
 }
 
@@ -43,8 +65,8 @@ ${body}
 </testsuites>
 `;
 
-    const xmlPath = path.join(os.tmpdir(), `policy-junit-${uuidV4()}.xml`);
-    fs.writeFileSync(xmlPath, xml, 'utf-8');
+    const xmlPath = path.join(tempDir(), `policy-junit-${uuidV4()}.xml`);
+    writePrivateFile(xmlPath, xml);
     return xmlPath;
 }
 
@@ -141,10 +163,18 @@ export function buildPolicySarif(result: PolicyResult, engine: string): SarifLog
 
 /** Writes a SARIF 2.1.0 report and returns its path. */
 export function writeSarif(result: PolicyResult, engine: string, sarifPath?: string): string {
-    const outPath = sarifPath && sarifPath.trim().length > 0
-        ? path.resolve(sarifPath)
-        : path.join(os.tmpdir(), `policy-results-${uuidV4()}.sarif`);
+    const explicitPath = sarifPath && sarifPath.trim().length > 0;
+    const outPath = explicitPath
+        ? path.resolve(sarifPath!)
+        : path.join(tempDir(), `policy-results-${uuidV4()}.sarif`);
     fs.mkdirSync(path.dirname(outPath), { recursive: true });
-    fs.writeFileSync(outPath, JSON.stringify(buildPolicySarif(result, engine), null, 2), 'utf-8');
+    const json = JSON.stringify(buildPolicySarif(result, engine), null, 2);
+    if (explicitPath) {
+        // User-chosen destination (e.g. a staging dir published as an artifact):
+        // keep overwrite semantics so re-runs against the same path succeed.
+        fs.writeFileSync(outPath, json, 'utf-8');
+    } else {
+        writePrivateFile(outPath, json);
+    }
     return outPath;
 }

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
@@ -163,7 +163,11 @@ function generateConfig(policyDir: string, inputFile: string, level: string, tem
         lines.push('');
     }
 
-    const configDir = path.join(os.tmpdir(), `sentinel-config-${uuidV4()}`);
+    // Agent.TempDirectory is auto-purged by the ADO agent at job end, which
+    // backstops cleanup even if the process is killed before index.ts's
+    // finally/cleanup() can run — bare os.tmpdir() has no such guarantee
+    // (matches policy-source.ts's cloneDir convention; issues #503/#505).
+    const configDir = path.join(tasks.getVariable('Agent.TempDirectory') || os.tmpdir(), `sentinel-config-${uuidV4()}`);
     fs.mkdirSync(configDir, { recursive: true });
     const configPath = path.join(configDir, 'sentinel.hcl');
     fs.writeFileSync(configPath, lines.join('\n'), 'utf-8');

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "8",
+        "Minor": "9",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
## Summary

Security hardening of TerraformPolicyCheckV1's temp-file handling plus a regression test for the `policyRepoToken` secret masking. All changes are confined to `Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1` (task.json Minor bumped 1.8.0 → 1.9.0).

Fixes #487
Fixes #503
Fixes #505
Fixes #510

## Per-issue changes

### #487 — results/JUnit/SARIF files in world-readable os.tmpdir()

`src/results.ts` now writes `writeResultsFile`/`writeJUnit`/`writeSarif` (default path) under `tasks.getVariable('Agent.TempDirectory') || os.tmpdir()` via a shared `tempDir()` helper, and through a new `writePrivateFile()` helper that creates the file with owner-only permissions (`mode: 0o600`, `chmodSync` backstop for the umask) and `O_EXCL` (`flag: 'wx'`) to defeat a pre-created-symlink hazard — mirroring TerraformDriftReport's summary-file pattern.

These files are **deliberately not deleted at step end**: later pipeline steps consume them through the `resultsFilePath`/`sarifFilePath` output variables, so an in-task delete would break downstream consumers. The ADO agent's job-end purge of `Agent.TempDirectory` is the cleanup mechanism — which is exactly what moving them off bare `os.tmpdir()` buys.

The explicit `sarifPath` branch of `writeSarif` (user-chosen destination, e.g. an artifact staging dir) keeps its existing overwrite semantics so re-runs against a fixed path still succeed.

### #503 / #505 — Sentinel generated config dir on bare os.tmpdir()

`src/sentinel-engine.ts` `generateConfig()` now creates the `sentinel-config-<uuid>` directory under `tasks.getVariable('Agent.TempDirectory') || os.tmpdir()`, matching `policy-source.ts`'s `cloneDir` convention in the same task. One line change closes both issues: the generated `sentinel.hcl` (embedding plan/policy paths) now gets the agent's job-end purge guarantee even if the process is hard-killed before `index.ts`'s `finally`/`cleanup()` runs.

### #510 — no verifying test for policyRepoToken masking (tests-only)

`Tests/L0.ts`'s `GitShaCheckout` scenario was upgraded from a bare `expectSuccess` to a dedicated assertion block that verifies both `##vso[task.setsecret]secrettoken` (the raw token) and `##vso[task.setsecret]<base64 of ":secrettoken">` (the derived Basic credential) appear in the task output — mirroring the DriftReport `Tests/L0.ts` callback-token pattern. This guards against a future accidental removal of the two `tasks.setSecret()` calls in `policy-source.ts`.

## Tests (TDD)

New tests were written first and observed failing before the fixes:

- `Tests/ResultsL0.ts` — new `results: temp file hygiene` describe block: `writeResultsFile`, `writeJUnit`, and `writeSarif` (default path) each write under a fake `AGENT_TEMPDIRECTORY` with mode `0600` (mode assertion skipped on win32, exercised on the ubuntu CI leg).
- `Tests/SentinelConfigTempDir.ts` (new mock scenario) + L0 assertion — full-task Sentinel run with `AGENT_TEMPDIRECTORY` set and a fixed UUID: asserts the generated config dir was created (and cleaned up) under `Agent.TempDirectory` and the results file landed there and survives step end.
- `Tests/L0.ts` — `GitShaCheckout` masking assertions (#510).
- `Tests/GitSourceClone.ts` / `Tests/GitShaCheckout.ts` — remove a stale fixed-UUID results file up front so the new `O_EXCL` write is idempotent across repeated local runs.

## Test evidence

```
Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1:
  npm run compile   → zero errors
  npm test          → 32 passing (was 28), run twice back-to-back to verify O_EXCL idempotency
  npm run lint      → clean

Repo root:
  node scripts/check-shared-modules.js        → all parity checks passed
  node scripts/check-minor-bumps.js v1.9.4 HEAD → OK TerraformPolicyCheckV1: src changed, Minor 8 -> 9
  node scripts/check-versions.js              → all version checks passed
```
