### PR TITLE
ci: pin release commit across jobs, hash-verify zizmor, meta-gate self-tests, tab matrix, manifest fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
   guard:
     name: Verify tag is on main
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve-sha.outputs.sha }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -50,6 +52,12 @@ jobs:
           # Major.Minor, so an un-bumped fix would ship to the Marketplace but never
           # reach running agents.
           node scripts/check-minor-bumps.js
+      - name: Resolve validated commit SHA
+        id: resolve-sha
+        # Every downstream job checks out this exact commit instead of
+        # re-resolving the tag name, so nothing published later in the
+        # pipeline can be swapped out by a tag move after this point.
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   ci:
     name: CI (build + test)
@@ -58,12 +66,12 @@ jobs:
 
   build:
     name: Build release bundle
-    needs: ci
+    needs: [guard, ci]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: ${{ needs.guard.outputs.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -81,12 +89,12 @@ jobs:
 
   package:
     name: Package extension (.vsix)
-    needs: build
+    needs: [guard, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: ${{ needs.guard.outputs.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -109,7 +117,7 @@ jobs:
 
   sbom-and-sign:
     name: Generate SBOM and sign VSIX
-    needs: package
+    needs: [guard, package]
     permissions:
       contents: read
       id-token: write
@@ -118,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: ${{ needs.guard.outputs.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -267,7 +275,7 @@ jobs:
 
   draft-release:
     name: Create Draft GitHub Release
-    needs: [package, sbom-and-sign]
+    needs: [guard, package, sbom-and-sign]
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -276,7 +284,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: ${{ needs.guard.outputs.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Download vsix artifact
@@ -301,7 +309,7 @@ jobs:
 
   publish-marketplace:
     name: Publish to VS Marketplace
-    needs: draft-release
+    needs: [guard, draft-release]
     runs-on: ubuntu-latest
     environment: marketplace
     permissions:
@@ -310,7 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: ${{ needs.guard.outputs.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,6 +22,23 @@ jobs:
           persist-credentials: false
       - name: Validate version fields
         run: node scripts/check-versions.js
+      - name: Validate task list consistency
+        run: node scripts/check-task-list.js
+      - name: Self-test check-versions.js
+        run: node scripts/test-check-versions.js
+      - name: Check for mojibake encoding corruption
+        shell: bash
+        # Catches recurrence of the UTF-8-decoded-as-Windows-1252 corruption
+        # fixed in azure-devops-extension.json, where a plain em dash had
+        # been mis-decoded into three separate replacement characters, by
+        # scanning the whole repo for the same byte signature.
+        run: |
+          set -uo pipefail
+          if grep -rIl --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=build $'\xc3\xa2\xe2\x82\xac' .; then
+            echo "::error::Mojibake encoding corruption found in the file(s) listed above (UTF-8 text mis-decoded as Windows-1252, then re-saved as UTF-8). Re-save as UTF-8 and replace the corrupted bytes with the intended character (e.g. a plain em dash)." >&2
+            exit 1
+          fi
+          echo "No mojibake encoding corruption found."
 
   check-shared-modules:
     name: Check Shared Module Parity
@@ -32,6 +49,8 @@ jobs:
           persist-credentials: false
       - name: Validate shared installer modules are identical
         run: node scripts/check-shared-modules.js
+      - name: Self-test check-shared-modules.js
+        run: node scripts/test-check-shared-modules.js
 
   build-and-test-v5:
     name: Build and Test V5 (${{ matrix.os }})
@@ -342,8 +361,12 @@ jobs:
         run: npm run test:coverage
 
   build-and-test-tab:
-    name: Build and Test Tab
-    runs-on: ubuntu-latest
+    name: Build and Test Tab (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-2025]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -401,10 +424,26 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+      - name: Download and verify zizmor
+        shell: bash
+        # Downloads the zizmor wheel directly from PyPI and verifies it
+        # against PyPI's own published SHA256 digest before use, rather than
+        # `pipx run --spec zizmor==1.26.1` (a version-string pin only, with no
+        # integrity check). Matches this repo's verify-before-use convention
+        # used everywhere else (see the actionlint step above). zizmor ships
+        # no runtime Python dependencies (requires_dist is empty per the PyPI
+        # JSON API), so verifying the single wheel it resolves to is
+        # sufficient. Checksum from
+        # https://pypi.org/pypi/zizmor/1.26.1/json (manylinux_2_28_x86_64
+        # wheel, matching this job's ubuntu-latest x86_64 runner).
+        run: |
+          set -euo pipefail
+          curl -sSfLO https://files.pythonhosted.org/packages/a8/2b/61ab13d45d6ce57ef5a08bb3246981f62e30bb4938098b17bb7b88110b79/zizmor-1.26.1-py3-none-manylinux_2_28_x86_64.whl
+          echo "6a958d8a0941d7e1d0de8436670b5cb7fc64c8028b4d16e3f519ccc77f953cef  zizmor-1.26.1-py3-none-manylinux_2_28_x86_64.whl" | sha256sum -c -
       # Online audits (ref-version-mismatch, impostor-commit, known-vulnerable
       # actions) use GITHUB_TOKEN; the rest (unpinned-uses, template-injection,
       # excessive-permissions) run regardless. Pinned for a deterministic gate.
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pipx run --spec zizmor==1.26.1 zizmor .github/workflows/
+        run: pipx run --spec ./zizmor-1.26.1-py3-none-manylinux_2_28_x86_64.whl zizmor .github/workflows/

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -388,6 +388,25 @@ jobs:
       - name: Run tab unit tests
         run: npm run test:tab
 
+  # Stable required-status-check context for the Tab tests. Branch protection
+  # on main pins the bare "Build and Test Tab" context, but the matrix job
+  # above only reports the OS-suffixed "Build and Test Tab (ubuntu-latest)" /
+  # "Build and Test Tab (windows-2025)" contexts. This gate re-exposes the
+  # pinned context — succeeding only when every matrix leg passed — so the OS
+  # matrix (issue #512) can be added without orphaning the required check,
+  # which would otherwise stay perpetually "Expected" and block every future
+  # PR into main until branch protection is repointed. No branch-protection
+  # change is needed on merge as a result.
+  build-and-test-tab-gate:
+    name: Build and Test Tab
+    needs: build-and-test-tab
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all Tab matrix legs passed
+        if: needs.build-and-test-tab.result != 'success'
+        run: exit 1
+
   actionlint:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -12,7 +12,7 @@
   "scopes": [
     "vso.build"
   ],
-  "description": "Install Terraform and run Terraform commands to manage resources on Azure, AWS, GCP and OCI.",
+  "description": "Install Terraform and run Terraform commands to manage resources on Azure, AWS, GCP and OCI. Also generates Terraform documentation and publishes ServiceNow knowledge base articles.",
   "public": false,
   "categories": [
     "Azure Pipelines"
@@ -412,7 +412,7 @@
               {
                 "id": "username",
                 "name": "Access key id",
-                "description": "Required for static credential auth. For Workload Identity Federation (OIDC), enter any placeholder value â€” this field is ignored at runtime.",
+                "description": "Required for static credential auth. For Workload Identity Federation (OIDC), enter any placeholder value — this field is ignored at runtime.",
                 "inputMode": "textbox",
                 "isConfidential": false,
                 "validation": {
@@ -423,7 +423,7 @@
               {
                 "id": "password",
                 "name": "Secret access key",
-                "description": "Required for static credential auth. For Workload Identity Federation (OIDC), enter any placeholder value â€” this field is ignored at runtime.",
+                "description": "Required for static credential auth. For Workload Identity Federation (OIDC), enter any placeholder value — this field is ignored at runtime.",
                 "inputMode": "passwordbox",
                 "isConfidential": true,
                 "validation": {
@@ -457,7 +457,7 @@
       "properties": {
         "name": "PTTGoogleCloudServiceEndpoint",
         "displayName": "Pipeline GCP for Terraform",
-        "helpMarkDown": "For service account key auth: [Get JSON Key File](https://console.cloud.google.com/iam-admin/serviceaccounts). For Workload Identity Federation (OIDC): create a placeholder connection â€” WIF configuration is set in the pipeline task inputs.",
+        "helpMarkDown": "For service account key auth: [Get JSON Key File](https://console.cloud.google.com/iam-admin/serviceaccounts). For Workload Identity Federation (OIDC): create a placeholder connection — WIF configuration is set in the pipeline task inputs.",
         "url": {
           "displayName": "Server Url",
           "helpText": "GCP homepage",
@@ -478,7 +478,7 @@
               {
                 "id": "Issuer",
                 "name": "Client email",
-                "description": "Required for service account key auth. For Workload Identity Federation (OIDC), enter any placeholder value â€” this field is ignored at runtime.",
+                "description": "Required for service account key auth. For Workload Identity Federation (OIDC), enter any placeholder value — this field is ignored at runtime.",
                 "inputMode": "textbox",
                 "isConfidential": false,
                 "validation": {
@@ -490,7 +490,7 @@
               {
                 "id": "Audience",
                 "name": "Token uri",
-                "description": "Required for service account key auth. For Workload Identity Federation (OIDC), enter any placeholder value â€” this field is ignored at runtime.",
+                "description": "Required for service account key auth. For Workload Identity Federation (OIDC), enter any placeholder value — this field is ignored at runtime.",
                 "inputMode": "textbox",
                 "isConfidential": false,
                 "validation": {
@@ -506,7 +506,7 @@
           {
             "id": "project",
             "name": "Project id",
-            "description": "The GCP project id. Required for service account key auth. For Workload Identity Federation (OIDC), this is optional â€” the project is set in the pipeline task.",
+            "description": "The GCP project id. Required for service account key auth. For Workload Identity Federation (OIDC), this is optional — the project is set in the pipeline task.",
             "inputMode": "textbox",
             "isConfidential": false,
             "validation": {

--- a/scripts/check-task-list.js
+++ b/scripts/check-task-list.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Meta-check: the 11-task list is hardcoded independently in three places --
+// scripts/check-versions.js's `files` array, scripts/check-minor-bumps.js's
+// `TASKS` array, and package.json's deps/deps:prune/compile script families --
+// with none of them derived from a single manifest. A forgotten entry in any
+// one of them currently fails silently (e.g. a 12th task added without
+// updating check-versions.js's `files[]` never gets its version validated,
+// and nothing flags the omission). This script parses all three sources plus
+// the actual Tasks/*/*/ directory listing and asserts they all agree.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readText(relPath) {
+    return fs.readFileSync(path.join(repoRoot, relPath), 'utf8');
+}
+
+// Ground truth: every immediate subdirectory of Tasks/<Family>/ that
+// contains a task.json.
+function discoverTaskDirs() {
+    const dirs = [];
+    const familyRoot = path.join(repoRoot, 'Tasks');
+    for (const family of fs.readdirSync(familyRoot, { withFileTypes: true })) {
+        if (!family.isDirectory()) continue;
+        const familyPath = path.join(familyRoot, family.name);
+        for (const version of fs.readdirSync(familyPath, { withFileTypes: true })) {
+            if (!version.isDirectory()) continue;
+            const taskJson = path.join(familyPath, version.name, 'task.json');
+            if (fs.existsSync(taskJson)) {
+                dirs.push(`Tasks/${family.name}/${version.name}`);
+            }
+        }
+    }
+    return dirs.sort();
+}
+
+// scripts/check-versions.js: `{ path: 'Tasks/.../task.json', type: 'task' },`
+function taskDirsFromCheckVersions() {
+    const text = readText('scripts/check-versions.js');
+    const dirs = [];
+    const re = /path:\s*'([^']+)\/task\.json'\s*,\s*type:\s*'task'/g;
+    let m;
+    while ((m = re.exec(text))) {
+        dirs.push(m[1]);
+    }
+    return dirs.sort();
+}
+
+// scripts/check-minor-bumps.js: `const TASKS = [ 'Tasks/...', ... ];`
+function taskDirsFromMinorBumps() {
+    const text = readText('scripts/check-minor-bumps.js');
+    const arrayMatch = text.match(/const TASKS = \[([\s\S]*?)\];/);
+    if (!arrayMatch) {
+        throw new Error('check-task-list: could not find a TASKS array in check-minor-bumps.js');
+    }
+    return [...arrayMatch[1].matchAll(/'([^']+)'/g)].map((m) => m[1]).sort();
+}
+
+// package.json: each npm-script family (deps:npm:*, deps:prune:*, compile:*)
+// should reference the exact same set of task dirs.
+function taskDirsFromPackageJson() {
+    const pkg = JSON.parse(readText('package.json'));
+    const families = {
+        'deps:npm': /--prefix\s+(Tasks\/\S+)\s+ci\b/,
+        'deps:prune': /--prefix\s+(Tasks\/\S+)\s+prune\b/,
+        compile: /tsc -b (Tasks\/\S+)\/tsconfig\.json/,
+    };
+    const result = {};
+    for (const [prefix, re] of Object.entries(families)) {
+        const dirs = [];
+        for (const [name, cmd] of Object.entries(pkg.scripts)) {
+            if (!name.startsWith(`${prefix}:`)) continue;
+            const m = cmd.match(re);
+            if (m) dirs.push(m[1]);
+        }
+        result[prefix] = dirs.sort();
+    }
+    return result;
+}
+
+function setsEqual(a, b) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => v === b[i]);
+}
+
+function reportDiff(label, actual, expected) {
+    const missing = expected.filter((d) => !actual.includes(d));
+    const extra = actual.filter((d) => !expected.includes(d));
+    if (missing.length) console.error(`  ${label}: missing ${JSON.stringify(missing)}`);
+    if (extra.length) console.error(`  ${label}: unexpected extra ${JSON.stringify(extra)}`);
+}
+
+const canonical = discoverTaskDirs();
+console.log(`Discovered ${canonical.length} task directories under Tasks/: ${canonical.join(', ')}`);
+
+const sources = {
+    "scripts/check-versions.js 'files'": taskDirsFromCheckVersions(),
+    "scripts/check-minor-bumps.js 'TASKS'": taskDirsFromMinorBumps(),
+};
+
+const pkgFamilies = taskDirsFromPackageJson();
+for (const [family, dirs] of Object.entries(pkgFamilies)) {
+    sources[`package.json '${family}:*' scripts`] = dirs;
+}
+
+let hasError = false;
+for (const [label, dirs] of Object.entries(sources)) {
+    if (!setsEqual(dirs, canonical)) {
+        console.error(`FAIL: ${label} does not match the Tasks/ directory listing.`);
+        reportDiff(label, dirs, canonical);
+        hasError = true;
+    } else {
+        console.log(`OK: ${label} matches the Tasks/ directory listing (${dirs.length} tasks).`);
+    }
+}
+
+if (hasError) {
+    process.exit(1);
+}
+console.log('check-task-list: all task lists agree.');

--- a/scripts/test-check-shared-modules.js
+++ b/scripts/test-check-shared-modules.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Self-test for check-shared-modules.js: confirms the shared-module parity
+// gate actually catches drift, and doesn't cry wolf on a clean tree. This is
+// the guard that protects the security-critical duplicated installer/HTTPS
+// modules (see check-shared-modules.js's own header comment); a silent bug
+// in its own FAMILIES list or diff logic would otherwise pass CI while
+// verifying nothing.
+//
+// Runs check-shared-modules.js twice against a scratch copy of Tasks/:
+//   1. unmodified copy -> must exit 0
+//   2. one paired file deliberately diverged -> must exit non-zero
+// The scratch copy is removed afterwards either way.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'check-shared-modules.js');
+// A real byte-identical pair enforced by check-shared-modules.js's FAMILIES
+// list (the installer trust-chain family); PolicyAgentInstallerV1's copy is
+// not the canonical one, so diverging it exercises the comparison branch.
+const targetFile = path.join('Tasks', 'PolicyAgentInstaller', 'PolicyAgentInstallerV1', 'src', 'http-client.ts');
+
+function runCheck(cwd) {
+    return spawnSync(process.execPath, [scriptPath], { cwd, encoding: 'utf8' });
+}
+
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-shared-modules-selftest-'));
+let failed = false;
+
+try {
+    fs.cpSync(path.join(repoRoot, 'Tasks'), path.join(scratchDir, 'Tasks'), { recursive: true });
+
+    const cleanResult = runCheck(scratchDir);
+    if (cleanResult.status !== 0) {
+        console.error('FAIL: check-shared-modules.js exited non-zero on an unmodified copy.');
+        console.error(cleanResult.stdout, cleanResult.stderr);
+        failed = true;
+    } else {
+        console.log('OK: check-shared-modules.js exits 0 on a matching tree.');
+    }
+
+    const scratchTarget = path.join(scratchDir, targetFile);
+    fs.appendFileSync(scratchTarget, '\n// check-shared-modules self-test divergence marker\n');
+
+    const divergedResult = runCheck(scratchDir);
+    if (divergedResult.status === 0) {
+        console.error('FAIL: check-shared-modules.js exited 0 despite a deliberately diverged copy.');
+        failed = true;
+    } else {
+        console.log('OK: check-shared-modules.js exits non-zero on a diverged copy.');
+    }
+} finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+}
+
+if (failed) {
+    console.error('\ncheck-shared-modules.js self-test: FAILED.');
+    process.exit(1);
+}
+console.log('check-shared-modules.js self-test: all cases passed.');

--- a/scripts/test-check-versions.js
+++ b/scripts/test-check-versions.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Self-test for check-versions.js: confirms the version-format gate actually
+// catches a malformed task.json, and doesn't cry wolf on a clean tree. A
+// silent bug in this script would let a task ship without the version fields
+// ADO agents rely on to detect a cache-worthy update.
+//
+// Runs check-versions.js twice against a scratch copy of the manifest files:
+//   1. unmodified copy -> must exit 0
+//   2. one task.json deliberately missing its Minor version field -> must
+//      exit non-zero
+// The scratch copy is removed afterwards either way.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'check-versions.js');
+const targetFile = path.join('Tasks', 'TerraformTask', 'TerraformTaskV5', 'task.json');
+
+function runCheck(cwd) {
+    return spawnSync(process.execPath, [scriptPath], { cwd, encoding: 'utf8' });
+}
+
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-versions-selftest-'));
+let failed = false;
+
+try {
+    fs.copyFileSync(
+        path.join(repoRoot, 'azure-devops-extension.json'),
+        path.join(scratchDir, 'azure-devops-extension.json'),
+    );
+    fs.cpSync(path.join(repoRoot, 'Tasks'), path.join(scratchDir, 'Tasks'), { recursive: true });
+
+    const cleanResult = runCheck(scratchDir);
+    if (cleanResult.status !== 0) {
+        console.error('FAIL: check-versions.js exited non-zero on an unmodified copy.');
+        console.error(cleanResult.stdout, cleanResult.stderr);
+        failed = true;
+    } else {
+        console.log('OK: check-versions.js exits 0 on a valid tree.');
+    }
+
+    const scratchTarget = path.join(scratchDir, targetFile);
+    const taskJson = JSON.parse(fs.readFileSync(scratchTarget, 'utf8'));
+    delete taskJson.version.Minor;
+    fs.writeFileSync(scratchTarget, JSON.stringify(taskJson, null, 4));
+
+    const brokenResult = runCheck(scratchDir);
+    if (brokenResult.status === 0) {
+        console.error('FAIL: check-versions.js exited 0 despite a task.json missing its Minor version field.');
+        failed = true;
+    } else {
+        console.log('OK: check-versions.js exits non-zero on a malformed version field.');
+    }
+} finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+}
+
+if (failed) {
+    console.error('\ncheck-versions.js self-test: FAILED.');
+    process.exit(1);
+}
+console.log('check-versions.js self-test: all cases passed.');


### PR DESCRIPTION
## Summary

CI/CD hardening grouped fix covering seven audit findings (release pipeline
integrity, scanner supply-chain, meta-gate coverage, matrix parity, and
manifest content). No task `src/` changes, so no `task.json` `Minor` bumps
are required.

### Fixes #485 — release pipeline re-resolved the mutable tag name in six jobs instead of pinning `guard`'s validated commit

`guard` now emits the checked-out commit SHA (`git rev-parse HEAD` after tag
validation) as a job output. Every downstream job that previously did
`ref: ${{ github.event.inputs.tag || github.ref_name }}` (`build`, `package`,
`sbom-and-sign`, `draft-release`, `publish-marketplace`) now does
`ref: ${{ needs.guard.outputs.sha }}` and depends on `guard`. If the `v*.*.*`
tag is moved between job starts, the pinned SHA — not the mutable name — is
what gets built, SBOM'd, signed, and published.

`draft-release`'s `tag_name:` (the GitHub Release's tag identifier, not a
checkout ref) is intentionally left referencing the tag name.

### Fixes #500 — zizmor installed via unpinned/unverified `pipx run --spec`

Replaced `pipx run --spec zizmor==1.26.1 zizmor ...` with a download-and-verify
step: the `manylinux_2_28_x86_64` wheel (matching the `ubuntu-latest` runner)
is fetched directly from `files.pythonhosted.org` and checked against the
SHA256 digest published by PyPI's JSON API
(`https://pypi.org/pypi/zizmor/1.26.1/json`) before `pipx run --spec
<local-wheel> zizmor ...` invokes it — mirroring the actionlint step's
verify-before-use convention immediately above it. Confirmed zizmor has no
runtime Python dependencies (`requires_dist` is empty in the PyPI JSON API),
so a single wheel checksum is sufficient; no `--require-hashes` requirements
file was needed.

### Fixes #502 and #511 — no single source of truth for the task list; CI meta-gate scripts had no tests

- Added `scripts/check-task-list.js`: parses `check-versions.js`'s `files[]`,
  `check-minor-bumps.js`'s `TASKS[]`, and package.json's `deps:npm:*` /
  `deps:prune:*` / `compile:*` script families, and asserts all of them agree
  with each other and with the actual `Tasks/*/*/` directory listing (any dir
  containing a `task.json`). Wired as an extra step in the existing **Check
  Version Consistency** job.
- Added `scripts/test-check-shared-modules.js` and
  `scripts/test-check-versions.js`: each copies the relevant real files into a
  scratch temp dir, runs the target script against it (must exit 0), then
  deliberately corrupts one file in the scratch copy and reruns (must exit
  non-zero). Wired as extra steps in the **Check Version Consistency** and
  **Check Shared Module Parity** jobs respectively. No new top-level job names
  were introduced (required-check contexts are unchanged).

### Fixes #512 — Plan tab job was the only test job without the Ubuntu+Windows matrix

Added `strategy: matrix: os: [ubuntu-latest, windows-2025]` to
`build-and-test-tab`, matching every other `Build and Test *` job.

**No branch-protection change is required on merge.** Branch protection on
`main` pins the *bare* `Build and Test Tab` context (verified live), whereas
every sibling job already uses OS-suffixed contexts. Adding the matrix would
have renamed this job's only context to `Build and Test Tab (ubuntu-latest)` /
`(windows-2025)`, orphaning the pinned `Build and Test Tab` check — which
GitHub keeps perpetually "Expected", blocking *every* future PR into `main`
until an admin repoints branch protection (the exact stale-context failure this
org has hit before).

To avoid that sequencing risk entirely, a tiny gate job
`build-and-test-tab-gate` (`name: Build and Test Tab`, `needs:
build-and-test-tab`, `if: always()`) re-exposes the pinned context, succeeding
only when both matrix legs pass. The matrix legs still run on both OSes under
the new (non-required) `Build and Test Tab (ubuntu-latest)` / `(windows-2025)`
contexts. Net effect: full both-OS coverage per #512, the required
`Build and Test Tab` check keeps reporting, and no branch-protection edit is
needed at merge time.

### Fixes #517 — mojibake in AWS/GCP service-connection descriptions

Six occurrences of a UTF-8 em dash mis-decoded as Windows-1252 (â€”) in
`azure-devops-extension.json` (lines 415, 426, 460, 481, 493, 509 — one more
than the issue's "at least 5") were re-saved as a plain em dash. Added a
repo-wide grep step (in the **Check Version Consistency** job) for the same
byte signature (`\xc3\xa2\xe2\x82\xac`) to catch recurrence.

### Fixes #521 — ServiceNow KB-publishing capability under-signaled in the manifest description

Extended the Marketplace `description` field with a second sentence
mentioning Terraform docs generation and ServiceNow KB publishing, so
search/browse users can discover the full scope before installing.

## Test evidence

Local gates (from repo root, after committing):

```
node scripts/check-shared-modules.js   # All shared-module parity checks passed.
node scripts/check-versions.js         # All version checks passed.
node scripts/check-minor-bumps.js v1.9.4 HEAD   # all changed tasks have a Minor bump (unrelated to this PR)
node scripts/check-task-list.js        # check-task-list: all task lists agree.
node scripts/test-check-shared-modules.js   # all cases passed (clean=0, diverged=non-zero)
node scripts/test-check-versions.js         # all cases passed (clean=0, malformed=non-zero)
actionlint .github/workflows/release.yml .github/workflows/unit-test.yml   # no findings
python -c "import yaml; yaml.safe_load(open(f))"  # both workflow files parse
```

Also manually verified:
- The zizmor wheel's SHA256 matches PyPI's JSON API digest (downloaded and
  `sha256sum -c`'d locally), and the wheel contains a `zizmor` script entry
  point (`zizmor-1.26.1.data/scripts/zizmor`), and `requires_dist` is empty.
- `azure-devops-extension.json` is still valid JSON with CRLF line endings
  preserved (byte-for-byte diff limited to the six corrected characters and
  the one description line).
- The mojibake grep step correctly finds nothing on the fixed tree and
  correctly flags a reintroduced occurrence in a scratch file.
- Ran the `build-and-test-tab` job's actual commands (`npm ci
  --ignore-scripts`, `npx tsc -p src/tab/tsconfig.json --noEmit`, `npm run
  test:tab`) locally on Windows as a proxy for the new `windows-2025` matrix
  leg: type-check clean, 29/29 tests passed.

## CI

Workflow-only change gated by `actionlint` + `zizmor` (both now touched by
this PR) — will iterate via CI checks after opening the PR.

