### PR TITLE
feat: structured Plan/Apply tab UI with safe digest parsing

### DIFF
--- a/src/tab/components/ApplyTimeline.test.tsx
+++ b/src/tab/components/ApplyTimeline.test.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ApplyTimeline } from "./ApplyTimeline";
+import { ApplyResource } from "../digest-schema";
+
+function res(overrides: Partial<ApplyResource>): ApplyResource {
+  return { address: "aws_instance.web", action: "create", status: "complete", ...overrides };
+}
+
+describe("ApplyTimeline", () => {
+  it("renders each resource with address, action, status", () => {
+    const html = renderToStaticMarkup(
+      <ApplyTimeline resources={[res({ address: "a", action: "create", status: "complete", durationMs: 1500 })]} />
+    );
+    expect(html).toContain("a");
+    expect(html).toMatch(/create/i);
+    expect(html).toMatch(/complete/i);
+    expect(html).toContain("1.5s");
+  });
+
+  it("marks an errored resource distinctly", () => {
+    const html = renderToStaticMarkup(<ApplyTimeline resources={[res({ status: "errored" })]} />);
+    expect(html).toMatch(/errored/i);
+  });
+
+  it("renders a duration in milliseconds when under a second", () => {
+    const html = renderToStaticMarkup(<ApplyTimeline resources={[res({ durationMs: 250 })]} />);
+    expect(html).toContain("250ms");
+  });
+
+  it("omits a duration when not provided", () => {
+    const html = renderToStaticMarkup(<ApplyTimeline resources={[res({ durationMs: undefined })]} />);
+    expect(html).not.toContain("undefined");
+  });
+
+  it("shows appliedBeforeFailure addresses when provided", () => {
+    const html = renderToStaticMarkup(
+      <ApplyTimeline resources={[res({})]} appliedBeforeFailure={["aws_instance.a", "aws_instance.b"]} />
+    );
+    expect(html).toContain("aws_instance.a");
+    expect(html).toContain("aws_instance.b");
+    expect(html).toMatch(/before/i);
+  });
+
+  it("renders an empty state when there are no resources", () => {
+    const html = renderToStaticMarkup(<ApplyTimeline resources={[]} />);
+    expect(html).toMatch(/no resources/i);
+  });
+
+  it("HTML-escapes an address as a text node", () => {
+    const html = renderToStaticMarkup(<ApplyTimeline resources={[res({ address: "<img src=x onerror=alert(1)>" })]} />);
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+});

--- a/src/tab/components/ApplyTimeline.tsx
+++ b/src/tab/components/ApplyTimeline.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { ApplyResource } from "../digest-schema";
+
+export interface ApplyTimelineProps {
+    resources: ApplyResource[];
+    appliedBeforeFailure?: string[];
+}
+
+function formatDuration(ms: number | undefined): string | null {
+    if (ms === undefined) return null;
+    return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+}
+
+/** Per-resource apply status + duration, in the order the digest reported them. */
+export function ApplyTimeline({ resources, appliedBeforeFailure }: ApplyTimelineProps): JSX.Element {
+    if (resources.length === 0) {
+        return <div className="apply-timeline-empty">No resources were applied.</div>;
+    }
+
+    return (
+        <div className="apply-timeline">
+            <ul className="apply-timeline-list">
+                {resources.map((resource, i) => {
+                    const duration = formatDuration(resource.durationMs);
+                    return (
+                        <li key={`${resource.address}-${i}`} className={`apply-timeline-item status-${resource.status}`}>
+                            <span className="apply-timeline-address">{resource.address}</span>
+                            <span className="apply-timeline-action">{resource.action}</span>
+                            <span className="apply-timeline-status">{resource.status}</span>
+                            {duration && <span className="apply-timeline-duration">{duration}</span>}
+                        </li>
+                    );
+                })}
+            </ul>
+            {appliedBeforeFailure && appliedBeforeFailure.length > 0 && (
+                <div className="apply-timeline-before-failure">
+                    <div>Completed before the apply errored:</div>
+                    <ul>
+                        {appliedBeforeFailure.map((address) => (
+                            <li key={address}>{address}</li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/tab/components/DiagnosticsPanel.test.tsx
+++ b/src/tab/components/DiagnosticsPanel.test.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DiagnosticsPanel } from "./DiagnosticsPanel";
+import { Diagnostic } from "../digest-schema";
+
+describe("DiagnosticsPanel", () => {
+  it("renders severity, summary, and address", () => {
+    const diagnostics: Diagnostic[] = [{ severity: "error", summary: "Invalid value", address: "aws_instance.web" }];
+    const html = renderToStaticMarkup(<DiagnosticsPanel diagnostics={diagnostics} />);
+    expect(html).toMatch(/error/i);
+    expect(html).toContain("Invalid value");
+    expect(html).toContain("aws_instance.web");
+  });
+
+  it("renders detail when present", () => {
+    const diagnostics: Diagnostic[] = [{ severity: "warning", summary: "Deprecated attribute", detail: "Use new_attr instead." }];
+    const html = renderToStaticMarkup(<DiagnosticsPanel diagnostics={diagnostics} />);
+    expect(html).toContain("Use new_attr instead.");
+  });
+
+  it("omits the detail section entirely when detail is absent (safe-default diagnostic mode)", () => {
+    const diagnostics: Diagnostic[] = [{ severity: "warning", summary: "Deprecated attribute" }];
+    const html = renderToStaticMarkup(<DiagnosticsPanel diagnostics={diagnostics} />);
+    expect(html).not.toContain("diagnostics-panel-detail");
+  });
+
+  it("sorts errors before warnings", () => {
+    const diagnostics: Diagnostic[] = [
+      { severity: "warning", summary: "warn-first" },
+      { severity: "error", summary: "err-first" },
+    ];
+    const html = renderToStaticMarkup(<DiagnosticsPanel diagnostics={diagnostics} />);
+    expect(html.indexOf("err-first")).toBeLessThan(html.indexOf("warn-first"));
+  });
+
+  it("renders an empty state (no diagnostics) distinctly", () => {
+    const html = renderToStaticMarkup(<DiagnosticsPanel diagnostics={[]} />);
+    expect(html).toMatch(/no diagnostics/i);
+  });
+
+  it("HTML-escapes freeform summary/detail text as text nodes (no script injection)", () => {
+    const diagnostics: Diagnostic[] = [
+      { severity: "error", summary: '<script>alert(1)</script>', detail: '<img src=x onerror=alert(1)>' },
+    ];
+    const html = renderToStaticMarkup(<DiagnosticsPanel diagnostics={diagnostics} />);
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/src/tab/components/DiagnosticsPanel.tsx
+++ b/src/tab/components/DiagnosticsPanel.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { Diagnostic } from "../digest-schema";
+
+export interface DiagnosticsPanelProps {
+    diagnostics: Diagnostic[];
+}
+
+/**
+ * Apply/plan diagnostics list, errors first. `summary`/`detail` are freeform
+ * text the task has already scrubbed (spec §5.4) but the tab still renders
+ * them purely as React text nodes — never as HTML.
+ */
+export function DiagnosticsPanel({ diagnostics }: DiagnosticsPanelProps): JSX.Element {
+    if (diagnostics.length === 0) {
+        return <div className="diagnostics-panel-empty">No diagnostics.</div>;
+    }
+
+    const sorted = [...diagnostics].sort((a, b) => {
+        if (a.severity === b.severity) return 0;
+        return a.severity === "error" ? -1 : 1;
+    });
+
+    return (
+        <ul className="diagnostics-panel">
+            {sorted.map((diagnostic, i) => (
+                <li key={i} className={`diagnostics-panel-item severity-${diagnostic.severity}`}>
+                    <span className="diagnostics-panel-severity">{diagnostic.severity}</span>
+                    <span className="diagnostics-panel-summary">{diagnostic.summary}</span>
+                    {diagnostic.address && <span className="diagnostics-panel-address">{diagnostic.address}</span>}
+                    {diagnostic.detail && (
+                        <div className="diagnostics-panel-detail">{diagnostic.detail}</div>
+                    )}
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/src/tab/components/OutputsPanel.test.tsx
+++ b/src/tab/components/OutputsPanel.test.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OutputsPanel } from "./OutputsPanel";
+import { OutputChange } from "../digest-schema";
+
+describe("OutputsPanel", () => {
+  it("renders each output name, action, and value", () => {
+    const outputs: OutputChange[] = [{ name: "url", action: "create", value: { kind: "value", json: '"https://example.test"' } }];
+    const html = renderToStaticMarkup(<OutputsPanel outputs={outputs} />);
+    expect(html).toContain("url");
+    expect(html).toMatch(/create/i);
+    expect(html).toContain("https://example.test");
+  });
+
+  it('renders a sensitive output as "(sensitive)"', () => {
+    const outputs: OutputChange[] = [{ name: "db_password", action: "create", value: { kind: "sensitive" } }];
+    const html = renderToStaticMarkup(<OutputsPanel outputs={outputs} />);
+    expect(html).toContain("(sensitive)");
+    expect(html).not.toContain("db_password_value");
+  });
+
+  it('renders an unknown output as "(known after apply)"', () => {
+    const outputs: OutputChange[] = [{ name: "instance_id", action: "create", value: { kind: "unknown" } }];
+    const html = renderToStaticMarkup(<OutputsPanel outputs={outputs} />);
+    expect(html).toContain("(known after apply)");
+  });
+
+  it("renders an empty state when there are no outputs", () => {
+    const html = renderToStaticMarkup(<OutputsPanel outputs={[]} />);
+    expect(html).toMatch(/no outputs/i);
+  });
+
+  it("HTML-escapes an output name as a text node", () => {
+    const outputs: OutputChange[] = [{ name: "<img src=x onerror=alert(1)>", action: "create", value: { kind: "unknown" } }];
+    const html = renderToStaticMarkup(<OutputsPanel outputs={outputs} />);
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+});

--- a/src/tab/components/OutputsPanel.tsx
+++ b/src/tab/components/OutputsPanel.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { OutputChange } from "../digest-schema";
+import { formatRedactedValue } from "./redacted-value";
+
+export interface OutputsPanelProps {
+    outputs: OutputChange[];
+}
+
+/** Masked outputs list (plan `outputChanges` or apply `outputs`). */
+export function OutputsPanel({ outputs }: OutputsPanelProps): JSX.Element {
+    if (outputs.length === 0) {
+        return <div className="outputs-panel-empty">No outputs.</div>;
+    }
+
+    return (
+        <table className="outputs-panel">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Action</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {outputs.map((output) => (
+                    <tr key={output.name}>
+                        <td className="outputs-panel-name">{output.name}</td>
+                        <td className="outputs-panel-action">{output.action}</td>
+                        <td className="outputs-panel-value">{formatRedactedValue(output.value)}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}

--- a/src/tab/components/OverviewList.test.tsx
+++ b/src/tab/components/OverviewList.test.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OverviewList, OverviewItem } from "./OverviewList";
+
+const planItems: OverviewItem[] = [
+  {
+    id: "a",
+    name: "plan-a",
+    status: "ok",
+    counts: { add: 2, change: 0, destroy: 0 },
+    noChanges: false,
+    driftDetected: false,
+  },
+  {
+    id: "b",
+    name: "plan-b (no-op)",
+    status: "ok",
+    counts: { add: 0, change: 0, destroy: 0 },
+    noChanges: true,
+    driftDetected: false,
+  },
+  {
+    id: "c",
+    name: "plan-c (drift)",
+    status: "ok",
+    counts: { add: 0, change: 1, destroy: 0, replace: 1 },
+    noChanges: false,
+    driftDetected: true,
+  },
+  { id: "d", name: "plan-d (broken)", status: "error", message: "malformed digest" },
+];
+
+describe("OverviewList", () => {
+  it("renders one row per item with name and count chips", () => {
+    const html = renderToStaticMarkup(<OverviewList items={planItems} selectedId="a" onSelect={() => {}} />);
+    expect(html).toContain("plan-a");
+    expect(html).toContain("plan-b (no-op)");
+    expect(html).toContain("plan-c (drift)");
+    expect(html).toContain("+2");
+  });
+
+  it("shows a no-op badge for noChanges items and a drift badge for drifted items", () => {
+    const html = renderToStaticMarkup(<OverviewList items={planItems} selectedId="a" onSelect={() => {}} />);
+    expect(html).toContain("No changes");
+    expect(html).toContain("Drift");
+  });
+
+  it("shows a replace badge when the item has replacements", () => {
+    const html = renderToStaticMarkup(<OverviewList items={planItems} selectedId="a" onSelect={() => {}} />);
+    expect(html).toContain("Replace");
+  });
+
+  it("shows an error indicator for an unparseable item, without a count chip", () => {
+    const html = renderToStaticMarkup(<OverviewList items={planItems} selectedId="a" onSelect={() => {}} />);
+    expect(html).toContain("plan-d (broken)");
+    expect(html).toContain("malformed digest");
+  });
+
+  it("marks the selected row", () => {
+    const html = renderToStaticMarkup(<OverviewList items={planItems} selectedId="b" onSelect={() => {}} />);
+    expect(html).toMatch(/overview-item[^"]*selected[^>]*>[\s\S]*plan-b/);
+  });
+
+  it("invokes onSelect with the item id when a row is clicked", () => {
+    const onSelect = jest.fn();
+    // renderToStaticMarkup can't dispatch events; verify the click handler is
+    // wired by simulating the call directly against the exported row logic —
+    // instead, assert via a controlled component harness using react-dom/test-utils-free approach:
+    // call the component function directly to exercise its onClick closures.
+    const el = OverviewList({ items: planItems, selectedId: "a", onSelect }) as React.ReactElement;
+    // Find the second row's onClick handler in the rendered tree and invoke it.
+    const rows = (el.props.children as React.ReactElement[]).filter(Boolean);
+    const secondRow = rows[1];
+    expect(typeof secondRow.props.onClick).toBe("function");
+    secondRow.props.onClick();
+    expect(onSelect).toHaveBeenCalledWith("b");
+  });
+
+  it("renders an empty state when there are no items", () => {
+    const html = renderToStaticMarkup(<OverviewList items={[]} selectedId={null} onSelect={() => {}} />);
+    expect(html).toContain("No items");
+  });
+});

--- a/src/tab/components/OverviewList.tsx
+++ b/src/tab/components/OverviewList.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { SummaryHeaderCounts } from "./SummaryHeader";
+
+export type OverviewItem =
+    | {
+          id: string;
+          name: string;
+          status: "ok";
+          counts: SummaryHeaderCounts;
+          noChanges?: boolean;
+          driftDetected?: boolean;
+          outcome?: "succeeded" | "failed";
+      }
+    | {
+          id: string;
+          name: string;
+          status: "error";
+          message: string;
+      };
+
+export interface OverviewListProps {
+    items: OverviewItem[];
+    selectedId: string | null;
+    onSelect: (id: string) => void;
+}
+
+/**
+ * Multi-item overview: one row per published plan/apply digest with name,
+ * count chips, and status badges (drift/replace/no-op/error). Selecting a
+ * row opens its detail view. All item names/messages are untrusted digest
+ * text rendered as React text nodes.
+ */
+export function OverviewList({ items, selectedId, onSelect }: OverviewListProps): JSX.Element {
+    if (items.length === 0) {
+        return <div className="overview-empty">No items to display.</div>;
+    }
+
+    return (
+        <ul className="overview-list" role="listbox">
+            {items.map((item) => (
+                <li
+                    key={item.id}
+                    role="option"
+                    aria-selected={item.id === selectedId}
+                    className={`overview-item${item.id === selectedId ? " selected" : ""}`}
+                    onClick={() => onSelect(item.id)}
+                >
+                    <span className="overview-item-name">{item.name}</span>
+                    {item.status === "error" ? (
+                        <span className="overview-item-error">
+                            <span className="badge badge-error">Unparseable</span>
+                            <span className="overview-item-error-message">{item.message}</span>
+                        </span>
+                    ) : (
+                        <span className="overview-item-badges">
+                            <span className="count count-add">+{item.counts.add}</span>
+                            <span className="count count-change">~{item.counts.change}</span>
+                            <span className="count count-destroy">-{item.counts.destroy}</span>
+                            {!!item.counts.replace && <span className="badge badge-replace">Replace</span>}
+                            {item.driftDetected && <span className="badge badge-drift">Drift</span>}
+                            {item.noChanges && <span className="badge badge-no-changes">No changes</span>}
+                            {item.outcome && (
+                                <span className={`badge badge-outcome-${item.outcome}`}>
+                                    {item.outcome === "succeeded" ? "Succeeded" : "Failed"}
+                                </span>
+                            )}
+                        </span>
+                    )}
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/src/tab/components/RawView.test.tsx
+++ b/src/tab/components/RawView.test.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { RawView } from "./RawView";
+import { ansiToHtml } from "../ansi-to-html";
+
+describe("RawView", () => {
+  it("routes content through ansiToHtml before rendering (no raw HTML injected)", () => {
+    const rawContent = '<script>alert(1)</script>\x1b[31mred & <b>bold</b>\x1b[0m';
+    const html = renderToStaticMarkup(<RawView name="plan.txt" content={rawContent} />);
+    expect(html).toContain(ansiToHtml(rawContent));
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("shows the attachment name as a text node (not injected as HTML)", () => {
+    const html = renderToStaticMarkup(<RawView name="<img src=x>" content="plain output" />);
+    expect(html).toContain("&lt;img src=x&gt;");
+  });
+
+  it("renders a download link instead of inline output when content exceeds the render-size cap", () => {
+    const oversized = "x".repeat(2 * 1024 * 1024 + 1);
+    const html = renderToStaticMarkup(<RawView name="huge-plan.txt" content={oversized} />);
+    expect(html).toContain("too large to render inline");
+    expect(html).toContain("Download raw output");
+    expect(html).not.toContain("dangerouslySetInnerHTML");
+  });
+});

--- a/src/tab/components/RawView.tsx
+++ b/src/tab/components/RawView.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { ansiToHtml } from "../ansi-to-html";
+
+/** Maximum attachment size (bytes) to render inline. Larger content gets a download link. */
+const MAX_RENDER_SIZE = 2 * 1024 * 1024; // 2 MB
+
+/** Cap on the sanitized download filename length (excluding the fixed ".txt" suffix). */
+const MAX_DOWNLOAD_NAME_LENGTH = 100;
+
+/**
+ * Sanitize an untrusted attachment name into a filesystem-safe download
+ * filename (§5.3.2): allowlist `[A-Za-z0-9._-]`, cap length, never empty.
+ */
+export function sanitizeDownloadFilename(name: string): string {
+    const sanitized = name.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, MAX_DOWNLOAD_NAME_LENGTH);
+    return sanitized.length > 0 ? sanitized : "terraform-output";
+}
+
+export interface RawViewProps {
+    /** Untrusted attachment name — rendered as a text node only, never into an attribute/HTML sink. */
+    name: string;
+    /** Untrusted raw attachment body (plain text, may contain ANSI SGR sequences). */
+    content: string;
+}
+
+/**
+ * Renders raw (non-structured) terraform CLI output. This is the ONLY
+ * component in the tab allowed to use `dangerouslySetInnerHTML` (§5.3/§8.1) —
+ * it is exclusively fed through `ansiToHtml`, which HTML-escapes all text and
+ * only ever emits a small, fixed set of `<span class="ansi-*">` wrapper tags.
+ * Every structured component must render digest strings as plain React text
+ * nodes instead; see the no-dangerouslySetInnerHTML tripwire test.
+ */
+export function RawView({ name, content }: RawViewProps): JSX.Element {
+    if (content.length > MAX_RENDER_SIZE) {
+        return (
+            <div className="plan-oversize">
+                <p>
+                    Output for <strong>{name}</strong> is too large to render inline (
+                    {(content.length / (1024 * 1024)).toFixed(1)} MB).
+                </p>
+                <a
+                    href={URL.createObjectURL(new Blob([content], { type: "text/plain" }))}
+                    download={`${sanitizeDownloadFilename(name)}.txt`}
+                >
+                    Download raw output
+                </a>
+            </div>
+        );
+    }
+
+    return (
+        <div className="raw-view">
+            <div className="raw-view-name">{name}</div>
+            {/* eslint-disable-next-line react/no-danger -- sole sanitizer-backed sink, see module doc comment */}
+            <pre dangerouslySetInnerHTML={{ __html: ansiToHtml(content) }} />
+        </div>
+    );
+}

--- a/src/tab/components/ResourceDiff.test.tsx
+++ b/src/tab/components/ResourceDiff.test.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ResourceDiff } from "./ResourceDiff";
+import { PlanResource } from "../digest-schema";
+
+function resource(overrides: Partial<PlanResource>): PlanResource {
+  return {
+    address: "aws_instance.web",
+    type: "aws_instance",
+    name: "web",
+    providerName: "registry.terraform.io/hashicorp/aws",
+    actions: ["update"],
+    attributeChanges: [],
+    ...overrides,
+  };
+}
+
+describe("ResourceDiff", () => {
+  it("renders address, type, and actions", () => {
+    const html = renderToStaticMarkup(<ResourceDiff resource={resource({})} />);
+    expect(html).toContain("aws_instance.web");
+    expect(html).toContain("aws_instance");
+    expect(html).toMatch(/update/i);
+  });
+
+  it("shows an actionReason and replacePaths when present", () => {
+    const html = renderToStaticMarkup(
+      <ResourceDiff
+        resource={resource({
+          actions: ["delete", "create"],
+          actionReason: "replace_because_cannot_update",
+          replacePaths: ["ami", "availability_zone"],
+        })}
+      />
+    );
+    expect(html).toContain("replace_because_cannot_update");
+    expect(html).toContain("ami");
+    expect(html).toContain("availability_zone");
+  });
+
+  it("renders each attribute change with before/after values", () => {
+    const html = renderToStaticMarkup(
+      <ResourceDiff
+        resource={resource({
+          attributeChanges: [
+            { path: "instance_type", before: { kind: "value", json: '"t2.micro"' }, after: { kind: "value", json: '"t3.micro"' } },
+          ],
+        })}
+      />
+    );
+    expect(html).toContain("instance_type");
+    expect(html).toContain("t2.micro");
+    expect(html).toContain("t3.micro");
+  });
+
+  it('renders a sensitive attribute as "(sensitive)" and never leaks it as (value)', () => {
+    const html = renderToStaticMarkup(
+      <ResourceDiff
+        resource={resource({
+          attributeChanges: [{ path: "password", before: { kind: "unknown" }, after: { kind: "sensitive" } }],
+        })}
+      />
+    );
+    expect(html).toContain("(sensitive)");
+    expect(html).toContain("(known after apply)");
+  });
+
+  it("renders an omitted-too-large value placeholder", () => {
+    const html = renderToStaticMarkup(
+      <ResourceDiff
+        resource={resource({
+          attributeChanges: [{ path: "big_blob", before: { kind: "unknown" }, after: { kind: "omitted", reason: "too-large" } }],
+        })}
+      />
+    );
+    expect(html).toContain("omitted");
+  });
+
+  it("shows a no-attribute-changes message when there are none (e.g. a create with no before)", () => {
+    const html = renderToStaticMarkup(<ResourceDiff resource={resource({ attributeChanges: [] })} />);
+    expect(html).toMatch(/no attribute changes/i);
+  });
+
+  it("HTML-escapes an attribute path and value as text nodes", () => {
+    const html = renderToStaticMarkup(
+      <ResourceDiff
+        resource={resource({
+          attributeChanges: [
+            {
+              path: "<script>alert(1)</script>",
+              before: { kind: "unknown" },
+              after: { kind: "value", json: '"<img src=x onerror=alert(1)>"' },
+            },
+          ],
+        })}
+      />
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/src/tab/components/ResourceDiff.tsx
+++ b/src/tab/components/ResourceDiff.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { PlanResource } from "../digest-schema";
+import { formatRedactedValue } from "./redacted-value";
+
+export interface ResourceDiffProps {
+    resource: PlanResource;
+}
+
+/**
+ * Before → after attribute diff table for a single plan resource. Every
+ * digest string (address, path, redacted-value text) is rendered as a React
+ * text node — see `formatRedactedValue`, which only ever returns the
+ * already-redacted `json` text or a fixed placeholder.
+ */
+export function ResourceDiff({ resource }: ResourceDiffProps): JSX.Element {
+    return (
+        <div className="resource-diff">
+            <div className="resource-diff-header">
+                <span className="resource-diff-address">{resource.address}</span>
+                <span className="resource-diff-type">{resource.type}</span>
+                <span className="resource-diff-actions">{resource.actions.join(", ")}</span>
+            </div>
+            {resource.actionReason && (
+                <div className="resource-diff-reason">Reason: {resource.actionReason}</div>
+            )}
+            {resource.replacePaths && resource.replacePaths.length > 0 && (
+                <div className="resource-diff-replace-paths">
+                    Forces replacement: {resource.replacePaths.join(", ")}
+                </div>
+            )}
+            {resource.attributeChanges.length === 0 ? (
+                <div className="resource-diff-empty">No attribute changes recorded for this resource.</div>
+            ) : (
+                <table className="resource-diff-table">
+                    <thead>
+                        <tr>
+                            <th>Attribute</th>
+                            <th>Before</th>
+                            <th>After</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {resource.attributeChanges.map((change) => (
+                            <tr key={change.path}>
+                                <td className="resource-diff-path">{change.path}</td>
+                                <td className="resource-diff-before">{formatRedactedValue(change.before)}</td>
+                                <td className="resource-diff-after">{formatRedactedValue(change.after)}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+}

--- a/src/tab/components/ResourceList.test.tsx
+++ b/src/tab/components/ResourceList.test.tsx
@@ -1,0 +1,135 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ResourceList, ResourceListProps } from "./ResourceList";
+import { PlanResource } from "../digest-schema";
+
+function resource(overrides: Partial<PlanResource>): PlanResource {
+  return {
+    address: "aws_instance.web",
+    type: "aws_instance",
+    name: "web",
+    providerName: "registry.terraform.io/hashicorp/aws",
+    actions: ["create"],
+    attributeChanges: [],
+    ...overrides,
+  };
+}
+
+function baseProps(overrides: Partial<ResourceListProps> = {}): ResourceListProps {
+  return {
+    resources: [],
+    selectedAddress: null,
+    onSelect: jest.fn(),
+    searchText: "",
+    onSearchTextChange: jest.fn(),
+    ...overrides,
+  };
+}
+
+/** Render via the plain function call (no hooks used) to reach nested onClick/onChange closures. */
+function callComponent(props: ResourceListProps): React.ReactElement {
+  return ResourceList(props) as React.ReactElement;
+}
+
+describe("ResourceList", () => {
+  it("groups resources by action and shows group headings", () => {
+    const resources = [
+      resource({ address: "aws_instance.a", actions: ["create"] }),
+      resource({ address: "aws_instance.b", actions: ["delete"] }),
+      resource({ address: "aws_instance.c", actions: ["update"] }),
+    ];
+    const html = renderToStaticMarkup(<ResourceList {...baseProps({ resources })} />);
+    expect(html).toMatch(/create/i);
+    expect(html).toMatch(/delete/i);
+    expect(html).toMatch(/update/i);
+    expect(html).toContain("aws_instance.a");
+    expect(html).toContain("aws_instance.b");
+    expect(html).toContain("aws_instance.c");
+  });
+
+  it("groups a replace action distinctly from create/delete", () => {
+    const resources = [resource({ address: "aws_instance.r", actions: ["replace"], actionReason: "replace_because_cannot_update" })];
+    const html = renderToStaticMarkup(<ResourceList {...baseProps({ resources })} />);
+    expect(html).toContain("aws_instance.r");
+    expect(html).toMatch(/replace/i);
+  });
+
+  it("filters resources by address substring using the (controlled) search text", () => {
+    const resources = [resource({ address: "aws_instance.web" }), resource({ address: "aws_s3_bucket.assets" })];
+    const html = renderToStaticMarkup(<ResourceList {...baseProps({ resources, searchText: "s3" })} />);
+    expect(html).not.toContain("aws_instance.web");
+    expect(html).toContain("aws_s3_bucket.assets");
+  });
+
+  it("calls onSearchTextChange when the search input changes (controlled, no internal state)", () => {
+    const onSearchTextChange = jest.fn();
+    const el = callComponent(baseProps({ resources: [resource({})], onSearchTextChange }));
+    const input = findByTag(el, "input");
+    expect(input).toBeTruthy();
+    input!.props.onChange({ target: { value: "s3" } });
+    expect(onSearchTextChange).toHaveBeenCalledWith("s3");
+  });
+
+  it("calls onSelect with the resource address when a row is clicked", () => {
+    const onSelect = jest.fn();
+    const resources = [resource({ address: "aws_instance.web" })];
+    const el = callComponent(baseProps({ resources, onSelect }));
+    const row = findByTestId(el, "resource-row-aws_instance.web");
+    expect(row).toBeTruthy();
+    row!.props.onClick();
+    expect(onSelect).toHaveBeenCalledWith("aws_instance.web");
+  });
+
+  it("shows a truncated banner and caps rendered rows at maxRenderedRows", () => {
+    const resources = Array.from({ length: 5 }, (_, i) => resource({ address: `aws_instance.r${i}` }));
+    const html = renderToStaticMarkup(<ResourceList {...baseProps({ resources, maxRenderedRows: 3 })} />);
+    expect(html).toMatch(/list truncated/i);
+    expect(html).not.toContain("aws_instance.r4");
+  });
+
+  it("renders an empty state when there are no resources", () => {
+    const html = renderToStaticMarkup(<ResourceList {...baseProps()} />);
+    expect(html).toMatch(/no resource changes/i);
+  });
+
+  it("renders an empty-filter state distinct from the no-resources state when search matches nothing", () => {
+    const resources = [resource({ address: "aws_instance.web" })];
+    const html = renderToStaticMarkup(<ResourceList {...baseProps({ resources, searchText: "nomatch" })} />);
+    expect(html).toMatch(/no resources match/i);
+  });
+
+  it("HTML-escapes a malicious address as a text node", () => {
+    const resources = [resource({ address: "<img src=x onerror=alert(1)>" })];
+    const html = renderToStaticMarkup(<ResourceList {...baseProps({ resources })} />);
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+});
+
+// --- tiny React-element tree helpers (no DOM/testing-library dependency) ---
+
+function findByTag(node: React.ReactNode, tag: string): React.ReactElement | null {
+  return findNode(node, (n) => React.isValidElement(n) && n.type === tag);
+}
+
+function findByTestId(node: React.ReactNode, testId: string): React.ReactElement | null {
+  return findNode(
+    node,
+    (n) => React.isValidElement(n) && (n.props as Record<string, unknown>)["data-testid"] === testId
+  );
+}
+
+/** Depth-first search over a React element tree, recursing through arrays-of-arrays (e.g. nested `.map()` output). */
+function findNode(node: React.ReactNode, predicate: (n: React.ReactNode) => boolean): React.ReactElement | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findNode(child, predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!React.isValidElement(node)) return null;
+  if (predicate(node)) return node;
+  const children = (node.props as { children?: React.ReactNode }).children;
+  return findNode(children, predicate);
+}

--- a/src/tab/components/ResourceList.tsx
+++ b/src/tab/components/ResourceList.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { PlanResource } from "../digest-schema";
+import { TAB_MAX_RENDERED_ROWS } from "../caps";
+
+const GROUP_ORDER = ["replace", "delete", "create", "update", "read", "forget", "no-op"] as const;
+
+function groupKey(actions: PlanResource["actions"]): (typeof GROUP_ORDER)[number] {
+    if (actions.includes("replace")) return "replace";
+    if (actions.includes("delete") && actions.includes("create")) return "replace";
+    if (actions.length === 0) return "no-op";
+    const first = actions[0];
+    return (GROUP_ORDER as readonly string[]).includes(first) ? (first as (typeof GROUP_ORDER)[number]) : "no-op";
+}
+
+export interface ResourceListProps {
+    resources: PlanResource[];
+    selectedAddress: string | null;
+    onSelect: (address: string) => void;
+    /** Controlled search text — this component holds no internal state. */
+    searchText: string;
+    onSearchTextChange: (text: string) => void;
+    maxRenderedRows?: number;
+}
+
+/**
+ * Grouped, filterable resource list. Fully controlled (search text + caller):
+ * no internal component state, so it renders deterministically from props
+ * alone and needs no DOM/hook-testing infrastructure to unit test.
+ */
+export function ResourceList(props: ResourceListProps): JSX.Element {
+    const { resources, selectedAddress, onSelect, searchText, onSearchTextChange } = props;
+    const maxRows = props.maxRenderedRows ?? TAB_MAX_RENDERED_ROWS;
+
+    if (resources.length === 0) {
+        return <div className="resource-list-empty">No resource changes in this plan.</div>;
+    }
+
+    const needle = searchText.trim().toLowerCase();
+    const filtered = needle ? resources.filter((r) => r.address.toLowerCase().includes(needle)) : resources;
+
+    const truncated = filtered.length > maxRows;
+    const shown = truncated ? filtered.slice(0, maxRows) : filtered;
+
+    const groups = new Map<(typeof GROUP_ORDER)[number], PlanResource[]>();
+    for (const resource of shown) {
+        const key = groupKey(resource.actions);
+        const bucket = groups.get(key);
+        if (bucket) bucket.push(resource);
+        else groups.set(key, [resource]);
+    }
+
+    return (
+        <div className="resource-list">
+            <input
+                type="text"
+                className="resource-list-search"
+                placeholder="Search resources by address…"
+                value={searchText}
+                onChange={(e) => onSearchTextChange(e.target.value)}
+            />
+            {truncated && (
+                <div className="resource-list-truncated-banner">
+                    List truncated to {maxRows} of {filtered.length} matching resources.
+                </div>
+            )}
+            {filtered.length === 0 ? (
+                <div className="resource-list-empty">No resources match "{searchText}".</div>
+            ) : (
+                GROUP_ORDER.filter((g) => groups.has(g)).map((group) => (
+                    <div className="resource-group" key={group}>
+                        <div className="resource-group-heading">
+                            {group} ({groups.get(group)!.length})
+                        </div>
+                        <ul className="resource-group-list">
+                            {groups.get(group)!.map((resource) => (
+                                <li
+                                    key={resource.address}
+                                    data-testid={`resource-row-${resource.address}`}
+                                    className={`resource-row${resource.address === selectedAddress ? " selected" : ""}`}
+                                    onClick={() => onSelect(resource.address)}
+                                >
+                                    <span className="resource-row-address">{resource.address}</span>
+                                    <span className="resource-row-type">{resource.type}</span>
+                                    {resource.actionReason && (
+                                        <span className="resource-row-reason">{resource.actionReason}</span>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                ))
+            )}
+        </div>
+    );
+}

--- a/src/tab/components/SummaryHeader.test.tsx
+++ b/src/tab/components/SummaryHeader.test.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SummaryHeader } from "./SummaryHeader";
+
+describe("SummaryHeader", () => {
+  it("renders plan counts and title as text nodes", () => {
+    const html = renderToStaticMarkup(
+      <SummaryHeader
+        title="plan-main"
+        kind="plan"
+        counts={{ add: 3, change: 1, destroy: 2, replace: 1, read: 0 }}
+        noChanges={false}
+      />
+    );
+    expect(html).toContain("plan-main");
+    expect(html).toContain("+3");
+    expect(html).toContain("~1");
+    expect(html).toContain("-2");
+  });
+
+  it("shows a no-changes badge when noChanges is true", () => {
+    const html = renderToStaticMarkup(
+      <SummaryHeader title="plan-noop" kind="plan" counts={{ add: 0, change: 0, destroy: 0 }} noChanges={true} />
+    );
+    expect(html).toContain("No changes");
+  });
+
+  it("shows a drift badge when driftDetected is true", () => {
+    const html = renderToStaticMarkup(
+      <SummaryHeader
+        title="plan-drift"
+        kind="plan"
+        counts={{ add: 0, change: 0, destroy: 0 }}
+        driftDetected={true}
+      />
+    );
+    expect(html).toContain("Drift detected");
+  });
+
+  it("renders an apply outcome badge (succeeded/failed)", () => {
+    const succeeded = renderToStaticMarkup(
+      <SummaryHeader title="apply-ok" kind="apply" counts={{ add: 1, change: 0, destroy: 0 }} outcome="succeeded" />
+    );
+    expect(succeeded).toContain("Succeeded");
+
+    const failed = renderToStaticMarkup(
+      <SummaryHeader title="apply-fail" kind="apply" counts={{ add: 1, change: 0, destroy: 0 }} outcome="failed" />
+    );
+    expect(failed).toContain("Failed");
+  });
+
+  it("shows a truncated banner with notes when truncated", () => {
+    const html = renderToStaticMarkup(
+      <SummaryHeader
+        title="plan-big"
+        kind="plan"
+        counts={{ add: 9999, change: 0, destroy: 0 }}
+        truncated={true}
+        truncationNotes={["resource list capped at 2000"]}
+      />
+    );
+    expect(html).toContain("truncated");
+    expect(html).toContain("resource list capped at 2000");
+  });
+
+  it("HTML-escapes a malicious title instead of injecting it", () => {
+    const html = renderToStaticMarkup(
+      <SummaryHeader title={'<img src=x onerror=alert(1)>'} kind="plan" counts={{ add: 0, change: 0, destroy: 0 }} />
+    );
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+});

--- a/src/tab/components/SummaryHeader.tsx
+++ b/src/tab/components/SummaryHeader.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+export interface SummaryHeaderCounts {
+    add: number;
+    change: number;
+    destroy: number;
+    replace?: number;
+    read?: number;
+}
+
+export interface SummaryHeaderProps {
+    /** Untrusted digest name / roll-up label — rendered as a text node only. */
+    title: string;
+    kind: "plan" | "apply";
+    counts: SummaryHeaderCounts;
+    noChanges?: boolean;
+    driftDetected?: boolean;
+    /** Apply only. */
+    outcome?: "succeeded" | "failed";
+    truncated?: boolean;
+    truncationNotes?: string[];
+    toolLabel?: string;
+}
+
+/**
+ * Summary counts + status badges for a single plan/apply digest, or an
+ * aggregated roll-up across multiple digests. Every value is rendered as a
+ * React text node — no HTML sinks.
+ */
+export function SummaryHeader(props: SummaryHeaderProps): JSX.Element {
+    const { title, kind, counts, noChanges, driftDetected, outcome, truncated, truncationNotes, toolLabel } = props;
+
+    return (
+        <div className="summary-header">
+            <div className="summary-header-title-row">
+                <span className="summary-header-title">{title}</span>
+                {toolLabel && <span className="summary-header-tool">{toolLabel}</span>}
+                {kind === "apply" && outcome && (
+                    <span className={`badge badge-outcome-${outcome}`}>
+                        {outcome === "succeeded" ? "Succeeded" : "Failed"}
+                    </span>
+                )}
+                {driftDetected && <span className="badge badge-drift">Drift detected</span>}
+                {noChanges && <span className="badge badge-no-changes">No changes</span>}
+            </div>
+            <div className="summary-header-counts">
+                <span className="count count-add">+{counts.add}</span>
+                <span className="count count-change">~{counts.change}</span>
+                <span className="count count-destroy">-{counts.destroy}</span>
+                {typeof counts.replace === "number" && counts.replace > 0 && (
+                    <span className="count count-replace">±{counts.replace} replace</span>
+                )}
+                {typeof counts.read === "number" && counts.read > 0 && (
+                    <span className="count count-read">{counts.read} read</span>
+                )}
+            </div>
+            {truncated && (
+                <div className="summary-header-truncated">
+                    <span>This digest was truncated.</span>
+                    {truncationNotes && truncationNotes.length > 0 && (
+                        <ul>
+                            {truncationNotes.map((note, i) => (
+                                <li key={i}>{note}</li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/tab/components/redacted-value.test.ts
+++ b/src/tab/components/redacted-value.test.ts
@@ -1,0 +1,20 @@
+import { formatRedactedValue } from "./redacted-value";
+
+describe("formatRedactedValue", () => {
+  it('renders a "value" RedactedValue as its underlying JSON text', () => {
+    expect(formatRedactedValue({ kind: "value", json: '"t3.micro"' })).toBe('"t3.micro"');
+    expect(formatRedactedValue({ kind: "value", json: "42" })).toBe("42");
+  });
+
+  it('renders "sensitive" as (sensitive)', () => {
+    expect(formatRedactedValue({ kind: "sensitive" })).toBe("(sensitive)");
+  });
+
+  it('renders "unknown" as (known after apply)', () => {
+    expect(formatRedactedValue({ kind: "unknown" })).toBe("(known after apply)");
+  });
+
+  it('renders "omitted" as (value omitted: too large)', () => {
+    expect(formatRedactedValue({ kind: "omitted", reason: "too-large" })).toBe("(value omitted: too large)");
+  });
+});

--- a/src/tab/components/redacted-value.ts
+++ b/src/tab/components/redacted-value.ts
@@ -1,0 +1,22 @@
+import { RedactedValue } from "../digest-schema";
+
+/**
+ * Render a `RedactedValue` as plain display text. The result is ALWAYS meant
+ * to be placed into a React text node (`{formatRedactedValue(v)}`), never
+ * into an attribute or HTML sink — see the no-dangerouslySetInnerHTML
+ * tripwire test. Never returns anything but the already-redacted `json`
+ * string or one of the three fixed placeholder strings, so it can never leak
+ * a value shape the digest didn't already declare safe.
+ */
+export function formatRedactedValue(value: RedactedValue): string {
+  switch (value.kind) {
+    case "value":
+      return value.json;
+    case "sensitive":
+      return "(sensitive)";
+    case "unknown":
+      return "(known after apply)";
+    case "omitted":
+      return "(value omitted: too large)";
+  }
+}

--- a/src/tab/digest-model.test.ts
+++ b/src/tab/digest-model.test.ts
@@ -1,0 +1,583 @@
+import { parseDigestText } from "./digest-model";
+import * as caps from "./caps";
+
+/** A minimal, schema-valid v1 plan digest. */
+function validPlanDigestObj(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    kind: "plan",
+    producedBy: { task: "TerraformTaskV5", taskVersion: "5.12.0" },
+    tool: { name: "terraform", version: "1.14.6" },
+    meta: {
+      name: "plan-main",
+      workingDirectory: "infra/prod",
+      stage: "Deploy",
+      job: "TerraformPlan",
+      createdIso: "2026-07-01T12:00:00.000Z",
+    },
+    truncated: false,
+    summary: { add: 2, change: 1, destroy: 0, replace: 0, read: 0, noChanges: false, driftDetected: false },
+    resources: [
+      {
+        address: "aws_instance.web",
+        type: "aws_instance",
+        name: "web",
+        providerName: "registry.terraform.io/hashicorp/aws",
+        actions: ["create"],
+        attributeChanges: [
+          { path: "instance_type", before: { kind: "unknown" }, after: { kind: "value", json: '"t3.micro"' } },
+          { path: "password", before: { kind: "unknown" }, after: { kind: "sensitive" } },
+        ],
+      },
+    ],
+    outputChanges: [{ name: "db_password", action: "create", value: { kind: "sensitive" } }],
+  };
+}
+
+/** A minimal, schema-valid v1 apply digest. */
+function validApplyDigestObj(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    kind: "apply",
+    producedBy: { task: "TerraformTaskV5", taskVersion: "5.12.0" },
+    tool: { name: "terraform", version: "1.14.6" },
+    meta: { name: "apply-main", createdIso: "2026-07-01T12:05:00.000Z" },
+    truncated: false,
+    outcome: "succeeded",
+    summary: { add: 1, change: 0, destroy: 0, durationMs: 4321 },
+    resources: [{ address: "aws_instance.web", action: "create", status: "complete", durationMs: 1200 }],
+    diagnostics: [],
+    outputs: [{ name: "db_password", action: "create", value: { kind: "sensitive" } }],
+  };
+}
+
+function json(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+describe("parseDigestText — valid v1 digests", () => {
+  it("parses a valid v1 plan digest into a typed object", () => {
+    const result = parseDigestText(json(validPlanDigestObj()));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.unknownVersion).toBe(false);
+    expect(result.detectedSchemaVersion).toBe(1);
+    expect(result.digest.kind).toBe("plan");
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.summary.add).toBe(2);
+    expect(result.digest.resources).toHaveLength(1);
+    expect(result.digest.resources[0].address).toBe("aws_instance.web");
+    expect(result.digest.resources[0].attributeChanges[0].after).toEqual({ kind: "value", json: '"t3.micro"' });
+    expect(result.digest.resources[0].attributeChanges[1].after).toEqual({ kind: "sensitive" });
+    expect(result.digest.meta.name).toBe("plan-main");
+  });
+
+  it("parses a valid v1 apply digest into a typed object", () => {
+    const result = parseDigestText(json(validApplyDigestObj()));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.unknownVersion).toBe(false);
+    expect(result.digest.kind).toBe("apply");
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.outcome).toBe("succeeded");
+    expect(result.digest.resources[0].status).toBe("complete");
+    expect(result.digest.outputs[0].value).toEqual({ kind: "sensitive" });
+  });
+
+  it("is deterministic: parsing the same input twice yields deep-equal digests", () => {
+    const raw = json(validPlanDigestObj());
+    const a = parseDigestText(raw);
+    const b = parseDigestText(raw);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("parseDigestText — malformed JSON", () => {
+  it("returns a malformed-json failure without throwing", () => {
+    expect(() => parseDigestText("{ not valid json")).not.toThrow();
+    const result = parseDigestText("{ not valid json");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("malformed-json");
+  });
+
+  it("rejects a non-object JSON root (array/primitive) without throwing", () => {
+    expect(parseDigestText("42").ok).toBe(false);
+    expect(parseDigestText("[1,2,3]").ok).toBe(false);
+    expect(parseDigestText("null").ok).toBe(false);
+    expect(parseDigestText('"just a string"').ok).toBe(false);
+  });
+});
+
+describe("parseDigestText — oversize refusal (parse ceiling)", () => {
+  it("refuses a digest over the tab parse ceiling using an explicit byte length, before JSON.parse runs", () => {
+    const parseSpy = jest.spyOn(JSON, "parse");
+    const result = parseDigestText("{}", caps.TAB_PARSE_CEILING_BYTES + 1);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("oversize");
+    expect(parseSpy).not.toHaveBeenCalled();
+    parseSpy.mockRestore();
+  });
+
+  it("refuses an oversize digest even without an explicit byte length (measures the raw text)", () => {
+    const huge = json({ ...validPlanDigestObj(), padding: "x".repeat(caps.TAB_PARSE_CEILING_BYTES) });
+    const result = parseDigestText(huge);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("oversize");
+  });
+
+  it("accepts a digest comfortably under the ceiling", () => {
+    const result = parseDigestText(json(validPlanDigestObj()), 1024);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("parseDigestText — prototype-pollution keys", () => {
+  it("rejects a digest with a top-level __proto__ key and never pollutes Object.prototype", () => {
+    const malicious = { ...validPlanDigestObj(), __proto__: { polluted: true } };
+    // Constructing the object above via object-literal spread with a literal
+    // "__proto__" key sets the *actual* prototype in JS semantics, not an own
+    // property — so build the attack the way an attacker actually would: via
+    // JSON, where "__proto__" becomes a genuine own property (see digest-model
+    // comments for why JSON.parse's own-property semantics differ from object
+    // literals).
+    const raw = '{"__proto__":{"polluted":true},' + json(validPlanDigestObj()).slice(1);
+    const result = parseDigestText(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unsafe-keys");
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    void malicious;
+  });
+
+  it("rejects a digest with a nested constructor/prototype key deep inside the resource array", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as unknown[]).push({ constructor: { prototype: { polluted: true } } });
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unsafe-keys");
+  });
+});
+
+describe("parseDigestText — unknown newer schemaVersion", () => {
+  it("degrades gracefully (no crash) on a far-future schemaVersion and signals a partial render", () => {
+    const obj = { ...validPlanDigestObj(), schemaVersion: 999 };
+    expect(() => parseDigestText(json(obj))).not.toThrow();
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.unknownVersion).toBe(true);
+    expect(result.detectedSchemaVersion).toBe(999);
+    expect(result.notes.length).toBeGreaterThan(0);
+    expect(result.digest.kind).toBe("plan");
+  });
+
+  it("degrades gracefully even when a schemaVersion:999 digest is missing most fields, still requiring only `kind`", () => {
+    const raw = json({ schemaVersion: 999, kind: "apply" });
+    expect(() => parseDigestText(raw)).not.toThrow();
+    const result = parseDigestText(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.unknownVersion).toBe(true);
+    expect(result.digest.kind).toBe("apply");
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.resources).toEqual([]);
+    expect(result.digest.diagnostics).toEqual([]);
+  });
+
+  it("fails safely (not a throw) when even `kind` is unrecognizable on an unknown schemaVersion", () => {
+    const raw = json({ schemaVersion: 999, kind: "state-inventory" });
+    const result = parseDigestText(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unsupported-kind");
+  });
+});
+
+describe("parseDigestText — unsupported kind", () => {
+  it("rejects a digest whose kind is neither plan nor apply", () => {
+    const result = parseDigestText(json({ ...validPlanDigestObj(), kind: "destroy" }));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unsupported-kind");
+  });
+});
+
+describe("parseDigestText — missing/typo'd required fields (v1, rejected safely)", () => {
+  it("rejects a v1 plan digest missing `summary` entirely, rather than rendering undefined", () => {
+    const obj = validPlanDigestObj();
+    delete obj.summary;
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("invalid-envelope");
+  });
+
+  it("rejects a v1 plan digest missing `resources` entirely", () => {
+    const obj = validPlanDigestObj();
+    delete obj.resources;
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("invalid-envelope");
+  });
+
+  it("rejects a v1 apply digest missing `diagnostics` entirely", () => {
+    const obj = validApplyDigestObj();
+    delete obj.diagnostics;
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("invalid-envelope");
+  });
+
+  it("rejects a v1 digest missing the `meta` envelope object", () => {
+    const obj = validPlanDigestObj();
+    delete obj.meta;
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseDigestText — RedactedValue fail-closed on shape mismatch", () => {
+  it("masks (never renders) a RedactedValue claiming kind:\"value\" with no json string", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = [
+      { path: "secret_url", before: { kind: "unknown" }, after: { kind: "value" } },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].attributeChanges[0].after).toEqual({ kind: "sensitive" });
+    expect(result.notes.some((n: string) => n.includes("fail-closed") || n.toLowerCase().includes("masked"))).toBe(true);
+  });
+
+  it("masks a RedactedValue with an unrecognized kind rather than passing it through", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = [
+      { path: "x", before: { kind: "unknown" }, after: { kind: "totally-new-kind", raw: "leaked-secret" } },
+    ];
+    const raw = json(obj);
+    expect(raw).toContain("leaked-secret");
+    const result = parseDigestText(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].attributeChanges[0].after).toEqual({ kind: "sensitive" });
+    // The unrecognized shape must never be echoed anywhere in the parsed digest.
+    expect(JSON.stringify(result.digest)).not.toContain("leaked-secret");
+  });
+
+  it("defensively truncates an oversize RedactedValue.json beyond the redacted-value byte cap", () => {
+    const obj = validPlanDigestObj();
+    const oversizedJson = JSON.stringify("x".repeat(caps.MAX_REDACTED_VALUE_BYTES + 500));
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = [
+      { path: "big", before: { kind: "unknown" }, after: { kind: "value", json: oversizedJson } },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    const after = result.digest.resources[0].attributeChanges[0].after;
+    expect(after.kind).toBe("value");
+    if (after.kind !== "value") return;
+    expect(after.json.length).toBeLessThanOrEqual(caps.MAX_REDACTED_VALUE_BYTES + 32);
+  });
+});
+
+describe("parseDigestText — defensive tab-side caps (§6, don't trust `truncated`)", () => {
+  it("caps the resources array at MAX_RESOURCES even when the digest claims truncated:false", () => {
+    const obj = validPlanDigestObj();
+    const template = (obj.resources as unknown[])[0] as Record<string, unknown>;
+    obj.resources = Array.from({ length: caps.MAX_RESOURCES + 5 }, (_, i) => ({
+      ...template,
+      address: `aws_instance.web[${i}]`,
+    }));
+    obj.truncated = false;
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources).toHaveLength(caps.MAX_RESOURCES);
+    expect(result.digest.truncated).toBe(true);
+  });
+
+  it("caps attributeChanges per resource at MAX_ATTR_CHANGES_PER_RESOURCE", () => {
+    const obj = validPlanDigestObj();
+    const many = Array.from({ length: caps.MAX_ATTR_CHANGES_PER_RESOURCE + 3 }, (_, i) => ({
+      path: `attr_${i}`,
+      before: { kind: "unknown" },
+      after: { kind: "value", json: String(i) },
+    }));
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = many;
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].attributeChanges).toHaveLength(caps.MAX_ATTR_CHANGES_PER_RESOURCE);
+  });
+
+  it("caps diagnostics at MAX_DIAGNOSTICS", () => {
+    const obj = validApplyDigestObj();
+    obj.diagnostics = Array.from({ length: caps.MAX_DIAGNOSTICS + 10 }, (_, i) => ({
+      severity: "warning",
+      summary: `warn ${i}`,
+    }));
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.diagnostics).toHaveLength(caps.MAX_DIAGNOSTICS);
+  });
+});
+
+describe("parseDigestText — drift resources (resource_drift)", () => {
+  it("parses a valid drift entry, masking sensitive drifted attributes", () => {
+    const obj = validPlanDigestObj();
+    obj.drift = [
+      {
+        address: "aws_instance.drifted",
+        type: "aws_instance",
+        name: "drifted",
+        providerName: "registry.terraform.io/hashicorp/aws",
+        attributeChanges: [
+          { path: "tags.owner", before: { kind: "value", json: '"alice"' }, after: { kind: "value", json: '"bob"' } },
+          { path: "password", before: { kind: "unknown" }, after: { kind: "sensitive" } },
+        ],
+      },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.drift).toHaveLength(1);
+    expect(result.digest.drift?.[0].address).toBe("aws_instance.drifted");
+    expect(result.digest.drift?.[0].attributeChanges[1].after).toEqual({ kind: "sensitive" });
+  });
+
+  it("skips a drift entry that is not an object, and one missing an address", () => {
+    const obj = validPlanDigestObj();
+    obj.drift = ["not-an-object", { type: "aws_instance", name: "no-address" }];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.drift).toEqual([]);
+  });
+
+  it("caps a drift entry's attributeChanges at MAX_ATTR_CHANGES_PER_RESOURCE", () => {
+    const obj = validPlanDigestObj();
+    const many = Array.from({ length: caps.MAX_ATTR_CHANGES_PER_RESOURCE + 2 }, (_, i) => ({
+      path: `attr_${i}`,
+      before: { kind: "unknown" },
+      after: { kind: "value", json: String(i) },
+    }));
+    obj.drift = [
+      { address: "aws_instance.drifted", type: "aws_instance", name: "drifted", providerName: "x", attributeChanges: many },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.drift?.[0].attributeChanges).toHaveLength(caps.MAX_ATTR_CHANGES_PER_RESOURCE);
+  });
+
+  it("omits `drift` entirely when the field is absent (it is optional)", () => {
+    const result = parseDigestText(json(validPlanDigestObj()));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.drift).toBeUndefined();
+  });
+});
+
+describe("parseDigestText — remaining field/element coercion branches", () => {
+  it("carries replacePaths through for a resource forced to replace", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].actions = ["delete", "create"];
+    (obj.resources as Array<Record<string, unknown>>)[0].replacePaths = ["ami", "availability_zone"];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].replacePaths).toEqual(["ami", "availability_zone"]);
+  });
+
+  it("carries appliedBeforeFailure through for a partially-failed apply", () => {
+    const obj = validApplyDigestObj();
+    obj.appliedBeforeFailure = ["aws_instance.a", "aws_instance.b"];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.appliedBeforeFailure).toEqual(["aws_instance.a", "aws_instance.b"]);
+  });
+
+  it("masks a RedactedValue that is not an object at all (e.g. a bare string or null)", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = [
+      { path: "weird", before: "not-an-object", after: null },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    const change = result.digest.resources[0].attributeChanges[0];
+    expect(change.before).toEqual({ kind: "sensitive" });
+    expect(change.after).toEqual({ kind: "sensitive" });
+  });
+
+  it('passes through an "omitted" RedactedValue as-is', () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = [
+      { path: "huge", before: { kind: "unknown" }, after: { kind: "omitted", reason: "too-large" } },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].attributeChanges[0].after).toEqual({ kind: "omitted", reason: "too-large" });
+  });
+
+  it("skips a plan resource array element that is not an object", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as unknown[]).push("not-an-object");
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources).toHaveLength(1);
+  });
+
+  it("treats an actions array with only unrecognized strings as empty, with a note", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].actions = ["totally-bogus"];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].actions).toEqual([]);
+    expect(result.notes.some((n) => n.includes("no recognized action"))).toBe(true);
+  });
+
+  it("skips an attributeChanges element that is not an object", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = ["not-an-object"];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].attributeChanges).toEqual([]);
+  });
+
+  it('skips an attributeChanges element missing "path"', () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].attributeChanges = [
+      { before: { kind: "unknown" }, after: { kind: "unknown" } },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources[0].attributeChanges).toEqual([]);
+  });
+
+  it("skips an outputChanges element that is not an object, one missing a name, and one with an unrecognized action", () => {
+    const obj = validPlanDigestObj();
+    obj.outputChanges = [
+      "not-an-object",
+      { action: "create", value: { kind: "unknown" } },
+      { name: "bad_action", action: "bogus", value: { kind: "unknown" } },
+      { name: "good", action: "update", value: { kind: "unknown" } },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.outputChanges).toEqual([{ name: "good", action: "update", value: { kind: "unknown" } }]);
+  });
+
+  it("defensively caps apply resources at MAX_RESOURCES", () => {
+    const obj = validApplyDigestObj();
+    const template = (obj.resources as unknown[])[0] as Record<string, unknown>;
+    obj.resources = Array.from({ length: caps.MAX_RESOURCES + 5 }, (_, i) => ({
+      ...template,
+      address: `aws_instance.web[${i}]`,
+    }));
+    obj.truncated = false;
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.resources).toHaveLength(caps.MAX_RESOURCES);
+    expect(result.digest.truncated).toBe(true);
+  });
+
+  it("skips an apply resource array element that is not an object, and one missing an address", () => {
+    const obj = validApplyDigestObj();
+    (obj.resources as unknown[]).push("not-an-object", { action: "create", status: "complete" });
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.resources).toHaveLength(1);
+  });
+
+  it("defaults an apply resource's status to \"started\" when missing/unrecognized", () => {
+    const obj = validApplyDigestObj();
+    (obj.resources as Array<Record<string, unknown>>)[0].status = "bogus-status";
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.resources[0].status).toBe("started");
+  });
+
+  it("skips a diagnostic element that is not an object, one with a missing/unrecognized severity, and one missing summary", () => {
+    const obj = validApplyDigestObj();
+    obj.diagnostics = [
+      "not-an-object",
+      { severity: "critical", summary: "bad severity" },
+      { severity: "error" },
+      { severity: "warning", summary: "kept" },
+    ];
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.diagnostics).toEqual([{ severity: "warning", summary: "kept", detail: undefined, address: undefined }]);
+  });
+});
+
+describe("parseDigestText — malformed array elements are skipped, not fatal", () => {
+  it("skips a resource missing its address, keeping the other valid resources", () => {
+    const obj = validPlanDigestObj();
+    (obj.resources as unknown[]).push({ type: "aws_instance", name: "no-address" });
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "plan") return;
+    expect(result.digest.resources).toHaveLength(1);
+    expect(result.notes.length).toBeGreaterThan(0);
+  });
+
+  it("skips an apply resource missing a recognizable action", () => {
+    const obj = validApplyDigestObj();
+    (obj.resources as unknown[]).push({ address: "aws_instance.bad", action: "not-a-real-action", status: "complete" });
+    const result = parseDigestText(json(obj));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.digest.kind !== "apply") return;
+    expect(result.digest.resources).toHaveLength(1);
+  });
+
+  it("does not crash when an array field itself is the wrong JSON type (e.g. resources is an object)", () => {
+    const obj = validPlanDigestObj();
+    obj.resources = { not: "an array" };
+    expect(() => parseDigestText(json(obj))).not.toThrow();
+  });
+});

--- a/src/tab/digest-model.ts
+++ b/src/tab/digest-model.ts
@@ -1,0 +1,693 @@
+/**
+ * Safe parsing & validation of a plan/apply digest fetched from a pipeline
+ * attachment (§5.3.4 of docs/initiatives/structured-plan-apply-tabs.md).
+ *
+ * The digest is UNTRUSTED INPUT: it was produced by a task run inside a
+ * customer pipeline, but the tab (running in the ADO web UI) must not assume
+ * it is well-formed or safe to spread into component state. This module is
+ * the single choke point between `JSON.parse` and every structured component
+ * — nothing downstream should ever see a raw `unknown` value.
+ *
+ * Rules enforced here (see design §5.3.4 / §12.2):
+ *  - JSON.parse only (never eval/Function).
+ *  - Reject digests over the tab parse ceiling BEFORE parsing (avoid a
+ *    browser OOM from a malicious/huge attachment).
+ *  - Reject prototype-pollution keys (`__proto__`/`constructor`/`prototype`)
+ *    anywhere in the parsed tree — the whole digest is rejected rather than
+ *    silently stripping the key, since a document that carries one is
+ *    already suspect.
+ *  - Field-by-field coercion into the typed `Digest` shapes from
+ *    digest-schema.ts — never `{...parsed}` spread an untrusted object into
+ *    typed state.
+ *  - A required top-level field that is missing/mistyped on a *known*
+ *    schemaVersion (1) fails the whole parse (§12.2: "rejected safely, not
+ *    rendered as undefined"). An *unknown* schemaVersion instead degrades:
+ *    every field softens to a safe default and the caller is told via
+ *    `unknownVersion`/`notes` so it can offer the raw fallback.
+ *  - `RedactedValue` is the one place a redaction/shape bug becomes a
+ *    disclosure, so it ALWAYS fails closed to `{kind:"sensitive"}` on any
+ *    unrecognized shape, in both strict and lenient mode — this is a
+ *    defense-in-depth mirror of the task-side fail-closed rule (spec §5.2.4),
+ *    not merely a "best-effort" default like every other field.
+ *  - Container arrays (resources/diagnostics/outputs/...) are defensively
+ *    re-capped tab-side to the §6 limits regardless of the digest's own
+ *    `truncated` claim (§5.5: "don't trust `truncated`"); a malformed array
+ *    element is skipped (with a note) rather than failing the whole digest.
+ */
+
+import {
+  Digest,
+  PlanDigest,
+  ApplyDigest,
+  PlanResource,
+  DriftResource,
+  AttrChange,
+  RedactedValue,
+  OutputChange,
+  ApplyResource,
+  Diagnostic,
+} from "./digest-schema";
+import {
+  MAX_RESOURCES,
+  MAX_ATTR_CHANGES_PER_RESOURCE,
+  MAX_REDACTED_VALUE_BYTES,
+  MAX_DIAGNOSTICS,
+  TAB_PARSE_CEILING_BYTES,
+} from "./caps";
+
+/** The only schemaVersion this tab fully understands. */
+const KNOWN_SCHEMA_VERSION = 1;
+
+/** Keys that must never be read/walked into — the prototype-pollution surface. */
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+export type DigestParseFailureReason =
+  | "oversize"
+  | "malformed-json"
+  | "unsafe-keys"
+  | "invalid-envelope"
+  | "unsupported-kind";
+
+export interface DigestParseFailure {
+  ok: false;
+  reason: DigestParseFailureReason;
+  message: string;
+}
+
+export interface DigestParseSuccess {
+  ok: true;
+  /** Typed per the frozen v1 contract. See `unknownVersion`/`detectedSchemaVersion` below. */
+  digest: Digest;
+  /** True when the source `schemaVersion` is newer than KNOWN_SCHEMA_VERSION; `digest` is a best-effort, partial reconstruction. */
+  unknownVersion: boolean;
+  /** The raw `schemaVersion` value found on the wire (may differ from `digest.schemaVersion`, which is normalized to the known literal). */
+  detectedSchemaVersion: number;
+  /** Human-readable notes: degraded/defaulted fields, defensive caps applied, fail-closed masks. */
+  notes: string[];
+}
+
+export type DigestParseResult = DigestParseSuccess | DigestParseFailure;
+
+/**
+ * Parse and validate a digest attachment's raw text body.
+ * @param raw the attachment body, already decoded to a string
+ * @param byteLength optional known byte length (e.g. from a `Content-Length`
+ *   header) so the caller can refuse an oversize body before even reading it
+ *   into `raw`; when omitted, the UTF-8 byte length of `raw` itself is used.
+ */
+export function parseDigestText(raw: string, byteLength?: number): DigestParseResult {
+  const size = byteLength ?? utf8ByteLength(raw);
+  if (size > TAB_PARSE_CEILING_BYTES) {
+    return {
+      ok: false,
+      reason: "oversize",
+      message: `Digest is ${size} bytes, over the ${TAB_PARSE_CEILING_BYTES}-byte tab parse ceiling.`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, reason: "malformed-json", message: err instanceof Error ? err.message : "Invalid JSON." };
+  }
+
+  if (!isPlainObject(parsed)) {
+    return { ok: false, reason: "invalid-envelope", message: "Digest root is not a JSON object." };
+  }
+
+  if (containsForbiddenKey(parsed)) {
+    return {
+      ok: false,
+      reason: "unsafe-keys",
+      message: "Digest contains a disallowed key (__proto__ / constructor / prototype).",
+    };
+  }
+
+  const kind = parsed["kind"];
+  if (kind !== "plan" && kind !== "apply") {
+    return { ok: false, reason: "unsupported-kind", message: `Unrecognized digest kind: ${JSON.stringify(kind)}` };
+  }
+
+  const rawSchemaVersion = parsed["schemaVersion"];
+  const detectedSchemaVersion = typeof rawSchemaVersion === "number" ? rawSchemaVersion : NaN;
+  const unknownVersion = detectedSchemaVersion !== KNOWN_SCHEMA_VERSION;
+
+  const notes: string[] = [];
+  if (unknownVersion) {
+    notes.push(
+      `This digest was produced with schemaVersion ${JSON.stringify(
+        rawSchemaVersion
+      )}, which this tab does not fully understand (known: ${KNOWN_SCHEMA_VERSION}). Rendering best-effort from recognized fields only; use the raw view for the full content.`
+    );
+  }
+
+  const envelope = coerceEnvelope(parsed, unknownVersion, notes);
+  if (!envelope.ok) {
+    return { ok: false, reason: "invalid-envelope", message: envelope.message };
+  }
+
+  const built =
+    kind === "plan"
+      ? coercePlanDigest(parsed, envelope.value, unknownVersion, notes)
+      : coerceApplyDigest(parsed, envelope.value, unknownVersion, notes);
+
+  if (!built.ok) {
+    return { ok: false, reason: "invalid-envelope", message: built.message };
+  }
+
+  return { ok: true, digest: built.value, unknownVersion, detectedSchemaVersion, notes };
+}
+
+// ---------------------------------------------------------------------------
+// Generic safety primitives
+// ---------------------------------------------------------------------------
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Recursively checks whether any object in the tree carries an OWN property
+ * literally named `__proto__`, `constructor`, or `prototype`. `Object.keys`
+ * only enumerates own properties and is not affected by the prototype chain,
+ * so this is safe to run on untrusted `JSON.parse` output — reading
+ * `obj["__proto__"]` on such an object returns the JSON value (an own
+ * property shadows the inherited accessor), never `Object.prototype` itself.
+ * The danger this guards against is downstream: if some other code later
+ * copied keys via generic bracket-assignment (`target[key] = value`), that
+ * assignment path (unlike simple reads) *does* invoke the inherited
+ * `__proto__` setter. Rejecting the whole digest here removes the need for
+ * every downstream coercer to reason about that possibility.
+ */
+function containsForbiddenKey(value: unknown, seen: Set<unknown> = new Set()): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.some((v) => containsForbiddenKey(v, seen));
+  }
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return true;
+    if (containsForbiddenKey((value as Record<string, unknown>)[key], seen)) return true;
+  }
+  return false;
+}
+
+function utf8ByteLength(s: string): number {
+  return new TextEncoder().encode(s).length;
+}
+
+type FieldResult<T> = { ok: true; value: T } | { ok: false; message: string };
+
+/** A required top-level object field. Hard-fails in strict mode; empty-object-defaults in lenient mode. */
+function requireObject(
+  obj: Record<string, unknown>,
+  key: string,
+  lenient: boolean,
+  notes: string[],
+  path: string
+): FieldResult<Record<string, unknown>> {
+  const v = obj[key];
+  if (isPlainObject(v)) return { ok: true, value: v };
+  if (lenient) {
+    notes.push(`${path}.${key} missing or invalid; defaulted to an empty object.`);
+    return { ok: true, value: {} };
+  }
+  return { ok: false, message: `${path}.${key} is required and must be an object.` };
+}
+
+/** A required top-level array field. Hard-fails in strict mode; empty-array-defaults in lenient mode. */
+function requireArray(
+  obj: Record<string, unknown>,
+  key: string,
+  lenient: boolean,
+  notes: string[],
+  path: string
+): FieldResult<unknown[]> {
+  const v = obj[key];
+  if (Array.isArray(v)) return { ok: true, value: v };
+  if (lenient) {
+    notes.push(`${path}.${key} missing or invalid; defaulted to an empty list.`);
+    return { ok: true, value: [] };
+  }
+  return { ok: false, message: `${path}.${key} is required and must be an array.` };
+}
+
+function softString(obj: Record<string, unknown>, key: string, fallback: string, notes: string[], path: string): string {
+  const v = obj[key];
+  if (typeof v === "string") return v;
+  notes.push(`${path}.${key} missing or not a string; defaulted.`);
+  return fallback;
+}
+
+function optionalString(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function optionalStringArray(obj: Record<string, unknown>, key: string): string[] | undefined {
+  const v = obj[key];
+  if (!Array.isArray(v)) return undefined;
+  const strings = v.filter((x): x is string => typeof x === "string");
+  return strings.length > 0 ? strings : undefined;
+}
+
+function softNumber(obj: Record<string, unknown>, key: string, fallback: number, notes: string[], path: string): number {
+  const v = obj[key];
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  notes.push(`${path}.${key} missing or not a number; defaulted to ${fallback}.`);
+  return fallback;
+}
+
+function optionalNumber(obj: Record<string, unknown>, key: string): number | undefined {
+  const v = obj[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function softBoolean(obj: Record<string, unknown>, key: string, fallback: boolean, notes: string[], path: string): boolean {
+  const v = obj[key];
+  if (typeof v === "boolean") return v;
+  notes.push(`${path}.${key} missing or not a boolean; defaulted to ${fallback}.`);
+  return fallback;
+}
+
+function softEnum<T extends string>(
+  obj: Record<string, unknown>,
+  key: string,
+  allowed: readonly T[],
+  fallback: T,
+  notes: string[],
+  path: string
+): T {
+  const v = obj[key];
+  if (typeof v === "string" && (allowed as readonly string[]).includes(v)) return v as T;
+  notes.push(`${path}.${key} missing or not one of ${allowed.join("/")}; defaulted to "${fallback}".`);
+  return fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+interface EnvelopeFields {
+  producedByTask: string;
+  producedByTaskVersion: string;
+  toolName: string;
+  toolVersion: string;
+  metaName: string;
+  metaWorkingDirectory?: string;
+  metaStage?: string;
+  metaJob?: string;
+  metaCreatedIso: string;
+  truncated: boolean;
+  truncationNotes?: string[];
+}
+
+function coerceEnvelope(
+  obj: Record<string, unknown>,
+  lenient: boolean,
+  notes: string[]
+): FieldResult<EnvelopeFields> {
+  const producedBy = requireObject(obj, "producedBy", lenient, notes, "digest");
+  if (!producedBy.ok) return producedBy;
+  const tool = requireObject(obj, "tool", lenient, notes, "digest");
+  if (!tool.ok) return tool;
+  const meta = requireObject(obj, "meta", lenient, notes, "digest");
+  if (!meta.ok) return meta;
+
+  return {
+    ok: true,
+    value: {
+      producedByTask: softString(producedBy.value, "task", "unknown", notes, "digest.producedBy"),
+      producedByTaskVersion: softString(producedBy.value, "taskVersion", "unknown", notes, "digest.producedBy"),
+      toolName: softString(tool.value, "name", "terraform", notes, "digest.tool"),
+      toolVersion: softString(tool.value, "version", "unknown", notes, "digest.tool"),
+      metaName: softString(meta.value, "name", "", notes, "digest.meta"),
+      metaWorkingDirectory: optionalString(meta.value, "workingDirectory"),
+      metaStage: optionalString(meta.value, "stage"),
+      metaJob: optionalString(meta.value, "job"),
+      metaCreatedIso: softString(meta.value, "createdIso", "", notes, "digest.meta"),
+      truncated: softBoolean(obj, "truncated", false, notes, "digest"),
+      truncationNotes: optionalStringArray(obj, "truncationNotes"),
+    },
+  };
+}
+
+function envelopeBase(
+  env: EnvelopeFields
+): Pick<PlanDigest, "schemaVersion" | "producedBy" | "tool" | "meta" | "truncated" | "truncationNotes"> {
+  return {
+    // The wire schemaVersion may legitimately differ (see `unknownVersion` /
+    // `detectedSchemaVersion` on the parse result) — the frozen contract
+    // types this literally as `1`, so any value is normalized to it here;
+    // callers must consult `unknownVersion` before trusting this field.
+    schemaVersion: 1,
+    producedBy: { task: "TerraformTaskV5", taskVersion: env.producedByTaskVersion },
+    tool: { name: env.toolName === "opentofu" ? "opentofu" : "terraform", version: env.toolVersion },
+    meta: {
+      name: env.metaName,
+      workingDirectory: env.metaWorkingDirectory,
+      stage: env.metaStage,
+      job: env.metaJob,
+      createdIso: env.metaCreatedIso,
+    },
+    truncated: env.truncated,
+    truncationNotes: env.truncationNotes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RedactedValue — always fails closed, never aborts the parse
+// ---------------------------------------------------------------------------
+
+function coerceRedactedValue(v: unknown, notes: string[], path: string): RedactedValue {
+  if (!isPlainObject(v)) {
+    notes.push(`${path} is not a valid RedactedValue; masked (fail-closed).`);
+    return { kind: "sensitive" };
+  }
+  const kind = v["kind"];
+  switch (kind) {
+    case "value": {
+      const raw = v["json"];
+      if (typeof raw !== "string") {
+        notes.push(`${path} claimed kind "value" but had no json string; masked (fail-closed).`);
+        return { kind: "sensitive" };
+      }
+      if (raw.length > MAX_REDACTED_VALUE_BYTES) {
+        notes.push(`${path}.json exceeded the tab's defensive size cap and was truncated.`);
+        return { kind: "value", json: raw.slice(0, MAX_REDACTED_VALUE_BYTES) + "…(truncated)" };
+      }
+      return { kind: "value", json: raw };
+    }
+    case "sensitive":
+      return { kind: "sensitive" };
+    case "unknown":
+      return { kind: "unknown" };
+    case "omitted":
+      return { kind: "omitted", reason: "too-large" };
+    default:
+      notes.push(`${path} has an unrecognized RedactedValue kind (${JSON.stringify(kind)}); masked (fail-closed).`);
+      return { kind: "sensitive" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plan digest
+// ---------------------------------------------------------------------------
+
+const PLAN_ACTIONS = ["no-op", "create", "read", "update", "delete", "replace", "forget"] as const;
+
+function coercePlanDigest(
+  obj: Record<string, unknown>,
+  env: EnvelopeFields,
+  lenient: boolean,
+  notes: string[]
+): FieldResult<PlanDigest> {
+  const summaryObj = requireObject(obj, "summary", lenient, notes, "digest");
+  if (!summaryObj.ok) return summaryObj;
+  const resourcesArr = requireArray(obj, "resources", lenient, notes, "digest");
+  if (!resourcesArr.ok) return resourcesArr;
+  const outputChangesArr = requireArray(obj, "outputChanges", lenient, notes, "digest");
+  if (!outputChangesArr.ok) return outputChangesArr;
+
+  const summary = {
+    add: softNumber(summaryObj.value, "add", 0, notes, "digest.summary"),
+    change: softNumber(summaryObj.value, "change", 0, notes, "digest.summary"),
+    destroy: softNumber(summaryObj.value, "destroy", 0, notes, "digest.summary"),
+    replace: softNumber(summaryObj.value, "replace", 0, notes, "digest.summary"),
+    read: softNumber(summaryObj.value, "read", 0, notes, "digest.summary"),
+    noChanges: softBoolean(summaryObj.value, "noChanges", false, notes, "digest.summary"),
+    driftDetected: softBoolean(summaryObj.value, "driftDetected", false, notes, "digest.summary"),
+  };
+
+  let truncated = env.truncated;
+  const truncationNotes = env.truncationNotes ? [...env.truncationNotes] : [];
+
+  let resources = resourcesArr.value
+    .map((r, i) => coercePlanResource(r, notes, `digest.resources[${i}]`))
+    .filter((r): r is PlanResource => r !== null);
+  if (resources.length > MAX_RESOURCES) {
+    resources = resources.slice(0, MAX_RESOURCES);
+    truncated = true;
+    truncationNotes.push(`resource list capped at ${MAX_RESOURCES} (tab-side defensive cap)`);
+  }
+
+  const outputChanges = outputChangesArr.value
+    .map((o, i) => coerceOutputChange(o, notes, `digest.outputChanges[${i}]`))
+    .filter((o): o is OutputChange => o !== null);
+
+  const driftArr = obj["drift"];
+  let drift: DriftResource[] | undefined;
+  if (Array.isArray(driftArr)) {
+    drift = driftArr
+      .map((d, i) => coerceDriftResource(d, notes, `digest.drift[${i}]`))
+      .filter((d): d is DriftResource => d !== null);
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...envelopeBase(env),
+      truncated,
+      truncationNotes: truncationNotes.length > 0 ? truncationNotes : undefined,
+      kind: "plan",
+      summary,
+      resources,
+      outputChanges,
+      drift,
+    },
+  };
+}
+
+function coercePlanResource(v: unknown, notes: string[], path: string): PlanResource | null {
+  if (!isPlainObject(v)) {
+    notes.push(`${path} skipped: not an object.`);
+    return null;
+  }
+  const address = optionalString(v, "address");
+  if (!address) {
+    notes.push(`${path} skipped: missing "address".`);
+    return null;
+  }
+  const rawActions = Array.isArray(v["actions"]) ? (v["actions"] as unknown[]) : [];
+  const actions = rawActions.filter((a): a is (typeof PLAN_ACTIONS)[number] =>
+    typeof a === "string" && (PLAN_ACTIONS as readonly string[]).includes(a)
+  );
+  if (rawActions.length > 0 && actions.length === 0) {
+    notes.push(`${path}.actions contained no recognized action; treated as empty.`);
+  }
+
+  let attributeChanges = (Array.isArray(v["attributeChanges"]) ? (v["attributeChanges"] as unknown[]) : [])
+    .map((a, i) => coerceAttrChange(a, notes, `${path}.attributeChanges[${i}]`))
+    .filter((a): a is AttrChange => a !== null);
+  if (attributeChanges.length > MAX_ATTR_CHANGES_PER_RESOURCE) {
+    attributeChanges = attributeChanges.slice(0, MAX_ATTR_CHANGES_PER_RESOURCE);
+    notes.push(`${path}.attributeChanges capped at ${MAX_ATTR_CHANGES_PER_RESOURCE} (tab-side defensive cap)`);
+  }
+
+  return {
+    address,
+    type: softString(v, "type", "", notes, path),
+    name: softString(v, "name", "", notes, path),
+    providerName: softString(v, "providerName", "", notes, path),
+    actions,
+    actionReason: optionalString(v, "actionReason"),
+    replacePaths: optionalStringArray(v, "replacePaths"),
+    attributeChanges,
+  };
+}
+
+function coerceDriftResource(v: unknown, notes: string[], path: string): DriftResource | null {
+  if (!isPlainObject(v)) {
+    notes.push(`${path} skipped: not an object.`);
+    return null;
+  }
+  const address = optionalString(v, "address");
+  if (!address) {
+    notes.push(`${path} skipped: missing "address".`);
+    return null;
+  }
+  let attributeChanges = (Array.isArray(v["attributeChanges"]) ? (v["attributeChanges"] as unknown[]) : [])
+    .map((a, i) => coerceAttrChange(a, notes, `${path}.attributeChanges[${i}]`))
+    .filter((a): a is AttrChange => a !== null);
+  if (attributeChanges.length > MAX_ATTR_CHANGES_PER_RESOURCE) {
+    attributeChanges = attributeChanges.slice(0, MAX_ATTR_CHANGES_PER_RESOURCE);
+    notes.push(`${path}.attributeChanges capped at ${MAX_ATTR_CHANGES_PER_RESOURCE} (tab-side defensive cap)`);
+  }
+  return {
+    address,
+    type: softString(v, "type", "", notes, path),
+    name: softString(v, "name", "", notes, path),
+    providerName: softString(v, "providerName", "", notes, path),
+    attributeChanges,
+  };
+}
+
+function coerceAttrChange(v: unknown, notes: string[], path: string): AttrChange | null {
+  if (!isPlainObject(v)) {
+    notes.push(`${path} skipped: not an object.`);
+    return null;
+  }
+  const attrPath = optionalString(v, "path");
+  if (attrPath === undefined) {
+    notes.push(`${path} skipped: missing "path".`);
+    return null;
+  }
+  return {
+    path: attrPath,
+    before: coerceRedactedValue(v["before"], notes, `${path}.before`),
+    after: coerceRedactedValue(v["after"], notes, `${path}.after`),
+  };
+}
+
+const OUTPUT_ACTIONS = ["create", "update", "delete", "no-op"] as const;
+
+function coerceOutputChange(v: unknown, notes: string[], path: string): OutputChange | null {
+  if (!isPlainObject(v)) {
+    notes.push(`${path} skipped: not an object.`);
+    return null;
+  }
+  const name = optionalString(v, "name");
+  if (!name) {
+    notes.push(`${path} skipped: missing "name".`);
+    return null;
+  }
+  const action = v["action"];
+  if (typeof action !== "string" || !(OUTPUT_ACTIONS as readonly string[]).includes(action)) {
+    notes.push(`${path} skipped: missing/unrecognized "action".`);
+    return null;
+  }
+  return {
+    name,
+    action: action as (typeof OUTPUT_ACTIONS)[number],
+    value: coerceRedactedValue(v["value"], notes, `${path}.value`),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Apply digest
+// ---------------------------------------------------------------------------
+
+const APPLY_ACTIONS = ["create", "update", "delete", "replace", "read"] as const;
+const APPLY_STATUSES = ["started", "complete", "errored"] as const;
+const APPLY_OUTCOMES = ["succeeded", "failed"] as const;
+const DIAGNOSTIC_SEVERITIES = ["error", "warning"] as const;
+
+function coerceApplyDigest(
+  obj: Record<string, unknown>,
+  env: EnvelopeFields,
+  lenient: boolean,
+  notes: string[]
+): FieldResult<ApplyDigest> {
+  const summaryObj = requireObject(obj, "summary", lenient, notes, "digest");
+  if (!summaryObj.ok) return summaryObj;
+  const resourcesArr = requireArray(obj, "resources", lenient, notes, "digest");
+  if (!resourcesArr.ok) return resourcesArr;
+  const diagnosticsArr = requireArray(obj, "diagnostics", lenient, notes, "digest");
+  if (!diagnosticsArr.ok) return diagnosticsArr;
+  const outputsArr = requireArray(obj, "outputs", lenient, notes, "digest");
+  if (!outputsArr.ok) return outputsArr;
+
+  const outcome = softEnum(obj, "outcome", APPLY_OUTCOMES, "failed", notes, "digest");
+
+  const summary = {
+    add: softNumber(summaryObj.value, "add", 0, notes, "digest.summary"),
+    change: softNumber(summaryObj.value, "change", 0, notes, "digest.summary"),
+    destroy: softNumber(summaryObj.value, "destroy", 0, notes, "digest.summary"),
+    durationMs: optionalNumber(summaryObj.value, "durationMs"),
+  };
+
+  let resources = resourcesArr.value
+    .map((r, i) => coerceApplyResource(r, notes, `digest.resources[${i}]`))
+    .filter((r): r is ApplyResource => r !== null);
+  let truncated = env.truncated;
+  const truncationNotes = env.truncationNotes ? [...env.truncationNotes] : [];
+  if (resources.length > MAX_RESOURCES) {
+    resources = resources.slice(0, MAX_RESOURCES);
+    truncated = true;
+    truncationNotes.push(`resource list capped at ${MAX_RESOURCES} (tab-side defensive cap)`);
+  }
+
+  let diagnostics = diagnosticsArr.value
+    .map((d, i) => coerceDiagnostic(d, notes, `digest.diagnostics[${i}]`))
+    .filter((d): d is Diagnostic => d !== null);
+  if (diagnostics.length > MAX_DIAGNOSTICS) {
+    diagnostics = diagnostics.slice(0, MAX_DIAGNOSTICS);
+    truncated = true;
+    truncationNotes.push(`diagnostics capped at ${MAX_DIAGNOSTICS} (tab-side defensive cap)`);
+  }
+
+  const outputs = outputsArr.value
+    .map((o, i) => coerceOutputChange(o, notes, `digest.outputs[${i}]`))
+    .filter((o): o is OutputChange => o !== null);
+
+  const appliedBeforeFailure = optionalStringArray(obj, "appliedBeforeFailure");
+
+  return {
+    ok: true,
+    value: {
+      ...envelopeBase(env),
+      truncated,
+      truncationNotes: truncationNotes.length > 0 ? truncationNotes : undefined,
+      kind: "apply",
+      outcome,
+      summary,
+      resources,
+      diagnostics,
+      outputs,
+      appliedBeforeFailure,
+    },
+  };
+}
+
+function coerceApplyResource(v: unknown, notes: string[], path: string): ApplyResource | null {
+  if (!isPlainObject(v)) {
+    notes.push(`${path} skipped: not an object.`);
+    return null;
+  }
+  const address = optionalString(v, "address");
+  if (!address) {
+    notes.push(`${path} skipped: missing "address".`);
+    return null;
+  }
+  const action = v["action"];
+  if (typeof action !== "string" || !(APPLY_ACTIONS as readonly string[]).includes(action)) {
+    notes.push(`${path} skipped: missing/unrecognized "action".`);
+    return null;
+  }
+  const status = v["status"];
+  const resolvedStatus =
+    typeof status === "string" && (APPLY_STATUSES as readonly string[]).includes(status)
+      ? (status as (typeof APPLY_STATUSES)[number])
+      : ((notes.push(`${path}.status missing/unrecognized; defaulted to "started".`), "started" as const));
+  return {
+    address,
+    action: action as (typeof APPLY_ACTIONS)[number],
+    status: resolvedStatus,
+    durationMs: optionalNumber(v, "durationMs"),
+  };
+}
+
+function coerceDiagnostic(v: unknown, notes: string[], path: string): Diagnostic | null {
+  if (!isPlainObject(v)) {
+    notes.push(`${path} skipped: not an object.`);
+    return null;
+  }
+  const severity = v["severity"];
+  if (typeof severity !== "string" || !(DIAGNOSTIC_SEVERITIES as readonly string[]).includes(severity)) {
+    notes.push(`${path} skipped: missing/unrecognized "severity".`);
+    return null;
+  }
+  const summary = optionalString(v, "summary");
+  if (summary === undefined) {
+    notes.push(`${path} skipped: missing "summary".`);
+    return null;
+  }
+  return {
+    severity: severity as (typeof DIAGNOSTIC_SEVERITIES)[number],
+    summary,
+    detail: optionalString(v, "detail"),
+    address: optionalString(v, "address"),
+  };
+}

--- a/src/tab/security-tripwires.test.ts
+++ b/src/tab/security-tripwires.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Anti-regression tripwires (design §12.4 / this WP's tripwires 2 and 4).
+ * These are permanent, static-analysis guards over the tab source tree — not
+ * behavioral unit tests — so a future change that reintroduces an HTML sink
+ * or a new network destination fails CI loudly, even if no one writes a
+ * behavioral test for the specific new code path.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const TAB_SRC_DIR = path.resolve(__dirname);
+
+function listSourceFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files: string[] = [];
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === "__mocks__") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files = files.concat(listSourceFiles(full));
+      continue;
+    }
+    if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe("tripwire (2): dangerouslySetInnerHTML is confined to the raw-fallback sink", () => {
+  const allowlist = new Set([path.join(TAB_SRC_DIR, "components", "RawView.tsx"), path.join(TAB_SRC_DIR, "ansi-to-html.ts")]);
+  // Matches only the actual JSX prop usage (`dangerouslySetInnerHTML={...}`),
+  // not doc-comment mentions of the name (this file, and several components,
+  // reference the term in prose to explain why they DON'T use it).
+  const ACTUAL_USAGE_PATTERN = /dangerouslySetInnerHTML\s*=\s*\{/;
+
+  it("appears (as actual JSX usage) in no other source file under src/tab", () => {
+    const offenders = listSourceFiles(TAB_SRC_DIR).filter(
+      (file) => !allowlist.has(file) && ACTUAL_USAGE_PATTERN.test(fs.readFileSync(file, "utf8"))
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("is present as actual JSX usage in RawView.tsx (sanity check: the tripwire is not vacuously passing)", () => {
+    const content = fs.readFileSync(path.join(TAB_SRC_DIR, "components", "RawView.tsx"), "utf8");
+    expect(content).toMatch(ACTUAL_USAGE_PATTERN);
+  });
+
+  it("every allowlisted file still exists (catches a rename that would silently widen the allowlist)", () => {
+    for (const file of allowlist) {
+      expect(fs.existsSync(file)).toBe(true);
+    }
+  });
+});
+
+describe("tripwire (4): no new network surface — fetch only ever targets the ADO attachment link", () => {
+  it("tabContent.tsx has exactly the two known fetch() call sites, both using attachment._links.self.href", () => {
+    const content = fs.readFileSync(path.join(TAB_SRC_DIR, "tabContent.tsx"), "utf8");
+    const fetchCalls = content.match(/\bfetch\(/g) ?? [];
+    const adoAttachmentFetchCalls = content.match(/fetch\(attachment\._links\.self\.href/g) ?? [];
+    expect(fetchCalls.length).toBe(adoAttachmentFetchCalls.length);
+    expect(fetchCalls.length).toBeGreaterThan(0);
+  });
+
+  it("no fetch() call anywhere under src/tab uses a literal http(s) URL (only the ADO-provided attachment href)", () => {
+    for (const file of listSourceFiles(TAB_SRC_DIR)) {
+      const content = fs.readFileSync(file, "utf8");
+      expect(content).not.toMatch(/fetch\(\s*["'`]https?:\/\//);
+    }
+  });
+
+  it("no source file under src/tab references a CDN, telemetry, analytics, or font host", () => {
+    const suspiciousHostPattern = /(cdn\.|googleapis\.com|fonts\.(googleapis|gstatic)|google-analytics|segment\.io|sentry\.io|doubleclick|mixpanel)/i;
+    for (const file of listSourceFiles(TAB_SRC_DIR)) {
+      const content = fs.readFileSync(file, "utf8");
+      expect(content).not.toMatch(suspiciousHostPattern);
+    }
+  });
+
+  it("no source file other than tabContent.tsx performs its own network call (fetch/XMLHttpRequest/WebSocket)", () => {
+    for (const file of listSourceFiles(TAB_SRC_DIR)) {
+      if (file === path.join(TAB_SRC_DIR, "tabContent.tsx")) continue;
+      const content = fs.readFileSync(file, "utf8");
+      expect(content).not.toMatch(/\bfetch\(/);
+      expect(content).not.toMatch(/XMLHttpRequest/);
+      expect(content).not.toMatch(/new WebSocket/);
+    }
+  });
+});

--- a/src/tab/tabContent.css
+++ b/src/tab/tabContent.css
@@ -102,3 +102,311 @@
 .plan-oversize a:hover {
     background: #005a9e;
 }
+
+/* --- Structured plan/apply tab (Plan/Apply pivots) --- */
+
+.terraform-container,
+.terraform-container button,
+.terraform-container select,
+.terraform-container input,
+.terraform-container details {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.pivot-bar {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 16px;
+}
+
+.pivot-tab {
+    padding: 8px 16px;
+    font-size: 14px;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    color: #444;
+}
+
+.pivot-tab.active {
+    border-bottom-color: #0078d4;
+    color: #0078d4;
+    font-weight: 600;
+}
+
+.pivot-panel {
+    font-size: 14px;
+}
+
+.digest-detail {
+    margin-top: 12px;
+}
+
+.unknown-version-banner {
+    background: #fff8e1;
+    border: 1px solid #f0c419;
+    padding: 8px 12px;
+    border-radius: 4px;
+    margin-bottom: 12px;
+    font-size: 13px;
+}
+
+.digest-parse-error {
+    padding: 12px 0;
+}
+
+.summary-header {
+    margin-bottom: 12px;
+}
+
+.summary-header-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.summary-header-title {
+    font-weight: 600;
+    font-size: 15px;
+}
+
+.summary-header-tool {
+    color: #777;
+    font-size: 12px;
+}
+
+.summary-header-counts {
+    display: flex;
+    gap: 12px;
+    margin-top: 4px;
+    font-family: 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+}
+
+.summary-header-truncated {
+    margin-top: 6px;
+    color: #a15c00;
+    font-size: 12px;
+}
+
+.badge {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #fff;
+    background: #777;
+}
+
+.badge-drift {
+    background: #d9822b;
+}
+
+.badge-no-changes {
+    background: #6b7280;
+}
+
+.badge-replace {
+    background: #b35900;
+}
+
+.badge-error {
+    background: #cd3131;
+}
+
+.badge-outcome-succeeded {
+    background: #107c10;
+}
+
+.badge-outcome-failed {
+    background: #cd3131;
+}
+
+.count-add {
+    color: #0dbc79;
+}
+
+.count-change {
+    color: #e5a713;
+}
+
+.count-destroy {
+    color: #cd3131;
+}
+
+.overview-list {
+    list-style: none;
+    margin: 0 0 16px 0;
+    padding: 0;
+    border: 1px solid #e1e1e1;
+    border-radius: 4px;
+}
+
+.overview-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+}
+
+.overview-item:last-child {
+    border-bottom: none;
+}
+
+.overview-item.selected {
+    background: #eef6fc;
+}
+
+.overview-item-badges {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-family: 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+}
+
+.overview-item-error-message {
+    color: #cd3131;
+    font-size: 12px;
+    margin-left: 8px;
+}
+
+.resource-list-search {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    margin-bottom: 8px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font-size: 13px;
+}
+
+.resource-list-truncated-banner {
+    background: #fff8e1;
+    padding: 6px 8px;
+    margin-bottom: 8px;
+    font-size: 12px;
+}
+
+.resource-group-heading {
+    font-weight: 600;
+    text-transform: capitalize;
+    margin: 8px 0 4px 0;
+    font-size: 13px;
+}
+
+.resource-group-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.resource-row {
+    display: flex;
+    gap: 8px;
+    padding: 4px 8px;
+    cursor: pointer;
+    font-family: 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+    font-size: 13px;
+}
+
+.resource-row:hover {
+    background: #f5f5f5;
+}
+
+.resource-row.selected {
+    background: #eef6fc;
+}
+
+.resource-row-type {
+    color: #888;
+}
+
+.resource-diff {
+    margin-top: 12px;
+    border: 1px solid #e1e1e1;
+    border-radius: 4px;
+    padding: 8px 12px;
+}
+
+.resource-diff-header {
+    display: flex;
+    gap: 8px;
+    font-family: 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+}
+
+.resource-diff-table,
+.outputs-panel {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 8px;
+    font-size: 13px;
+}
+
+.resource-diff-table th,
+.resource-diff-table td,
+.outputs-panel th,
+.outputs-panel td {
+    text-align: left;
+    padding: 4px 8px;
+    border-bottom: 1px solid #eee;
+}
+
+.apply-timeline-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.apply-timeline-item {
+    display: flex;
+    gap: 8px;
+    padding: 4px 8px;
+    font-family: 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+    font-size: 13px;
+    border-bottom: 1px solid #eee;
+}
+
+.apply-timeline-item.status-errored {
+    color: #cd3131;
+}
+
+.diagnostics-panel {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.diagnostics-panel-item {
+    padding: 6px 8px;
+    border-left: 3px solid #ccc;
+    margin-bottom: 6px;
+}
+
+.diagnostics-panel-item.severity-error {
+    border-left-color: #cd3131;
+}
+
+.diagnostics-panel-item.severity-warning {
+    border-left-color: #e5a713;
+}
+
+.diagnostics-panel-detail {
+    font-size: 12px;
+    color: #555;
+    margin-top: 4px;
+    white-space: pre-wrap;
+}
+
+.raw-details {
+    margin-top: 16px;
+}
+
+.raw-details summary {
+    cursor: pointer;
+    color: #0078d4;
+    font-size: 13px;
+}

--- a/src/tab/tabContent.test.tsx
+++ b/src/tab/tabContent.test.tsx
@@ -18,19 +18,94 @@ jest.mock('azure-devops-extension-api/Build', () => ({
 import { renderToStaticMarkup } from 'react-dom/server';
 import { getClient } from 'azure-devops-extension-api';
 import { TerraformPlanTab } from './tabContent';
-import { ansiToHtml } from './ansi-to-html';
 
-/**
- * Creates an unmounted TerraformPlanTab with setState monkey-patched to merge
- * synchronously into the instance's own state — a real (unmounted) component's
- * setState is a no-op (there is no updater attached outside a live React tree),
- * which is why every test that exercises state transitions needs this. An
- * optional partial state can be applied up front for render-only fixtures.
- */
-function makeTestableTab(initialState: Record<string, unknown> = {}): TerraformPlanTab {
+const PLAN_SUMMARY_TYPE = 'terraform-plan-summary';
+const APPLY_SUMMARY_TYPE = 'terraform-apply-summary';
+const LEGACY_RAW_TYPE = 'terraform-plan-results';
+
+function validPlanDigest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    kind: 'plan',
+    producedBy: { task: 'TerraformTaskV5', taskVersion: '5.12.0' },
+    tool: { name: 'terraform', version: '1.14.6' },
+    meta: { name: 'plan-main', createdIso: '2026-07-01T12:00:00.000Z' },
+    truncated: false,
+    summary: { add: 2, change: 0, destroy: 0, replace: 0, read: 0, noChanges: false, driftDetected: false },
+    resources: [
+      {
+        address: 'aws_instance.web',
+        type: 'aws_instance',
+        name: 'web',
+        providerName: 'registry.terraform.io/hashicorp/aws',
+        actions: ['create'],
+        attributeChanges: [
+          { path: 'instance_type', before: { kind: 'unknown' }, after: { kind: 'value', json: '"t3.micro"' } },
+        ],
+      },
+    ],
+    outputChanges: [{ name: 'url', action: 'create', value: { kind: 'unknown' } }],
+    ...overrides,
+  };
+}
+
+function validApplyDigest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    kind: 'apply',
+    producedBy: { task: 'TerraformTaskV5', taskVersion: '5.12.0' },
+    tool: { name: 'terraform', version: '1.14.6' },
+    meta: { name: 'apply-main', createdIso: '2026-07-01T12:05:00.000Z' },
+    truncated: false,
+    outcome: 'succeeded',
+    summary: { add: 1, change: 0, destroy: 0, durationMs: 1234 },
+    resources: [{ address: 'aws_instance.web', action: 'create', status: 'complete', durationMs: 900 }],
+    diagnostics: [],
+    outputs: [{ name: 'url', action: 'create', value: { kind: 'unknown' } }],
+    ...overrides,
+  };
+}
+
+function attachment(name: string) {
+  return { name, _links: { self: { href: `https://example.test/${name}` } } };
+}
+
+/** Wires getClient(BuildRestClient).getAttachments to branch by attachment type, and fetch to return the given text bodies keyed by name. */
+function mockLoad(options: {
+  planNames?: string[];
+  applyNames?: string[];
+  legacyNames?: string[];
+  bodies: Record<string, string>;
+}) {
+  const { planNames = [], applyNames = [], legacyNames = [], bodies } = options;
+
+  (getClient as jest.Mock).mockReturnValue({
+    getAttachments: jest.fn((_project: string, _id: number, type: string) => {
+      if (type === PLAN_SUMMARY_TYPE) return Promise.resolve(planNames.map(attachment));
+      if (type === APPLY_SUMMARY_TYPE) return Promise.resolve(applyNames.map(attachment));
+      if (type === LEGACY_RAW_TYPE) return Promise.resolve(legacyNames.map(attachment));
+      return Promise.resolve([]);
+    }),
+  });
+
+  (global as unknown as { fetch: jest.Mock }).fetch = jest.fn((url: string) => {
+    const name = url.split('/').pop() as string;
+    const body = bodies[name];
+    if (body === undefined) {
+      return Promise.resolve({ ok: false, text: () => Promise.resolve(''), headers: { get: () => null } });
+    }
+    return Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve(body),
+      headers: { get: (h: string) => (h === 'content-length' ? String(body.length) : null) },
+    });
+  });
+}
+
+/** Creates an unmounted TerraformPlanTab with setState monkey-patched to merge synchronously into instance state. */
+function makeTestableTab(): TerraformPlanTab {
   const tab = new TerraformPlanTab({});
   const inst = tab as unknown as { state: Record<string, unknown> };
-  inst.state = { ...inst.state, ...initialState };
   (tab as unknown as { setState: (u: unknown) => void }).setState = (update: unknown): void => {
     const next = typeof update === 'function' ? (update as (s: unknown) => object)(inst.state) : update;
     inst.state = { ...inst.state, ...(next as object) };
@@ -38,147 +113,182 @@ function makeTestableTab(initialState: Record<string, unknown> = {}): TerraformP
   return tab;
 }
 
+function html(tab: TerraformPlanTab): string {
+  return renderToStaticMarkup(tab.render());
+}
+
+const build = { project: { id: 'proj' }, id: 1 } as never;
+
 describe('TerraformPlanTab', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('routes fetched plan content through ansiToHtml before rendering (no raw HTML injected)', async () => {
-    // A malicious/coloured attachment: raw HTML tag plus an ANSI SGR sequence.
-    const rawContent = '<script>alert(1)</script>\x1b[31mred & <b>bold</b>\x1b[0m';
-
-    (getClient as jest.Mock).mockReturnValue({
-      getAttachments: jest.fn().mockResolvedValue([
-        { name: 'plan.txt', _links: { self: { href: 'https://example.test/attachment' } } },
-      ]),
-    });
-
-    (global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      text: () => Promise.resolve(rawContent),
-    });
-
+  it('renders a loading indicator before any results have been fetched', () => {
     const tab = makeTestableTab();
-
-    await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
-
-    // Render the populated component to a static HTML string (no DOM required).
-    const html = renderToStaticMarkup(tab.render());
-
-    // Content is routed through ansiToHtml (HTML-escaped), not injected raw into
-    // the dangerouslySetInnerHTML sink.
-    expect(html).toContain(ansiToHtml(rawContent));
-    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
-    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html(tab)).toContain('Loading terraform results...');
   });
 
-  it('renders a loading indicator before any plans have been fetched', () => {
-    const tab = makeTestableTab();
-    const html = renderToStaticMarkup(tab.render());
-    expect(html).toContain('Loading terraform plans...');
-  });
-
-  it('renders an error message when loading the attachments failed', () => {
-    const tab = makeTestableTab({ loading: false, error: 'boom' });
-    const html = renderToStaticMarkup(tab.render());
-    expect(html).toContain('Error: boom');
-  });
-
-  it('renders an empty-state message when the build published no plans', () => {
-    const tab = makeTestableTab({ loading: false, error: null, plans: [] });
-    const html = renderToStaticMarkup(tab.render());
-    expect(html).toContain('No terraform plans have been published for this pipeline run.');
-  });
-
-  it('renders a <select> plan picker for multiple plans, and onPlanSelect updates the selected index', () => {
-    const tab = makeTestableTab({
-      loading: false,
-      error: null,
-      plans: [
-        { name: 'plan-a.txt', content: 'aaa' },
-        { name: 'plan-b.txt', content: 'bbb' },
-      ],
-      selectedIndex: 0,
-    });
-
-    const html = renderToStaticMarkup(tab.render());
-    expect(html).toContain('<select');
-    expect(html).toContain('plan-a.txt');
-    expect(html).toContain('plan-b.txt');
-
-    (tab as unknown as { onPlanSelect: (e: unknown) => void }).onPlanSelect({ target: { value: '1' } });
-    expect((tab as unknown as { state: { selectedIndex: number } }).state.selectedIndex).toBe(1);
-  });
-
-  it('renders a download link instead of inline output when plan content exceeds the render-size cap', () => {
-    const oversized = 'x'.repeat(2 * 1024 * 1024 + 1);
-    const tab = makeTestableTab({
-      loading: false,
-      error: null,
-      plans: [{ name: 'huge-plan.txt', content: oversized }],
-      selectedIndex: 0,
-    });
-
-    const html = renderToStaticMarkup(tab.render());
-    expect(html).toContain('too large to render inline');
-    expect(html).toContain('Download raw output');
-    expect(html).not.toContain('dangerouslySetInnerHTML');
-  });
-
-  it('loadPlans sets an empty plans list and stops loading when the build has no attachments', async () => {
-    (getClient as jest.Mock).mockReturnValue({
-      getAttachments: jest.fn().mockResolvedValue([]),
-    });
-
-    const tab = makeTestableTab();
-    await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
-
-    const state = (tab as unknown as { state: { plans: unknown[]; loading: boolean } }).state;
-    expect(state.plans).toEqual([]);
-    expect(state.loading).toBe(false);
-  });
-
-  it('loadPlans skips an attachment whose download throws and one that returns a non-OK response, keeping only the successful download', async () => {
-    (getClient as jest.Mock).mockReturnValue({
-      getAttachments: jest.fn().mockResolvedValue([
-        { name: 'network-error.txt', _links: { self: { href: 'https://example.test/a' } } },
-        { name: 'not-found.txt', _links: { self: { href: 'https://example.test/b' } } },
-        { name: 'ok.txt', _links: { self: { href: 'https://example.test/c' } } },
-      ]),
-    });
-
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { /* silence expected log */ });
-
-    (global as unknown as { fetch: jest.Mock }).fetch = jest.fn()
-      .mockRejectedValueOnce(new Error('network down'))
-      .mockResolvedValueOnce({ ok: false, text: () => Promise.resolve('') })
-      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('plan output') });
-
-    const tab = makeTestableTab();
-    await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
-
-    const state = (tab as unknown as { state: { plans: Array<{ name: string }>; loading: boolean } }).state;
-    expect(state.plans).toHaveLength(1);
-    expect(state.plans[0].name).toBe('ok.txt');
-    expect(state.loading).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to download attachment network-error.txt:'),
-      expect.any(Error),
-    );
-
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('loadPlans sets an error state when fetching the attachment list itself fails', async () => {
+  it('renders an error message when the attachment list itself fails to load', async () => {
     (getClient as jest.Mock).mockReturnValue({
       getAttachments: jest.fn().mockRejectedValue(new Error('attachments API unavailable')),
     });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+    expect(html(tab)).toContain('Error: attachments API unavailable');
+  });
+
+  it('renders an empty state when nothing has been published', async () => {
+    mockLoad({ bodies: {} });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+    expect(html(tab)).toContain('No terraform plans or applies have been published');
+  });
+
+  it('renders a single plan digest: summary header + resource list, no overview list for one item', async () => {
+    mockLoad({ planNames: ['plan-a'], bodies: { 'plan-a': JSON.stringify(validPlanDigest()) } });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+    const out = html(tab);
+    expect(out).toContain('plan-a');
+    expect(out).toContain('aws_instance.web');
+    expect(out).toContain('+2');
+    expect(out).not.toContain('overview-list');
+  });
+
+  it('renders a roll-up header + overview list for multiple plan digests, and switches detail on select', async () => {
+    mockLoad({
+      planNames: ['plan-a', 'plan-b'],
+      bodies: {
+        'plan-a': JSON.stringify(validPlanDigest({ meta: { name: 'plan-a', createdIso: 'x' } })),
+        'plan-b': JSON.stringify(
+          validPlanDigest({
+            meta: { name: 'plan-b', createdIso: 'x' },
+            resources: [
+              {
+                address: 'aws_instance.other',
+                type: 'aws_instance',
+                name: 'other',
+                providerName: 'registry.terraform.io/hashicorp/aws',
+                actions: ['delete'],
+                attributeChanges: [],
+              },
+            ],
+            summary: { add: 0, change: 0, destroy: 1, replace: 0, read: 0, noChanges: false, driftDetected: false },
+          })
+        ),
+      },
+    });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+
+    let out = html(tab);
+    expect(out).toContain('All plans (2)');
+    expect(out).toContain('plan-a');
+    expect(out).toContain('plan-b');
+    // First item selected by default.
+    expect(out).toContain('aws_instance.web');
+
+    (tab as unknown as { onSelectPlan: (id: string) => void }).onSelectPlan('plan-b#1');
+    out = html(tab);
+    expect(out).toContain('aws_instance.other');
+  });
+
+  it('falls back to the legacy raw view when no structured plan attachments exist', async () => {
+    mockLoad({ legacyNames: ['legacy-plan.txt'], bodies: { 'legacy-plan.txt': 'Plan: 1 to add' } });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+    expect(html(tab)).toContain('Plan: 1 to add');
+  });
+
+  it('renders the Apply pivot with timeline, diagnostics, and outputs', async () => {
+    mockLoad({ applyNames: ['apply-a'], bodies: { 'apply-a': JSON.stringify(validApplyDigest()) } });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+    // No plan/legacy published, so the tab defaults to the Apply pivot.
+    const out = html(tab);
+    expect(out).toContain('apply-a');
+    expect(out).toContain('Succeeded');
+    expect(out).toContain('aws_instance.web');
+  });
+
+  it('switches between Plan and Apply pivots via setActivePivot', async () => {
+    mockLoad({
+      planNames: ['plan-a'],
+      applyNames: ['apply-a'],
+      bodies: {
+        'plan-a': JSON.stringify(validPlanDigest()),
+        'apply-a': JSON.stringify(validApplyDigest()),
+      },
+    });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+    expect(html(tab)).toContain('plan-a');
+
+    (tab as unknown as { setActivePivot: (p: 'plan' | 'apply') => void }).setActivePivot('apply');
+    expect(html(tab)).toContain('apply-a');
+  });
+
+  it('shows a parse-error item with its raw content instead of crashing', async () => {
+    mockLoad({ planNames: ['broken-plan'], bodies: { 'broken-plan': '{ not valid json' } });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+    const out = html(tab);
+    expect(out).toContain('Could not render structured results');
+    expect(out).toContain('broken-plan');
+  });
+
+  it('degrades (does not crash) on a schemaVersion:999 plan digest and shows the unknown-version banner + raw fallback', async () => {
+    const futureDigest = { schemaVersion: 999, kind: 'plan', resources: [], outputChanges: [], summary: {} };
+    mockLoad({ planNames: ['future-plan'], bodies: { 'future-plan': JSON.stringify(futureDigest) } });
+    const tab = makeTestableTab();
+    expect(async () => tab.loadAll(build)).not.toThrow();
+    await tab.loadAll(build);
+    const out = html(tab);
+    expect(out).toContain('schemaVersion 999');
+    expect(out).toContain('View raw digest');
+  });
+
+  it('selecting a resource shows its attribute diff, selecting again hides it', async () => {
+    mockLoad({ planNames: ['plan-a'], bodies: { 'plan-a': JSON.stringify(validPlanDigest()) } });
+    const tab = makeTestableTab();
+    await tab.loadAll(build);
+
+    (tab as unknown as { onSelectResource: (a: string) => void }).onSelectResource('aws_instance.web');
+    let out = html(tab);
+    expect(out).toContain('instance_type');
+    expect(out).toContain('t3.micro');
+
+    (tab as unknown as { onSelectResource: (a: string) => void }).onSelectResource('aws_instance.web');
+    out = html(tab);
+    expect(out).not.toContain('resource-diff-table');
+  });
+
+  it('skips an attachment whose fetch throws, keeping the others', async () => {
+    (getClient as jest.Mock).mockReturnValue({
+      getAttachments: jest.fn((_p: string, _id: number, type: string) => {
+        if (type === PLAN_SUMMARY_TYPE) return Promise.resolve([attachment('ok-plan'), attachment('network-error')]);
+        return Promise.resolve([]);
+      }),
+    });
+    (global as unknown as { fetch: jest.Mock }).fetch = jest
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify(validPlanDigest())),
+          headers: { get: () => null },
+        })
+      )
+      .mockImplementationOnce(() => Promise.reject(new Error('network down')));
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { /* silence expected log */ });
 
     const tab = makeTestableTab();
-    await tab.loadPlans({ project: { id: 'proj' }, id: 1 } as never);
-
-    const state = (tab as unknown as { state: { error: string | null; loading: boolean } }).state;
-    expect(state.error).toBe('attachments API unavailable');
-    expect(state.loading).toBe(false);
+    await tab.loadAll(build);
+    const out = html(tab);
+    expect(out).toContain('ok-plan');
+    expect(out).not.toContain('network-error');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/src/tab/tabContent.tsx
+++ b/src/tab/tabContent.tsx
@@ -1,15 +1,23 @@
 /**
- * Terraform Plan Tab — Azure DevOps Pipeline Build Results Tab
+ * Terraform Tab — Azure DevOps Pipeline Build Results Tab
  *
- * Displays terraform plan output published as pipeline attachments.
- * Uses the standard Azure DevOps Extension SDK pattern:
- *   SDK.init() → SDK.ready() → config.onBuildChanged() → BuildRestClient.getAttachments()
+ * Displays structured plan/apply digests (Plan/Apply pivots) published as
+ * pipeline attachments, with a raw ANSI fallback for legacy attachments and
+ * for any digest that fails to parse. Uses the standard Azure DevOps
+ * Extension SDK pattern: SDK.init() -> SDK.ready() -> config.onBuildChanged()
+ * -> BuildRestClient.getAttachments().
  *
  * Architecture informed by studying:
  *   - jason-johnson/azure-pipelines-tasks-terraform (MIT, Copyright 2021 Charles Zipp, 2023 Jason Johnson)
  *   - JaydenMaalouf/azure-pipelines-terraform-output (MIT, Copyright Microsoft Corporation)
  * See THIRD_PARTY_NOTICES.md for full attribution.
  * No code was copied from either project. All implementation below is original.
+ *
+ * SECURITY: this component (and every component it composes, other than
+ * RawView) renders every digest value as a React text node — never via
+ * `dangerouslySetInnerHTML` — per design §5.3/§8.1. `digest-model.ts` is the
+ * only place raw fetched JSON is parsed; nothing here ever spreads an
+ * untrusted parsed object into state or props.
  */
 
 import * as React from "react";
@@ -17,147 +25,516 @@ import * as ReactDOM from "react-dom/client";
 import * as SDK from "azure-devops-extension-sdk";
 import { Build, BuildRestClient } from "azure-devops-extension-api/Build";
 import { getClient } from "azure-devops-extension-api";
-import { ansiToHtml } from "./ansi-to-html";
+import { parseDigestText } from "./digest-model";
+import { Digest, PlanResource } from "./digest-schema";
+import { SummaryHeader, SummaryHeaderCounts } from "./components/SummaryHeader";
+import { OverviewList, OverviewItem } from "./components/OverviewList";
+import { ResourceList } from "./components/ResourceList";
+import { ResourceDiff } from "./components/ResourceDiff";
+import { ApplyTimeline } from "./components/ApplyTimeline";
+import { OutputsPanel } from "./components/OutputsPanel";
+import { DiagnosticsPanel } from "./components/DiagnosticsPanel";
+import { RawView } from "./components/RawView";
 import "./tabContent.css";
 
-/** Attachment type matching jason-johnson convention for migration compatibility */
-const ATTACHMENT_TYPE = "terraform-plan-results";
+/** New structured attachment types (§7 of the design doc), additive to the legacy raw attachment. */
+const PLAN_SUMMARY_ATTACHMENT_TYPE = "terraform-plan-summary";
+const APPLY_SUMMARY_ATTACHMENT_TYPE = "terraform-apply-summary";
+/** Legacy raw attachment type, kept for backward compatibility (jason-johnson migration convention). */
+const LEGACY_RAW_ATTACHMENT_TYPE = "terraform-plan-results";
 
-/** Maximum attachment size (bytes) to render inline. Larger content gets a download link. */
-const MAX_RENDER_SIZE = 2 * 1024 * 1024; // 2 MB
+interface AttachmentRef {
+    name: string;
+    _links: { self: { href: string } };
+}
 
-interface PlanAttachment {
+interface RawAttachment {
     name: string;
     content: string;
 }
 
-interface TerraformPlanTabState {
-    plans: PlanAttachment[];
-    selectedIndex: number;
+/** A single published plan/apply digest attachment, after fetch + safe parse. `raw` is always the fetched body (used for the raw-fallback view and download). */
+type DigestItem =
+    | { id: string; name: string; status: "ok"; digest: Digest; unknownVersion: boolean; notes: string[]; raw: RawAttachment }
+    | { id: string; name: string; status: "error"; message: string; raw: RawAttachment };
+
+interface TerraformTabState {
     loading: boolean;
     error: string | null;
+    activePivot: "plan" | "apply";
+    planItems: DigestItem[];
+    applyItems: DigestItem[];
+    legacyRaw: RawAttachment[];
+    selectedPlanId: string | null;
+    selectedApplyId: string | null;
+    selectedLegacyIndex: number;
+    selectedResourceAddress: string | null;
+    resourceSearchText: string;
 }
 
+function byNameCaseInsensitive<T extends { name: string }>(a: T, b: T): number {
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+}
 
-export class TerraformPlanTab extends React.Component<{}, TerraformPlanTabState> {
+/** Adapts a DriftResource (no `actions`/`actionReason`/`replacePaths`) into the PlanResource shape ResourceDiff renders. */
+function driftAsPlanResource(drift: NonNullable<Extract<Digest, { kind: "plan" }>["drift"]>[number]): PlanResource {
+    return { ...drift, actions: [] };
+}
+
+export class TerraformPlanTab extends React.Component<{}, TerraformTabState> {
     constructor(props: {}) {
         super(props);
         this.state = {
-            plans: [],
-            selectedIndex: 0,
             loading: true,
             error: null,
+            activePivot: "plan",
+            planItems: [],
+            applyItems: [],
+            legacyRaw: [],
+            selectedPlanId: null,
+            selectedApplyId: null,
+            selectedLegacyIndex: 0,
+            selectedResourceAddress: null,
+            resourceSearchText: "",
         };
     }
 
     public render(): JSX.Element {
-        const { plans, selectedIndex, loading, error } = this.state;
+        const { loading, error } = this.state;
 
         if (loading) {
-            return <div className="plan-loading">Loading terraform plans...</div>;
+            return <div className="plan-loading">Loading terraform results...</div>;
         }
 
         if (error) {
             return <div className="plan-empty">Error: {error}</div>;
         }
 
-        if (plans.length === 0) {
+        const { planItems, applyItems, legacyRaw } = this.state;
+        if (planItems.length === 0 && applyItems.length === 0 && legacyRaw.length === 0) {
             return (
                 <div className="plan-empty">
-                    No terraform plans have been published for this pipeline run.
-                    <br /><br />
-                    Set <code>publishPlanResults</code> on the terraform plan task to publish plan output here.
+                    No terraform plans or applies have been published for this pipeline run.
+                    <br />
+                    <br />
+                    Set <code>publishPlanResults</code>, <code>publishPlanSummary</code>, or{" "}
+                    <code>publishApplyResults</code> on the terraform task to publish results here.
                 </div>
             );
         }
 
-        const selectedPlan = plans[selectedIndex];
-
         return (
             <div className="terraform-container">
-                {plans.length > 1 && (
-                    <div className="plan-header">
-                        <label htmlFor="plan-select">Plan:</label>
-                        <select
-                            id="plan-select"
-                            className="plan-select"
-                            value={selectedIndex}
-                            onChange={this.onPlanSelect}
-                        >
-                            {plans.map((plan, i) => (
-                                <option key={plan.name} value={i}>{plan.name}</option>
-                            ))}
-                        </select>
-                    </div>
-                )}
-                {plans.length === 1 && (
-                    <div className="plan-header">
-                        <strong>{selectedPlan.name}</strong>
-                    </div>
-                )}
-                {selectedPlan.content.length > MAX_RENDER_SIZE ? (
-                    <div className="plan-oversize">
-                        <p>
-                            Plan output is too large to render inline
-                            ({(selectedPlan.content.length / (1024 * 1024)).toFixed(1)} MB).
-                        </p>
-                        <a
-                            href={URL.createObjectURL(new Blob([selectedPlan.content], { type: "text/plain" }))}
-                            download={`${selectedPlan.name}.txt`}
-                        >
-                            Download raw output
-                        </a>
-                    </div>
-                ) : (
-                    <pre dangerouslySetInnerHTML={{ __html: ansiToHtml(selectedPlan.content) }} />
-                )}
+                <div className="pivot-bar" role="tablist">
+                    <button
+                        role="tab"
+                        aria-selected={this.state.activePivot === "plan"}
+                        className={`pivot-tab${this.state.activePivot === "plan" ? " active" : ""}`}
+                        onClick={() => this.setActivePivot("plan")}
+                    >
+                        Plan
+                    </button>
+                    <button
+                        role="tab"
+                        aria-selected={this.state.activePivot === "apply"}
+                        className={`pivot-tab${this.state.activePivot === "apply" ? " active" : ""}`}
+                        onClick={() => this.setActivePivot("apply")}
+                    >
+                        Apply
+                    </button>
+                </div>
+                {this.state.activePivot === "plan" ? this.renderPlanPivot() : this.renderApplyPivot()}
             </div>
         );
     }
 
-    private onPlanSelect = (event: React.ChangeEvent<HTMLSelectElement>): void => {
-        this.setState({ selectedIndex: parseInt(event.target.value, 10) });
+    private renderPlanPivot(): JSX.Element {
+        const { planItems, legacyRaw, selectedPlanId } = this.state;
+
+        if (planItems.length === 0) {
+            if (legacyRaw.length === 0) {
+                return <div className="plan-empty">No terraform plans have been published for this pipeline run.</div>;
+            }
+            return this.renderLegacyRawFallback();
+        }
+
+        const okItems = planItems.filter((i): i is Extract<DigestItem, { status: "ok" }> => i.status === "ok");
+        const rollup = aggregatePlanRollup(okItems);
+        const overviewItems: OverviewItem[] = planItems.map(toPlanOverviewItem);
+        const selected = planItems.find((i) => i.id === selectedPlanId) ?? planItems[0];
+
+        return (
+            <div className="pivot-panel">
+                {planItems.length > 1 && (
+                    <SummaryHeader
+                        title={`All plans (${planItems.length})`}
+                        kind="plan"
+                        counts={rollup.counts}
+                        noChanges={rollup.noChanges}
+                        driftDetected={rollup.driftDetected}
+                    />
+                )}
+                {planItems.length > 1 && (
+                    <OverviewList items={overviewItems} selectedId={selectedPlanId} onSelect={this.onSelectPlan} />
+                )}
+                {selected && this.renderPlanDetail(selected)}
+            </div>
+        );
+    }
+
+    private renderPlanDetail(item: DigestItem): JSX.Element {
+        if (item.status === "error") {
+            return this.renderDigestError(item);
+        }
+        if (item.digest.kind !== "plan") {
+            return this.renderDigestError({ message: "Unexpected digest kind.", raw: item.raw, name: item.name });
+        }
+        const digest = item.digest;
+        const { selectedResourceAddress, resourceSearchText } = this.state;
+        const selectedResource = digest.resources.find((r) => r.address === selectedResourceAddress) ?? null;
+
+        return (
+            <div className="digest-detail">
+                {item.unknownVersion && <div className="unknown-version-banner">{item.notes.join(" ")}</div>}
+                <SummaryHeader
+                    title={item.name}
+                    kind="plan"
+                    counts={digest.summary}
+                    noChanges={digest.summary.noChanges}
+                    driftDetected={digest.summary.driftDetected}
+                    truncated={digest.truncated}
+                    truncationNotes={digest.truncationNotes}
+                    toolLabel={`${digest.tool.name} ${digest.tool.version}`}
+                />
+                <ResourceList
+                    resources={digest.resources}
+                    selectedAddress={selectedResourceAddress}
+                    onSelect={this.onSelectResource}
+                    searchText={resourceSearchText}
+                    onSearchTextChange={this.onResourceSearchChange}
+                />
+                {selectedResource && <ResourceDiff resource={selectedResource} />}
+                {digest.drift && digest.drift.length > 0 && (
+                    <div className="drift-section">
+                        <h3>Drift detected</h3>
+                        {digest.drift.map((d) => (
+                            <ResourceDiff key={d.address} resource={driftAsPlanResource(d)} />
+                        ))}
+                    </div>
+                )}
+                <OutputsPanel outputs={digest.outputChanges} />
+                {this.renderRawDetails(item.raw)}
+            </div>
+        );
+    }
+
+    private renderApplyPivot(): JSX.Element {
+        const { applyItems, selectedApplyId } = this.state;
+
+        if (applyItems.length === 0) {
+            return (
+                <div className="plan-empty">No terraform apply results have been published for this pipeline run.</div>
+            );
+        }
+
+        const okItems = applyItems.filter((i): i is Extract<DigestItem, { status: "ok" }> => i.status === "ok");
+        const rollup = aggregateApplyRollup(okItems);
+        const overviewItems: OverviewItem[] = applyItems.map(toApplyOverviewItem);
+        const selected = applyItems.find((i) => i.id === selectedApplyId) ?? applyItems[0];
+
+        return (
+            <div className="pivot-panel">
+                {applyItems.length > 1 && (
+                    <SummaryHeader title={`All applies (${applyItems.length})`} kind="apply" counts={rollup.counts} />
+                )}
+                {applyItems.length > 1 && (
+                    <OverviewList items={overviewItems} selectedId={selectedApplyId} onSelect={this.onSelectApply} />
+                )}
+                {selected && this.renderApplyDetail(selected)}
+            </div>
+        );
+    }
+
+    private renderApplyDetail(item: DigestItem): JSX.Element {
+        if (item.status === "error") {
+            return this.renderDigestError(item);
+        }
+        if (item.digest.kind !== "apply") {
+            return this.renderDigestError({ message: "Unexpected digest kind.", raw: item.raw, name: item.name });
+        }
+        const digest = item.digest;
+
+        return (
+            <div className="digest-detail">
+                {item.unknownVersion && <div className="unknown-version-banner">{item.notes.join(" ")}</div>}
+                <SummaryHeader
+                    title={item.name}
+                    kind="apply"
+                    counts={digest.summary}
+                    outcome={digest.outcome}
+                    truncated={digest.truncated}
+                    truncationNotes={digest.truncationNotes}
+                    toolLabel={`${digest.tool.name} ${digest.tool.version}`}
+                />
+                <ApplyTimeline resources={digest.resources} appliedBeforeFailure={digest.appliedBeforeFailure} />
+                <DiagnosticsPanel diagnostics={digest.diagnostics} />
+                <OutputsPanel outputs={digest.outputs} />
+                {this.renderRawDetails(item.raw)}
+            </div>
+        );
+    }
+
+    private renderDigestError(item: { message: string; raw: RawAttachment; name: string }): JSX.Element {
+        return (
+            <div className="digest-parse-error">
+                <p>
+                    Could not render structured results for <strong>{item.name}</strong>: {item.message}
+                </p>
+                <RawView name={item.raw.name} content={item.raw.content} />
+            </div>
+        );
+    }
+
+    private renderRawDetails(raw: RawAttachment): JSX.Element {
+        return (
+            <details className="raw-details">
+                <summary>View raw digest</summary>
+                <RawView name={raw.name} content={raw.content} />
+            </details>
+        );
+    }
+
+    private renderLegacyRawFallback(): JSX.Element {
+        const { legacyRaw, selectedLegacyIndex } = this.state;
+        const selected = legacyRaw[selectedLegacyIndex] ?? legacyRaw[0];
+
+        return (
+            <div className="pivot-panel">
+                {legacyRaw.length > 1 && (
+                    <div className="plan-header">
+                        <label htmlFor="legacy-plan-select">Plan:</label>
+                        <select
+                            id="legacy-plan-select"
+                            className="plan-select"
+                            value={selectedLegacyIndex}
+                            onChange={this.onSelectLegacy}
+                        >
+                            {legacyRaw.map((plan, i) => (
+                                <option key={plan.name} value={i}>
+                                    {plan.name}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+                {legacyRaw.length === 1 && (
+                    <div className="plan-header">
+                        <strong>{selected.name}</strong>
+                    </div>
+                )}
+                {selected && <RawView name={selected.name} content={selected.content} />}
+            </div>
+        );
+    }
+
+    private setActivePivot = (pivot: "plan" | "apply"): void => {
+        this.setState({ activePivot: pivot });
     };
 
-    public async loadPlans(build: Build): Promise<void> {
+    private onSelectPlan = (id: string): void => {
+        this.setState({ selectedPlanId: id, selectedResourceAddress: null, resourceSearchText: "" });
+    };
+
+    private onSelectApply = (id: string): void => {
+        this.setState({ selectedApplyId: id });
+    };
+
+    private onSelectResource = (address: string): void => {
+        this.setState((prev: TerraformTabState) => ({
+            selectedResourceAddress: prev.selectedResourceAddress === address ? null : address,
+        }));
+    };
+
+    private onResourceSearchChange = (text: string): void => {
+        this.setState({ resourceSearchText: text });
+    };
+
+    private onSelectLegacy = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+        this.setState({ selectedLegacyIndex: parseInt(event.target.value, 10) });
+    };
+
+    /** Fetch an attachment's body, parse it as a plan/apply digest, and classify it as ok/error. Non-OK HTTP responses and network failures are skipped (logged), matching the legacy loader's behavior. */
+    private async loadDigestItems(
+        attachments: AttachmentRef[],
+        authHeader: string,
+        expectedKind: "plan" | "apply"
+    ): Promise<DigestItem[]> {
+        const items: DigestItem[] = [];
+        for (let i = 0; i < attachments.length; i++) {
+            const attachment = attachments[i];
+            const id = `${attachment.name}#${i}`;
+            try {
+                const response = await fetch(attachment._links.self.href, { headers: { Authorization: authHeader } });
+                if (!response.ok) continue;
+                const content = await response.text();
+                const contentLengthHeader = response.headers.get("content-length");
+                const parsedLength = contentLengthHeader ? Number(contentLengthHeader) : undefined;
+                const byteLength = Number.isFinite(parsedLength) ? parsedLength : undefined;
+                const raw: RawAttachment = { name: attachment.name, content };
+
+                const parsed = parseDigestText(content, byteLength);
+                if (parsed.ok && parsed.digest.kind === expectedKind) {
+                    items.push({
+                        id,
+                        name: attachment.name,
+                        status: "ok",
+                        digest: parsed.digest,
+                        unknownVersion: parsed.unknownVersion,
+                        notes: parsed.notes,
+                        raw,
+                    });
+                } else if (parsed.ok) {
+                    items.push({
+                        id,
+                        name: attachment.name,
+                        status: "error",
+                        message: `Digest kind "${parsed.digest.kind}" does not match the expected "${expectedKind}" attachment type.`,
+                        raw,
+                    });
+                } else {
+                    items.push({ id, name: attachment.name, status: "error", message: parsed.message, raw });
+                }
+            } catch (err) {
+                console.error(`Failed to download attachment ${attachment.name}:`, err);
+            }
+        }
+        return items;
+    }
+
+    private async loadRawAttachments(attachments: AttachmentRef[], authHeader: string): Promise<RawAttachment[]> {
+        const items: RawAttachment[] = [];
+        for (const attachment of attachments) {
+            try {
+                const response = await fetch(attachment._links.self.href, { headers: { Authorization: authHeader } });
+                if (response.ok) {
+                    const content = await response.text();
+                    items.push({ name: attachment.name, content });
+                }
+            } catch (err) {
+                console.error(`Failed to download attachment ${attachment.name}:`, err);
+            }
+        }
+        return items;
+    }
+
+    public async loadAll(build: Build): Promise<void> {
         try {
             const buildClient = getClient(BuildRestClient);
-            const attachments = await buildClient.getAttachments(
-                build.project.id,
-                build.id,
-                ATTACHMENT_TYPE
-            );
-
-            if (!attachments || attachments.length === 0) {
-                this.setState({ plans: [], loading: false });
-                return;
-            }
-
-            const plans: PlanAttachment[] = [];
             const accessToken = await SDK.getAccessToken();
             const authHeader = "Basic " + btoa(":" + accessToken);
 
-            for (const attachment of attachments) {
-                try {
-                    const response = await fetch(attachment._links.self.href, {
-                        headers: { Authorization: authHeader },
-                    });
-                    if (response.ok) {
-                        const content = await response.text();
-                        plans.push({ name: attachment.name, content });
-                    }
-                } catch (err) {
-                    console.error(`Failed to download attachment ${attachment.name}:`, err);
-                }
-            }
+            const [planAttachments, applyAttachments, legacyAttachments] = await Promise.all([
+                buildClient.getAttachments(build.project.id, build.id, PLAN_SUMMARY_ATTACHMENT_TYPE),
+                buildClient.getAttachments(build.project.id, build.id, APPLY_SUMMARY_ATTACHMENT_TYPE),
+                buildClient.getAttachments(build.project.id, build.id, LEGACY_RAW_ATTACHMENT_TYPE),
+            ]);
 
-            plans.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
-            this.setState({ plans, selectedIndex: 0, loading: false });
+            const [planItems, applyItems, legacyRaw] = await Promise.all([
+                this.loadDigestItems(planAttachments ?? [], authHeader, "plan"),
+                this.loadDigestItems(applyAttachments ?? [], authHeader, "apply"),
+                this.loadRawAttachments(legacyAttachments ?? [], authHeader),
+            ]);
+
+            planItems.sort(byNameCaseInsensitive);
+            applyItems.sort(byNameCaseInsensitive);
+            legacyRaw.sort(byNameCaseInsensitive);
+
+            const activePivot = planItems.length === 0 && legacyRaw.length === 0 && applyItems.length > 0 ? "apply" : "plan";
+
+            this.setState({
+                planItems,
+                applyItems,
+                legacyRaw,
+                selectedPlanId: planItems[0]?.id ?? null,
+                selectedApplyId: applyItems[0]?.id ?? null,
+                selectedLegacyIndex: 0,
+                selectedResourceAddress: null,
+                resourceSearchText: "",
+                activePivot,
+                loading: false,
+            });
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             this.setState({ error: message, loading: false });
         }
     }
+}
+
+function toPlanOverviewItem(item: DigestItem): OverviewItem {
+    if (item.status === "error" || item.digest.kind !== "plan") {
+        return { id: item.id, name: item.name, status: "error", message: item.status === "error" ? item.message : "Unexpected digest kind." };
+    }
+    const s = item.digest.summary;
+    return {
+        id: item.id,
+        name: item.name,
+        status: "ok",
+        counts: { add: s.add, change: s.change, destroy: s.destroy, replace: s.replace, read: s.read },
+        noChanges: s.noChanges,
+        driftDetected: s.driftDetected,
+    };
+}
+
+function toApplyOverviewItem(item: DigestItem): OverviewItem {
+    if (item.status === "error" || item.digest.kind !== "apply") {
+        return { id: item.id, name: item.name, status: "error", message: item.status === "error" ? item.message : "Unexpected digest kind." };
+    }
+    const s = item.digest.summary;
+    return {
+        id: item.id,
+        name: item.name,
+        status: "ok",
+        counts: { add: s.add, change: s.change, destroy: s.destroy },
+        outcome: item.digest.outcome,
+    };
+}
+
+interface PlanRollup {
+    counts: SummaryHeaderCounts;
+    noChanges: boolean;
+    driftDetected: boolean;
+}
+
+function aggregatePlanRollup(items: Array<Extract<DigestItem, { status: "ok" }>>): PlanRollup {
+    const rollup: PlanRollup = { counts: { add: 0, change: 0, destroy: 0, replace: 0, read: 0 }, noChanges: items.length > 0, driftDetected: false };
+    for (const item of items) {
+        if (item.digest.kind !== "plan") continue;
+        const s = item.digest.summary;
+        rollup.counts.add += s.add;
+        rollup.counts.change += s.change;
+        rollup.counts.destroy += s.destroy;
+        rollup.counts.replace = (rollup.counts.replace ?? 0) + s.replace;
+        rollup.counts.read = (rollup.counts.read ?? 0) + s.read;
+        rollup.noChanges = rollup.noChanges && s.noChanges;
+        rollup.driftDetected = rollup.driftDetected || s.driftDetected;
+    }
+    return rollup;
+}
+
+interface ApplyRollup {
+    counts: SummaryHeaderCounts;
+}
+
+function aggregateApplyRollup(items: Array<Extract<DigestItem, { status: "ok" }>>): ApplyRollup {
+    const counts: SummaryHeaderCounts = { add: 0, change: 0, destroy: 0 };
+    for (const item of items) {
+        if (item.digest.kind !== "apply") continue;
+        const s = item.digest.summary;
+        counts.add += s.add;
+        counts.change += s.change;
+        counts.destroy += s.destroy;
+    }
+    return { counts };
 }
 
 // Initialize the Azure DevOps Extension SDK and render the tab
@@ -180,7 +557,7 @@ SDK.ready().then(() => {
 
         config.onBuildChanged((build: Build) => {
             if (tabRef.current) {
-                tabRef.current.loadPlans(build);
+                tabRef.current.loadAll(build);
             }
         });
     } else {


### PR DESCRIPTION
## Summary

WP-3 of the structured-plan-apply-tabs initiative (`docs/initiatives/structured-plan-apply-tabs.md` §8). Depends only on WP-0's frozen `digest-schema.ts`/`caps.ts` (already on this base branch); runs independently of WP-1/WP-2.

- **`src/tab/digest-model.ts`** — safe parse+validate of untrusted plan/apply digest attachments (§5.3.4):
  - `JSON.parse` only; refuses input over `TAB_PARSE_CEILING_BYTES` (16 MiB) before parsing.
  - Rejects any object carrying a `__proto__`/`constructor`/`prototype` own-property key anywhere in the tree.
  - Coerces field-by-field into the frozen `digest-schema.ts` types — never spreads an untrusted parsed object into typed state.
  - A v1 digest missing a required top-level field (e.g. `summary`, `resources`) is rejected safely, not rendered as `undefined`.
  - An unrecognized newer `schemaVersion` degrades best-effort (defaults missing/malformed fields, collects notes) instead of throwing — proven by a `schemaVersion: 999` regression case at both the model and `tabContent` level.
  - `RedactedValue` coercion **always** fails closed to `{kind:"sensitive"}` on any unrecognized/malformed shape, in both strict and lenient parsing modes — mirrors the task-side fail-closed rule (spec §5.2.4) as tab-side defense in depth.
  - Defensively re-caps `resources`/`attributeChanges`/`diagnostics` to the §6 limits regardless of the digest's own `truncated` claim (§5.5: "don't trust `truncated`").
  - 97.4% statement coverage (>= the 90% security-critical-module bar).

- **`src/tab/components/*`** — pure presentational components: `SummaryHeader`, `OverviewList`, `ResourceList` (grouped by action, controlled search/filter — no internal hooks), `ResourceDiff`, `ApplyTimeline`, `OutputsPanel`, `DiagnosticsPanel`, `RawView` (the sole `dangerouslySetInnerHTML` sink, reusing `ansi-to-html`, download filename sanitized to `[A-Za-z0-9._-]`), and a `redacted-value.ts` formatting helper (`(sensitive)` / `(known after apply)` / `(value omitted: too large)`). Every digest string renders as a React text node.

- **`src/tab/tabContent.tsx`** — converted to Plan/Apply pivots. Loads `terraform-plan-summary` + `terraform-apply-summary` (structured) and the legacy `terraform-plan-results` raw attachment (fallback when no structured attachments exist for that pivot, or per-item when a specific digest fails to parse). Multi-item overview list with a roll-up summary header across items; selecting an item opens its detail (resource list → diff, or apply timeline/diagnostics/outputs). A parse failure or unrecognized `schemaVersion` renders a banner/error plus a raw-view fallback instead of crashing.

- **`src/tab/security-tripwires.test.ts`** — the two anti-regression tripwires this WP owns (§12.4):
  - (2) `dangerouslySetInnerHTML` appears (as actual JSX usage, not doc-comment mentions) only in `RawView.tsx`/`ansi-to-html.ts`, nowhere else under `src/tab`.
  - (4) `fetch()` only ever targets `attachment._links.self.href` (the ADO-provided attachment link); no literal external URL, and no CDN/telemetry/font/analytics host reference anywhere under `src/tab`.

**No new dependency.** The design suggested `azure-devops-ui` `Tabs`/`Pivot` for the Plan/Apply pivots, but it isn't actually a devDependency in this repo today (checked `package.json`/`package-lock.json`) despite §5.9's "prefer azure-devops-ui primitives already bundled" — since it isn't bundled, and this WP's own instructions say "add none if avoidable," the pivots and `ResourceList`'s search/filter are built with plain controlled React (no internal `useState`/hooks), which also kept every new component testable via `renderToStaticMarkup` without a jsdom/testing-library addition.

**Regression fixtures.** WP-1's golden `.expected.json` corpus doesn't exist yet in this worktree (WP-1 runs in parallel, not a dependency of WP-3). The `schemaVersion:999` degrade-not-crash regression and all other digest fixtures are therefore authored inline in this WP's own tests (`digest-model.test.ts`, `tabContent.test.tsx`) rather than consumed from WP-1. Once WP-1's corpus lands, a follow-up WP (WP-4/WP-5) may wire real golden fixtures through these components as additional snapshot coverage; that isn't done here.

**Local gates (from the worktree root):**
- `npx tsc -p src/tab/tsconfig.json --noEmit` — clean.
- `npm run test:tab` — 139/139 tests passing, coverage 92.5/86.5/89.9/94.3 (stmt/branch/func/line) against the 80/78/60/80 thresholds; `digest-model.ts` 97.4% statements.
- `node scripts/check-shared-modules.js` — passes (digest-schema.ts/caps.ts parity families already registered by WP-0).
- `node scripts/check-versions.js` — passes.
- `node scripts/check-minor-bumps.js v1.9.5 HEAD` — **fails**, pre-existing on this base branch since WP-0's commit (verified via `git diff v1.9.5..<WP-0 commit>` — only `src/results/{caps,digest-schema}.ts` were added, no version bump). Per the repo conventions, WP-2 owns the one Minor bump for the whole feature; this WP does not touch `task.json`.

## Test plan
- [x] `npx tsc -p src/tab/tsconfig.json --noEmit` (matches CI's "Type-check tab" step)
- [x] `npm run test:tab` (matches CI's "Run tab unit tests" step) — both OS legs will run in the PR's `Build and Test Tab` matrix job
- [x] `node scripts/check-shared-modules.js`
- [x] `node scripts/check-versions.js`
