### PR TITLE
feat: add plan/apply redaction + digest core [WP-1]

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -37,6 +37,14 @@ import './CrossCloudBackendCredentialTests/HcpOciGenericConfigureBackendCredenti
 import './BinaryNameAllowlistL0';
 // Direct unit tests for the GCP static-key token_uri (Audience) validation.
 import './GcpTokenUriValidationL0';
+// Direct unit tests for the plan/apply digest REDACTION CORE (WP-1, the single
+// most security-critical unit): recursive redaction, digest builders, freeform
+// diagnostic scrub, and the golden-fixture regression + no-leak tripwire.
+import './results/RedactL0';
+import './results/PlanDigestL0';
+import './results/ApplyDigestL0';
+import './results/SecretScrubL0';
+import './results/GoldenFixturesL0';
 
 describe('Terraform Test Suite', function () {
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-partial-failure.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-partial-failure.expected.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "kind": "apply",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-apply",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": true,
+  "outcome": "failed",
+  "summary": {
+    "add": 1,
+    "change": 0,
+    "destroy": 0,
+    "durationMs": 4200
+  },
+  "resources": [
+    {
+      "address": "aws_s3_bucket.ok",
+      "action": "create",
+      "status": "complete",
+      "durationMs": 1000
+    },
+    {
+      "address": "aws_db_instance.bad",
+      "action": "create",
+      "status": "errored",
+      "durationMs": 1900
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "error",
+      "summary": "invalid value for password: (redacted)",
+      "address": "aws_db_instance.bad"
+    }
+  ],
+  "outputs": [],
+  "appliedBeforeFailure": [
+    "aws_s3_bucket.ok"
+  ],
+  "truncationNotes": [
+    "skipped 1 malformed apply event line(s)"
+  ]
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-partial-failure.ndjson
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-partial-failure.ndjson
@@ -1,0 +1,8 @@
+{"@level":"info","@message":"Terraform 1.9.5","@timestamp":"2026-07-15T11:00:00.000000Z","type":"version","terraform":"1.9.5"}
+{"@level":"info","@message":"aws_s3_bucket.ok: Creating...","@timestamp":"2026-07-15T11:00:01.000000Z","type":"apply_start","hook":{"resource":{"addr":"aws_s3_bucket.ok"},"action":"create"}}
+{"@level":"info","@message":"aws_s3_bucket.ok: Creation complete after 1s","@timestamp":"2026-07-15T11:00:02.000000Z","type":"apply_complete","hook":{"resource":{"addr":"aws_s3_bucket.ok"},"action":"create","elapsed_seconds":1}}
+{"@level":"info","@message":"aws_db_instance.bad: Creating...","@timestamp":"2026-07-15T11:00:02.100000Z","type":"apply_start","hook":{"resource":{"addr":"aws_db_instance.bad"},"action":"create"}}
+this line is not valid json {{{ and must be tolerated
+{"@level":"error","@message":"Error: creation failed","@timestamp":"2026-07-15T11:00:04.000000Z","type":"apply_errored","hook":{"resource":{"addr":"aws_db_instance.bad"},"action":"create"}}
+{"@level":"error","@message":"Error: invalid password value","@timestamp":"2026-07-15T11:00:04.100000Z","type":"diagnostic","diagnostic":{"severity":"error","summary":"invalid value for password: APPLYSECRET_pw_42","detail":"the supplied password APPLYSECRET_pw_42 was rejected by the provider","address":"aws_db_instance.bad"}}
+{"@level":"info","@message":"Apply complete","@timestamp":"2026-07-15T11:00:04.200000Z","type":"change_summary","changes":{"add":1,"change":0,"remove":0,"operation":"apply"}}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-success.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-success.expected.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "kind": "apply",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-apply",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "outcome": "succeeded",
+  "summary": {
+    "add": 1,
+    "change": 0,
+    "destroy": 0,
+    "durationMs": 3600
+  },
+  "resources": [
+    {
+      "address": "aws_s3_bucket.data",
+      "action": "create",
+      "status": "complete",
+      "durationMs": 2000
+    }
+  ],
+  "diagnostics": [],
+  "outputs": [
+    {
+      "name": "bucket_name",
+      "action": "no-op",
+      "value": {
+        "kind": "value",
+        "json": "\"my-data-bucket\""
+      }
+    }
+  ]
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-success.ndjson
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/apply-success.ndjson
@@ -1,0 +1,5 @@
+{"@level":"info","@message":"Terraform 1.9.5","@timestamp":"2026-07-15T10:00:00.000000Z","type":"version","terraform":"1.9.5","ui":"1.2"}
+{"@level":"info","@message":"aws_s3_bucket.data: Creating...","@timestamp":"2026-07-15T10:00:01.000000Z","type":"apply_start","hook":{"resource":{"addr":"aws_s3_bucket.data","resource_type":"aws_s3_bucket","resource_name":"data"},"action":"create"}}
+{"@level":"info","@message":"aws_s3_bucket.data: Creation complete after 2s [id=my-data-bucket]","@timestamp":"2026-07-15T10:00:03.000000Z","type":"apply_complete","hook":{"resource":{"addr":"aws_s3_bucket.data"},"action":"create","id_key":"id","id_value":"my-data-bucket","elapsed_seconds":2}}
+{"@level":"info","@message":"Apply complete! Resources: 1 added, 0 changed, 0 destroyed.","@timestamp":"2026-07-15T10:00:03.500000Z","type":"change_summary","changes":{"add":1,"change":0,"remove":0,"operation":"apply"}}
+{"@level":"info","@message":"Outputs: 1","@timestamp":"2026-07-15T10:00:03.600000Z","type":"outputs","outputs":{"bucket_name":{"sensitive":false,"type":"string","value":"my-data-bucket"}}}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-create.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-create.expected.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "kind": "plan",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-plan",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "summary": {
+    "add": 1,
+    "change": 0,
+    "destroy": 0,
+    "replace": 0,
+    "read": 0,
+    "noChanges": false,
+    "driftDetected": false
+  },
+  "resources": [
+    {
+      "address": "aws_s3_bucket.data",
+      "type": "aws_s3_bucket",
+      "name": "data",
+      "providerName": "registry.terraform.io/hashicorp/aws",
+      "actions": [
+        "create"
+      ],
+      "attributeChanges": [
+        {
+          "path": "acl",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "value",
+            "json": "\"private\""
+          }
+        },
+        {
+          "path": "arn",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "unknown"
+          }
+        },
+        {
+          "path": "bucket",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "value",
+            "json": "\"my-data-bucket\""
+          }
+        },
+        {
+          "path": "id",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "unknown"
+          }
+        },
+        {
+          "path": "tags",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "value",
+            "json": "{\"env\":\"prod\"}"
+          }
+        }
+      ]
+    }
+  ],
+  "outputChanges": [
+    {
+      "name": "bucket_name",
+      "action": "create",
+      "value": {
+        "kind": "value",
+        "json": "\"my-data-bucket\""
+      }
+    }
+  ]
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-create.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-create.json
@@ -1,0 +1,36 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.5",
+  "resource_changes": [
+    {
+      "address": "aws_s3_bucket.data",
+      "type": "aws_s3_bucket",
+      "name": "data",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "id": null,
+          "arn": null,
+          "bucket": "my-data-bucket",
+          "acl": "private",
+          "tags": { "env": "prod" }
+        },
+        "after_unknown": { "id": true, "arn": true },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "output_changes": {
+    "bucket_name": {
+      "actions": ["create"],
+      "before": null,
+      "after": "my-data-bucket",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    }
+  }
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-destroy.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-destroy.expected.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "kind": "plan",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-plan",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "summary": {
+    "add": 0,
+    "change": 0,
+    "destroy": 1,
+    "replace": 0,
+    "read": 0,
+    "noChanges": false,
+    "driftDetected": false
+  },
+  "resources": [
+    {
+      "address": "aws_db_instance.main",
+      "type": "aws_db_instance",
+      "name": "main",
+      "providerName": "registry.terraform.io/hashicorp/aws",
+      "actions": [
+        "delete"
+      ],
+      "attributeChanges": [
+        {
+          "path": "allocated_storage",
+          "before": {
+            "kind": "value",
+            "json": "20"
+          },
+          "after": {
+            "kind": "value",
+            "json": "null"
+          }
+        },
+        {
+          "path": "id",
+          "before": {
+            "kind": "value",
+            "json": "\"db-0123456789\""
+          },
+          "after": {
+            "kind": "value",
+            "json": "null"
+          }
+        },
+        {
+          "path": "identifier",
+          "before": {
+            "kind": "value",
+            "json": "\"maindb\""
+          },
+          "after": {
+            "kind": "value",
+            "json": "null"
+          }
+        }
+      ]
+    }
+  ],
+  "outputChanges": []
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-destroy.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-destroy.json
@@ -1,0 +1,21 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.5",
+  "resource_changes": [
+    {
+      "address": "aws_db_instance.main",
+      "type": "aws_db_instance",
+      "name": "main",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["delete"],
+        "before": { "identifier": "maindb", "id": "db-0123456789", "allocated_storage": 20 },
+        "after": null,
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "output_changes": {}
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-drift.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-drift.expected.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": 1,
+  "kind": "plan",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-plan",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "summary": {
+    "add": 0,
+    "change": 1,
+    "destroy": 0,
+    "replace": 0,
+    "read": 0,
+    "noChanges": false,
+    "driftDetected": true
+  },
+  "resources": [
+    {
+      "address": "aws_instance.web",
+      "type": "aws_instance",
+      "name": "web",
+      "providerName": "registry.terraform.io/hashicorp/aws",
+      "actions": [
+        "update"
+      ],
+      "attributeChanges": [
+        {
+          "path": "tags",
+          "before": {
+            "kind": "value",
+            "json": "{\"Name\":\"web\"}"
+          },
+          "after": {
+            "kind": "value",
+            "json": "{\"Name\":\"web-2\"}"
+          }
+        }
+      ]
+    }
+  ],
+  "outputChanges": [],
+  "drift": [
+    {
+      "address": "aws_instance.web",
+      "type": "aws_instance",
+      "name": "web",
+      "providerName": "registry.terraform.io/hashicorp/aws",
+      "attributeChanges": [
+        {
+          "path": "tags",
+          "before": {
+            "kind": "value",
+            "json": "{\"Name\":\"web-old\"}"
+          },
+          "after": {
+            "kind": "value",
+            "json": "{\"Name\":\"web\"}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-drift.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-drift.json
@@ -1,0 +1,37 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.5",
+  "resource_changes": [
+    {
+      "address": "aws_instance.web",
+      "type": "aws_instance",
+      "name": "web",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["update"],
+        "before": { "tags": { "Name": "web" } },
+        "after": { "tags": { "Name": "web-2" } },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "resource_drift": [
+    {
+      "address": "aws_instance.web",
+      "type": "aws_instance",
+      "name": "web",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["update"],
+        "before": { "tags": { "Name": "web-old" } },
+        "after": { "tags": { "Name": "web" } },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "output_changes": {}
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-multi-provider.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-multi-provider.expected.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "kind": "plan",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-plan",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "summary": {
+    "add": 1,
+    "change": 1,
+    "destroy": 0,
+    "replace": 0,
+    "read": 0,
+    "noChanges": false,
+    "driftDetected": false
+  },
+  "resources": [
+    {
+      "address": "aws_s3_bucket.a",
+      "type": "aws_s3_bucket",
+      "name": "a",
+      "providerName": "registry.terraform.io/hashicorp/aws",
+      "actions": [
+        "create"
+      ],
+      "attributeChanges": [
+        {
+          "path": "bucket",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "value",
+            "json": "\"bucket-a\""
+          }
+        }
+      ]
+    },
+    {
+      "address": "azurerm_resource_group.b",
+      "type": "azurerm_resource_group",
+      "name": "b",
+      "providerName": "registry.terraform.io/hashicorp/azurerm",
+      "actions": [
+        "update"
+      ],
+      "attributeChanges": [
+        {
+          "path": "location",
+          "before": {
+            "kind": "value",
+            "json": "\"eastus\""
+          },
+          "after": {
+            "kind": "value",
+            "json": "\"westus\""
+          }
+        }
+      ]
+    }
+  ],
+  "outputChanges": []
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-multi-provider.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-multi-provider.json
@@ -1,0 +1,35 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.5",
+  "resource_changes": [
+    {
+      "address": "aws_s3_bucket.a",
+      "type": "aws_s3_bucket",
+      "name": "a",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": { "bucket": "bucket-a" },
+        "after_unknown": { "id": true },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "azurerm_resource_group.b",
+      "type": "azurerm_resource_group",
+      "name": "b",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["update"],
+        "before": { "location": "eastus", "name": "rg-b" },
+        "after": { "location": "westus", "name": "rg-b" },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "output_changes": {}
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-noop.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-noop.expected.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "kind": "plan",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-plan",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "summary": {
+    "add": 0,
+    "change": 0,
+    "destroy": 0,
+    "replace": 0,
+    "read": 0,
+    "noChanges": true,
+    "driftDetected": false
+  },
+  "resources": [
+    {
+      "address": "null_resource.noop",
+      "type": "null_resource",
+      "name": "noop",
+      "providerName": "registry.terraform.io/hashicorp/null",
+      "actions": [
+        "no-op"
+      ],
+      "attributeChanges": []
+    }
+  ],
+  "outputChanges": []
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-noop.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-noop.json
@@ -1,0 +1,21 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.5",
+  "resource_changes": [
+    {
+      "address": "null_resource.noop",
+      "type": "null_resource",
+      "name": "noop",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": ["no-op"],
+        "before": { "id": "8140581574625882000", "triggers": null },
+        "after": { "id": "8140581574625882000", "triggers": null },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "output_changes": {}
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-replace.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-replace.expected.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "kind": "plan",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-plan",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "summary": {
+    "add": 1,
+    "change": 0,
+    "destroy": 1,
+    "replace": 1,
+    "read": 0,
+    "noChanges": false,
+    "driftDetected": false
+  },
+  "resources": [
+    {
+      "address": "aws_instance.web",
+      "type": "aws_instance",
+      "name": "web",
+      "providerName": "registry.terraform.io/hashicorp/aws",
+      "actions": [
+        "delete",
+        "create"
+      ],
+      "attributeChanges": [
+        {
+          "path": "ami",
+          "before": {
+            "kind": "value",
+            "json": "\"ami-0old\""
+          },
+          "after": {
+            "kind": "value",
+            "json": "\"ami-1new\""
+          }
+        },
+        {
+          "path": "id",
+          "before": {
+            "kind": "value",
+            "json": "\"i-0123456789\""
+          },
+          "after": {
+            "kind": "unknown"
+          }
+        }
+      ],
+      "actionReason": "replace_because_cannot_update",
+      "replacePaths": [
+        "ami"
+      ]
+    }
+  ],
+  "outputChanges": []
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-replace.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-replace.json
@@ -1,0 +1,23 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.5",
+  "resource_changes": [
+    {
+      "address": "aws_instance.web",
+      "type": "aws_instance",
+      "name": "web",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "action_reason": "replace_because_cannot_update",
+      "change": {
+        "actions": ["delete", "create"],
+        "before": { "ami": "ami-0old", "instance_type": "t3.micro", "id": "i-0123456789" },
+        "after": { "ami": "ami-1new", "instance_type": "t3.micro", "id": null },
+        "after_unknown": { "id": true },
+        "before_sensitive": {},
+        "after_sensitive": {},
+        "replace_paths": [["ami"]]
+      }
+    }
+  ],
+  "output_changes": {}
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-sensitive.expected.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-sensitive.expected.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "kind": "plan",
+  "producedBy": {
+    "task": "TerraformTaskV5",
+    "taskVersion": "0.0.0-test"
+  },
+  "tool": {
+    "name": "terraform",
+    "version": "1.9.5"
+  },
+  "meta": {
+    "name": "terraform-plan",
+    "workingDirectory": "infra",
+    "createdIso": "2026-07-15T00:00:00Z"
+  },
+  "truncated": false,
+  "summary": {
+    "add": 1,
+    "change": 0,
+    "destroy": 0,
+    "replace": 0,
+    "read": 0,
+    "noChanges": false,
+    "driftDetected": false
+  },
+  "resources": [
+    {
+      "address": "aws_db_instance.main",
+      "type": "aws_db_instance",
+      "name": "main",
+      "providerName": "registry.terraform.io/hashicorp/aws",
+      "actions": [
+        "create"
+      ],
+      "attributeChanges": [
+        {
+          "path": "config",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "value",
+            "json": "{\"host\":\"db.internal\",\"token\":\"(sensitive)\"}"
+          }
+        },
+        {
+          "path": "endpoint",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "unknown"
+          }
+        },
+        {
+          "path": "password",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "sensitive"
+          }
+        },
+        {
+          "path": "ports",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "value",
+            "json": "[5432,\"(sensitive)\"]"
+          }
+        },
+        {
+          "path": "username",
+          "before": {
+            "kind": "value",
+            "json": "null"
+          },
+          "after": {
+            "kind": "value",
+            "json": "\"admin\""
+          }
+        }
+      ]
+    }
+  ],
+  "outputChanges": [
+    {
+      "name": "db_host",
+      "action": "create",
+      "value": {
+        "kind": "value",
+        "json": "\"db.internal\""
+      }
+    },
+    {
+      "name": "db_password",
+      "action": "create",
+      "value": {
+        "kind": "sensitive"
+      }
+    }
+  ]
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-sensitive.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/fixtures/plan-sensitive.json
@@ -1,0 +1,48 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.5",
+  "resource_changes": [
+    {
+      "address": "aws_db_instance.main",
+      "type": "aws_db_instance",
+      "name": "main",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "username": "admin",
+          "password": "SUPERSECRET_pw_9f3k",
+          "endpoint": null,
+          "config": { "host": "db.internal", "token": "TOK_abc123secret" },
+          "ports": [5432, "PORTSECRET_literal"]
+        },
+        "after_unknown": { "endpoint": true },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "password": true,
+          "config": { "token": true },
+          "ports": [false, true]
+        }
+      }
+    }
+  ],
+  "output_changes": {
+    "db_password": {
+      "actions": ["create"],
+      "before": null,
+      "after": "OUTPUTSECRET_xyz",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": true
+    },
+    "db_host": {
+      "actions": ["create"],
+      "before": null,
+      "after": "db.internal",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    }
+  }
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/ApplyDigestL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/ApplyDigestL0.ts
@@ -1,0 +1,141 @@
+import * as assert from 'assert';
+import { buildApplyDigest } from '../../src/results/apply-digest';
+import { DigestMeta } from '../../src/results/plan-digest';
+import { MAX_DIAGNOSTICS } from '../../src/results/caps';
+
+const META: DigestMeta = {
+  taskVersion: '0.0.0-test',
+  toolName: 'terraform',
+  name: 'terraform-apply',
+  createdIso: '2026-07-15T00:00:00Z',
+};
+
+function line(o: unknown): string {
+  return JSON.stringify(o);
+}
+
+describe('buildApplyDigest', () => {
+  it('parses a successful stream: resources, durations, outcome, summary, outputs', () => {
+    const ndjson = [
+      line({ '@timestamp': '2026-07-15T10:00:00.000Z', type: 'version', terraform: '1.9.5' }),
+      line({ '@timestamp': '2026-07-15T10:00:01.000Z', type: 'apply_start', hook: { resource: { addr: 'aws_s3_bucket.data' }, action: 'create' } }),
+      line({ '@timestamp': '2026-07-15T10:00:03.000Z', type: 'apply_complete', hook: { resource: { addr: 'aws_s3_bucket.data' }, action: 'create', elapsed_seconds: 2 } }),
+      line({ '@timestamp': '2026-07-15T10:00:03.500Z', type: 'change_summary', changes: { add: 1, change: 0, remove: 0, operation: 'apply' } }),
+      line({ '@timestamp': '2026-07-15T10:00:03.600Z', type: 'outputs', outputs: { bucket_name: { sensitive: false, type: 'string', value: 'my-bucket' } } }),
+    ].join('\n');
+    const d = buildApplyDigest(ndjson, META);
+    assert.strictEqual(d.outcome, 'succeeded');
+    assert.strictEqual(d.tool.version, '1.9.5');
+    assert.strictEqual(d.resources.length, 1);
+    assert.deepStrictEqual(d.resources[0], { address: 'aws_s3_bucket.data', action: 'create', status: 'complete', durationMs: 2000 });
+    assert.deepStrictEqual(d.summary, { add: 1, change: 0, destroy: 0, durationMs: 3600 });
+    assert.deepStrictEqual(d.outputs, [{ name: 'bucket_name', action: 'no-op', value: { kind: 'value', json: '"my-bucket"' } }]);
+    assert.strictEqual(d.appliedBeforeFailure, undefined);
+    assert.strictEqual(d.truncated, false);
+  });
+
+  it('computes durationMs from start/complete timestamps (not Date.now)', () => {
+    const ndjson = [
+      line({ '@timestamp': '2026-07-15T10:00:00.000Z', type: 'apply_start', hook: { resource: { addr: 'r.a' }, action: 'update' } }),
+      line({ '@timestamp': '2026-07-15T10:00:07.500Z', type: 'apply_complete', hook: { resource: { addr: 'r.a' }, action: 'update' } }),
+    ].join('\n');
+    const d = buildApplyDigest(ndjson, META);
+    assert.strictEqual(d.resources[0].durationMs, 7500);
+  });
+
+  it('marks a partial failure: outcome failed, appliedBeforeFailure lists completed addresses, errored status set', () => {
+    const ndjson = [
+      line({ '@timestamp': '2026-07-15T11:00:01.000Z', type: 'apply_start', hook: { resource: { addr: 'r.ok' }, action: 'create' } }),
+      line({ '@timestamp': '2026-07-15T11:00:02.000Z', type: 'apply_complete', hook: { resource: { addr: 'r.ok' }, action: 'create' } }),
+      line({ '@timestamp': '2026-07-15T11:00:02.100Z', type: 'apply_start', hook: { resource: { addr: 'r.bad' }, action: 'create' } }),
+      line({ '@timestamp': '2026-07-15T11:00:04.000Z', type: 'apply_errored', hook: { resource: { addr: 'r.bad' }, action: 'create' } }),
+    ].join('\n');
+    const d = buildApplyDigest(ndjson, META);
+    assert.strictEqual(d.outcome, 'failed');
+    assert.deepStrictEqual(d.appliedBeforeFailure, ['r.ok']);
+    const bad = d.resources.find((r) => r.address === 'r.bad');
+    const ok = d.resources.find((r) => r.address === 'r.ok');
+    assert.strictEqual(bad?.status, 'errored');
+    assert.strictEqual(ok?.status, 'complete');
+  });
+
+  it('treats an error-severity diagnostic as a failed apply', () => {
+    const ndjson = line({ '@timestamp': '2026-07-15T11:00:04.100Z', type: 'diagnostic', diagnostic: { severity: 'error', summary: 'boom' } });
+    assert.strictEqual(buildApplyDigest(ndjson, META).outcome, 'failed');
+  });
+
+  it('tolerates malformed / partial NDJSON lines (skipped + noted, never throws)', () => {
+    const ndjson = [
+      line({ '@timestamp': '2026-07-15T11:00:01.000Z', type: 'apply_start', hook: { resource: { addr: 'r.ok' }, action: 'create' } }),
+      'this is not json {{{',
+      '',
+      '{ "partial": ',
+      line({ '@timestamp': '2026-07-15T11:00:02.000Z', type: 'apply_complete', hook: { resource: { addr: 'r.ok' }, action: 'create' } }),
+    ].join('\n');
+    let d: ReturnType<typeof buildApplyDigest>;
+    assert.doesNotThrow(() => {
+      d = buildApplyDigest(ndjson, META);
+    });
+    d = buildApplyDigest(ndjson, META);
+    assert.strictEqual(d.resources.length, 1);
+    assert.strictEqual(d.truncated, true);
+    assert.ok((d.truncationNotes ?? []).some((n) => n.includes('malformed apply event line')));
+  });
+
+  it('masks sensitive outputs from the outputs event', () => {
+    const ndjson = line({ '@timestamp': '2026-07-15T10:00:03.600Z', type: 'outputs', outputs: { pw: { sensitive: true, type: 'string', value: 'APPLY_TOPSECRET' }, host: { sensitive: false, type: 'string', value: 'h' } } });
+    const d = buildApplyDigest(ndjson, META);
+    const pw = d.outputs.find((o) => o.name === 'pw');
+    assert.deepStrictEqual(pw?.value, { kind: 'sensitive' });
+    assert.ok(!JSON.stringify(d).includes('APPLY_TOPSECRET'));
+  });
+
+  describe('diagnostics', () => {
+    const diagLine = line({ type: 'diagnostic', diagnostic: { severity: 'error', summary: 'bad password: SEKRET_pw_value', detail: 'the password SEKRET_pw_value failed', address: 'r.bad' } });
+
+    it('omits detail by default (safe mode) and scrubs the known secret from summary', () => {
+      const d = buildApplyDigest(diagLine, META, { knownSecrets: ['SEKRET_pw_value'] });
+      assert.strictEqual(d.diagnostics.length, 1);
+      assert.strictEqual(d.diagnostics[0].detail, undefined);
+      assert.ok(!d.diagnostics[0].summary.includes('SEKRET_pw_value'));
+      assert.strictEqual(d.diagnostics[0].address, 'r.bad');
+      assert.ok(!JSON.stringify(d).includes('SEKRET_pw_value'));
+    });
+
+    it('includes scrubbed detail when includeDiagnosticDetail is set', () => {
+      const d = buildApplyDigest(diagLine, META, { knownSecrets: ['SEKRET_pw_value'], includeDiagnosticDetail: true });
+      assert.ok(d.diagnostics[0].detail !== undefined);
+      assert.ok(!d.diagnostics[0].detail!.includes('SEKRET_pw_value'));
+    });
+
+    it('caps diagnostics keeping errors first, and notes the remainder', () => {
+      const lines: string[] = [];
+      for (let i = 0; i < 10; i++) lines.push(line({ type: 'diagnostic', diagnostic: { severity: 'warning', summary: `w${i}` } }));
+      for (let i = 0; i < MAX_DIAGNOSTICS; i++) lines.push(line({ type: 'diagnostic', diagnostic: { severity: 'error', summary: `e${i}` } }));
+      const d = buildApplyDigest(lines.join('\n'), META);
+      assert.strictEqual(d.diagnostics.length, MAX_DIAGNOSTICS);
+      assert.ok(d.diagnostics.every((x) => x.severity === 'error'), 'errors survive, warnings dropped past the cap');
+      assert.strictEqual(d.truncated, true);
+      assert.ok((d.truncationNotes ?? []).some((n) => n.includes('diagnostics capped')));
+    });
+  });
+
+  it('derives summary counts from resources when no change_summary event is present', () => {
+    const ndjson = [
+      line({ type: 'apply_complete', hook: { resource: { addr: 'r.c' }, action: 'create' } }),
+      line({ type: 'apply_complete', hook: { resource: { addr: 'r.u' }, action: 'update' } }),
+      line({ type: 'apply_complete', hook: { resource: { addr: 'r.d' }, action: 'delete' } }),
+    ].join('\n');
+    const d = buildApplyDigest(ndjson, META);
+    assert.strictEqual(d.summary.add, 1);
+    assert.strictEqual(d.summary.change, 1);
+    assert.strictEqual(d.summary.destroy, 1);
+  });
+
+  it('does not throw on empty input', () => {
+    assert.doesNotThrow(() => buildApplyDigest('', META));
+    const d = buildApplyDigest('', META);
+    assert.strictEqual(d.outcome, 'succeeded');
+    assert.strictEqual(d.resources.length, 0);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/GoldenFixturesL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/GoldenFixturesL0.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FIXTURES, FIXTURES_DIR, serializeFixture } from './golden-fixtures';
+
+// REGRESSION FOUNDATION (§12.3) + NO-LEAK TRIPWIRE (§12.4.1).
+//
+// Each fixture is a SANITIZED capture (synthetic — it contains only FAKE
+// secret-looking literals, never a real secret) under Tests/fixtures/. For each:
+//   * the builder output is asserted BYTE-FOR-BYTE against a committed
+//     `.expected.json` golden — a redaction/digest change that alters output
+//     fails loudly and the diff shows exactly what changed; and
+//   * every known-secret literal embedded in the INPUT is asserted to appear
+//     NOWHERE in the serialized digest (the generic catch-all that trips even
+//     for a value shape no targeted test covers).
+//
+// The digest builders are deterministic (redact.ts §2.6), so these goldens are
+// byte-stable.
+
+describe('golden fixtures (§12.3 regression) + no-leak tripwire (§12.4.1)', () => {
+  for (const spec of FIXTURES) {
+    describe(spec.input, () => {
+      it('reproduces the committed golden byte-for-byte', () => {
+        const expected = fs.readFileSync(path.join(FIXTURES_DIR, spec.expected), 'utf8').replace(/\r?\n$/, '');
+        assert.strictEqual(serializeFixture(spec), expected, `${spec.expected} drifted — review the redaction/digest change`);
+      });
+
+      it('leaks no known-secret literal into the serialized digest', () => {
+        const digest = serializeFixture(spec);
+        for (const secret of spec.secrets) {
+          assert.ok(!digest.includes(secret), `SECURITY: secret literal "${secret}" leaked into ${spec.input} digest`);
+        }
+      });
+    });
+  }
+
+  it('is deterministic: building twice yields byte-identical output', () => {
+    for (const spec of FIXTURES) {
+      assert.strictEqual(serializeFixture(spec), serializeFixture(spec), `${spec.input} is non-deterministic`);
+    }
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/GoldenFixturesL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/GoldenFixturesL0.ts
@@ -21,7 +21,10 @@ describe('golden fixtures (§12.3 regression) + no-leak tripwire (§12.4.1)', ()
   for (const spec of FIXTURES) {
     describe(spec.input, () => {
       it('reproduces the committed golden byte-for-byte', () => {
-        const expected = fs.readFileSync(path.join(FIXTURES_DIR, spec.expected), 'utf8').replace(/\r?\n$/, '');
+        // JSON.stringify always emits LF; normalize the committed golden's line
+        // endings (a Windows checkout with core.autocrlf may deliver CRLF) and
+        // its trailing newline so the comparison is content-exact on both OS legs.
+        const expected = fs.readFileSync(path.join(FIXTURES_DIR, spec.expected), 'utf8').replace(/\r\n/g, '\n').replace(/\n$/, '');
         assert.strictEqual(serializeFixture(spec), expected, `${spec.expected} drifted — review the redaction/digest change`);
       });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/PlanDigestL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/PlanDigestL0.ts
@@ -1,0 +1,284 @@
+import * as assert from 'assert';
+import { buildPlanDigest, DigestMeta } from '../../src/results/plan-digest';
+import { MAX_RESOURCES, MAX_ATTR_CHANGES_PER_RESOURCE } from '../../src/results/caps';
+
+const META: DigestMeta = {
+  taskVersion: '0.0.0-test',
+  toolName: 'terraform',
+  name: 'terraform-plan',
+  workingDirectory: 'infra',
+  createdIso: '2026-07-15T00:00:00Z',
+};
+
+function change(overrides: Record<string, unknown>) {
+  return { actions: ['no-op'], before: {}, after: {}, after_unknown: {}, before_sensitive: {}, after_sensitive: {}, ...overrides };
+}
+
+describe('buildPlanDigest', () => {
+  it('classifies create/update/delete/read/no-op and counts the summary', () => {
+    const plan = {
+      terraform_version: '1.9.5',
+      resource_changes: [
+        { address: 'r.c', type: 't', name: 'c', provider_name: 'p', change: change({ actions: ['create'], before: null, after: { x: 1 } }) },
+        { address: 'r.u', type: 't', name: 'u', provider_name: 'p', change: change({ actions: ['update'], before: { x: 1 }, after: { x: 2 } }) },
+        { address: 'r.d', type: 't', name: 'd', provider_name: 'p', change: change({ actions: ['delete'], before: { x: 1 }, after: null }) },
+        { address: 'r.r', type: 't', name: 'r', provider_name: 'p', change: change({ actions: ['read'], before: null, after: { x: 1 } }) },
+        { address: 'r.n', type: 't', name: 'n', provider_name: 'p', change: change({ actions: ['no-op'], before: { x: 1 }, after: { x: 1 } }) },
+      ],
+      output_changes: {},
+    };
+    const d = buildPlanDigest(plan, META);
+    assert.deepStrictEqual(d.summary, { add: 1, change: 1, destroy: 1, replace: 0, read: 1, noChanges: false, driftDetected: false });
+    assert.strictEqual(d.resources.length, 5);
+  });
+
+  it('treats a two-element [delete,create] as a replace in the summary (add+destroy+replace)', () => {
+    const plan = {
+      terraform_version: '1.9.5',
+      resource_changes: [
+        { address: 'r.x', type: 't', name: 'x', provider_name: 'p', action_reason: 'replace_because_cannot_update', change: change({ actions: ['delete', 'create'], before: { a: 1 }, after: { a: 2 }, replace_paths: [['a']] }) },
+      ],
+      output_changes: {},
+    };
+    const d = buildPlanDigest(plan, META);
+    assert.deepStrictEqual(d.summary, { add: 1, change: 0, destroy: 1, replace: 1, read: 0, noChanges: false, driftDetected: false });
+    assert.strictEqual(d.resources[0].actionReason, 'replace_because_cannot_update');
+    assert.deepStrictEqual(d.resources[0].replacePaths, ['a']);
+  });
+
+  it('emits ONLY changed attributes, skipping unchanged ones', () => {
+    const plan = {
+      terraform_version: '1.9.5',
+      resource_changes: [
+        { address: 'r.u', type: 't', name: 'u', provider_name: 'p', change: change({ actions: ['update'], before: { same: 1, diff: 'old' }, after: { same: 1, diff: 'new' } }) },
+      ],
+      output_changes: {},
+    };
+    const d = buildPlanDigest(plan, META);
+    const attrs = d.resources[0].attributeChanges;
+    assert.strictEqual(attrs.length, 1);
+    assert.strictEqual(attrs[0].path, 'diff');
+    assert.deepStrictEqual(attrs[0].before, { kind: 'value', json: '"old"' });
+    assert.deepStrictEqual(attrs[0].after, { kind: 'value', json: '"new"' });
+  });
+
+  it('surfaces an unknown after value without ever emitting the before as the after (§2.7)', () => {
+    const plan = {
+      terraform_version: '1.9.5',
+      resource_changes: [
+        { address: 'r.u', type: 't', name: 'u', provider_name: 'p', change: change({ actions: ['update'], before: { ip: '10.0.0.1' }, after: { ip: null }, after_unknown: { ip: true } }) },
+      ],
+      output_changes: {},
+    };
+    const d = buildPlanDigest(plan, META);
+    const attr = d.resources[0].attributeChanges[0];
+    assert.strictEqual(attr.path, 'ip');
+    assert.deepStrictEqual(attr.after, { kind: 'unknown' });
+    // the old value is the "before"; it must never surface as the after.
+    assert.deepStrictEqual(attr.before, { kind: 'value', json: '"10.0.0.1"' });
+    assert.ok(!JSON.stringify(attr.after).includes('10.0.0.1'));
+  });
+
+  it('sets driftDetected and builds masked drift resources from resource_drift', () => {
+    const plan = {
+      terraform_version: '1.9.5',
+      resource_changes: [],
+      resource_drift: [
+        { address: 'r.w', type: 't', name: 'w', provider_name: 'p', change: change({ actions: ['update'], before: { tag: 'old' }, after: { tag: 'real' } }) },
+      ],
+      output_changes: {},
+    };
+    const d = buildPlanDigest(plan, META);
+    assert.strictEqual(d.summary.driftDetected, true);
+    assert.ok(d.drift && d.drift.length === 1);
+    assert.strictEqual(d.drift[0].attributeChanges[0].path, 'tag');
+  });
+
+  it('noChanges is true for an empty plan and false when any resource acts', () => {
+    assert.strictEqual(buildPlanDigest({ terraform_version: '1.9.5', resource_changes: [], output_changes: {} }, META).summary.noChanges, true);
+    const noop = { terraform_version: '1.9.5', resource_changes: [{ address: 'r.n', type: 't', name: 'n', provider_name: 'p', change: change({ actions: ['no-op'], before: { x: 1 }, after: { x: 1 } }) }], output_changes: {} };
+    assert.strictEqual(buildPlanDigest(noop, META).summary.noChanges, true);
+  });
+
+  it('masks sensitive output values via the after_sensitive mask', () => {
+    const plan = {
+      terraform_version: '1.9.5',
+      resource_changes: [],
+      output_changes: {
+        secret_out: { actions: ['create'], before: null, after: 'TOPSECRET', after_unknown: false, before_sensitive: false, after_sensitive: true },
+        plain_out: { actions: ['create'], before: null, after: 'visible', after_unknown: false, before_sensitive: false, after_sensitive: false },
+      },
+    };
+    const d = buildPlanDigest(plan, META);
+    const secret = d.outputChanges.find((o) => o.name === 'secret_out');
+    const plain = d.outputChanges.find((o) => o.name === 'plain_out');
+    assert.deepStrictEqual(secret?.value, { kind: 'sensitive' });
+    assert.deepStrictEqual(plain?.value, { kind: 'value', json: '"visible"' });
+    assert.ok(!JSON.stringify(d).includes('TOPSECRET'));
+  });
+
+  it('derives tool.version from terraform_version and echoes validated meta', () => {
+    const d = buildPlanDigest({ terraform_version: '1.10.0', resource_changes: [], output_changes: {} }, META);
+    assert.deepStrictEqual(d.tool, { name: 'terraform', version: '1.10.0' });
+    assert.strictEqual(d.meta.name, 'terraform-plan');
+    assert.strictEqual(d.meta.workingDirectory, 'infra');
+    assert.strictEqual(d.producedBy.taskVersion, '0.0.0-test');
+    assert.strictEqual(d.schemaVersion, 1);
+  });
+
+  it('tolerates malformed / missing input without throwing', () => {
+    assert.doesNotThrow(() => buildPlanDigest(null, META));
+    assert.doesNotThrow(() => buildPlanDigest({}, META));
+    assert.doesNotThrow(() => buildPlanDigest({ resource_changes: 'nope' }, META));
+    const d = buildPlanDigest({ resource_changes: [{ nonsense: true }, { address: '', change: {} }] }, META);
+    assert.strictEqual(d.resources.length, 0, 'entries without an address are dropped');
+  });
+
+  describe('caps (§6)', () => {
+    it('caps attribute changes per resource and notes the remainder', () => {
+      const before: Record<string, unknown> = {};
+      const after: Record<string, unknown> = {};
+      for (let i = 0; i < MAX_ATTR_CHANGES_PER_RESOURCE + 25; i++) {
+        before[`a${String(i).padStart(4, '0')}`] = i;
+        after[`a${String(i).padStart(4, '0')}`] = i + 1;
+      }
+      const plan = { terraform_version: '1.9.5', resource_changes: [{ address: 'r.big', type: 't', name: 'big', provider_name: 'p', change: change({ actions: ['update'], before, after }) }], output_changes: {} };
+      const d = buildPlanDigest(plan, META);
+      assert.strictEqual(d.resources[0].attributeChanges.length, MAX_ATTR_CHANGES_PER_RESOURCE);
+      assert.strictEqual(d.truncated, true);
+      assert.ok((d.truncationNotes ?? []).some((n) => n.includes('attribute changes for r.big capped')));
+    });
+
+    it('caps the resource list by action priority (destroy/replace survive) and notes the count', () => {
+      const resource_changes = [];
+      // MAX_RESOURCES creates first, then a handful of deletes that must survive.
+      for (let i = 0; i < MAX_RESOURCES; i++) {
+        resource_changes.push({ address: `r.create.${i}`, type: 't', name: `${i}`, provider_name: 'p', change: change({ actions: ['create'], before: null, after: { x: 1 } }) });
+      }
+      resource_changes.push({ address: 'r.delete.keep', type: 't', name: 'k', provider_name: 'p', change: change({ actions: ['delete'], before: { x: 1 }, after: null }) });
+      const d = buildPlanDigest({ terraform_version: '1.9.5', resource_changes, output_changes: {} }, META);
+      assert.strictEqual(d.resources.length, MAX_RESOURCES);
+      assert.ok(d.resources.some((r) => r.address === 'r.delete.keep'), 'the delete survives truncation by priority');
+      assert.strictEqual(d.truncated, true);
+      assert.ok((d.truncationNotes ?? []).some((n) => n.includes('resource list capped')));
+    });
+
+    it('does not set truncated for an ordinary plan within all caps', () => {
+      const d = buildPlanDigest({ terraform_version: '1.9.5', resource_changes: [{ address: 'r.c', type: 't', name: 'c', provider_name: 'p', change: change({ actions: ['create'], before: null, after: { x: 1 } }) }], output_changes: {} }, META);
+      assert.strictEqual(d.truncated, false);
+      assert.strictEqual(d.truncationNotes, undefined);
+    });
+  });
+
+  describe('normalization / classification branches', () => {
+    it('classifies output actions: update (delete+create), delete, and no-op fallback', () => {
+      const plan = {
+        terraform_version: '1.9.5',
+        resource_changes: [],
+        output_changes: {
+          o_update: { actions: ['delete', 'create'], before: 'a', after: 'b', after_unknown: false, before_sensitive: false, after_sensitive: false },
+          o_delete: { actions: ['delete'], before: 'a', after: null, after_unknown: false, before_sensitive: false, after_sensitive: false },
+          o_noop: { actions: ['no-op'], before: 'a', after: 'a', after_unknown: false, before_sensitive: false, after_sensitive: false },
+          o_weird: { actions: 'not-an-array', before: null, after: 'x', after_unknown: false, before_sensitive: false, after_sensitive: false },
+        },
+      };
+      const d = buildPlanDigest(plan, META);
+      const byName = Object.fromEntries(d.outputChanges.map((o) => [o.name, o.action]));
+      assert.strictEqual(byName.o_update, 'update');
+      assert.strictEqual(byName.o_delete, 'delete');
+      assert.strictEqual(byName.o_noop, 'no-op');
+      assert.strictEqual(byName.o_weird, 'no-op');
+    });
+
+    it('normalizes non-array / unrecognized actions to ["no-op"]', () => {
+      const plan = {
+        terraform_version: '1.9.5',
+        resource_changes: [
+          { address: 'r.bad', type: 't', name: 'b', provider_name: 'p', change: change({ actions: 'garbage', before: { x: 1 }, after: { x: 1 } }) },
+          { address: 'r.unk', type: 't', name: 'u', provider_name: 'p', change: change({ actions: ['frobnicate'], before: { x: 1 }, after: { x: 1 } }) },
+        ],
+        output_changes: {},
+      };
+      const d = buildPlanDigest(plan, META);
+      assert.deepStrictEqual(d.resources[0].actions, ['no-op']);
+      assert.deepStrictEqual(d.resources[1].actions, ['no-op']);
+    });
+
+    it('renders replace_paths with indexed and nested segments', () => {
+      const plan = {
+        terraform_version: '1.9.5',
+        resource_changes: [
+          { address: 'r.x', type: 't', name: 'x', provider_name: 'p', change: change({ actions: ['delete', 'create'], before: { a: 1 }, after: { a: 2 }, replace_paths: [['tags', 0, 'Name'], 'not-an-array'] }) },
+        ],
+        output_changes: {},
+      };
+      const d = buildPlanDigest(plan, META);
+      assert.deepStrictEqual(d.resources[0].replacePaths, ['tags[0].Name']);
+    });
+
+    it('ignores an action_reason of "none" and non-string types/names', () => {
+      const plan = {
+        terraform_version: '1.9.5',
+        resource_changes: [{ address: 'r.c', type: 123, name: null, provider_name: undefined, action_reason: 'none', change: change({ actions: ['create'], before: null, after: { x: 1 } }) }],
+        output_changes: {},
+      };
+      const d = buildPlanDigest(plan, META);
+      assert.strictEqual(d.resources[0].actionReason, undefined);
+      assert.strictEqual(d.resources[0].type, '');
+      assert.strictEqual(d.resources[0].name, '');
+      assert.strictEqual(d.resources[0].providerName, '');
+    });
+
+    it('drops non-object resource_changes / resource_drift entries', () => {
+      const plan = {
+        terraform_version: '1.9.5',
+        resource_changes: ['a string', 42, null],
+        resource_drift: ['junk', { address: 'r.d', type: 't', name: 'd', provider_name: 'p', change: change({ actions: ['update'], before: { t: 'a' }, after: { t: 'b' } }) }],
+        output_changes: {},
+      };
+      const d = buildPlanDigest(plan, META);
+      assert.strictEqual(d.resources.length, 0);
+      assert.ok(d.drift && d.drift.length === 1);
+    });
+
+    it('detects an unknown leaf nested inside an array (anyTrue array recursion)', () => {
+      const plan = {
+        terraform_version: '1.9.5',
+        resource_changes: [{ address: 'r.a', type: 't', name: 'a', provider_name: 'p', change: change({ actions: ['update'], before: { list: ['x', 'y'] }, after: { list: ['x', null] }, after_unknown: { list: [false, true] } }) }],
+        output_changes: {},
+      };
+      const d = buildPlanDigest(plan, META);
+      const attr = d.resources[0].attributeChanges.find((a) => a.path === 'list');
+      assert.deepStrictEqual(attr?.after, { kind: 'value', json: '["x","(known after apply)"]' });
+    });
+
+    it('echoes optional stage/job meta when provided', () => {
+      const d = buildPlanDigest({ terraform_version: '1.9.5', resource_changes: [], output_changes: {} }, { ...META, stage: 'Deploy', job: 'apply_job' });
+      assert.strictEqual(d.meta.stage, 'Deploy');
+      assert.strictEqual(d.meta.job, 'apply_job');
+    });
+
+    it('preserves destroy/replace over update/read/no-op when the resource list is capped', () => {
+      const resource_changes = [];
+      for (let i = 0; i < MAX_RESOURCES; i++) {
+        const kind = i % 3;
+        const actions = kind === 0 ? ['update'] : kind === 1 ? ['read'] : ['no-op'];
+        resource_changes.push({ address: `r.pad.${i}`, type: 't', name: `${i}`, provider_name: 'p', change: change({ actions, before: { x: 1 }, after: kind === 0 ? { x: 2 } : { x: 1 } }) });
+      }
+      resource_changes.push({ address: 'r.replace.keep', type: 't', name: 'k', provider_name: 'p', change: change({ actions: ['delete', 'create'], before: { x: 1 }, after: { x: 2 } }) });
+      const d = buildPlanDigest({ terraform_version: '1.9.5', resource_changes, output_changes: {} }, META);
+      assert.strictEqual(d.resources.length, MAX_RESOURCES);
+      assert.ok(d.resources.some((r) => r.address === 'r.replace.keep'), 'the replace survives by action priority');
+    });
+  });
+
+  it('drops prototype-pollution attribute keys and notes them', () => {
+    const after = JSON.parse('{"__proto__":{"x":1},"safe":"v"}');
+    const plan = { terraform_version: '1.9.5', resource_changes: [{ address: 'r.p', type: 't', name: 'p', provider_name: 'p', change: change({ actions: ['create'], before: null, after }) }], output_changes: {} };
+    const d = buildPlanDigest(plan, META);
+    const paths = d.resources[0].attributeChanges.map((a) => a.path);
+    assert.ok(!paths.includes('__proto__'));
+    assert.ok(paths.includes('safe'));
+    assert.strictEqual(({} as Record<string, unknown>).x, undefined);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/RedactL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/RedactL0.ts
@@ -1,0 +1,275 @@
+import * as assert from 'assert';
+import {
+  redactValue,
+  newRedactContext,
+  stableStringify,
+  utf8ByteLength,
+  deepEqual,
+  serializeDigest,
+  capDigestBytes,
+} from '../../src/results/redact';
+import { PlanDigest, ApplyDigest } from '../../src/results/digest-schema';
+import { MAX_REDACTED_VALUE_BYTES } from '../../src/results/caps';
+
+// The exhaustive redaction matrix (design §12.2). Redaction is the #1 control:
+// a gap here is a secret disclosure, so every sensitivity source, the
+// fail-closed shape-mismatch rule, the prototype-pollution guard, the size cap,
+// and determinism each have a direct assertion.
+describe('redactValue — redaction core', () => {
+  function ctx(maxValueBytes?: number) {
+    return newRedactContext(maxValueBytes !== undefined ? { maxValueBytes } : undefined);
+  }
+
+  describe('non-sensitive values -> {kind:"value"}', () => {
+    it('redacts a primitive string to bounded JSON', () => {
+      const rv = redactValue('hello', false, false, ctx());
+      assert.deepStrictEqual(rv, { kind: 'value', json: '"hello"' });
+    });
+
+    it('redacts a number/boolean/null', () => {
+      assert.deepStrictEqual(redactValue(42, false, false, ctx()), { kind: 'value', json: '42' });
+      assert.deepStrictEqual(redactValue(true, false, false, ctx()), { kind: 'value', json: 'true' });
+      assert.deepStrictEqual(redactValue(null, false, false, ctx()), { kind: 'value', json: 'null' });
+    });
+
+    it('coerces an undefined leaf (attribute absent on one diff side) to JSON null', () => {
+      assert.deepStrictEqual(redactValue(undefined, false, false, ctx()), { kind: 'value', json: 'null' });
+      assert.deepStrictEqual(redactValue([undefined], false, false, ctx()), { kind: 'value', json: '[null]' });
+    });
+
+    it('redacts a collection with sorted-key JSON', () => {
+      const rv = redactValue({ b: 1, a: [2, 3] }, false, false, ctx());
+      assert.deepStrictEqual(rv, { kind: 'value', json: '{"a":[2,3],"b":1}' });
+    });
+  });
+
+  describe('sensitivity sources (§5.2.1)', () => {
+    it('after_sensitive:true at a leaf -> {kind:"sensitive"} and the value never appears', () => {
+      const c = ctx();
+      const rv = redactValue('hunter2', true, false, c);
+      assert.deepStrictEqual(rv, { kind: 'sensitive' });
+      assert.ok(!JSON.stringify(rv).includes('hunter2'), 'secret must not appear in output');
+    });
+
+    it('before_sensitive form (whole-value boolean mask) masks the before value', () => {
+      const rv = redactValue('old-secret', true, false, ctx());
+      assert.deepStrictEqual(rv, { kind: 'sensitive' });
+    });
+
+    it('sensitive_values form (shape-parallel object mask) masks nested leaves only', () => {
+      const c = ctx();
+      // Secret values are chosen so they are NOT substrings of any key name,
+      // so the leak check cannot false-positive on a key like "token".
+      const rv = redactValue(
+        { user: 'adminuser', password: 'PWLEAF_secret', nested: { token: 'TOKLEAF_secret', keep: 'keepval' } },
+        { password: true, nested: { token: true } },
+        false,
+        c,
+      );
+      assert.strictEqual(rv.kind, 'value');
+      const json = (rv as { json: string }).json;
+      assert.ok(!json.includes('PWLEAF_secret'), 'sensitive leaf must be masked');
+      assert.ok(!json.includes('TOKLEAF_secret'), 'nested sensitive leaf must be masked');
+      assert.ok(json.includes('adminuser'), 'non-sensitive sibling preserved');
+      assert.ok(json.includes('keepval'), 'non-sensitive nested sibling preserved');
+      assert.ok(json.includes('(sensitive)'), 'masked leaves become the sentinel');
+    });
+
+    it('output sensitivity (whole-output boolean) masks the whole value', () => {
+      assert.deepStrictEqual(redactValue('OUTPUT_SECRET', true, false, ctx()), { kind: 'sensitive' });
+    });
+
+    it('partial-sensitive array masks only the sensitive index', () => {
+      const rv = redactValue([1, 'SECRET', 3], [false, true, false], false, ctx());
+      assert.deepStrictEqual(rv, { kind: 'value', json: '[1,"(sensitive)",3]' });
+    });
+  });
+
+  describe('unknown source (§5.2.3)', () => {
+    it('after_unknown:true -> {kind:"unknown"}', () => {
+      assert.deepStrictEqual(redactValue(null, false, true, ctx()), { kind: 'unknown' });
+    });
+
+    it('sensitivity wins over unknown at the same leaf', () => {
+      assert.deepStrictEqual(redactValue('x', true, true, ctx()), { kind: 'sensitive' });
+    });
+
+    it('partial-unknown collection substitutes the unknown sentinel', () => {
+      const rv = redactValue({ a: 1, b: 2 }, false, { b: true }, ctx());
+      assert.deepStrictEqual(rv, { kind: 'value', json: '{"a":1,"b":"(known after apply)"}' });
+    });
+  });
+
+  describe('FAIL CLOSED on shape mismatch (§2.8 — the single most important rule)', () => {
+    it('container sensitivity mask over a scalar value -> masked + note', () => {
+      const c = ctx();
+      const rv = redactValue('scalar', { inner: true }, false, c);
+      assert.deepStrictEqual(rv, { kind: 'sensitive' });
+      assert.ok(c.notes.some((n) => n.includes('mask shape mismatch')), 'records an observable note');
+    });
+
+    it('container unknown mask over a scalar value -> masked', () => {
+      assert.deepStrictEqual(redactValue(7, false, { inner: true }, ctx()), { kind: 'sensitive' });
+    });
+
+    it('object mask over an array value -> masked', () => {
+      const c = ctx();
+      const rv = redactValue([1, 2, 3], { 0: true }, false, c);
+      assert.deepStrictEqual(rv, { kind: 'sensitive' });
+      assert.ok(c.notes.length > 0);
+    });
+
+    it('array mask over an object value -> masked', () => {
+      const c = ctx();
+      const rv = redactValue({ a: 1 }, [true], false, c);
+      assert.deepStrictEqual(rv, { kind: 'sensitive' });
+      assert.ok(c.notes.length > 0);
+    });
+
+    it('mismatch nested inside a collection masks only that leaf, not the sibling', () => {
+      // value.a is a scalar but its mask is a container -> that leaf fails closed;
+      // value.b is a clean scalar and survives.
+      const rv = redactValue({ a: 'leak-me', b: 'keep-me' }, { a: { deep: true } }, false, ctx());
+      assert.strictEqual(rv.kind, 'value');
+      const json = (rv as { json: string }).json;
+      assert.ok(!json.includes('leak-me'), 'mismatched leaf masked');
+      assert.ok(json.includes('keep-me'), 'clean sibling preserved');
+      assert.ok(json.includes('(sensitive)'));
+    });
+  });
+
+  describe('prototype-pollution guard (§2.5)', () => {
+    it('drops __proto__ / constructor / prototype keys and never pollutes Object.prototype', () => {
+      const evil = JSON.parse('{"__proto__":{"polluted":true},"constructor":{"x":1},"prototype":{"y":2},"safe":"ok"}');
+      const c = ctx();
+      const rv = redactValue(evil, false, false, c);
+      assert.strictEqual(rv.kind, 'value');
+      const json = (rv as { json: string }).json;
+      assert.strictEqual(json, '{"safe":"ok"}');
+      assert.strictEqual(({} as Record<string, unknown>).polluted, undefined, 'Object.prototype must not be polluted');
+      assert.ok(c.notes.some((n) => n.includes('unsafe key')), 'records dropped-key notes');
+    });
+  });
+
+  describe('size cap (§6)', () => {
+    it('a value just over the per-value byte cap -> {kind:"omitted",reason:"too-large"}', () => {
+      const big = 'x'.repeat(MAX_REDACTED_VALUE_BYTES + 10);
+      const c = ctx();
+      const rv = redactValue(big, false, false, c);
+      assert.deepStrictEqual(rv, { kind: 'omitted', reason: 'too-large' });
+      assert.ok(c.notes.some((n) => n.includes('over per-value size cap')));
+    });
+
+    it('a value exactly at the cap is kept', () => {
+      // JSON-encoded length = content + 2 quotes; choose content so json == cap.
+      const content = 'y'.repeat(MAX_REDACTED_VALUE_BYTES - 2);
+      const rv = redactValue(content, false, false, ctx());
+      assert.strictEqual(rv.kind, 'value');
+    });
+  });
+
+  describe('determinism (§2.6)', () => {
+    it('identical input -> byte-identical output regardless of key insertion order', () => {
+      const a = redactValue({ z: 1, a: 2, m: { y: 3, b: 4 } }, false, false, ctx());
+      const b = redactValue({ m: { b: 4, y: 3 }, a: 2, z: 1 }, false, false, ctx());
+      assert.deepStrictEqual(a, b);
+      assert.strictEqual((a as { json: string }).json, (b as { json: string }).json);
+    });
+  });
+});
+
+describe('shared serialization / size utilities', () => {
+  it('stableStringify sorts object keys lexicographically at every level', () => {
+    assert.strictEqual(stableStringify({ b: { d: 1, c: 2 }, a: [3, { f: 4, e: 5 }] }), '{"a":[3,{"e":5,"f":4}],"b":{"c":2,"d":1}}');
+  });
+
+  it('utf8ByteLength counts UTF-8 bytes, not code units', () => {
+    assert.strictEqual(utf8ByteLength('abc'), 3);
+    assert.strictEqual(utf8ByteLength('é'), 2); // é is 2 UTF-8 bytes
+  });
+
+  it('deepEqual compares JSON structures', () => {
+    assert.ok(deepEqual({ a: [1, 2], b: null }, { b: null, a: [1, 2] }));
+    assert.ok(!deepEqual({ a: 1 }, { a: 1, b: 2 }));
+    assert.ok(!deepEqual([1, 2], [1, 2, 3]));
+  });
+});
+
+describe('capDigestBytes — digest-level byte ceilings (§3)', () => {
+  function planWithAttrs(n: number): PlanDigest {
+    const resources = [];
+    for (let i = 0; i < n; i++) {
+      resources.push({
+        address: `res.${i}`,
+        type: 'x',
+        name: `${i}`,
+        providerName: 'p',
+        actions: ['update'] as PlanDigest['resources'][number]['actions'],
+        attributeChanges: [{ path: 'big', before: { kind: 'value', json: '"' + 'a'.repeat(200) + '"' } as const, after: { kind: 'value', json: '"b"' } as const }],
+      });
+    }
+    return {
+      schemaVersion: 1,
+      kind: 'plan',
+      producedBy: { task: 'TerraformTaskV5', taskVersion: 't' },
+      tool: { name: 'terraform', version: '1' },
+      meta: { name: 'n', createdIso: 'i' },
+      truncated: false,
+      summary: { add: 0, change: n, destroy: 0, replace: 0, read: 0, noChanges: false, driftDetected: false },
+      resources,
+      outputChanges: [],
+    };
+  }
+
+  it('within the soft ceiling: returned unchanged', () => {
+    const d = planWithAttrs(3);
+    const out = capDigestBytes(d, 10 * 1024 * 1024, 20 * 1024 * 1024);
+    assert.strictEqual(out.resources[0].attributeChanges.length, 1);
+    assert.strictEqual(out.truncated, false);
+  });
+
+  it('over soft ceiling: drops attributeChanges arrays, keeps rows + summary, sets truncated', () => {
+    const d = planWithAttrs(50);
+    const out = capDigestBytes(d, 2000, 20 * 1024 * 1024);
+    assert.strictEqual(out.resources.length, 50, 'resource rows preserved');
+    assert.ok(out.resources.every((r) => r.attributeChanges.length === 0), 'attribute arrays dropped');
+    assert.strictEqual(out.truncated, true);
+    assert.ok((out.truncationNotes ?? []).some((n) => n.includes('soft size ceiling')));
+  });
+
+  it('over hard ceiling: collapses to a summary-only digest', () => {
+    const d = planWithAttrs(50);
+    const out = capDigestBytes(d, 500, 800);
+    assert.strictEqual(out.resources.length, 0, 'summary-only drops resource rows');
+    assert.strictEqual(out.outputChanges.length, 0);
+    assert.strictEqual(out.truncated, true);
+    assert.deepStrictEqual(out.summary, d.summary, 'summary counts preserved');
+    assert.ok((out.truncationNotes ?? []).some((n) => n.includes('hard size ceiling')));
+  });
+
+  it('apply digest over soft ceiling drops diagnostic detail', () => {
+    const diagnostics = [];
+    for (let i = 0; i < 40; i++) diagnostics.push({ severity: 'error' as const, summary: `e${i}`, detail: 'd'.repeat(200) });
+    const d: ApplyDigest = {
+      schemaVersion: 1,
+      kind: 'apply',
+      producedBy: { task: 'TerraformTaskV5', taskVersion: 't' },
+      tool: { name: 'terraform', version: '1' },
+      meta: { name: 'n', createdIso: 'i' },
+      truncated: false,
+      outcome: 'failed',
+      summary: { add: 0, change: 0, destroy: 0 },
+      resources: [],
+      diagnostics,
+      outputs: [],
+    };
+    const out = capDigestBytes(d, 2000, 20 * 1024 * 1024);
+    assert.ok(out.diagnostics.every((x) => x.detail === undefined), 'diagnostic detail dropped');
+    assert.strictEqual(out.truncated, true);
+  });
+
+  it('serializeDigest is deterministic pretty JSON', () => {
+    const d = planWithAttrs(1);
+    assert.strictEqual(serializeDigest(d), serializeDigest(d));
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/SecretScrubL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/SecretScrubL0.ts
@@ -1,0 +1,75 @@
+import * as assert from 'assert';
+import { scrubSecrets, sanitizeAttachmentName } from '../../src/results/secret-scrub';
+
+describe('scrubSecrets — freeform diagnostic scrub (§5.4)', () => {
+  it('removes an explicitly-registered secret literal', () => {
+    const out = scrubSecrets('login failed for token abcd-token-1234 today', ['abcd-token-1234']);
+    assert.ok(!out.includes('abcd-token-1234'));
+    assert.ok(out.includes('(redacted)'));
+    assert.ok(out.includes('login failed'), 'surrounding text preserved');
+  });
+
+  it('removes multiple occurrences of a registered secret', () => {
+    const out = scrubSecrets('X=SEKRETVALUE and again SEKRETVALUE', ['SEKRETVALUE']);
+    assert.strictEqual(out.match(/SEKRETVALUE/g), null);
+  });
+
+  it('scrubs a PEM private-key block by heuristic', () => {
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1234\nabcd\n-----END RSA PRIVATE KEY-----';
+    const out = scrubSecrets(`error near key ${pem} end`, []);
+    assert.ok(!out.includes('MIIEpAIBAAKCAQEA1234'));
+    assert.ok(out.includes('(redacted PEM)'));
+  });
+
+  it('scrubs a long high-entropy base64/hex run by heuristic', () => {
+    const token = 'A'.repeat(20) + 'b3F9' + 'C'.repeat(20); // > 40 chars
+    const out = scrubSecrets(`bearer ${token} rejected`, []);
+    assert.ok(!out.includes(token));
+    assert.ok(out.includes('(redacted)'));
+  });
+
+  it('leaves a benign diagnostic intact (no over-scrubbing)', () => {
+    const benign = 'Error: invalid value "us-east-1" for region; expected one of us-west-2, eu-central-1.';
+    assert.strictEqual(scrubSecrets(benign, []), benign);
+  });
+
+  it('ignores empty / too-short registered secrets (avoids catastrophic over-scrub)', () => {
+    const text = 'the letter a appears often in banana';
+    assert.strictEqual(scrubSecrets(text, ['', 'a']), text);
+  });
+
+  it('returns non-string / empty input unchanged', () => {
+    assert.strictEqual(scrubSecrets('', ['x']), '');
+    assert.strictEqual(scrubSecrets(undefined as unknown as string, ['x']), undefined as unknown as string);
+  });
+});
+
+describe('sanitizeAttachmentName — logging-command / CRLF injection guard (§5.6)', () => {
+  it('strips CR/LF and logging-command control characters', () => {
+    const r = sanitizeAttachmentName('name\r\nwith];%injection');
+    assert.strictEqual(r.name, 'namewithinjection');
+    assert.ok(r.note && r.note.includes('sanitized'));
+  });
+
+  it('leaves a clean name unchanged with no note', () => {
+    const r = sanitizeAttachmentName('terraform-plan_prod.01');
+    assert.strictEqual(r.name, 'terraform-plan_prod.01');
+    assert.strictEqual(r.note, undefined);
+  });
+
+  it('caps an overly long name and notes the truncation', () => {
+    const r = sanitizeAttachmentName('n'.repeat(500));
+    assert.strictEqual(r.name.length, 256);
+    assert.ok(r.note && r.note.includes('truncated'));
+  });
+
+  it('falls back to "terraform" when the sanitized name is empty', () => {
+    const r = sanitizeAttachmentName('\r\n];%');
+    assert.strictEqual(r.name, 'terraform');
+  });
+
+  it('handles a non-string input', () => {
+    const r = sanitizeAttachmentName(undefined as unknown as string);
+    assert.strictEqual(r.name, 'terraform');
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/golden-fixtures.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/golden-fixtures.ts
@@ -1,0 +1,74 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildPlanDigest, DigestMeta } from '../../src/results/plan-digest';
+import { buildApplyDigest, ApplyDigestOptions } from '../../src/results/apply-digest';
+import { serializeDigest } from '../../src/results/redact';
+
+// Shared fixture manifest + build helper for the golden regression suite
+// (GoldenFixturesL0.ts). Kept free of any mocha global (no describe/it) so a
+// one-off generator can `require` it to (re)write the committed goldens.
+
+export const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+
+// FIXED meta so goldens never churn: never Date.now(), never the real task
+// version (§2.6 determinism).
+export const PLAN_META: DigestMeta = {
+  taskVersion: '0.0.0-test',
+  toolName: 'terraform',
+  name: 'terraform-plan',
+  workingDirectory: 'infra',
+  createdIso: '2026-07-15T00:00:00Z',
+};
+
+export const APPLY_META: DigestMeta = {
+  taskVersion: '0.0.0-test',
+  toolName: 'terraform',
+  name: 'terraform-apply',
+  workingDirectory: 'infra',
+  createdIso: '2026-07-15T00:00:00Z',
+};
+
+export interface FixtureSpec {
+  /** input file under Tests/fixtures/ */
+  input: string;
+  /** committed golden under Tests/fixtures/ */
+  expected: string;
+  kind: 'plan' | 'apply';
+  /** fake secret literals that MUST NOT appear in the serialized digest */
+  secrets: string[];
+  /** secrets the task would have registered via setSecret (apply scrub input) */
+  knownSecrets?: string[];
+}
+
+export const FIXTURES: FixtureSpec[] = [
+  { input: 'plan-noop.json', expected: 'plan-noop.expected.json', kind: 'plan', secrets: [] },
+  { input: 'plan-create.json', expected: 'plan-create.expected.json', kind: 'plan', secrets: [] },
+  { input: 'plan-replace.json', expected: 'plan-replace.expected.json', kind: 'plan', secrets: [] },
+  { input: 'plan-destroy.json', expected: 'plan-destroy.expected.json', kind: 'plan', secrets: [] },
+  {
+    input: 'plan-sensitive.json',
+    expected: 'plan-sensitive.expected.json',
+    kind: 'plan',
+    secrets: ['SUPERSECRET_pw_9f3k', 'TOK_abc123secret', 'PORTSECRET_literal', 'OUTPUTSECRET_xyz'],
+  },
+  { input: 'plan-multi-provider.json', expected: 'plan-multi-provider.expected.json', kind: 'plan', secrets: [] },
+  { input: 'plan-drift.json', expected: 'plan-drift.expected.json', kind: 'plan', secrets: [] },
+  { input: 'apply-success.ndjson', expected: 'apply-success.expected.json', kind: 'apply', secrets: [] },
+  {
+    input: 'apply-partial-failure.ndjson',
+    expected: 'apply-partial-failure.expected.json',
+    kind: 'apply',
+    secrets: ['APPLYSECRET_pw_42'],
+    knownSecrets: ['APPLYSECRET_pw_42'],
+  },
+];
+
+/** Build the digest for a fixture and return the canonical serialized form. */
+export function serializeFixture(spec: FixtureSpec): string {
+  const raw = fs.readFileSync(path.join(FIXTURES_DIR, spec.input), 'utf8');
+  if (spec.kind === 'plan') {
+    return serializeDigest(buildPlanDigest(JSON.parse(raw), PLAN_META));
+  }
+  const options: ApplyDigestOptions = { knownSecrets: spec.knownSecrets ?? [] };
+  return serializeDigest(buildApplyDigest(raw, APPLY_META, options));
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/apply-digest.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/apply-digest.ts
@@ -1,0 +1,348 @@
+// APPLY DIGEST BUILDER — turns a `terraform apply -json` NDJSON event stream into
+// a redacted `ApplyDigest` (schemaVersion 1). Structured (secret-bearing) event
+// fields are only ever consumed here and pass through redaction / secret-scrub
+// before entering the digest; the live console log is preserved separately by the
+// task echoing each event's `@message` (decision D2 — not this module's job).
+//
+// Spec: docs/design/plan-apply-digest-spec.md §1.3 (shape), §4.9 (diagnostic
+// scrub), §3 (caps). Source events (spec §1.3 / design §4.3): apply_start /
+// apply_progress / apply_complete / apply_errored, diagnostic, change_summary,
+// outputs, version. A malformed / partial NDJSON line is skipped + noted, never
+// thrown (§12.2).
+
+import { ApplyDigest, ApplyResource, Diagnostic, OutputChange } from './digest-schema';
+import { MAX_RESOURCES, MAX_DIAGNOSTICS, SOFT_MAX_DIGEST_BYTES, HARD_MAX_DIGEST_BYTES } from './caps';
+import { redactValue, newRedactContext, capDigestBytes, RedactContext } from './redact';
+import { scrubSecrets, sanitizeAttachmentName } from './secret-scrub';
+import { DigestMeta, DigestByteLimits } from './plan-digest';
+
+/** Apply-specific build options (diagnostic handling + the byte-cap test seam). */
+export interface ApplyDigestOptions extends DigestByteLimits {
+  /** Include scrubbed diagnostic `detail`? Safe default false (§5.4). */
+  includeDiagnosticDetail?: boolean;
+  /** Secrets the task registered via setSecret, for freeform diagnostic scrub. */
+  knownSecrets?: string[];
+}
+
+const RES_ACTIONS = new Set(['create', 'update', 'delete', 'replace', 'read']);
+
+interface ResAcc {
+  address: string;
+  action: ApplyResource['action'];
+  status: ApplyResource['status'];
+  startTs?: number;
+  endTs?: number;
+  elapsedSeconds?: number;
+  order: number;
+}
+
+/**
+ * Build a redacted ApplyDigest from the raw `terraform apply -json` NDJSON stream.
+ * @param ndjson  the raw multi-line stdout of `apply -json`
+ * @param meta    provenance/identity supplied by the caller
+ * @param options diagnostic-detail toggle, known secrets, byte-cap test seam
+ */
+export function buildApplyDigest(ndjson: string, meta: DigestMeta, options?: ApplyDigestOptions): ApplyDigest {
+  const ctx = newRedactContext();
+  const includeDetail = options?.includeDiagnosticDetail === true;
+  const knownSecrets = options?.knownSecrets ?? [];
+
+  const events = parseNdjson(ndjson, ctx);
+
+  const resAcc = new Map<string, ResAcc>();
+  const diagnostics: Diagnostic[] = [];
+  const appliedOrder: string[] = [];
+  let sawErroredEvent = false;
+  let sawErrorDiag = false;
+  let changeSummary: { add: number; change: number; destroy: number } | undefined;
+  let latestOutputs: Record<string, unknown> | undefined;
+  let toolVersion = 'unknown';
+  let minTs: number | undefined;
+  let maxTs: number | undefined;
+  let order = 0;
+
+  for (const ev of events) {
+    const ts = parseTs((ev as Record<string, unknown>)['@timestamp']);
+    if (ts !== undefined) {
+      if (minTs === undefined || ts < minTs) minTs = ts;
+      if (maxTs === undefined || ts > maxTs) maxTs = ts;
+    }
+    const type = typeof (ev as Record<string, unknown>).type === 'string' ? ((ev as Record<string, unknown>).type as string) : '';
+    const e = ev as Record<string, unknown>;
+
+    switch (type) {
+      case 'version': {
+        if (typeof e.terraform === 'string') toolVersion = e.terraform;
+        break;
+      }
+      case 'apply_start': {
+        const { addr, action } = hookInfo(e);
+        if (addr) {
+          const acc = ensureAcc(resAcc, addr, action, order++);
+          acc.status = 'started';
+          if (ts !== undefined) acc.startTs = ts;
+        }
+        break;
+      }
+      case 'apply_complete': {
+        const { addr, action, elapsed } = hookInfo(e);
+        if (addr) {
+          const acc = ensureAcc(resAcc, addr, action, order++);
+          acc.status = 'complete';
+          if (ts !== undefined) acc.endTs = ts;
+          if (elapsed !== undefined) acc.elapsedSeconds = elapsed;
+          appliedOrder.push(addr);
+        }
+        break;
+      }
+      case 'apply_errored': {
+        sawErroredEvent = true;
+        const { addr, action } = hookInfo(e);
+        if (addr) {
+          const acc = ensureAcc(resAcc, addr, action, order++);
+          acc.status = 'errored';
+          if (ts !== undefined) acc.endTs = ts;
+        }
+        break;
+      }
+      case 'diagnostic': {
+        const diag = buildDiagnostic(e, includeDetail, knownSecrets);
+        if (diag) {
+          if (diag.severity === 'error') sawErrorDiag = true;
+          diagnostics.push(diag);
+        }
+        break;
+      }
+      case 'change_summary': {
+        const cs = e.changes && typeof e.changes === 'object' ? (e.changes as Record<string, unknown>) : undefined;
+        if (cs) {
+          changeSummary = {
+            add: num(cs.add),
+            change: num(cs.change),
+            destroy: num(cs.remove),
+          };
+        }
+        break;
+      }
+      case 'outputs': {
+        if (e.outputs && typeof e.outputs === 'object') latestOutputs = e.outputs as Record<string, unknown>;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // resources in first-seen order
+  let resources: ApplyResource[] = [...resAcc.values()]
+    .sort((a, b) => a.order - b.order)
+    .map((acc) => {
+      const r: ApplyResource = { address: acc.address, action: acc.action, status: acc.status };
+      const dur = durationMs(acc);
+      if (dur !== undefined) r.durationMs = dur;
+      return r;
+    });
+
+  const droppedResources = resources.length - MAX_RESOURCES;
+  if (droppedResources > 0) {
+    resources = [...resources]
+      .sort((a, b) => actionPriority(a.action) - actionPriority(b.action) || (a.address < b.address ? -1 : a.address > b.address ? 1 : 0))
+      .slice(0, MAX_RESOURCES);
+    ctx.notes.push(`resource list capped at ${MAX_RESOURCES} (${droppedResources} more not shown)`);
+  }
+
+  const cappedDiags = capDiagnostics(diagnostics, ctx);
+
+  const outputs = buildOutputs(latestOutputs, ctx);
+
+  const outcome: ApplyDigest['outcome'] = sawErroredEvent || sawErrorDiag ? 'failed' : 'succeeded';
+  const summary = buildSummary(changeSummary, resources, minTs, maxTs);
+
+  const safeName = sanitizeAttachmentName(meta.name);
+  if (safeName.note) ctx.notes.push(safeName.note);
+
+  const digest: ApplyDigest = {
+    schemaVersion: 1,
+    kind: 'apply',
+    producedBy: { task: 'TerraformTaskV5', taskVersion: meta.taskVersion },
+    tool: { name: meta.toolName, version: toolVersion },
+    meta: {
+      name: safeName.name,
+      ...(meta.workingDirectory !== undefined ? { workingDirectory: meta.workingDirectory } : {}),
+      ...(meta.stage !== undefined ? { stage: meta.stage } : {}),
+      ...(meta.job !== undefined ? { job: meta.job } : {}),
+      createdIso: meta.createdIso,
+    },
+    truncated: false,
+    outcome,
+    summary,
+    resources,
+    diagnostics: cappedDiags,
+    outputs,
+    ...(outcome === 'failed' ? { appliedBeforeFailure: appliedOrder } : {}),
+  };
+  finalizeTruncation(digest, ctx);
+
+  return capDigestBytes(digest, options?.softMaxBytes ?? SOFT_MAX_DIGEST_BYTES, options?.hardMaxBytes ?? HARD_MAX_DIGEST_BYTES);
+}
+
+// ---- parsing / accumulation helpers ----
+
+function parseNdjson(ndjson: string, ctx: RedactContext): unknown[] {
+  const out: unknown[] = [];
+  if (typeof ndjson !== 'string') return out;
+  const lines = ndjson.split('\n');
+  let malformed = 0;
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '').trim();
+    if (line === '') continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === 'object') out.push(parsed);
+      else malformed++;
+    } catch {
+      malformed++;
+    }
+  }
+  if (malformed > 0) ctx.notes.push(`skipped ${malformed} malformed apply event line(s)`);
+  return out;
+}
+
+function ensureAcc(map: Map<string, ResAcc>, address: string, action: ApplyResource['action'], order: number): ResAcc {
+  let acc = map.get(address);
+  if (!acc) {
+    acc = { address, action, status: 'started', order };
+    map.set(address, acc);
+  } else if (acc.action === 'update' && action !== 'update') {
+    // Upgrade a defaulted-'update' action if a later event carries a concrete
+    // one (deterministic — apply_start usually carries the real action).
+    acc.action = action;
+  }
+  return acc;
+}
+
+function hookInfo(e: Record<string, unknown>): { addr: string; action: ApplyResource['action']; elapsed?: number } {
+  const hook = e.hook && typeof e.hook === 'object' ? (e.hook as Record<string, unknown>) : {};
+  const resource = hook.resource && typeof hook.resource === 'object' ? (hook.resource as Record<string, unknown>) : {};
+  const addr = typeof resource.addr === 'string' ? resource.addr : '';
+  const action = normalizeApplyAction(hook.action);
+  const elapsed = typeof hook.elapsed_seconds === 'number' && isFinite(hook.elapsed_seconds) ? hook.elapsed_seconds : undefined;
+  return { addr, action, elapsed };
+}
+
+function normalizeApplyAction(action: unknown): ApplyResource['action'] {
+  if (typeof action === 'string' && RES_ACTIONS.has(action)) return action as ApplyResource['action'];
+  return 'update';
+}
+
+function buildDiagnostic(e: Record<string, unknown>, includeDetail: boolean, knownSecrets: string[]): Diagnostic | null {
+  const d = e.diagnostic && typeof e.diagnostic === 'object' ? (e.diagnostic as Record<string, unknown>) : null;
+  if (!d) return null;
+  const severity: Diagnostic['severity'] = d.severity === 'error' ? 'error' : 'warning';
+  const summary = scrubSecrets(typeof d.summary === 'string' ? d.summary : '', knownSecrets);
+  const diag: Diagnostic = { severity, summary };
+  if (includeDetail && typeof d.detail === 'string' && d.detail.length > 0) {
+    diag.detail = scrubSecrets(d.detail, knownSecrets);
+  }
+  if (typeof d.address === 'string' && d.address.length > 0) diag.address = d.address;
+  return diag;
+}
+
+function capDiagnostics(diagnostics: Diagnostic[], ctx: RedactContext): Diagnostic[] {
+  if (diagnostics.length <= MAX_DIAGNOSTICS) return diagnostics;
+  const errors = diagnostics.filter((d) => d.severity === 'error');
+  const warnings = diagnostics.filter((d) => d.severity === 'warning');
+  const ordered = [...errors, ...warnings];
+  const dropped = ordered.length - MAX_DIAGNOSTICS;
+  ctx.notes.push(`diagnostics capped at ${MAX_DIAGNOSTICS} (${dropped} more not shown)`);
+  return ordered.slice(0, MAX_DIAGNOSTICS);
+}
+
+function buildOutputs(latestOutputs: Record<string, unknown> | undefined, ctx: RedactContext): OutputChange[] {
+  if (!latestOutputs) return [];
+  return Object.keys(latestOutputs)
+    .sort()
+    .map((name) => {
+      const raw = latestOutputs[name];
+      const entry = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+      const sensitive = entry.sensitive === true;
+      ctx.path = `output.${name}`;
+      const value = redactValue(entry.value, sensitive, false, ctx);
+      ctx.path = '';
+      const action: OutputChange['action'] =
+        entry.action === 'create' || entry.action === 'update' || entry.action === 'delete' || entry.action === 'no-op'
+          ? (entry.action as OutputChange['action'])
+          : 'no-op';
+      return { name, action, value };
+    });
+}
+
+function buildSummary(
+  changeSummary: { add: number; change: number; destroy: number } | undefined,
+  resources: ApplyResource[],
+  minTs: number | undefined,
+  maxTs: number | undefined,
+): ApplyDigest['summary'] {
+  let add: number;
+  let change: number;
+  let destroy: number;
+  if (changeSummary) {
+    add = changeSummary.add;
+    change = changeSummary.change;
+    destroy = changeSummary.destroy;
+  } else {
+    add = 0;
+    change = 0;
+    destroy = 0;
+    for (const r of resources) {
+      if (r.action === 'replace') {
+        add++;
+        destroy++;
+      } else if (r.action === 'create') add++;
+      else if (r.action === 'update') change++;
+      else if (r.action === 'delete') destroy++;
+    }
+  }
+  const summary: ApplyDigest['summary'] = { add, change, destroy };
+  if (minTs !== undefined && maxTs !== undefined && maxTs >= minTs) summary.durationMs = maxTs - minTs;
+  return summary;
+}
+
+function durationMs(acc: ResAcc): number | undefined {
+  if (acc.startTs !== undefined && acc.endTs !== undefined && acc.endTs >= acc.startTs) return acc.endTs - acc.startTs;
+  if (acc.elapsedSeconds !== undefined) return Math.round(acc.elapsedSeconds * 1000);
+  return undefined;
+}
+
+function actionPriority(action: ApplyResource['action']): number {
+  switch (action) {
+    case 'delete':
+    case 'replace':
+      return 0;
+    case 'update':
+      return 1;
+    case 'create':
+      return 2;
+    case 'read':
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function parseTs(v: unknown): number | undefined {
+  if (typeof v !== 'string') return undefined;
+  const t = Date.parse(v);
+  return isNaN(t) ? undefined : t;
+}
+
+function num(v: unknown): number {
+  return typeof v === 'number' && isFinite(v) ? v : 0;
+}
+
+function finalizeTruncation(digest: ApplyDigest, ctx: RedactContext): void {
+  if (ctx.notes.length > 0) {
+    digest.truncated = true;
+    digest.truncationNotes = [...ctx.notes];
+  }
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/plan-digest.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/plan-digest.ts
@@ -1,0 +1,325 @@
+// PLAN DIGEST BUILDER — turns a parsed `terraform show -json <planfile>` object
+// into a redacted `PlanDigest` (schemaVersion 1). Every attribute value flows
+// through the redaction core (redact.ts) BEFORE it enters the digest, so no raw
+// sensitive value is ever assembled. Pure and deterministic (§2.6): identical
+// input -> byte-identical digest.
+//
+// Spec: docs/design/plan-apply-digest-spec.md §1.2 (shape), §2.1 (sensitivity
+// sources), §2.7 (before/after asymmetry), §3 (caps). Source mapping (spec §1.2 /
+// design §4.2): resource_changes[] (.change.actions/.before/.after/.after_unknown/
+// .before_sensitive/.after_sensitive/.replace_paths, .action_reason),
+// output_changes, resource_drift, terraform_version.
+
+import {
+  PlanDigest,
+  PlanResource,
+  DriftResource,
+  AttrChange,
+  OutputChange,
+  RedactedValue,
+} from './digest-schema';
+import { MAX_RESOURCES, MAX_ATTR_CHANGES_PER_RESOURCE, SOFT_MAX_DIGEST_BYTES, HARD_MAX_DIGEST_BYTES } from './caps';
+import { redactValue, newRedactContext, deepEqual, capDigestBytes, RedactContext } from './redact';
+import { sanitizeAttachmentName } from './secret-scrub';
+
+/** Identity/provenance a caller supplies; kept out of the raw Terraform JSON. */
+export interface DigestMeta {
+  taskVersion: string;
+  toolName: 'terraform' | 'opentofu';
+  name: string;
+  workingDirectory?: string;
+  stage?: string;
+  job?: string;
+  /** Injected/agent-provided timestamp — never Date.now() (§2.6). */
+  createdIso: string;
+}
+
+/** Optional test seam for the digest-level byte ceilings; production omits it. */
+export interface DigestByteLimits {
+  softMaxBytes?: number;
+  hardMaxBytes?: number;
+}
+
+// A Terraform "Change" object (shared by resource_changes[].change and
+// output_changes[name]). All fields optional/defensive — a malformed plan must
+// degrade, not throw.
+interface TfChange {
+  actions?: unknown;
+  before?: unknown;
+  after?: unknown;
+  after_unknown?: unknown;
+  before_sensitive?: unknown;
+  after_sensitive?: unknown;
+  replace_paths?: unknown;
+}
+
+const KNOWN_ACTIONS = new Set(['no-op', 'create', 'read', 'update', 'delete', 'replace', 'forget']);
+
+/**
+ * Build a redacted PlanDigest from a parsed `terraform show -json` object.
+ * @param plan   parsed show -json (untrusted; validated defensively)
+ * @param meta   provenance/identity supplied by the caller
+ * @param limits optional test seam for the soft/hard byte ceilings
+ */
+export function buildPlanDigest(plan: unknown, meta: DigestMeta, limits?: DigestByteLimits): PlanDigest {
+  const ctx = newRedactContext();
+  const p = (plan && typeof plan === 'object' ? (plan as Record<string, unknown>) : {}) as Record<string, unknown>;
+
+  const rawChanges = Array.isArray(p.resource_changes) ? (p.resource_changes as unknown[]) : [];
+  let resources: PlanResource[] = [];
+  for (const rc of rawChanges) {
+    const res = buildPlanResource(rc, ctx);
+    if (res) resources.push(res);
+  }
+
+  const summary = summarize(resources);
+
+  // resources cap (§3): keep first MAX_RESOURCES by action priority (destroy/
+  // replace first). Only reorder when truncating so the un-truncated common
+  // case preserves Terraform's natural address order.
+  const droppedResources = resources.length - MAX_RESOURCES;
+  if (droppedResources > 0) {
+    resources = [...resources]
+      .sort((a, b) => actionPriority(a.actions) - actionPriority(b.actions) || (a.address < b.address ? -1 : a.address > b.address ? 1 : 0))
+      .slice(0, MAX_RESOURCES);
+    ctx.notes.push(`resource list capped at ${MAX_RESOURCES} (${droppedResources} more not shown)`);
+  }
+
+  const rawOutputs = p.output_changes && typeof p.output_changes === 'object' ? (p.output_changes as Record<string, unknown>) : {};
+  const outputChanges: OutputChange[] = Object.keys(rawOutputs)
+    .sort()
+    .map((name) => buildOutputChange(name, rawOutputs[name], ctx))
+    .filter((o): o is OutputChange => o !== null);
+
+  const rawDrift = Array.isArray(p.resource_drift) ? (p.resource_drift as unknown[]) : [];
+  const drift: DriftResource[] = [];
+  for (const rd of rawDrift) {
+    const d = buildDriftResource(rd, ctx);
+    if (d) drift.push(d);
+  }
+  summary.driftDetected = drift.length > 0;
+
+  const toolVersion = typeof p.terraform_version === 'string' ? p.terraform_version : 'unknown';
+  const safeName = sanitizeAttachmentName(meta.name);
+  if (safeName.note) ctx.notes.push(safeName.note);
+
+  const digest: PlanDigest = {
+    schemaVersion: 1,
+    kind: 'plan',
+    producedBy: { task: 'TerraformTaskV5', taskVersion: meta.taskVersion },
+    tool: { name: meta.toolName, version: toolVersion },
+    meta: {
+      name: safeName.name,
+      ...(meta.workingDirectory !== undefined ? { workingDirectory: meta.workingDirectory } : {}),
+      ...(meta.stage !== undefined ? { stage: meta.stage } : {}),
+      ...(meta.job !== undefined ? { job: meta.job } : {}),
+      createdIso: meta.createdIso,
+    },
+    truncated: false,
+    summary,
+    resources,
+    outputChanges,
+    ...(drift.length > 0 ? { drift } : {}),
+  };
+  finalizeTruncation(digest, ctx);
+
+  return capDigestBytes(digest, limits?.softMaxBytes ?? SOFT_MAX_DIGEST_BYTES, limits?.hardMaxBytes ?? HARD_MAX_DIGEST_BYTES);
+}
+
+function buildPlanResource(rc: unknown, ctx: RedactContext): PlanResource | null {
+  if (!rc || typeof rc !== 'object') return null;
+  const r = rc as Record<string, unknown>;
+  const address = typeof r.address === 'string' ? r.address : '';
+  if (!address) return null;
+  const change = (r.change && typeof r.change === 'object' ? r.change : {}) as TfChange;
+  const actions = normalizeActions(change.actions);
+
+  const resource: PlanResource = {
+    address,
+    type: typeof r.type === 'string' ? r.type : '',
+    name: typeof r.name === 'string' ? r.name : '',
+    providerName: typeof r.provider_name === 'string' ? r.provider_name : '',
+    actions,
+    attributeChanges: buildAttributeChanges(change, `${address}`, ctx),
+  };
+  if (typeof r.action_reason === 'string' && r.action_reason && r.action_reason !== 'none') {
+    resource.actionReason = r.action_reason;
+  }
+  const replacePaths = normalizeReplacePaths(change.replace_paths);
+  if (replacePaths.length > 0) resource.replacePaths = replacePaths;
+  return resource;
+}
+
+function buildDriftResource(rd: unknown, ctx: RedactContext): DriftResource | null {
+  if (!rd || typeof rd !== 'object') return null;
+  const r = rd as Record<string, unknown>;
+  const address = typeof r.address === 'string' ? r.address : '';
+  if (!address) return null;
+  const change = (r.change && typeof r.change === 'object' ? r.change : {}) as TfChange;
+  return {
+    address,
+    type: typeof r.type === 'string' ? r.type : '',
+    name: typeof r.name === 'string' ? r.name : '',
+    providerName: typeof r.provider_name === 'string' ? r.provider_name : '',
+    attributeChanges: buildAttributeChanges(change, `${address}`, ctx),
+  };
+}
+
+/**
+ * Diff a Change's top-level attributes and emit only the CHANGED ones as masked
+ * AttrChange[]. `before` is redacted with `before_sensitive` and NO unknown mask;
+ * `after` with `after_sensitive` AND `after_unknown` (spec §2.7). A missing side
+ * (create -> before=null; delete -> after=null) yields a JSON null for that side.
+ */
+function buildAttributeChanges(change: TfChange, addressPath: string, ctx: RedactContext): AttrChange[] {
+  const before = change.before;
+  const after = change.after;
+  const beforeObj = before && typeof before === 'object' && !Array.isArray(before) ? (before as Record<string, unknown>) : null;
+  const afterObj = after && typeof after === 'object' && !Array.isArray(after) ? (after as Record<string, unknown>) : null;
+
+  const keys = new Set<string>();
+  if (beforeObj) for (const k of Object.keys(beforeObj)) keys.add(k);
+  if (afterObj) for (const k of Object.keys(afterObj)) keys.add(k);
+
+  const changes: AttrChange[] = [];
+  for (const key of [...keys].sort()) {
+    if (UNSAFE_ATTR_KEYS.has(key)) {
+      ctx.notes.push(`dropped unsafe attribute key '${key}' at ${addressPath}`);
+      continue;
+    }
+    const rawBefore = beforeObj ? beforeObj[key] : null;
+    const rawAfter = afterObj ? afterObj[key] : null;
+    const uMask = prop(change.after_unknown, key);
+    const changed = !deepEqual(rawBefore, rawAfter) || anyTrue(uMask);
+    if (!changed) continue;
+
+    ctx.path = `${addressPath}.${key}`;
+    const beforeRV: RedactedValue = redactValue(rawBefore, prop(change.before_sensitive, key), false, ctx);
+    const afterRV: RedactedValue = redactValue(rawAfter, prop(change.after_sensitive, key), uMask, ctx);
+    ctx.path = '';
+    changes.push({ path: key, before: beforeRV, after: afterRV });
+  }
+
+  changes.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  const dropped = changes.length - MAX_ATTR_CHANGES_PER_RESOURCE;
+  if (dropped > 0) {
+    ctx.notes.push(`attribute changes for ${addressPath} capped at ${MAX_ATTR_CHANGES_PER_RESOURCE} (${dropped} more not shown)`);
+    return changes.slice(0, MAX_ATTR_CHANGES_PER_RESOURCE);
+  }
+  return changes;
+}
+
+function buildOutputChange(name: string, oc: unknown, ctx: RedactContext): OutputChange | null {
+  if (!oc || typeof oc !== 'object') return null;
+  const change = oc as TfChange;
+  ctx.path = `output.${name}`;
+  const value = redactValue(change.after, change.after_sensitive, change.after_unknown, ctx);
+  ctx.path = '';
+  return { name, action: classifyOutputAction(change.actions), value };
+}
+
+// ---- classification / normalization helpers ----
+
+function normalizeActions(actions: unknown): PlanResource['actions'] {
+  if (!Array.isArray(actions)) return ['no-op'];
+  const out = actions.filter((a): a is PlanResource['actions'][number] => typeof a === 'string' && KNOWN_ACTIONS.has(a));
+  return out.length > 0 ? out : ['no-op'];
+}
+
+// A replace is the two-element ["delete","create"] / ["create","delete"] array
+// Terraform emits (there is no single "replace" token in show -json).
+function isReplace(actions: string[]): boolean {
+  return actions.length === 2 && actions.includes('create') && actions.includes('delete');
+}
+
+function summarize(resources: PlanResource[]): PlanDigest['summary'] {
+  let add = 0;
+  let change = 0;
+  let destroy = 0;
+  let replace = 0;
+  let read = 0;
+  let allNoOp = true;
+  for (const r of resources) {
+    const a = r.actions;
+    if (!(a.length === 1 && a[0] === 'no-op')) allNoOp = false;
+    if (isReplace(a)) {
+      replace++;
+      add++;
+      destroy++;
+    } else if (a.length === 1) {
+      switch (a[0]) {
+        case 'create':
+          add++;
+          break;
+        case 'update':
+          change++;
+          break;
+        case 'delete':
+          destroy++;
+          break;
+        case 'read':
+          read++;
+          break;
+        default:
+          break; // no-op / forget contribute to no bucket
+      }
+    }
+  }
+  return { add, change, destroy, replace, read, noChanges: allNoOp, driftDetected: false };
+}
+
+function classifyOutputAction(actions: unknown): OutputChange['action'] {
+  if (!Array.isArray(actions)) return 'no-op';
+  const a = actions.filter((x): x is string => typeof x === 'string');
+  if (a.length === 2 && a.includes('create') && a.includes('delete')) return 'update';
+  if (a.includes('create')) return 'create';
+  if (a.includes('delete')) return 'delete';
+  if (a.includes('update')) return 'update';
+  return 'no-op';
+}
+
+// Action priority for the MAX_RESOURCES cap (spec §3): delete/replace first,
+// then update, create, read, no-op — most consequential changes survive.
+function actionPriority(actions: string[]): number {
+  if (isReplace(actions)) return 0;
+  if (actions.includes('delete')) return 0;
+  if (actions.includes('update')) return 1;
+  if (actions.includes('create')) return 2;
+  if (actions.includes('read')) return 3;
+  return 4;
+}
+
+function normalizeReplacePaths(replacePaths: unknown): string[] {
+  if (!Array.isArray(replacePaths)) return [];
+  const out: string[] = [];
+  for (const path of replacePaths) {
+    if (!Array.isArray(path)) continue;
+    let s = '';
+    for (const seg of path) {
+      if (typeof seg === 'number') s += `[${seg}]`;
+      else if (typeof seg === 'string') s += s === '' ? seg : `.${seg}`;
+    }
+    if (s) out.push(s);
+  }
+  return out;
+}
+
+// Local copies of the small helpers redact.ts uses internally, kept private here
+// so plan-digest does not depend on redact.ts internals it should not import.
+const UNSAFE_ATTR_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+function prop(mask: unknown, key: string): unknown {
+  return mask !== null && typeof mask === 'object' && !Array.isArray(mask) ? (mask as Record<string, unknown>)[key] : false;
+}
+function anyTrue(mask: unknown): boolean {
+  if (mask === true) return true;
+  if (Array.isArray(mask)) return mask.some(anyTrue);
+  if (mask !== null && typeof mask === 'object') return Object.values(mask as Record<string, unknown>).some(anyTrue);
+  return false;
+}
+
+function finalizeTruncation(digest: PlanDigest, ctx: RedactContext): void {
+  if (ctx.notes.length > 0) {
+    digest.truncated = true;
+    digest.truncationNotes = [...ctx.notes];
+  }
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/redact.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/redact.ts
@@ -1,0 +1,297 @@
+// REDACTION CORE — the single most security-critical module of the structured
+// plan/apply digest pipeline. It converts a raw Terraform value plus its
+// sensitivity / unknown *mask maps* into a `RedactedValue` that NEVER contains a
+// raw sensitive value.
+//
+// Normative spec: docs/design/plan-apply-digest-spec.md §2 (redaction algorithm),
+// §2.5 (prototype-pollution guard), §2.6 (determinism), §2.8 (fail-closed rule),
+// §3 (size caps). Design source: docs/initiatives/structured-plan-apply-tabs.md
+// §5.2 / §6.
+//
+// INVARIANTS (each has a unit test in Tests/results/):
+//  1. A leaf the mask marks sensitive is emitted as {kind:"sensitive"} and the
+//     underlying value appears NOWHERE in the digest (build the redacted tree
+//     FIRST, then serialize — never serialize raw then scrub, §2 / §5.2.5).
+//  2. FAIL CLOSED: whenever a mask's shape disagrees with the value's shape, the
+//     value is treated as sensitive (masked), never leaked, and a note is
+//     recorded so the event is observable (§2.8 — the single most important rule).
+//  3. `__proto__` / `constructor` / `prototype` keys are dropped, never walked
+//     into Object.prototype (§2.5).
+//  4. Deterministic: identical input -> byte-identical output (lexicographic key
+//     order in the serialized value, §2.6) so golden-fixture regression is real.
+//
+// This file also houses the shared serialization / size utilities the two digest
+// builders (plan-digest.ts, apply-digest.ts) both need — `stableStringify`,
+// `utf8ByteLength`, `deepEqual`, and the digest-level byte-cap enforcement
+// (`capDigestBytes`) — so those helpers have exactly one implementation and the
+// producer cannot drift from itself.
+
+import { RedactedValue, Digest, PlanDigest, ApplyDigest } from './digest-schema';
+import { MAX_REDACTED_VALUE_BYTES } from './caps';
+
+/**
+ * Context threaded through a redaction walk. Carries the caps (§3) and the sink
+ * for observability notes (a fail-closed mask mismatch, a dropped unsafe key, or
+ * an over-cap omission records a human-readable note here; the builder surfaces
+ * these as the digest's `truncationNotes`).
+ */
+export interface RedactContext {
+  /** Sink for observability notes (fail-closed events, dropped keys, omissions). */
+  notes: string[];
+  /** Per-value serialized-byte cap; defaults to caps.MAX_REDACTED_VALUE_BYTES. */
+  maxValueBytes: number;
+  /** Path label used only in note messages (e.g. the attribute address). */
+  path: string;
+}
+
+/** Build a RedactContext with the production caps as defaults. */
+export function newRedactContext(overrides?: Partial<RedactContext>): RedactContext {
+  return {
+    notes: overrides?.notes ?? [],
+    maxValueBytes: overrides?.maxValueBytes ?? MAX_REDACTED_VALUE_BYTES,
+    path: overrides?.path ?? '',
+  };
+}
+
+// Internal tagged node produced by the recursive walk. `plain.v` is a fully
+// known, non-sensitive JSON value with any nested sensitive/unknown leaves
+// already replaced by their sentinel strings.
+type RedactNode =
+  | { t: 'sensitive' }
+  | { t: 'unknown' }
+  | { t: 'plain'; v: unknown };
+
+const SENTINEL_SENSITIVE = '(sensitive)';
+const SENTINEL_UNKNOWN = '(known after apply)';
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isContainer(m: unknown): boolean {
+  return m !== null && typeof m === 'object';
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+// Mask lookups: an ABSENT index/key means "not sensitive/unknown" (false),
+// matching Terraform's sparse mask maps (§2.4 helpers).
+function elem(mask: unknown, i: number): unknown {
+  return Array.isArray(mask) ? mask[i] : false;
+}
+function prop(mask: unknown, key: string): unknown {
+  return isPlainObject(mask) ? mask[key] : false;
+}
+
+function note(ctx: RedactContext, msg: string): void {
+  const at = ctx.path ? ` at ${ctx.path}` : '';
+  ctx.notes.push(`${msg}${at}`);
+}
+
+function materialize(child: RedactNode): unknown {
+  if (child.t === 'sensitive') return SENTINEL_SENSITIVE;
+  if (child.t === 'unknown') return SENTINEL_UNKNOWN;
+  return child.v;
+}
+
+/**
+ * The recursive walk (spec §2.4). Returns a tagged node; sensitivity wins over
+ * unknown, and any mask/value SHAPE MISMATCH fails closed to `{t:"sensitive"}`.
+ */
+function redactNode(value: unknown, sMask: unknown, uMask: unknown, ctx: RedactContext): RedactNode {
+  // (1) whole-subtree sensitivity wins over everything
+  if (sMask === true) return { t: 'sensitive' };
+  // (2) whole-subtree unknown (only if not sensitive)
+  if (uMask === true) return { t: 'unknown' };
+
+  // (3) scalar / null value
+  if (value === null || typeof value !== 'object') {
+    // a container mask over a scalar value is a shape mismatch -> FAIL CLOSED
+    if (isContainer(sMask) || isContainer(uMask)) {
+      note(ctx, 'sensitivity mask shape mismatch (container mask over scalar); masked fail-closed');
+      return { t: 'sensitive' };
+    }
+    // Coerce `undefined` (an attribute present on only one side of a before/after
+    // diff) to JSON null so serialization stays well-formed — JSON has no undefined.
+    return { t: 'plain', v: value === undefined ? null : value };
+  }
+
+  // (4) array value — a container mask MUST be an array of the same shape
+  if (Array.isArray(value)) {
+    if ((isContainer(sMask) && !Array.isArray(sMask)) || (isContainer(uMask) && !Array.isArray(uMask))) {
+      note(ctx, 'sensitivity mask shape mismatch (object mask over array); masked fail-closed');
+      return { t: 'sensitive' };
+    }
+    const out: unknown[] = [];
+    for (let i = 0; i < value.length; i++) {
+      out.push(materialize(redactNode(value[i], elem(sMask, i), elem(uMask, i), ctx)));
+    }
+    return { t: 'plain', v: out };
+  }
+
+  // (5) object value — a container mask MUST be a (non-array) object
+  if ((isContainer(sMask) && Array.isArray(sMask)) || (isContainer(uMask) && Array.isArray(uMask))) {
+    note(ctx, 'sensitivity mask shape mismatch (array mask over object); masked fail-closed');
+    return { t: 'sensitive' };
+  }
+  // Null-prototype target so an attacker-supplied key can never reach
+  // Object.prototype even before the explicit UNSAFE_KEYS guard below.
+  const out: Record<string, unknown> = Object.create(null);
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  for (const key of keys) {
+    if (UNSAFE_KEYS.has(key)) {
+      note(ctx, `dropped unsafe key '${key}'`);
+      continue;
+    }
+    out[key] = materialize(redactNode((value as Record<string, unknown>)[key], prop(sMask, key), prop(uMask, key), ctx));
+  }
+  return { t: 'plain', v: out };
+}
+
+/**
+ * Redact a single value against its sensitivity mask and (for `after` values)
+ * its unknown mask, returning a `RedactedValue` (spec §2.4 top-level wrapper).
+ * The raw value is never present in the output for the sensitive/unknown/omitted
+ * variants; for `{kind:"value"}` the JSON is the already-redacted subtree,
+ * bounded by `ctx.maxValueBytes`.
+ */
+export function redactValue(value: unknown, sensitiveMask: unknown, unknownMask: unknown, ctx: RedactContext): RedactedValue {
+  const node = redactNode(value, sensitiveMask, unknownMask, ctx);
+  if (node.t === 'sensitive') return { kind: 'sensitive' };
+  if (node.t === 'unknown') return { kind: 'unknown' };
+  const json = stableStringify(node.v);
+  if (utf8ByteLength(json) > ctx.maxValueBytes) {
+    note(ctx, 'value omitted (over per-value size cap)');
+    return { kind: 'omitted', reason: 'too-large' };
+  }
+  return { kind: 'value', json };
+}
+
+// ---------------------------------------------------------------------------
+// Shared serialization / size / equality utilities (used by both builders)
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic JSON serialization with lexicographically-sorted object keys
+ * (§2.6). Relying on property insertion order is unsafe because JS reorders
+ * integer-like keys, so keys are sorted explicitly at every level. Input is
+ * always JSON-safe (it came from JSON.parse of Terraform output), so there are
+ * no undefined/NaN/function values to handle.
+ */
+export function stableStringify(v: unknown): string {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v) as string;
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`;
+  const obj = v as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+/** UTF-8 byte length of a string (what the §3 byte caps measure). */
+export function utf8ByteLength(s: string): number {
+  return Buffer.byteLength(s, 'utf8');
+}
+
+/** Structural deep-equality over JSON values (used to detect changed attributes). */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+  const aArr = Array.isArray(a);
+  const bArr = Array.isArray(b);
+  if (aArr !== bArr) return false;
+  if (aArr && bArr) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao);
+  const bk = Object.keys(bo);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+    if (!deepEqual(ao[k], bo[k])) return false;
+  }
+  return true;
+}
+
+/**
+ * Serialize a finished digest the way the attachment is written and the no-leak
+ * tripwire greps it (pretty-printed, stable field order — the builder constructs
+ * every object in a fixed key order so JSON.stringify is already deterministic).
+ */
+export function serializeDigest(digest: Digest): string {
+  return JSON.stringify(digest, null, 2);
+}
+
+/**
+ * Enforce the digest-level total-byte caps (§3, spec table rows "soft"/"hard").
+ * Returns the digest unchanged when it is within the soft ceiling; on the soft
+ * ceiling it drops the heavy per-attribute arrays (keeps resource rows +
+ * summary); on the hard ceiling it collapses to a summary-only digest. Every
+ * reduction sets `truncated` and appends a note — never a silent drop.
+ *
+ * `softMax` / `hardMax` are passed explicitly (defaulted by the builders to the
+ * caps.ts constants) so the boundary behavior can be unit-tested with small
+ * ceilings without configuring the production single-source caps.
+ */
+export function capDigestBytes<T extends Digest>(digest: T, softMax: number, hardMax: number): T {
+  const size = () => utf8ByteLength(serializeDigest(digest));
+  if (size() <= softMax) return digest;
+
+  if (digest.kind === 'plan') {
+    dropPlanAttributeArrays(digest as PlanDigest);
+  } else {
+    dropApplyDiagnosticDetail(digest as ApplyDigest);
+  }
+  digest.truncated = true;
+  addNote(digest, 'digest exceeded soft size ceiling; dropped detailed change arrays');
+
+  if (size() <= hardMax) return digest;
+
+  const summaryOnly = toSummaryOnly(digest);
+  return summaryOnly as T;
+}
+
+function dropPlanAttributeArrays(d: PlanDigest): void {
+  for (const r of d.resources) r.attributeChanges = [];
+  if (d.drift) for (const r of d.drift) r.attributeChanges = [];
+}
+
+function dropApplyDiagnosticDetail(d: ApplyDigest): void {
+  for (const diag of d.diagnostics) delete diag.detail;
+}
+
+function addNote(d: Digest, msg: string): void {
+  if (!d.truncationNotes) d.truncationNotes = [];
+  d.truncationNotes.push(msg);
+}
+
+// Collapse to counts + envelope only (hard ceiling). Kept in fixed field order
+// so serialization stays deterministic.
+function toSummaryOnly(d: Digest): Digest {
+  const base = {
+    schemaVersion: d.schemaVersion,
+    kind: d.kind,
+    producedBy: d.producedBy,
+    tool: d.tool,
+    meta: d.meta,
+    truncated: true,
+    truncationNotes: [...(d.truncationNotes ?? []), 'digest exceeded hard size ceiling; summary-only digest attached'],
+  };
+  if (d.kind === 'plan') {
+    const p: PlanDigest = { ...base, kind: 'plan', summary: d.summary, resources: [], outputChanges: [] };
+    return p;
+  }
+  const a: ApplyDigest = {
+    ...base,
+    kind: 'apply',
+    outcome: d.outcome,
+    summary: d.summary,
+    resources: [],
+    diagnostics: [],
+    outputs: [],
+  };
+  return a;
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/secret-scrub.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/secret-scrub.ts
@@ -1,0 +1,89 @@
+// PRODUCER-SIDE TEXT SAFETY — the freeform-text controls that cannot ride on a
+// structured mask. Two exports:
+//   * scrubSecrets()          — best-effort redaction of diagnostic summary/detail
+//                               (§5.4 / spec §4.9): explicit known-secret removal
+//                               plus a conservative high-entropy/PEM heuristic.
+//   * sanitizeAttachmentName() — strip logging-command / CRLF injection vectors
+//                               from a publish name before it becomes an
+//                               attachment name and is echoed into the digest
+//                               (§5.6 / spec §4.10).
+//
+// scrubSecrets is documented BEST-EFFORT, not a guarantee: a provider can echo a
+// secret the task never registered and that matches no heuristic. That residual
+// risk is why `includeDiagnosticDetail` defaults to false and is recorded in
+// SECURITY.md (§5.10 residual-risk register).
+
+const REDACTED = '(redacted)';
+
+// Known secrets shorter than this are ignored: real registered secrets (WIF
+// tokens, provider creds, keys) comfortably exceed it, and replacing a 1-3 char
+// string would destroy unrelated text (catastrophic over-scrub).
+const MIN_KNOWN_SECRET_LEN = 4;
+
+// PEM key/certificate blocks — multi-line, matched non-greedily.
+const PEM_BLOCK = /-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g;
+
+// Long high-entropy runs: base64 / base64url / hex tokens of 40+ chars. 40 is
+// conservative — ordinary words and short identifiers never reach it, so benign
+// diagnostics survive intact (a targeted test asserts no over-scrub).
+const HIGH_ENTROPY_RUN = /[A-Za-z0-9+/_-]{40,}={0,2}/g;
+
+/**
+ * Redact secrets from a freeform diagnostic string. Explicitly-registered
+ * secrets are removed first (exact literal match), then PEM blocks and long
+ * high-entropy runs are scrubbed by heuristic. Returns the input unchanged when
+ * nothing matches (no over-scrubbing of benign text).
+ *
+ * @param text         the freeform string (diagnostic summary or detail)
+ * @param knownSecrets values the task registered via setSecret (order irrelevant)
+ */
+export function scrubSecrets(text: string, knownSecrets: string[]): string {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  let out = text;
+
+  // (1) explicit known-secret removal — literal replacement, longest first so a
+  // secret that contains another is fully removed before its substring.
+  const secrets = [...new Set(knownSecrets)]
+    .filter((s) => typeof s === 'string' && s.length >= MIN_KNOWN_SECRET_LEN)
+    .sort((a, b) => b.length - a.length);
+  for (const secret of secrets) {
+    if (out.includes(secret)) out = out.split(secret).join(REDACTED);
+  }
+
+  // (2) heuristic scrub — PEM blocks first (they contain base64 the run rule
+  // would otherwise fragment), then long high-entropy runs.
+  out = out.replace(PEM_BLOCK, '(redacted PEM)');
+  out = out.replace(HIGH_ENTROPY_RUN, REDACTED);
+
+  return out;
+}
+
+// Characters that would break the `##vso[task.addattachment …;name=NAME;]path`
+// logging command or inject a new command: CR/LF, the `]` terminator, the `;`
+// field separator, and `%` (the ADO logging-command escape lead-in). Plus any
+// other C0 control character.
+const NAME_INJECTION_CHARS = /[\r\n\]%;\x00-\x1f]/g;
+const MAX_ATTACHMENT_NAME_LEN = 256;
+
+/**
+ * Make a publish name safe to use as an attachment name AND to interpolate into
+ * an ADO logging command. Strips CR/LF and the `]` / `;` / `%` control sequences
+ * (plus other control chars) and caps the length. Returns the sanitized name and
+ * an optional note when the input was altered (so the change is observable in the
+ * digest's truncationNotes). An empty/blank result falls back to "terraform".
+ */
+export function sanitizeAttachmentName(name: string): { name: string; note?: string } {
+  const raw = typeof name === 'string' ? name : '';
+  let sanitized = raw.replace(NAME_INJECTION_CHARS, '');
+  let capped = false;
+  if (sanitized.length > MAX_ATTACHMENT_NAME_LEN) {
+    sanitized = sanitized.slice(0, MAX_ATTACHMENT_NAME_LEN);
+    capped = true;
+  }
+  const trimmed = sanitized.trim();
+  const finalName = trimmed.length > 0 ? sanitized : 'terraform';
+  if (sanitized !== raw || capped) {
+    return { name: finalName, note: `publish name sanitized (removed control/injection characters${capped ? ', truncated' : ''})` };
+  }
+  return { name: finalName };
+}


### PR DESCRIPTION
## WP-1 — Redaction + digest core (security-critical)

Implements the single most security-critical unit of the structured plan/apply tabs feature (design §5.2/§5.4/§5.5/§6), against the frozen schemaVersion-1 contract from WP-0. Pure, deterministic, exhaustively unit-tested. Consumed by **WP-2** (task wiring) and **WP-3** (tab snapshots) — see downstream contract below.

### New modules (`Tasks/TerraformTask/TerraformTaskV5/src/results/`)
- **`redact.ts`** — recursive shape-parallel redaction (`redactValue(value, sensitiveMask, unknownMask, ctx)`), per spec §2.4. Sensitivity wins over unknown; **FAIL CLOSED** (mask) on any mask/value shape mismatch (§2.8) with an observable note; `__proto__`/`constructor`/`prototype` keys dropped (§2.5); builds the redacted tree **first**, then serializes (never serialize-raw-then-scrub, §5.2.5); lexicographic key order for byte-stable output (§2.6). Also houses the shared serialization/size utilities (`stableStringify`, `utf8ByteLength`, `deepEqual`, `serializeDigest`) and digest-level byte-cap enforcement `capDigestBytes` (soft → drop attribute arrays; hard → summary-only).
- **`plan-digest.ts`** — `buildPlanDigest(showJson, meta)` from `terraform show -json`: action/summary classification (replace = the 2-element `["delete","create"]` array; counted in add+destroy+replace), `action_reason`, `replace_paths`, **only-changed** `attributeChanges`, `resource_drift` → `driftDetected`, before/after unknown asymmetry (§2.7), §6 caps with truncation notes.
- **`apply-digest.ts`** — `buildApplyDigest(ndjson, meta, options)` from the `apply -json` NDJSON stream: malformed lines tolerated + noted (never throws), `appliedBeforeFailure`, durations from event `@timestamp` deltas (never `Date.now()`), diagnostics (safe-default: `detail` omitted unless `includeDiagnosticDetail`), masked final outputs.
- **`secret-scrub.ts`** — `scrubSecrets` (explicit known-secret removal + conservative PEM/high-entropy heuristic, documented best-effort, §5.4) and `sanitizeAttachmentName` (CRLF / `]`/`;`/`%` logging-command injection guard, §5.6).

### Testing (a WP-1 deliverable, §12)
Full mocha L0 matrix under `Tests/results/` covering every §12.2 case: non/partial-sensitive collections; **mask/value SHAPE MISMATCH → masked** (the critical fail-closed test); `before_sensitive`/`sensitive_values`/output sensitivity; `after_unknown`; each §6 cap boundary; prototype-pollution key ignored; malformed NDJSON tolerated; partial-apply `appliedBeforeFailure`; determinism (byte-identical on repeat).

**Regression foundation (§12.3) + no-leak tripwire (§12.4.1):** a scrubbed **synthetic** golden-fixture corpus under `Tests/fixtures/` (no-op / create / replace-with-reason / destroy / sensitive-outputs+nested / multi-provider / drift plans; success + partial-failure applies), each with a byte-for-byte `.expected.json` golden, plus the tripwire asserting every fixture's known-secret literals appear **nowhere** in the serialized digest. Fixtures contain only fake secret-looking literals.

### Gates (verified locally — see note on CI)
- `npm run compile` + `npm test`: **393 passing**.
- Coverage (`npm run test:coverage`, exit 0): security-critical modules ≥90% statements — redact **95.4**, plan-digest **96.8**, apply-digest **90.4**, secret-scrub **96.9**; no nyc exclusion hides them. Global 90.4/80.5/91.7 ≥ thresholds.
- `npx eslint src/ Tests/`: 0 errors.
- `node scripts/check-versions.js`, `check-shared-modules.js` (+ self-test): pass (WP-1 does not touch `digest-schema.ts`/`caps.ts`; parity intact).

> **CI note:** every repo workflow is gated on `branches: [main]`, so a PR into `feature/structured-plan-apply-tabs` triggers no checks — gates were run locally on Windows and will run in CI when WP-5 targets `main`. `check-minor-bumps` is intentionally **not** satisfied here: WP-2 owns the single Minor bump for the whole feature.

### Downstream contract (for WP-2 / WP-3)
- **WP-2** calls `buildPlanDigest(plan, meta)` / `buildApplyDigest(ndjson, meta, {includeDiagnosticDetail, knownSecrets})` and serializes with `serializeDigest`. `DigestMeta` = `{ taskVersion, toolName, name, workingDirectory?, stage?, job?, createdIso }` (`createdIso` must be an injected/agent timestamp, never `Date.now()`); `meta.name` is sanitized inside the builder, and `sanitizeAttachmentName` is exported for reuse in the `##vso[task.addattachment …]` command. Reuse `scrubSecrets` known-secret list from the task's `setSecret` registrations.
- **WP-3** can snapshot the committed goldens directly. `replace` is represented as a 2-element `actions` array (not a `"replace"` token); apply `outputs` carry `action:"no-op"` (final value, no delta); `capDigestBytes` may yield a summary-only digest (empty `resources`/`outputChanges`) with `truncated:true`.

No `task.json`/manifest/doc changes here (owned by WP-2/WP-4).
