### PR TITLE
fix: bump task Minor versions missed in the v1.10.1 release

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "5",
+        "Minor": "6",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "10",
+        "Minor": "11",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "8",
+        "Minor": "9",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "6",
+    "Minor": "7",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "9",
+    "Minor": "10",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "234",
+        "Minor": "235",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "8",
+        "Minor": "9",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "9",
+        "Minor": "10",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "8",
+        "Minor": "9",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "279",
+        "Minor": "280",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
The v1.10.1 release run failed at the **Verify per-task Minor bumps** guard (the release is stuck in Draft and never reached the Marketplace) because release PR #578 merged without the manual bump step. This PR applies the required Minor bump to all 10 tasks whose code changed in #577, verified with `node scripts/check-minor-bumps.js v1.10.0` (all OK).

Merging this lets release-please cut **1.10.2**, which will pass the guard and actually ship the #577 security fixes to agents (ADO caches tasks by Major.Minor).

Housekeeping after 1.10.2 ships: the stuck **v1.10.1 draft release and tag** can be deleted — leaving them is harmless but untidy; I have not deleted anything.

A separate PR automates the bump on the Release PR itself so this manual step disappears.