### PR TITLE
ci: automate release-PR task Minor bumps with a required merge-gate backstop

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -61,3 +61,35 @@ jobs:
           # (not just high/critical), matching the root/per-task npm audit gates.
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure
+
+  # Backstop merge gate for the per-task Minor bumps. release-pr-minor-bumps.yml
+  # applies the bumps automatically on the Release PR; this gate fails the PR if
+  # they are somehow still missing (e.g. the auto-bump workflow was broken or
+  # disabled), so a Release PR can never merge without them and reach the too-late
+  # tag-time guard in release.yml. This job ALWAYS runs (no job-level `if:`) so it
+  # reports a definite status and can be a required check without ever getting
+  # stuck "Expected" — the release-vs-normal-PR branching is inside the steps.
+  release-pr-minor-bumps:
+    name: Release PR Minor Bumps
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip for non-release PRs
+        if: ${{ ! startsWith(github.event.pull_request.head.ref, 'release-please--') }}
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          echo "Head ref '${HEAD_REF}' is not a release-please branch; the per-task Minor-bump gate only applies to Release PRs. Skipping (this gate always runs so it can be a required check)."
+      # For a release PR, check out the default pull_request context (the merge
+      # ref = main + this PR) with full history and tags, then run the check.
+      # Comparing the newest v*.*.* tag against that merge ref is exactly the
+      # right comparison: it is what main would look like once this PR merges.
+      - name: Checkout (release PRs only)
+        if: ${{ startsWith(github.event.pull_request.head.ref, 'release-please--') }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Verify per-task Minor bumps
+        if: ${{ startsWith(github.event.pull_request.head.ref, 'release-please--') }}
+        run: node scripts/check-minor-bumps.js

--- a/.github/workflows/release-pr-minor-bumps.yml
+++ b/.github/workflows/release-pr-minor-bumps.yml
@@ -1,0 +1,86 @@
+---
+name: Auto-bump Release PR Minor Versions
+
+# Auto-applies the mandatory per-task Minor bumps on the release-please Release
+# PR, so the manual step in CLAUDE.md's Release Process happens automatically.
+# ADO agents cache tasks by Major.Minor, so a task whose src/ changed since the
+# last release must have its task.json Minor incremented, or the fix reaches the
+# Marketplace but never running agents. The "Release PR Minor Bumps" merge gate
+# in pr-checks.yml is the backstop, and release.yml's tag-time "Verify per-task
+# Minor bumps" guard is the final defense.
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Serialize runs per Release PR branch: if a new synchronize (e.g. a
+# release-please force-push) arrives while an auto-bump is mid-flight, cancel the
+# in-flight run rather than letting two runs race to push the bump commit. The
+# bump is idempotent, so the surviving run applies (or re-applies) it cleanly.
+concurrency:
+  group: release-pr-minor-bumps-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
+jobs:
+  auto-bump:
+    name: Auto-bump task Minor versions
+    runs-on: ubuntu-latest
+    # Only the release-please Release PR, and only when it lives in this repo
+    # (never a fork — a fork PR has no access to the App key, and we must not
+    # push back to a fork's branch). release-please names its branch
+    # 'release-please--branches--main' etc.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--')
+    steps:
+      - name: Get GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: token
+        with:
+          client-id: ${{ vars.RELEASE_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
+          # Minted from the same App as release-please.yml. Pushing the bump
+          # commit with an App token (rather than the workflow's GITHUB_TOKEN)
+          # is what makes the push RE-TRIGGER the PR's required checks — a push
+          # authenticated by GITHUB_TOKEN would not, leaving the checks stale.
+          permission-contents: write
+
+      # Check out the PR HEAD branch itself (NOT the pull_request merge ref) with
+      # persist-credentials: false — this workflow commits back to that branch, so
+      # it must be on it, and the push below supplies the App token explicitly
+      # rather than persisting it into .git/config. fetch-depth: 0 + fetch-tags so
+      # the bump analysis can find the newest v*.*.* tag (the previous release).
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Bump task Minor versions and push
+        env:
+          BUMP_TOKEN: ${{ steps.token.outputs.token }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        # No ${{ }} interpolation inside this run block — every input arrives via
+        # env: indirection (actionlint + zizmor both scan this file). The bump
+        # script is idempotent: if the branch already carries the bumps (e.g. this
+        # workflow ran on a previous synchronize), `git diff --quiet` is clean and
+        # nothing is committed or pushed, so there is no push -> synchronize loop.
+        # Our own push does re-trigger `synchronize`, but that second run is a
+        # no-op for exactly this reason. release-please force-pushes its branch
+        # whenever a new commit lands on main, wiping this bump commit; this
+        # workflow re-runs on that synchronize and re-applies it — self-healing.
+        run: |
+          node scripts/bump-minor-versions.js
+          if git diff --quiet; then
+            echo "No Minor bumps needed; working tree clean. Nothing to commit or push."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: bump task Minor versions for release (automated)"
+          git push "https://x-access-token:${BUMP_TOKEN}@github.com/${REPO}.git" "HEAD:${PR_HEAD_REF}"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,6 +28,8 @@ jobs:
         run: node scripts/test-check-versions.js
       - name: Self-test check-minor-bumps.js
         run: node scripts/test-check-minor-bumps.js
+      - name: Self-test bump-minor-versions.js
+        run: node scripts/test-bump-minor-versions.js
       - name: Self-test check-task-list.js
         run: node scripts/test-check-task-list.js
       - name: Check for mojibake encoding corruption

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,16 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 
 1. Merge conventional-commit PRs to `main` — release-please accumulates them.
 2. release-please opens a **Release PR** that bumps `azure-devops-extension.json` (`version`) and updates `CHANGELOG.md`.
-3. Before merging the Release PR, manually bump the `Minor` field in `task.json` for every task whose code changed since the last release. ADO agents cache tasks by `Major.Minor` and will not pick up new code until `Minor` increments.
+3. The per-task `Minor` bumps happen **automatically** on the Release PR — this used to be a manual step and was repeatedly missed. ADO agents cache tasks by `Major.Minor` and will not pick up new code until `Minor` increments, so every task whose `src/` changed since the last release must have its `task.json` `Minor` incremented before the release is tagged. Three layers enforce this, so in the normal case there is nothing to do by hand:
 
-   **Security rule (mandatory):** for any release, every task whose code was touched by a **security** issue in at least one of the release's PRs **must** have its `Minor` bumped in that release — never ship a security fix while agents keep serving the cached old code. When unsure whether a change qualifies, bump it.
+   - **Auto-bump (primary):** `.github/workflows/release-pr-minor-bumps.yml` triggers on the Release PR (head branch `release-please--…`), runs `scripts/bump-minor-versions.js`, and commits + pushes the bumps back to the PR branch using the release App token — pushing with the App token (not `GITHUB_TOKEN`) is what re-triggers the PR's checks. It is idempotent and self-healing: release-please force-pushes its branch on every new `main` commit, wiping the bump commit, and this workflow re-runs on the resulting `synchronize` and re-applies it (its own push also fires `synchronize`, but that second run is a clean no-op).
+   - **Merge gate (backstop):** the `Release PR Minor Bumps` required check in `.github/workflows/pr-checks.yml` runs `scripts/check-minor-bumps.js` against the Release PR and fails it if any bump is still missing, so a Release PR can never merge un-bumped (e.g. if the auto-bump workflow was broken).
+   - **Tag-time guard (final defense, unchanged):** `release.yml`'s `Verify per-task Minor bumps` step re-runs the same check after the tag is pushed and fails the release if anything slipped through.
 
-   Files to update:
+   **Security rule (mandatory):** for any release, every task whose code was touched by a **security** issue in at least one of the release's PRs **must** have its `Minor` bumped in that release — never ship a security fix while agents keep serving the cached old code. The automation bumps any task whose `src/` changed, which already covers this; when unsure whether a change qualifies, bump it.
+
+   **Manual fallback (only if the automation is broken):** if the auto-bump workflow is disabled/failing and the merge gate is red, apply the bumps yourself — the simplest way is `node scripts/bump-minor-versions.js` from the repo root, which does exactly what the workflow does. To edit by hand instead, bump `Minor` by 1 (leave `Patch` at 0) in the `task.json` of every task whose `src/` changed since the last release:
+
    - `Tasks/TerraformTask/TerraformTaskV5/task.json` — if TerraformTaskV5 changed
    - `Tasks/TerraformInstaller/TerraformInstallerV1/task.json` — if TerraformInstallerV1 changed
    - `Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/task.json` — if TerraformProviderMirrorV1 changed
@@ -74,9 +79,7 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
    - `Tasks/Markdown2Html/Markdown2HtmlV1/task.json` — if Markdown2HtmlV1 changed
    - `Tasks/PublishKbArticle/PublishKbArticleV1/task.json` — if PublishKbArticleV1 changed
 
-   Increment `Minor` by 1, leave `Patch` at 0.
-
-   **Verify before bumping:** when a change must reach agents immediately (e.g. dropping a Node execution handler), the `Minor` may be bumped in the feature PR instead. If a task's `Minor` was already incremented in a merged feature PR since the last release, do **not** bump it again here — compare against the last release tag first to avoid a double-increment.
+   **Avoid a double-increment:** when a change must reach agents immediately (e.g. dropping a Node execution handler), `Minor` may have been bumped in the feature PR instead. A task already incremented in a merged feature PR since the last release must **not** be bumped again — both the bump script and the check compare against the last release tag and already skip such tasks, so prefer the script over hand-editing.
 
 4. Merge the Release PR. release-please creates a draft GitHub Release and pushes the `vX.Y.Z` tag.
 5. The `release.yml` workflow fires on the tag:
@@ -475,7 +478,7 @@ CI and local development both target Node 24 LTS (Active LTS, EOL April 2028). N
 
 **`main` branch:**
 
-- Required status checks (strict — branch must be up-to-date): the complete `unit-test.yml` matrix (27 contexts) — `Check Version Consistency`, `Check Shared Module Parity`, every `Build and Test *` job on both `ubuntu-latest` and `windows-2025` (V5, Installer V1, Provider Mirror V1, Module Publish V1, Policy Agent Installer V1, Policy Check V1, Drift Report V1, terraform-docs Installer V1, terraform-docs V1, Markdown2Html V1, Publish KB Article V1), `Build and Test Tab`, `Lint GitHub Actions`, and `Scan Workflows (zizmor)`. Pinned to the GitHub Actions app (`app_id` 15368). Add both matrix legs of any new task's job here when introducing a task.
+- Required status checks (strict — branch must be up-to-date): the complete `unit-test.yml` matrix (27 contexts) — `Check Version Consistency`, `Check Shared Module Parity`, every `Build and Test *` job on both `ubuntu-latest` and `windows-2025` (V5, Installer V1, Provider Mirror V1, Module Publish V1, Policy Agent Installer V1, Policy Check V1, Drift Report V1, terraform-docs Installer V1, terraform-docs V1, Markdown2Html V1, Publish KB Article V1), `Build and Test Tab`, `Lint GitHub Actions`, `Scan Workflows (zizmor)`, and `Release PR Minor Bumps` (the pr-checks.yml merge gate — a fast no-op pass on non-release PRs, and the layer-2 backstop that keeps an un-bumped Release PR from merging if the auto-bump workflow is ever broken). Pinned to the GitHub Actions app (`app_id` 15368). Add both matrix legs of any new task's job here when introducing a task.
 - Required pull request reviews: 1 approving review, dismiss stale reviews, require code owner review
 - Enforce admins: no (admin/owner can bypass review requirements as sole maintainer)
 - Required linear history: yes (squash/rebase only, no merge commits)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -9,7 +9,7 @@ Manual verification steps to run before publishing a release to the VS Marketpla
 - [ ] All CI checks pass on `main` (release-please opens the Release PR from `main`)
 - [ ] Version in `azure-devops-extension.json` matches the intended tag (e.g. `1.0.0` for `v1.0.0`) — release-please sets this in the Release PR
 - [ ] `CHANGELOG.md` has an entry for the release version (release-please generates this)
-- [ ] **Minor bumps (mandatory):** every task whose `src/` changed since the last release tag has its `Minor` incremented in `task.json`. ADO agents cache tasks by `Major.Minor`, so a code (especially security) fix to an un-bumped task would ship to the Marketplace but never reach running agents. The release `guard` job enforces this via `scripts/check-minor-bumps.js`; run it locally too: `node scripts/check-minor-bumps.js` (defaults to comparing `HEAD` against the previous `v*` tag).
+- [ ] **Minor bumps (now automated):** every task whose `src/` changed since the last release tag must have its `Minor` incremented in `task.json`. ADO agents cache tasks by `Major.Minor`, so a code (especially security) fix to an un-bumped task would ship to the Marketplace but never reach running agents. This is applied **automatically** on the Release PR by `.github/workflows/release-pr-minor-bumps.yml` (which runs `scripts/bump-minor-versions.js`), enforced as the required `Release PR Minor Bumps` merge gate in `pr-checks.yml`, and re-checked by the release `guard` job at tag time — so normally there is nothing to do here beyond confirming the gate is green. If the automation is broken, apply the bumps yourself (run `node scripts/bump-minor-versions.js` from the repo root, or edit by hand) and verify with `node scripts/check-minor-bumps.js` (defaults to comparing `HEAD` against the previous `v*` tag).
 - [ ] **Sibling-fork scan (recurring):** skim recent commits/issues in [microsoft/azure-pipelines-terraform](https://github.com/microsoft/azure-pipelines-terraform) and [jason-johnson/azure-pipelines-tasks-terraform](https://github.com/jason-johnson/azure-pipelines-tasks-terraform) since the last release for auth- or security-relevant fixes or reports worth reviewing or backporting to this fork.
 
 ## 2. Build the `.vsix` locally
@@ -129,7 +129,7 @@ Use a minimal Terraform configuration with an AzureRM backend and provider.
 Releases are automated by release-please — do NOT hand-tag.
 
 - [ ] Conventional-commit PRs are merged to `main`; release-please accumulates them into a **Release PR** ("chore(main): release X.Y.Z") that bumps `azure-devops-extension.json` and updates `CHANGELOG.md`
-- [ ] Before merging the Release PR, confirm the per-task `Minor` bumps (see section 1) — bump any missed task in the same PR
+- [ ] Before merging the Release PR, confirm the `Release PR Minor Bumps` gate is green — the per-task `Minor` bumps are auto-applied on the Release PR (see section 1); only intervene if the gate is red
 - [ ] Merge the Release PR — release-please pushes the `vX.Y.Z` tag automatically (the `guard` job fails the release if the tag version doesn't match `azure-devops-extension.json`)
 - [ ] The `release.yml` workflow triggers on the tag: verifies the tag is on `main`, runs full CI + the Minor-bump check, builds the `.vsix`, generates SBOMs + cosign signature, and creates a draft GitHub release
 - [ ] Approve the `marketplace` environment deployment when prompted

--- a/scripts/bump-minor-versions.js
+++ b/scripts/bump-minor-versions.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Auto-bumps each task's task.json Minor for every task whose src/ changed since
+// the previous release without a Minor increase — the manual step in CLAUDE.md's
+// Release Process, automated. ADO agents cache tasks by Major.Minor, so a code
+// (especially security) fix that ships without a Minor bump would reach the
+// Marketplace but never running agents. Run on the release-please Release PR by
+// .github/workflows/release-pr-minor-bumps.yml; also runnable locally.
+//
+// Usage: node scripts/bump-minor-versions.js [prevRef]
+//   prevRef defaults to the newest v*.*.* tag not at HEAD (the previous release).
+//
+// Reuses check-minor-bumps.js's analysis so the "which tasks need a bump" rule
+// lives in exactly one place. The bump is idempotent: the analysis compares each
+// task's CURRENT (working-tree) Minor against the previous release's, so a task
+// already bumped since prevRef — whether by an earlier feature PR (the documented
+// double-increment protection) or by a previous run of this script — is reported
+// as OK and left alone. Exits 0 whether or not anything needed bumping; a second
+// run makes no further change.
+
+const fs = require('fs');
+const path = require('path');
+const { resolvePrevRef, analyze } = require('./check-minor-bumps.js');
+
+// Resolve task.json paths against the current working directory (the repo root
+// the CLI/workflow is invoked from), mirroring how check-minor-bumps.js's git
+// calls operate on the cwd — so the self-test can point both at a throwaway repo.
+const repoRoot = process.cwd();
+
+function taskJsonPath(task) {
+  return path.join(repoRoot, task, 'task.json');
+}
+
+function readWorkingTreeMinor(task) {
+  const raw = fs.readFileSync(taskJsonPath(task), 'utf8');
+  return parseInt(JSON.parse(raw).version.Minor, 10);
+}
+
+// Match the version object's Minor value, anchored on the Major+Minor pair within
+// the "version" object so no other "Minor" key can be hit. The [^{}] runs cannot
+// cross an object boundary. Capture groups: (1) everything up to and including
+// "Minor":, (2) an optional opening quote, (3) the digits, (4) an optional
+// closing quote — so a function replacer can bump (3) while preserving the file's
+// existing quoting (string vs bare number) and every other byte.
+const MINOR_RE = /("version"\s*:\s*\{[^{}]*?"Major"\s*:\s*"?\d+"?[^{}]*?"Minor"\s*:\s*)("?)(\d+)("?)/;
+
+function bumpFile(task) {
+  const file = taskJsonPath(task);
+  const text = fs.readFileSync(file, 'utf8');
+  if (!MINOR_RE.test(text)) {
+    throw new Error(`could not locate the version.Minor field in ${task}/task.json`);
+  }
+  let current;
+  let next;
+  const updated = text.replace(MINOR_RE, (_full, prefix, openQuote, digits, closeQuote) => {
+    current = parseInt(digits, 10);
+    next = current + 1;
+    return `${prefix}${openQuote}${next}${closeQuote}`;
+  });
+  fs.writeFileSync(file, updated);
+  return { current, next };
+}
+
+function main() {
+  const prevRef = process.argv[2] || resolvePrevRef('HEAD');
+
+  if (!prevRef) {
+    console.log('bump-minor-versions: no previous release tag found; nothing to bump.');
+    process.exit(0);
+  }
+
+  console.log(`bump-minor-versions: comparing ${prevRef} -> working tree`);
+
+  let bumped = 0;
+  let failed = false;
+
+  for (const r of analyze({ prevRef, currRef: 'HEAD', readCurrMinor: readWorkingTreeMinor })) {
+    if (r.kind === 'diff-error') {
+      console.error(`  ! ${r.task}: could not diff (${r.message})`);
+      failed = true;
+    } else if (r.kind === 'version-error') {
+      console.error(`  ! ${r.task}: could not read task.json version (${r.message})`);
+      failed = true;
+    } else if (r.kind === 'needs-bump') {
+      const { current, next } = bumpFile(r.task);
+      console.log(`  bumped ${r.task}: Minor ${current} -> ${next}`);
+      bumped += 1;
+    }
+    // 'ok' (already bumped since prevRef) and 'unchanged' need no action.
+  }
+
+  if (failed) {
+    console.error('\nbump-minor-versions: FAILED to analyze one or more tasks (see above).');
+    process.exit(1);
+  }
+
+  if (bumped === 0) {
+    console.log('bump-minor-versions: no tasks needed a Minor bump.');
+  } else {
+    console.log(`bump-minor-versions: bumped ${bumped} task(s).`);
+  }
+}
+
+module.exports = { bumpFile, MINOR_RE };
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/check-minor-bumps.js
+++ b/scripts/check-minor-bumps.js
@@ -9,6 +9,11 @@
 //   prevRef defaults to the newest v*.*.* tag that is not the current HEAD commit
 //           (i.e. the previous release); currRef defaults to HEAD.
 // Only changes under <task>/src count — test/doc-only changes do not require a bump.
+//
+// The analysis is also reused by scripts/bump-minor-versions.js, so the pieces
+// below are exported via module.exports and the CLI runs only under the
+// `require.main === module` guard at the bottom. The CLI output strings are
+// asserted verbatim by scripts/test-check-minor-bumps.js and must not change.
 
 const { execSync } = require('child_process');
 
@@ -35,10 +40,11 @@ function minorAt(ref, taskDir) {
   return parseInt(JSON.parse(raw).version.Minor, 10);
 }
 
-let prevRef = process.argv[2];
-const currRef = process.argv[3] || 'HEAD';
-
-if (!prevRef) {
+// Resolve the previous release ref for a given currRef: the newest v*.*.* tag
+// that does not point at currRef's commit. Non-semver tags are filtered out and
+// the remaining tags are sorted by version (newest first). Returns undefined
+// when no such tag exists.
+function resolvePrevRef(currRef) {
   const head = git(`rev-parse ${currRef}`);
   const tags = git('tag --sort=-v:refname')
     .split('\n')
@@ -46,7 +52,7 @@ if (!prevRef) {
     .filter((t) => /^v\d+\.\d+\.\d+$/.test(t));
   // The previous release is the newest v* tag that does not point at the commit
   // being released (which typically already carries this release's own tag).
-  prevRef = tags.find((t) => {
+  return tags.find((t) => {
     try {
       return git(`rev-list -n1 ${t}`) !== head;
     } catch {
@@ -55,52 +61,97 @@ if (!prevRef) {
   });
 }
 
-if (!prevRef) {
-  console.log('check-minor-bumps: no previous release tag found; nothing to compare.');
-  process.exit(0);
+// Classify every task by whether its src/ changed between prevRef and currRef and
+// whether its Minor increased. Returns one result object per task, in TASKS order:
+//   { task, kind: 'unchanged' }                              — src did not change
+//   { task, kind: 'ok',         prevMinor, currMinor }       — src changed, Minor bumped
+//   { task, kind: 'needs-bump', prevMinor, currMinor }       — src changed, Minor NOT bumped
+//   { task, kind: 'diff-error', message }                    — the diff itself failed
+//   { task, kind: 'version-error', message }                 — task.json version unreadable
+// `readCurrMinor(task)` supplies the "current" Minor to compare against prevRef's
+// (default: the Minor committed at currRef). bump-minor-versions.js overrides it
+// to read the working-tree Minor so its bump is idempotent.
+function analyze({ prevRef, currRef, readCurrMinor }) {
+  const readCurr = readCurrMinor || ((task) => minorAt(currRef, task));
+  const results = [];
+  for (const task of TASKS) {
+    let changed;
+    try {
+      changed = git(`diff --name-only ${prevRef} ${currRef} -- ${task}/src`);
+    } catch (e) {
+      results.push({ task, kind: 'diff-error', message: e.message });
+      continue;
+    }
+    if (!changed) {
+      results.push({ task, kind: 'unchanged' }); // src unchanged since the last release; no bump required
+      continue;
+    }
+    let prevMinor;
+    let currMinor;
+    try {
+      prevMinor = minorAt(prevRef, task);
+      currMinor = readCurr(task);
+    } catch (e) {
+      results.push({ task, kind: 'version-error', message: e.message });
+      continue;
+    }
+    if (currMinor > prevMinor) {
+      results.push({ task, kind: 'ok', prevMinor, currMinor });
+    } else {
+      results.push({ task, kind: 'needs-bump', prevMinor, currMinor });
+    }
+  }
+  return results;
 }
 
-console.log(`check-minor-bumps: comparing ${prevRef} -> ${currRef}`);
-let failed = false;
+function main() {
+  let prevRef = process.argv[2];
+  const currRef = process.argv[3] || 'HEAD';
 
-for (const task of TASKS) {
-  let changed;
-  try {
-    changed = git(`diff --name-only ${prevRef} ${currRef} -- ${task}/src`);
-  } catch (e) {
-    console.error(`  ! ${task}: could not diff (${e.message})`);
-    failed = true;
-    continue;
+  if (!prevRef) {
+    prevRef = resolvePrevRef(currRef);
   }
-  if (!changed) {
-    continue; // src unchanged since the last release; no bump required
+
+  if (!prevRef) {
+    console.log('check-minor-bumps: no previous release tag found; nothing to compare.');
+    process.exit(0);
   }
-  let prevMinor;
-  let currMinor;
-  try {
-    prevMinor = minorAt(prevRef, task);
-    currMinor = minorAt(currRef, task);
-  } catch (e) {
-    console.error(`  ! ${task}: could not read task.json version (${e.message})`);
-    failed = true;
-    continue;
+
+  console.log(`check-minor-bumps: comparing ${prevRef} -> ${currRef}`);
+  let failed = false;
+
+  for (const r of analyze({ prevRef, currRef })) {
+    if (r.kind === 'diff-error') {
+      console.error(`  ! ${r.task}: could not diff (${r.message})`);
+      failed = true;
+    } else if (r.kind === 'unchanged') {
+      // no bump required
+    } else if (r.kind === 'version-error') {
+      console.error(`  ! ${r.task}: could not read task.json version (${r.message})`);
+      failed = true;
+    } else if (r.kind === 'ok') {
+      console.log(`  OK   ${r.task}: src changed, Minor ${r.prevMinor} -> ${r.currMinor}`);
+    } else {
+      console.error(
+        `  FAIL ${r.task}: src changed since ${prevRef} but Minor did not increase (still ${r.currMinor}). ` +
+        `Bump Minor in ${r.task}/task.json.`,
+      );
+      failed = true;
+    }
   }
-  if (currMinor > prevMinor) {
-    console.log(`  OK   ${task}: src changed, Minor ${prevMinor} -> ${currMinor}`);
-  } else {
+
+  if (failed) {
     console.error(
-      `  FAIL ${task}: src changed since ${prevRef} but Minor did not increase (still ${currMinor}). ` +
-      `Bump Minor in ${task}/task.json.`,
+      '\ncheck-minor-bumps: FAILED. Every task whose src/ changed since the last release ' +
+      'must have its Minor bumped — ADO agents cache tasks by Major.Minor. See CLAUDE.md > Release Process.',
     );
-    failed = true;
+    process.exit(1);
   }
+  console.log('check-minor-bumps: all changed tasks have a Minor bump.');
 }
 
-if (failed) {
-  console.error(
-    '\ncheck-minor-bumps: FAILED. Every task whose src/ changed since the last release ' +
-    'must have its Minor bumped — ADO agents cache tasks by Major.Minor. See CLAUDE.md > Release Process.',
-  );
-  process.exit(1);
+module.exports = { TASKS, git, minorAt, resolvePrevRef, analyze };
+
+if (require.main === module) {
+  main();
 }
-console.log('check-minor-bumps: all changed tasks have a Minor bump.');

--- a/scripts/test-bump-minor-versions.js
+++ b/scripts/test-bump-minor-versions.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// Self-test for bump-minor-versions.js: proves the release-time auto-bump edits
+// exactly the tasks whose src/ changed since the previous release without a Minor
+// increase, leaves everything else byte-for-byte untouched, preserves each file's
+// existing quoting (string vs bare number), is idempotent, and never
+// double-bumps a task already bumped since the previous release. A bug here would
+// either miss a bump (a fix reaches the Marketplace but not running agents, which
+// cache by Major.Minor) or double-bump (Minor drifts ahead of reality).
+//
+// Builds throwaway git repos in a scratch dir and runs the real
+// bump-minor-versions.js against each via spawnSync (cwd = the throwaway repo, so
+// both its git analysis and its task.json reads/writes operate on that repo),
+// mirroring the child-process style of the other self-tests. The scratch dir is
+// removed afterwards either way.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'bump-minor-versions.js');
+
+// All three are real entries in bump-minor-versions.js's (shared) TASKS list, so
+// their src/ changes are actually examined.
+const CHANGED_TASK = 'Tasks/TerraformTask/TerraformTaskV5';
+const UNCHANGED_TASK = 'Tasks/TerraformInstaller/TerraformInstallerV1';
+const BARE_TASK = 'Tasks/TerraformProviderMirror/TerraformProviderMirrorV1';
+
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-minor-versions-selftest-'));
+let failed = false;
+
+function check(cond, okMsg, failMsg, extra) {
+    if (cond) {
+        console.log(`OK: ${okMsg}`);
+    } else {
+        console.error(`FAIL: ${failMsg}`);
+        if (extra !== undefined) {
+            console.error(extra);
+        }
+        failed = true;
+    }
+}
+
+function git(cwd, args) {
+    return execSync(`git ${args}`, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function initRepo(dir) {
+    fs.mkdirSync(dir, { recursive: true });
+    git(dir, 'init -q');
+    git(dir, 'config user.email test@example.com');
+    git(dir, 'config user.name Test');
+    git(dir, 'config commit.gpgsign false');
+    git(dir, 'config tag.gpgsign false');
+    git(dir, 'config core.autocrlf false');
+    return dir;
+}
+
+// A realistic task.json (4-space indent, Major/Minor/Patch), with either quoted
+// string version fields (the repo's actual format, the CRITICAL case for
+// byte-preservation) or bare numbers (the other shape the bumper must handle).
+function taskJsonText(minor, quoted) {
+    const major = quoted ? '"1"' : '1';
+    const min = quoted ? `"${minor}"` : `${minor}`;
+    const patch = quoted ? '"0"' : '0';
+    return [
+        '{',
+        '    "id": "example-task",',
+        '    "name": "Example",',
+        '    "friendlyName": "Example Task",',
+        '    "version": {',
+        `        "Major": ${major},`,
+        `        "Minor": ${min},`,
+        `        "Patch": ${patch}`,
+        '    },',
+        '    "minimumAgentVersion": "4.265.1"',
+        '}',
+        '',
+    ].join('\n');
+}
+
+function writeTask(repo, taskDir, jsonText, srcBody) {
+    const abs = path.join(repo, taskDir);
+    fs.mkdirSync(path.join(abs, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(abs, 'task.json'), jsonText);
+    fs.writeFileSync(path.join(abs, 'src', 'index.ts'), srcBody);
+}
+
+function writeSrc(repo, taskDir, body) {
+    fs.writeFileSync(path.join(repo, taskDir, 'src', 'index.ts'), body);
+}
+
+function writeTaskJson(repo, taskDir, jsonText) {
+    fs.writeFileSync(path.join(repo, taskDir, 'task.json'), jsonText);
+}
+
+function readTaskJson(repo, taskDir) {
+    return fs.readFileSync(path.join(repo, taskDir, 'task.json'), 'utf8');
+}
+
+function readMinor(repo, taskDir) {
+    return parseInt(JSON.parse(readTaskJson(repo, taskDir)).version.Minor, 10);
+}
+
+function runBump(cwd, args = []) {
+    return spawnSync(process.execPath, [scriptPath, ...args], { cwd, encoding: 'utf8' });
+}
+
+// Base repo carrying the given tasks at their initial Minor, committed and tagged
+// v1.0.0 (plus an older v0.9.0 and a non-semver 'nightly' tag on the same commit,
+// to exercise the tag-regex filter + version sort in prevRef auto-discovery).
+// HEAD is left on the base commit; callers add the change commit.
+function makeBaseRepo(name, tasks) {
+    const repo = initRepo(path.join(scratchDir, name));
+    for (const t of tasks) {
+        writeTask(repo, t.dir, taskJsonText(t.minor, t.quoted), 'export const v = 1;\n');
+    }
+    git(repo, 'add -A');
+    git(repo, 'commit -q -m base');
+    git(repo, 'tag v0.9.0');
+    git(repo, 'tag v1.0.0');
+    git(repo, 'tag nightly'); // non-semver: must be ignored by the tag regex
+    return repo;
+}
+
+try {
+    // --- Case (a): bumps exactly the changed task; leaves unchanged tasks alone.
+    // Also serves as the fixture for the idempotency check (b). ---
+    const repoA = makeBaseRepo('bump-basic', [
+        { dir: CHANGED_TASK, minor: 5, quoted: true },
+        { dir: UNCHANGED_TASK, minor: 5, quoted: true },
+    ]);
+    const unchangedBefore = readTaskJson(repoA, UNCHANGED_TASK);
+    // Change only CHANGED_TASK's src (no Minor bump), commit.
+    writeSrc(repoA, CHANGED_TASK, 'export const v = 2;\n');
+    git(repoA, 'add -A');
+    git(repoA, 'commit -q -m change');
+
+    const resA = runBump(repoA); // no args -> prevRef auto-discovered as v1.0.0
+    const outA = `${resA.stdout}${resA.stderr}`;
+    check(
+        resA.status === 0 && outA.includes(`bumped ${CHANGED_TASK}: Minor 5 -> 6`),
+        'bumps the changed task (Minor 5 -> 6), exit 0, prevRef auto-discovered.',
+        'expected a clean bump of the changed task from Minor 5 to 6.',
+        `status=${resA.status}\n${outA}`,
+    );
+    check(
+        readMinor(repoA, CHANGED_TASK) === 6,
+        'changed task task.json now reads Minor 6.',
+        `changed task Minor should be 6 but is ${readMinor(repoA, CHANGED_TASK)}.`,
+    );
+    check(
+        readMinor(repoA, UNCHANGED_TASK) === 5 && readTaskJson(repoA, UNCHANGED_TASK) === unchangedBefore,
+        'unchanged task is left byte-for-byte untouched.',
+        'unchanged task task.json was modified but should not have been.',
+    );
+
+    // --- Case (c) (byte preservation) reuses repoA's post-bump changed file: the
+    // ONLY difference from the pre-bump bytes is the Minor digit; quoting + all
+    // other bytes are preserved. ---
+    const changedAfterA = readTaskJson(repoA, CHANGED_TASK);
+    const changedBeforeA = taskJsonText(5, true); // what was committed
+    check(
+        changedAfterA === changedBeforeA.replace('"Minor": "5"', '"Minor": "6"'),
+        'quoted-string version fields are preserved byte-for-byte except the bumped number.',
+        'the bumped file differs from the original by more than just the Minor digit (quoting/formatting drift).',
+        `before:\n${JSON.stringify(changedBeforeA)}\nafter:\n${JSON.stringify(changedAfterA)}`,
+    );
+
+    // --- Case (b): idempotent second run makes no further change. ---
+    const changedSnapshot = readTaskJson(repoA, CHANGED_TASK);
+    const resB = runBump(repoA);
+    const outB = `${resB.stdout}${resB.stderr}`;
+    check(
+        resB.status === 0 && outB.includes('no tasks needed a Minor bump'),
+        'second run is a no-op (exit 0, "no tasks needed a Minor bump").',
+        'second run did not report a clean no-op.',
+        `status=${resB.status}\n${outB}`,
+    );
+    check(
+        readTaskJson(repoA, CHANGED_TASK) === changedSnapshot && readMinor(repoA, CHANGED_TASK) === 6,
+        'second run left the already-bumped task.json unchanged (still Minor 6).',
+        'second run changed the task.json again (double-bump).',
+    );
+
+    // --- Case (c, bare numbers): a task using bare-number version fields keeps
+    // bare numbers after the bump (no quotes introduced). ---
+    const repoC = makeBaseRepo('bump-bare', [
+        { dir: BARE_TASK, minor: 8, quoted: false },
+    ]);
+    writeSrc(repoC, BARE_TASK, 'export const v = 2;\n');
+    git(repoC, 'add -A');
+    git(repoC, 'commit -q -m change');
+    const bareBefore = taskJsonText(8, false);
+    const resC = runBump(repoC);
+    const outC = `${resC.stdout}${resC.stderr}`;
+    const bareAfter = readTaskJson(repoC, BARE_TASK);
+    check(
+        resC.status === 0
+        && bareAfter === bareBefore.replace('"Minor": 8', '"Minor": 9')
+        && bareAfter.includes('"Minor": 9')
+        && !bareAfter.includes('"Minor": "9"'),
+        'bare-number version fields stay bare after the bump (no quoting introduced).',
+        'bare-number task.json was not preserved (typing changed or wrong value).',
+        `status=${resC.status}\nafter:\n${JSON.stringify(bareAfter)}`,
+    );
+
+    // --- Case (d): a task already manually bumped since prevRef is NOT
+    // double-bumped (documented double-increment protection). ---
+    const repoD = makeBaseRepo('bump-already', [
+        { dir: CHANGED_TASK, minor: 0, quoted: true },
+    ]);
+    // Change src AND bump the Minor to 1 in the same commit (as a feature PR would).
+    writeSrc(repoD, CHANGED_TASK, 'export const v = 2;\n');
+    writeTaskJson(repoD, CHANGED_TASK, taskJsonText(1, true));
+    git(repoD, 'add -A');
+    git(repoD, 'commit -q -m "change + manual bump"');
+    const resD = runBump(repoD);
+    const outD = `${resD.stdout}${resD.stderr}`;
+    check(
+        resD.status === 0
+        && outD.includes('no tasks needed a Minor bump')
+        && !outD.includes(`bumped ${CHANGED_TASK}`)
+        && readMinor(repoD, CHANGED_TASK) === 1,
+        'a task already bumped since prevRef is not double-bumped (stays Minor 1).',
+        'an already-bumped task was bumped again (double-increment).',
+        `status=${resD.status}\n${outD}`,
+    );
+} finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+}
+
+if (failed) {
+    console.error('\nbump-minor-versions.js self-test: FAILED.');
+    process.exit(1);
+}
+console.log('bump-minor-versions.js self-test: all cases passed.');


### PR DESCRIPTION
Closes the recurring miss behind the failed v1.10.1 release: the manual Release-PR Minor-bump step (CLAUDE.md release process step 3) is now automated, with the tag-time guard demoted from only-line-of-defense to last-line.

## Three layers

1. **Auto-bump** (`release-pr-minor-bumps.yml`): on `release-please--*` PRs, `scripts/bump-minor-versions.js` — which reuses `check-minor-bumps.js`'s exported analysis so the bumper and the gate cannot drift — bumps `task.json` Minor for every task whose `src/` changed since the last release tag, and pushes the commit back with the release App token (so PR checks re-run; a `GITHUB_TOKEN` push would not retrigger them). Idempotent, loop-free, self-heals after release-please force-pushes.
2. **Merge gate** (`pr-checks.yml` job **Release PR Minor Bumps**): always runs — fast no-op pass on normal PRs, real `check-minor-bumps.js` run on release PRs — so it is safe as a **required** branch-protection check and blocks an un-bumped Release PR from merging even if the auto-bump workflow breaks. I will add it to `main`'s required checks once this merges (CLAUDE.md's branch-protection list already updated).
3. **Tag-time guard** in `release.yml`: unchanged, final defense.

## Verification

- `test-check-minor-bumps.js` passes **unmodified** against the refactored gate (CLI output byte-identical; differential harness across 8 scenarios)
- New `test-bump-minor-versions.js` (wired into CI): bumps only changed tasks, idempotent re-run, preserves quoted-string version fields byte-for-byte, no double-increment for already-bumped tasks
- End-to-end in a git fixture: src change → gate FAILs → bump → gate PASSes → second bump is a no-op
- actionlint v1.7.12 and zizmor (default + pedantic personas) clean on all changed workflows
- Adversarially reviewed (token path, event-flow loops, required-check semantics, hostile task.json shapes): ship verdict; known accepted nit — on a release PR needing bumps, the gate is transiently red on `opened` until the auto-bump push's `synchronize` turns it green.

Expected first exercise: the Release PR for 1.10.2 (after #579 merges) — the auto-bump job should find nothing to do since #579 already applies the bumps.