### PR TITLE
fix: clear npm audit gate via task-lib refresh and adm-zip override

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/package-lock.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/package-lock.json
@@ -1162,12 +1162,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/package.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/package.json
@@ -26,7 +26,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
@@ -1183,12 +1183,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1298,9 +1298,9 @@
       "license": "Python-2.0"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha512-VaVvVaPe0ysvxGE10QysbEHuxL480kVDQvKjGd2gtO1eRY4/SkQKfAZrP6lLUAAgYMGk6eifl0I3kaRPzWQZ8g==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1308,8 +1308,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-tool-lib": {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
@@ -26,7 +26,8 @@
   "overrides": {
     "serialize-javascript": "^7.0.0",
     "diff": "^8.0.3",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/package-lock.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/package-lock.json
@@ -1169,12 +1169,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/package.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/package.json
@@ -23,7 +23,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformDocs/TerraformDocsV1/package-lock.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/package-lock.json
@@ -1124,12 +1124,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Tasks/TerraformDocs/TerraformDocsV1/package.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/package.json
@@ -22,7 +22,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
@@ -1138,12 +1138,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
@@ -25,7 +25,8 @@
   "overrides": {
     "serialize-javascript": "^7.0.0",
     "diff": "^8.0.3",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/package-lock.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/package-lock.json
@@ -1167,12 +1167,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1282,9 +1282,9 @@
       "license": "Python-2.0"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha512-VaVvVaPe0ysvxGE10QysbEHuxL480kVDQvKjGd2gtO1eRY4/SkQKfAZrP6lLUAAgYMGk6eifl0I3kaRPzWQZ8g==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1292,8 +1292,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4517,16 +4516,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
@@ -23,7 +23,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -1169,12 +1169,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1284,9 +1284,9 @@
       "license": "Python-2.0"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha512-6Wak5UB+Bs693LkPoE4gZTDNkNL5DDn2buQKMtvqIWh2ZCIJk+tc1nSzroGWntJa7USs8X3cYvdl0RiSsp4/5A==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1294,8 +1294,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-tool-lib": {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -26,7 +26,8 @@
   "overrides": {
     "serialize-javascript": "^7.0.0",
     "diff": "^8.0.3",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/package-lock.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/package-lock.json
@@ -1166,12 +1166,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1281,9 +1281,9 @@
       "license": "Python-2.0"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha512-VaVvVaPe0ysvxGE10QysbEHuxL480kVDQvKjGd2gtO1eRY4/SkQKfAZrP6lLUAAgYMGk6eifl0I3kaRPzWQZ8g==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1291,8 +1291,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4511,16 +4510,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
@@ -22,7 +22,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package-lock.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package-lock.json
@@ -1166,12 +1166,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1281,9 +1281,9 @@
       "license": "Python-2.0"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha512-VaVvVaPe0ysvxGE10QysbEHuxL480kVDQvKjGd2gtO1eRY4/SkQKfAZrP6lLUAAgYMGk6eifl0I3kaRPzWQZ8g==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1291,8 +1291,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4501,16 +4500,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package.json
@@ -23,7 +23,8 @@
   "overrides": {
     "serialize-javascript": "^7.0.0",
     "diff": "^8.0.3",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package-lock.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package-lock.json
@@ -1166,12 +1166,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1281,9 +1281,9 @@
       "license": "Python-2.0"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha512-VaVvVaPe0ysvxGE10QysbEHuxL480kVDQvKjGd2gtO1eRY4/SkQKfAZrP6lLUAAgYMGk6eifl0I3kaRPzWQZ8g==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1291,8 +1291,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4511,16 +4510,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package.json
@@ -22,7 +22,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroyFailurePublishSummaryExitCodePreserved.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroyFailurePublishSummaryExitCodePreserved.ts
@@ -4,19 +4,13 @@ import path = require('path');
 import os = require('os');
 import crypto = require('crypto');
 
-// Pin the first crypto.randomUUID() call (the -out planfile path) so the mock
-// exec answers below can match the exact command line -- see
-// AzureDestroySuccessPublishSummary.ts for the full rationale.
+// Pin crypto.randomUUID() to a fixed value for EVERY call (not just the
+// first) so the mock exec answers below can match the exact command line --
+// call-order-independent, see AzureDestroySuccessPublishSummary.ts for the
+// full rationale (azure-pipelines-task-lib's own Vault also calls
+// randomUUID() before task code runs).
 const FIXED_UUID = 'dddddddd-0000-4000-8000-000000000004';
-const realRandomUUID = crypto.randomUUID.bind(crypto);
-let usedFixed = false;
-(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (...args: unknown[]): string => {
-    if (!usedFixed) {
-        usedFixed = true;
-        return FIXED_UUID;
-    }
-    return (realRandomUUID as (...a: unknown[]) => string)(...args);
-};
+(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (): string => FIXED_UUID;
 
 const planFilePath = path.join(os.tmpdir(), `terraform-destroy-${FIXED_UUID}.tfplan`);
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessPublishSummary.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessPublishSummary.ts
@@ -7,20 +7,16 @@ import crypto = require('crypto');
 // destroy()'s structured-summary path adds `-out=<planfile>` to the destroy
 // command and later runs `terraform show -json <planfile>` on the SAME path
 // (mirroring plan()'s AzurePlanSuccessPublishSummary.ts), so the mock exec
-// answers below must know that path ahead of time. Pin the first
-// crypto.randomUUID() call (the -out planfile path) and let every later call
-// (the digest attachment's own random filename) fall through to the real
-// implementation.
+// answers below must know that path ahead of time. Pin crypto.randomUUID() to
+// a fixed value for EVERY call (not just the first) -- call-order-independent,
+// because azure-pipelines-task-lib >=5.276 also calls crypto.randomUUID()
+// internally (Vault.genKey(), constructed before task code runs) against this
+// same process-wide crypto module. The digest attachment's own random
+// filename reuses the same fixed value too, which is harmless (different
+// filename prefix/suffix, no path collision; the test never asserts the
+// temp path).
 const FIXED_UUID = 'cccccccc-0000-4000-8000-000000000003';
-const realRandomUUID = crypto.randomUUID.bind(crypto);
-let usedFixed = false;
-(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (...args: unknown[]): string => {
-    if (!usedFixed) {
-        usedFixed = true;
-        return FIXED_UUID;
-    }
-    return (realRandomUUID as (...a: unknown[]) => string)(...args);
-};
+(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (): string => FIXED_UUID;
 
 const planFilePath = path.join(os.tmpdir(), `terraform-destroy-${FIXED_UUID}.tfplan`);
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanPublishSummaryNameInjectionRejected.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanPublishSummaryNameInjectionRejected.ts
@@ -4,19 +4,13 @@ import path = require('path');
 import os = require('os');
 import crypto = require('crypto');
 
-// Pin the first crypto.randomUUID() call (the -out planfile path) so the mock
-// exec answers below can match the exact command line -- see
-// AzurePlanSuccessPublishSummary.ts for the full rationale.
+// Pin crypto.randomUUID() to a fixed value for EVERY call (not just the
+// first) so the mock exec answers below can match the exact command line --
+// call-order-independent, see AzurePlanSuccessPublishSummary.ts for the full
+// rationale (azure-pipelines-task-lib's own Vault also calls randomUUID()
+// before task code runs).
 const FIXED_UUID = 'bbbbbbbb-0000-4000-8000-000000000002';
-const realRandomUUID = crypto.randomUUID.bind(crypto);
-let usedFixed = false;
-(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (...args: unknown[]): string => {
-    if (!usedFixed) {
-        usedFixed = true;
-        return FIXED_UUID;
-    }
-    return (realRandomUUID as (...a: unknown[]) => string)(...args);
-};
+(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (): string => FIXED_UUID;
 
 const planFilePath = path.join(os.tmpdir(), `terraform-plan-${FIXED_UUID}.tfplan`);
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessPublishSummary.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/Azure/AzurePlanSuccessPublishSummary.ts
@@ -6,21 +6,17 @@ import crypto = require('crypto');
 
 // The structured plan-summary path adds `-out=<planfile>` to the plan command
 // and later runs `terraform show -json <planfile>` on the SAME path, so the
-// mock exec answers below must know that path ahead of time. base-terraform-
-// command-handler.ts's plan() makes exactly ONE crypto.randomUUID() call
-// before invoking terraform (the -out planfile path); pin that first call to a
-// fixed value and let every later call (the digest attachment's own random
-// filename) fall through to the real implementation.
+// mock exec answers below must know that path ahead of time. Pin
+// crypto.randomUUID() to a fixed value for EVERY call (not just the first) --
+// call-order-independent, because azure-pipelines-task-lib >=5.276 also calls
+// crypto.randomUUID() internally (Vault.genKey(), constructed before task code
+// runs) against this same process-wide crypto module, so "first call" is not
+// reliably the task's own -out planfile call. The digest attachment's own
+// random filename reuses the same fixed value too, which is harmless: it gets
+// a different filename prefix/suffix, so there is no path collision, and the
+// test only asserts the attachment's logical name/content, never its temp path.
 const FIXED_UUID = 'aaaaaaaa-0000-4000-8000-000000000001';
-const realRandomUUID = crypto.randomUUID.bind(crypto);
-let usedFixed = false;
-(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (...args: unknown[]): string => {
-    if (!usedFixed) {
-        usedFixed = true;
-        return FIXED_UUID;
-    }
-    return (realRandomUUID as (...a: unknown[]) => string)(...args);
-};
+(crypto as unknown as { randomUUID: (...a: unknown[]) => string }).randomUUID = (): string => FIXED_UUID;
 
 const planFilePath = path.join(os.tmpdir(), `terraform-plan-${FIXED_UUID}.tfplan`);
 

--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -1433,12 +1433,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha512-6Wak5UB+Bs693LkPoE4gZTDNkNL5DDn2buQKMtvqIWh2ZCIJk+tc1nSzroGWntJa7USs8X3cYvdl0RiSsp4/5A==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1613,18 +1613,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-tasks-artifacts-common": {

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -27,7 +27,8 @@
     "serialize-javascript": "^7.0.0",
     "diff": "^8.0.3",
     "@babel/core": "^7.29.7",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "adm-zip": "^0.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",


### PR DESCRIPTION
Refreshes 7 stale package-lock.json resolutions to azure-pipelines-task-lib 5.277.0 (drops the uuid dep, eliminating moderate GHSA-w5hq-g745-h8pq for task-lib-only tasks) and adds an `overrides` entry forcing adm-zip ^0.6.0 in all 11 tasks — every published task-lib declares vulnerable adm-zip ^0.5.10 (HIGH GHSA-xcpc-8h2w-3j85, published 2026-07-10, no fixed release) yet ships no file requiring it, so the override is runtime-inert and un-reds the `npm audit --audit-level=high` CI gate that this advisory broke on main. Four V5 publish-summary test fixtures are made call-order-independent (task-lib >=5.276 Vault.genKey() consumes the first crypto.randomUUID() call their old first-call-only stubs relied on).

Residual: the moderate uuid advisory remains in the 3 azure-pipelines-tool-lib tasks (no fixed tool-lib release). The threshold rationale and this remediation are documented in SECURITY.md in the companion PR from fix/audit-0717-ci (this branch deliberately touches no docs).

All 11 tasks: npm ci + compile + test green; npm audit --omit=dev --audit-level=high clean. Supports #596.