### PR TITLE
fix: override adm-zip at the repo root to clear the full-tree audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2231,12 +2231,13 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-            "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+            "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=12.0"
+                "node": ">=14.0"
             }
         },
         "node_modules/agent-base": {
@@ -12366,9 +12367,9 @@
             "requires": {}
         },
         "adm-zip": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-            "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+            "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
             "dev": true
         },
         "agent-base": {
@@ -12632,7 +12633,7 @@
             "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
             "dev": true,
             "requires": {
-                "adm-zip": "^0.5.10",
+                "adm-zip": "^0.6.0",
                 "minimatch": "^3.1.5",
                 "nodejs-file-downloader": "^4.11.1",
                 "q": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "@babel/core": "^7.29.7",
         "underscore": "^1.13.8",
         "semver": "^7.8.5",
-        "js-yaml": "^4.2.0"
+        "js-yaml": "^4.2.0",
+        "adm-zip": "^0.6.0"
     }
 }


### PR DESCRIPTION
Companion to #614: the root dev toolchain (task-lib/tool-lib via the tab/test harness) carries the same adm-zip HIGH (GHSA-xcpc-8h2w-3j85, no fixed SDK release), and Build and Test Tab's root `npm audit --audit-level=high` (full tree) went red on main when the advisory data updated. Adds the identical runtime-inert `overrides` entry at the root. Verified locally: root audit at high now exits clean (one pre-existing documented moderate remains).