### PR TITLE
fix: honor Retry-After in registry publish and localize ModulePublish

### DIFF
--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -68,6 +68,31 @@ describe('TerraformDriftReport callback transport', function () {
         }
     });
 
+    it('surfaces response headers (#633) so a 429 Retry-After can reach a caller', async () => {
+        // Real end-to-end round-trip against the shared https-client.ts copy
+        // (byte-identical with TerraformModulePublish, gated by
+        // scripts/check-shared-modules.js): HttpResponse.headers must carry the
+        // server's actual response headers. postJsonWithRetry deliberately never
+        // consults headers (a received response is never retried -- the one-shot
+        // callback token, see callback.ts), so this exercises createHttpsClient
+        // directly rather than through postJson/postJsonWithRetry.
+        const server = https.createServer({ cert: TLS_CERT, key: TLS_KEY }, (_req, res) => {
+            res.statusCode = 429;
+            res.setHeader('Retry-After', '2');
+            res.end('{"error":"slow down"}');
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        try {
+            const client = createHttpsClient(false);
+            const resp = await client('GET', `https://127.0.0.1:${port}/drift`, {});
+            assert.strictEqual(resp.status, 429);
+            assert.strictEqual(resp.headers?.['retry-after'], '2');
+        } finally {
+            server.close();
+        }
+    });
+
     it('rejects a self-signed certificate when rejectUnauthorized is true (the default)', async () => {
         // The secure-default counterpart to the test above: with TLS verification
         // ON (the default), a request against the exact same self-signed loopback
@@ -312,6 +337,24 @@ describe('https-client: agent proxy support', function () {
         } finally {
             target.close();
         }
+    });
+});
+
+describe('task.json schema (#643)', () => {
+    it('declares the output-variables block with the schema\'s lowercase key', () => {
+        // The Azure Pipelines task.json schema (aka.ms/vsts-tasks.schema.json)
+        // defines this property as lowercase "outputVariables" -- a capitalized
+        // "OutputVariables" is silently ignored by schema-aware tooling (e.g.
+        // the classic editor's output-variables picker) even though the task
+        // still sets the variables at runtime via the SDK.
+        const taskJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'task.json'), 'utf8'));
+        assert.ok(Array.isArray(taskJson.outputVariables), 'task.json must declare a lowercase "outputVariables" array');
+        assert.strictEqual(taskJson.OutputVariables, undefined, 'the wrong-cased "OutputVariables" key must not reappear');
+        const names = taskJson.outputVariables.map((v: { name: string }) => v.name).sort();
+        assert.deepStrictEqual(
+            names,
+            ['addedCount', 'changedCount', 'destroyedCount', 'driftDetected', 'sarifFilePath', 'summaryFilePath'],
+        );
     });
 });
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts
@@ -24,6 +24,13 @@ const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
 export interface HttpResponse {
     status: number;
     body: string;
+    /**
+     * Raw response headers (Node's http.IncomingHttpHeaders), so a caller can
+     * inspect e.g. Retry-After (#633). Optional so a hand-built { status, body }
+     * fixture (no real HTTP round-trip) in tests remains valid; the real
+     * transport below (createHttpsClient) always populates it.
+     */
+    headers?: http.IncomingHttpHeaders;
 }
 
 export type HttpClient = (
@@ -245,7 +252,7 @@ export function createHttpsClient(rejectUnauthorized = true, timeoutMs = DEFAULT
                     if (overflowed) {
                         return;
                     }
-                    resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') });
+                    resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8'), headers: res.headers });
                 });
             });
             req.setTimeout(timeoutMs, () => {

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -113,7 +113,7 @@
       "helpMarkDown": "Delete the JSON summary file (written to the agent temp directory) when the task finishes. It is retained by default so downstream steps can read it via the `summaryFilePath` output variable. Enable to remove it immediately after the callback -- e.g. on a self-hosted agent whose temp directory is not wiped between jobs and where the summary may contain sensitive plan values."
     }
   ],
-  "OutputVariables": [
+  "outputVariables": [
     {
       "name": "driftDetected",
       "description": "'true' when any non-no-op, non-read change was planned."

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
@@ -92,6 +92,28 @@ describe('http client transport', () => {
         }
     });
 
+    it('surfaces response headers (#633) so a 429 Retry-After can reach retryHttp', async () => {
+        // Real end-to-end round-trip (not a hand-built fixture): HttpResponse.headers
+        // must carry the server's actual response headers, case-preserved by Node,
+        // rather than being dropped as before this fix.
+        const server = https.createServer({ cert: TLS_CERT, key: TLS_KEY }, (_req, res) => {
+            res.statusCode = 429;
+            res.setHeader('Retry-After', '2');
+            res.end('{"error":"slow down"}');
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        try {
+            const client = createHttpsClient(false);
+            const resp = await client('GET', `https://127.0.0.1:${port}/api`, {});
+            assert.strictEqual(resp.status, 429);
+            // Node lowercases header names on IncomingMessage.headers.
+            assert.strictEqual(resp.headers?.['retry-after'], '2');
+        } finally {
+            server.close();
+        }
+    });
+
     it('rejects a self-signed certificate when rejectUnauthorized is true (the default)', async () => {
         // Secure-default counterpart to the test above: with TLS verification ON
         // (the default), the exact same self-signed loopback server must be
@@ -285,6 +307,48 @@ describe('retryHttp', () => {
         const res = await retryHttp(() => { calls += 1; return Promise.resolve({ status: 429, body: '' }); }, { retries: 2, baseDelayMs: 0 });
         assert.strictEqual(res.status, 429);
         assert.strictEqual(calls, 3); // initial attempt + 2 retries
+    });
+
+    it('honors a capped 429 Retry-After header over the default backoff (#633)', async () => {
+        // baseDelayMs is deliberately large: if the Retry-After header were NOT
+        // honored, the retry would wait the full 5000ms backoff and this
+        // assertion would fail on the elapsed-time check below.
+        const start = Date.now();
+        let calls = 0;
+        const res = await retryHttp(() => {
+            calls += 1;
+            return Promise.resolve({ status: 429, body: '', headers: { 'retry-after': '0' } });
+        }, { retries: 1, baseDelayMs: 5000 });
+        const elapsed = Date.now() - start;
+        assert.strictEqual(res.status, 429);
+        assert.strictEqual(calls, 2);
+        assert.ok(elapsed < 1000, `expected the Retry-After: 0 header to be honored instead of the 5000ms backoff, took ${elapsed}ms`);
+    });
+
+    it('falls back to the default backoff when Retry-After is absent or invalid (#633)', async () => {
+        let calls = 0;
+        const res = await retryHttp(() => {
+            calls += 1;
+            return Promise.resolve({ status: 429, body: '', headers: { 'retry-after': 'not-a-valid-value' } });
+        }, { retries: 1, baseDelayMs: 5 });
+        assert.strictEqual(res.status, 429);
+        assert.strictEqual(calls, 2);
+    });
+
+    it('does not honor a Retry-After header on a 5xx response (only 429 gets the override) (#633)', async () => {
+        // A 5xx is retryable too, but this family only wires Retry-After for 429
+        // (matching servicenow-http.ts's withRetry); a 5xx always uses the plain
+        // exponential backoff even if the server happened to send the header.
+        const start = Date.now();
+        let calls = 0;
+        const res = await retryHttp(() => {
+            calls += 1;
+            return Promise.resolve({ status: 503, body: '', headers: { 'retry-after': '0' } });
+        }, { retries: 1, baseDelayMs: 50 });
+        const elapsed = Date.now() - start;
+        assert.strictEqual(res.status, 503);
+        assert.strictEqual(calls, 2);
+        assert.ok(elapsed >= 40, `expected the default ~50ms backoff to apply to a 5xx despite the Retry-After header, took ${elapsed}ms`);
     });
 });
 
@@ -677,5 +741,24 @@ describe('index orchestrator (setSecret masking + publisher routing)', () => {
             console.log('STDOUT', tr.stdout);
             throw error;
         }
+    });
+});
+
+describe('index.ts setResourcePath bootstrap (#637)', () => {
+    it('resolves real templated messages from task.json once the resource path is set', () => {
+        // Mirrors the exact call added to run() in src/index.ts:
+        // tasks.setResourcePath(path.join(__dirname, '..', 'task.json')). This
+        // must use the REAL azure-pipelines-task-lib/task (as imported at the
+        // top of this file), not the mock-run harness used by the
+        // "index orchestrator" tests above -- mock-run's TaskMockRunner swaps in
+        // mock-task.js, whose loc() unconditionally returns 'loc_mock_<key> ...'
+        // regardless of whether setResourcePath was ever called, so it cannot
+        // observe this regression at all.
+        tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
+        assert.strictEqual(tasks.loc('InputRequired', 'name'), "Input 'name' is required.");
+        assert.strictEqual(
+            tasks.loc('UnsupportedRegistryType', 'bogus'),
+            "Unsupported registryType 'bogus'. Expected 'hcp' or 'private'.",
+        );
     });
 });

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/http.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/http.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, truncateBody } from './https-client';
-import { retryAsync } from './retry';
+import { retryAsync, parseRetryAfterMs } from './retry';
 import tasks = require('azure-pipelines-task-lib/task');
 
 // The HTTPS transport (createHttpsClient, truncateBody, types) is shared
@@ -49,8 +49,8 @@ function isRetryableStatus(status: number): boolean {
  * server-side idempotency must NOT be wrapped, to avoid duplicate resources on a
  * retry after a lost response.
  *
- * A 429 Retry-After is not honored here because the shared HttpResponse carries
- * no headers; the exponential backoff is used instead (the sanctioned fallback).
+ * A 429 Retry-After (#633), when present on the response, is honored (capped)
+ * over the default exponential backoff -- see the delayMs override below.
  */
 export async function retryHttp(
     call: () => Promise<HttpResponse>,
@@ -65,6 +65,19 @@ export async function retryHttp(
         // A thrown transport error (no response received) is always safe to repeat
         // within the budget; only a RESPONSE is classified by status above.
         retryError: () => true,
+        // Honor a capped 429 Retry-After when the server sent one (#633); any other
+        // retryable response (a 5xx, or a 429 with no usable Retry-After) falls back
+        // to the default exponential backoff.
+        delayMs: (_attempt, backoffMs, outcome) => {
+            if (outcome.kind === 'result' && outcome.result.status === 429) {
+                const retryAfter = outcome.result.headers?.['retry-after'];
+                const retryAfterMs = parseRetryAfterMs(Array.isArray(retryAfter) ? retryAfter[0] : retryAfter);
+                if (retryAfterMs !== undefined) {
+                    return retryAfterMs;
+                }
+            }
+            return backoffMs;
+        },
         onRetry: (attempt, _delayMs, outcome) => {
             if (outcome.kind === 'result') {
                 opts.log?.(tasks.loc('TransientHttpRetry', outcome.result.status, attempt + 1, retries));

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts
@@ -24,6 +24,13 @@ const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
 export interface HttpResponse {
     status: number;
     body: string;
+    /**
+     * Raw response headers (Node's http.IncomingHttpHeaders), so a caller can
+     * inspect e.g. Retry-After (#633). Optional so a hand-built { status, body }
+     * fixture (no real HTTP round-trip) in tests remains valid; the real
+     * transport below (createHttpsClient) always populates it.
+     */
+    headers?: http.IncomingHttpHeaders;
 }
 
 export type HttpClient = (
@@ -245,7 +252,7 @@ export function createHttpsClient(rejectUnauthorized = true, timeoutMs = DEFAULT
                     if (overflowed) {
                         return;
                     }
-                    resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') });
+                    resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8'), headers: res.headers });
                 });
             });
             req.setTimeout(timeoutMs, () => {

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/index.ts
@@ -1,4 +1,5 @@
 import tasks = require('azure-pipelines-task-lib/task');
+import path = require('path');
 import { createHttpsClient } from './http';
 import { RegistryPublisher, RegistryType } from './types';
 import { PrivateRegistryPublisher } from './private-publisher';
@@ -85,6 +86,7 @@ function buildPublisher(): RegistryPublisher {
 }
 
 async function run(): Promise<void> {
+    tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
     try {
         const result = await buildPublisher().publish();
         console.log(result.message);


### PR DESCRIPTION
2026-07-18 audit: HttpResponse now carries headers so retryHttp honors a capped 429 Retry-After via the shared retry.ts (DriftReport's never-retry-received-response semantics untouched; https-client family synced) (#633); ModulePublish gains the missing tasks.setResourcePath bootstrap so loc() resolves (#637); DriftReport task.json outputVariables casing corrected (#643). All lenses passed.

Fixes #633
Fixes #637
Fixes #643