### PR TITLE
fix: escape Sentinel HCL filenames and add terraform-docs arg terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Installs a policy engine — **OPA** (sha256-verified binary from the `open-poli
 
 Evaluates **OPA** or **Sentinel** policies against Terraform plan JSON (`terraform show -json` output) and gates the pipeline on the result.
 
+> **Note:** Sentinel here runs as a standalone CLI, not inside HCP Terraform/Terraform Enterprise. Policies see the **raw** `terraform show -json` document, not HCP Terraform's `tfplan/v2` mock, and `enforcement_level` is applied by this task (see `defaultEnforcementLevel`/`overrideSoftMandatory` below), not natively enforced by the CLI. An existing HCP Terraform Sentinel policy set will likely need adapting before it works here — see [docs/troubleshooting.md](docs/troubleshooting.md#sentinel-policies-written-for-hcp-terraform-dont-work).
+
 | Input                     | Default          | Description                                                                                               |
 | ------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
 | `engine`                  | `opa`            | `opa` or `sentinel`.                                                                                      |

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/AdditionalArgsSuccess.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/AdditionalArgsSuccess.ts
@@ -2,7 +2,10 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-// Free-form additional arguments are appended verbatim after the built arguments.
+// Free-form additional arguments are appended verbatim after the built flag
+// arguments but BEFORE the `--` module-path terminator, so a flag carried in
+// additionalArgs (e.g. --hide-empty) is still parsed as a flag rather than
+// being swallowed as an extra positional after `--` (#661).
 const tp = path.join(__dirname, '..', 'src', 'index.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
@@ -14,7 +17,7 @@ const a: ma.TaskLibAnswers = {
   which: { 'terraform-docs': 'terraform-docs' },
   checkPath: { 'terraform-docs': true },
   exec: {
-    'terraform-docs markdown table . --hide-empty': {
+    'terraform-docs markdown table --hide-empty -- .': {
       code: 0,
       stdout: 'ok'
     }

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ArgsBuilderL0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ArgsBuilderL0.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
-import { resolveFormatter, buildTerraformDocsArgs, sanitizeConfigFile, StatLike, StatSyncFn, TerraformDocsConfig } from '../src/args-builder';
+import { resolveFormatter, buildTerraformDocsArgs, buildModulePathArgs, sanitizeConfigFile, StatLike, StatSyncFn, TerraformDocsConfig } from '../src/args-builder';
 
 // Direct (parent-process) unit tests for the pure argument-building logic. These
 // cover every formatter mapping and flag branch that the MockTestRunner integration
@@ -34,67 +34,63 @@ describe('args-builder: resolveFormatter', () => {
 describe('args-builder: buildTerraformDocsArgs', () => {
   const base: TerraformDocsConfig = { formatter: 'markdown-table', modulePath: '.' };
 
-  it('emits the formatter tokens and the positional module path', () => {
-    assert.deepStrictEqual(buildTerraformDocsArgs(base), ['markdown', 'table', '.']);
-  });
-
-  it('defaults the module path to "." when empty', () => {
-    assert.deepStrictEqual(buildTerraformDocsArgs({ formatter: 'json', modulePath: '' }), ['json', '.']);
+  it('emits only the formatter tokens (module path is built separately)', () => {
+    assert.deepStrictEqual(buildTerraformDocsArgs(base), ['markdown', 'table']);
   });
 
   it('includes the config file when set', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, configFile: '.terraform-docs.yml' }),
-      ['markdown', 'table', '--config', '.terraform-docs.yml', '.']
+      ['markdown', 'table', '--config', '.terraform-docs.yml']
     );
   });
 
   it('includes output-file and output-mode', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, outputFile: 'README.md', outputMode: 'inject' }),
-      ['markdown', 'table', '--output-file', 'README.md', '--output-mode', 'inject', '.']
+      ['markdown', 'table', '--output-file', 'README.md', '--output-mode', 'inject']
     );
   });
 
   it('omits output-mode when there is no output file', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, outputMode: 'replace' }),
-      ['markdown', 'table', '.']
+      ['markdown', 'table']
     );
   });
 
   it('adds --output-check', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, outputFile: 'README.md', outputCheck: true }),
-      ['markdown', 'table', '--output-file', 'README.md', '--output-check', '.']
+      ['markdown', 'table', '--output-file', 'README.md', '--output-check']
     );
   });
 
   it('adds --sort-by when not the default ordering', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, sortBy: 'required' }),
-      ['markdown', 'table', '--sort-by', 'required', '.']
+      ['markdown', 'table', '--sort-by', 'required']
     );
   });
 
   it('omits --sort-by for the default ordering', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, sortBy: 'default' }),
-      ['markdown', 'table', '.']
+      ['markdown', 'table']
     );
   });
 
   it('adds --recursive and --recursive-path', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, recursive: true, recursivePath: 'modules' }),
-      ['markdown', 'table', '--recursive', '--recursive-path', 'modules', '.']
+      ['markdown', 'table', '--recursive', '--recursive-path', 'modules']
     );
   });
 
   it('adds --recursive without a submodule path', () => {
     assert.deepStrictEqual(
       buildTerraformDocsArgs({ ...base, recursive: true }),
-      ['markdown', 'table', '--recursive', '.']
+      ['markdown', 'table', '--recursive']
     );
   });
 
@@ -111,8 +107,29 @@ describe('args-builder: buildTerraformDocsArgs', () => {
         recursive: true,
         recursivePath: 'submodules',
       }),
-      ['asciidoc', 'document', '--config', 'cfg.yml', '--output-file', 'README.adoc', '--output-mode', 'replace', '--output-check', '--sort-by', 'type', '--recursive', '--recursive-path', 'submodules', './modules/vpc']
+      ['asciidoc', 'document', '--config', 'cfg.yml', '--output-file', 'README.adoc', '--output-mode', 'replace', '--output-check', '--sort-by', 'type', '--recursive', '--recursive-path', 'submodules']
     );
+  });
+});
+
+describe('args-builder: buildModulePathArgs', () => {
+  it('emits a `--` terminator before the module path', () => {
+    assert.deepStrictEqual(buildModulePathArgs('.'), ['--', '.']);
+  });
+
+  it('defaults the module path to "." when empty', () => {
+    assert.deepStrictEqual(buildModulePathArgs(''), ['--', '.']);
+  });
+
+  it('defaults the module path to "." when undefined', () => {
+    assert.deepStrictEqual(buildModulePathArgs(undefined), ['--', '.']);
+  });
+
+  it('rejects a modulePath being misparsed as a flag by preceding it with -- (regression for #661)', () => {
+    // Empirically verified against terraform-docs v0.24.0: `markdown table
+    // -weird` fails with "unknown shorthand flag: 'w' in -weird", while
+    // `markdown table -- -weird` succeeds.
+    assert.deepStrictEqual(buildModulePathArgs('-weird'), ['--', '-weird']);
   });
 });
 
@@ -182,6 +199,6 @@ describe('args-builder: sanitizeConfigFile', () => {
     const configFile = sanitizeConfigFile('/agent/_work/1/s', statAs(asDir));
     const args = buildTerraformDocsArgs({ formatter: 'markdown-table', modulePath: '/agent/_work/1/s', configFile });
     assert.ok(!args.includes('--config'), 'no --config should be emitted for the directory artifact');
-    assert.deepStrictEqual(args, ['markdown', 'table', '/agent/_work/1/s']);
+    assert.deepStrictEqual(args, ['markdown', 'table']);
   });
 });

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileDirectoryIgnored.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileDirectoryIgnored.ts
@@ -19,7 +19,7 @@ const a: ma.TaskLibAnswers = {
   which: { 'terraform-docs': 'terraform-docs' },
   checkPath: { 'terraform-docs': true },
   exec: {
-    'terraform-docs markdown table .': {
+    'terraform-docs markdown table -- .': {
       code: 0,
       stdout: 'generated'
     }

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileProvidedSuccess.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConfigFileProvidedSuccess.ts
@@ -18,7 +18,7 @@ const a: ma.TaskLibAnswers = {
   which: { 'terraform-docs': 'terraform-docs' },
   checkPath: { 'terraform-docs': true },
   exec: {
-    [`terraform-docs markdown table --config ${existingFile} .`]: {
+    [`terraform-docs markdown table --config ${existingFile} -- .`]: {
       code: 0,
       stdout: 'generated'
     }

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConsoleOutputSuccess.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ConsoleOutputSuccess.ts
@@ -13,7 +13,7 @@ const a: ma.TaskLibAnswers = {
   which: { 'terraform-docs': 'terraform-docs' },
   checkPath: { 'terraform-docs': true },
   exec: {
-    'terraform-docs json .': {
+    'terraform-docs json -- .': {
       code: 0,
       stdout: '{}'
     }

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/GenerateMarkdownSuccess.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/GenerateMarkdownSuccess.ts
@@ -14,7 +14,7 @@ const a: ma.TaskLibAnswers = {
   which: { 'terraform-docs': 'terraform-docs' },
   checkPath: { 'terraform-docs': true },
   exec: {
-    'terraform-docs markdown table --output-file README.md --output-mode inject .': {
+    'terraform-docs markdown table --output-file README.md --output-mode inject -- .': {
       code: 0,
       stdout: 'generated'
     }

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/OutputCheckFail.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/OutputCheckFail.ts
@@ -16,7 +16,7 @@ const a: ma.TaskLibAnswers = {
   which: { 'terraform-docs': 'terraform-docs' },
   checkPath: { 'terraform-docs': true },
   exec: {
-    'terraform-docs markdown table --output-file README.md --output-check .': {
+    'terraform-docs markdown table --output-file README.md --output-check -- .': {
       code: 1,
       stdout: 'README.md is out of date'
     }

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
@@ -111,9 +111,14 @@ export function sanitizeConfigFile(raw: string | undefined | null, statSync: Sta
 }
 
 /**
- * Builds the ordered terraform-docs argument list (excluding the binary itself and
- * any free-form additional arguments) for the given configuration. The module path
- * is emitted last as the positional argument terraform-docs scans.
+ * Builds the ordered terraform-docs *flag* argument list (excluding the binary
+ * itself, the trailing module-path positional, and any free-form additional
+ * arguments) for the given configuration.
+ *
+ * The module path is intentionally NOT included here -- see
+ * `buildModulePathArgs`. It must be appended last, after any `additionalArgs`
+ * the caller interposes, so a `--` terminator can precede it without also
+ * swallowing flags from `additionalArgs` as extra positionals.
  */
 export function buildTerraformDocsArgs(config: TerraformDocsConfig): string[] {
     const args = resolveFormatter(config.formatter);
@@ -140,6 +145,26 @@ export function buildTerraformDocsArgs(config: TerraformDocsConfig): string[] {
         }
     }
 
-    args.push(config.modulePath && config.modulePath.length > 0 ? config.modulePath : '.');
     return args;
+}
+
+/**
+ * Returns the trailing terraform-docs positional-path tokens: a `--` option
+ * terminator followed by the module path (defaulting to `.`).
+ *
+ * `--` stops terraform-docs' (cobra/pflag) option-parsing before the
+ * positional, so a modulePath beginning with `-` (e.g. a literal `-weird`
+ * directory name) can never be misparsed as a flag -- verified empirically
+ * against terraform-docs v0.24.0 (`-weird` alone fails with "unknown
+ * shorthand flag"; `-- -weird` succeeds). Matches the `--` discipline
+ * policy-source.ts uses before its own url/dir positionals.
+ *
+ * Callers MUST append this last -- after `buildTerraformDocsArgs`'s flags
+ * AND after any free-form `additionalArgs` -- because once terraform-docs
+ * sees `--` it stops parsing flags for the rest of the command line: a flag
+ * placed after this terminator would be treated as a second positional and
+ * rejected ("accepts 1 arg(s), received 2"), rather than parsed as a flag.
+ */
+export function buildModulePathArgs(modulePath: string | undefined): string[] {
+    return ['--', modulePath && modulePath.length > 0 ? modulePath : '.'];
 }

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
@@ -2,7 +2,7 @@ import tasks = require('azure-pipelines-task-lib/task');
 import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
 import fs = require('fs');
 import path = require('path');
-import { buildTerraformDocsArgs, sanitizeConfigFile, TerraformDocsConfig } from './args-builder';
+import { buildTerraformDocsArgs, buildModulePathArgs, sanitizeConfigFile, TerraformDocsConfig } from './args-builder';
 
 async function run() {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
@@ -30,9 +30,16 @@ async function run() {
             toolRunner.arg(arg);
         }
 
+        // additionalArgs is interposed here -- before the `--` module-path
+        // terminator below -- so any flags it carries are still parsed as
+        // flags rather than being swallowed as extra positionals.
         const additionalArgs = tasks.getInput('additionalArgs', false);
         if (additionalArgs) {
             toolRunner.line(additionalArgs);
+        }
+
+        for (const arg of buildModulePathArgs(config.modulePath)) {
+            toolRunner.arg(arg);
         }
 
         // ignoreReturnCode lets us surface a precise message. terraform-docs exits

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/HclEscapeL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/HclEscapeL0.ts
@@ -9,10 +9,12 @@ import { hcl } from '../src/sentinel-engine';
 // identifier syntax (unlike sentinelImportName): legitimate filenames commonly use
 // dashes (e.g. require-tags.sentinel, deny-public.sentinel -- both used by other
 // fixtures in this suite). Backslash and double-quote are escaped so the value
-// cannot break out of the quoted string, and `${` / `%{` are escaped to their
-// literal HCL forms (`$${` / `%%{`) so template-interpolation syntax in an
-// untrusted policy filename is reproduced literally instead of evaluated
-// (mirrors TerraformProviderMirror's escapeHclString; #553 sibling).
+// cannot break out of the quoted string, `${` / `%{` are escaped to their literal
+// HCL forms (`$${` / `%%{`) so template-interpolation syntax in an untrusted
+// policy filename is reproduced literally instead of evaluated, and CR/LF are
+// escaped to a literal `\n` so an embedded newline (valid in a filename on
+// Linux/macOS) can't produce a raw multi-line string (mirrors
+// TerraformProviderMirror's escapeHclString; #553 sibling, #648).
 describe('hcl() escaping for policy names and paths', () => {
     it('passes common filename characters through unchanged', () => {
         assert.strictEqual(hcl('require-tags'), 'require-tags');
@@ -22,7 +24,7 @@ describe('hcl() escaping for policy names and paths', () => {
 
     it('escapes an embedded double-quote so it cannot close the HCL string', () => {
         const escaped = hcl('evil" { source = "x" }\npolicy "injected');
-        assert.strictEqual(escaped, 'evil\\" { source = \\"x\\" }\npolicy \\"injected');
+        assert.strictEqual(escaped, 'evil\\" { source = \\"x\\" }\\npolicy \\"injected');
         // Re-embedding the escaped value in a quoted HCL string yields exactly one
         // opening and one closing (unescaped) quote -- the crafted quotes inside no
         // longer terminate the string early.
@@ -51,5 +53,37 @@ describe('hcl() escaping for policy names and paths', () => {
 
     it('doubles an already-doubled opener (input is a literal, not pre-escaped HCL)', () => {
         assert.strictEqual(hcl('$${a}'), '$$${a}');
+    });
+
+    // #648: a hostile policy filename (reachable when policySource=gitUrl points
+    // at a third-party policy repo) can carry a literal newline on Linux/macOS.
+    // Escape CR/LF to a literal `\n` so the generated `policy "<name>" { ... }`
+    // label stays on one well-formed HCL line, mirroring
+    // TerraformProviderMirror's escapeHclString (#553 sibling).
+    it('escapes an embedded LF to a literal \\n (#648)', () => {
+        assert.strictEqual(hcl('evil\npolicy "injected"'), 'evil\\npolicy \\"injected\\"');
+    });
+
+    it('escapes an embedded CRLF to a single literal \\n, not two (#648)', () => {
+        assert.strictEqual(hcl('evil\r\nnext-line'), 'evil\\nnext-line');
+    });
+
+    it('escapes a lone embedded CR to a literal \\n (#648)', () => {
+        assert.strictEqual(hcl('evil\rnext-line'), 'evil\\nnext-line');
+    });
+
+    it('a hostile filename with a newline, quote, and injection attempt renders as one well-formed HCL line (#648)', () => {
+        const hostile = 'evil"\n}\npolicy "injected" {\n  source = "*';
+        const escaped = hcl(hostile);
+
+        // No raw CR/LF survives, and the value stays interpolable on a single line.
+        assert.ok(!/[\r\n]/.test(escaped), 'no raw newline should remain in the escaped value');
+        const rebuilt = `policy "${escaped}" {`;
+        assert.ok(!/[\r\n]/.test(rebuilt), 'the rebuilt HCL policy label must be a single line');
+
+        // Exactly one opening and one closing (unescaped) quote survive -- the
+        // crafted quotes inside no longer terminate the string early.
+        const unescapedQuoteCount = (rebuilt.match(/(?<!\\)"/g) || []).length;
+        assert.strictEqual(unescapedQuoteCount, 2);
     });
 });

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
@@ -168,12 +168,13 @@ export function generateConfig(policyDir: string, inputFile: string, level: stri
         // quoted HCL string label here, not an identifier reference used elsewhere
         // in policy code like the import name above -- legitimate filenames commonly
         // use dashes (e.g. require-tags.sentinel), so it must not be restricted to
-        // identifier syntax. `hcl()` escaping is sufficient to keep it inside the
-        // string: a literal embedded newline is not a silent injection vector either
-        // way, since HCL's quoted-string grammar hard-fails to parse ("Invalid
-        // multi-line string") rather than treating it as a request to close the
-        // string. Reachable when policySource=gitUrl points at a shared/third-party
-        // policy repo whose filenames aren't fully trusted.
+        // identifier syntax. `hcl()` escaping (including CR/LF -> literal `\n`,
+        // #648) keeps the value inside the string on a single line, so a policy
+        // filename containing an embedded newline (reachable when
+        // policySource=gitUrl points at a shared/third-party policy repo whose
+        // filenames aren't fully trusted) renders as a literal `\n` in the label
+        // instead of producing a raw multi-line string that would otherwise hard-fail
+        // sentinel.hcl's parse ("Invalid multi-line string").
         const name = path.basename(policyFile, '.sentinel');
         lines.push(`policy "${hcl(name)}" {`);
         lines.push(`  source = "${hcl(policyFile)}"`);
@@ -200,18 +201,28 @@ export function generateConfig(policyDir: string, inputFile: string, level: stri
  * of the quoted string; `${` and `%{` are escaped to their literal HCL forms
  * (`$${` / `%%{`) so a policy filename carrying template-interpolation syntax
  * (reachable when policySource=gitUrl points at a third-party policy repo) is
- * reproduced literally instead of being evaluated by the HCL parser — matching
- * TerraformProviderMirror's escapeHclString. The `$`/`%` escapes use replacer
- * functions because a plain `'$${'` replacement string would itself be mangled
- * by JS's `$$` substitution rules; they only touch `$`/`%`/`{` and never a
- * backslash, so they cannot interfere with the backslash pass.
+ * reproduced literally instead of being evaluated by the HCL parser; CR/LF are
+ * escaped to a literal `\n` so a policy filename containing an embedded
+ * newline (valid on Linux/macOS) cannot produce a raw multi-line string in the
+ * generated sentinel.hcl — matching TerraformProviderMirror's escapeHclString.
+ * Without this, HCL's quoted-string grammar hard-fails to parse such a value
+ * ("Invalid multi-line string"), which is a fail-closed error rather than a
+ * bypass, but escaping keeps this generator consistent with its sibling and
+ * turns the failure into a normal, literal-string result instead of an opaque
+ * Sentinel parse error (#648). The `$`/`%` escapes use replacer functions
+ * because a plain `'$${'` replacement string would itself be mangled by JS's
+ * `$$` substitution rules; they only touch `$`/`%`/`{` and never a backslash
+ * or newline, so they cannot interfere with the backslash or CR/LF passes.
  */
 export function hcl(value: string): string {
     return value
         .replace(/\\/g, '\\\\')
         .replace(/"/g, '\\"')
         .replace(/\$\{/g, () => '$${')
-        .replace(/%\{/g, () => '%%{');
+        .replace(/%\{/g, () => '%%{')
+        .replace(/\r\n/g, '\\n')
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\n');
 }
 
 function findSentinelPolicies(dir: string): string[] {


### PR DESCRIPTION
2026-07-18 audit: sentinel.hcl generator escapes newlines in policy filenames consistently with sibling escapers (#648); Sentinel-vs-HCP semantics divergence documented per recommendation (#644); terraform-docs args-builder hardened for leading-dash paths (#661). All lenses passed.

Fixes #648
Fixes #644
Fixes #661