### PR TITLE
ci: fix shell quoting in the OpenTofu cosign canary script

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -239,7 +239,7 @@ jobs:
             const content = fs.readFileSync("SHA256SUMS", "utf8");
             const base = "https://github.com/opentofu/opentofu/releases/download/v" + version + "/tofu_" + version + "_SHA256SUMS";
             verifyCosignSignature(content, base + ".sig", base + ".pem", version, true)
-              .then(function () { console.log("OK: OpenTofu cosign signature verified via the installer's own verifier for tofu " + version); })
+              .then(function () { console.log("OK: OpenTofu cosign signature verified via the task-owned verifier for tofu " + version); })
               .catch(function (err) { console.error("OpenTofu cosign canary FAILED: " + (err && err.message ? err.message : err)); process.exit(1); });
           '
 


### PR DESCRIPTION
Hotfix for the red Lint GitHub Actions on main after #669: the upgraded cosign canary's single-quoted `node -e` script contained an apostrophe ("the installer's own verifier") that terminated the shell string (SC1011/SC1072). Message rephrased; scanned all other single-quoted node blocks in the file — this was the only embedded apostrophe. The CodeQL 'configuration not found' on #669 was a merge-ref config-drift artifact of the just-merged security-extended config and self-resolves on main.