### PR TITLE
fix: neutralize ##vso injection in echoed apply @message

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjection.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjection.ts
@@ -22,13 +22,19 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 // embedded newline (a JSON string escape here, not a literal control
 // character in the NDJSON line) followed by content shaped like an ADO
 // logging command. echoApplyMessages must neutralize the leading `##` on
-// the injected physical line rather than echoing it verbatim.
+// the injected physical line rather than echoing it verbatim. Also covers
+// the Unicode line/paragraph separators (U+2028/U+2029), which a plain
+// `\r?\n` split would not treat as a line boundary even though some
+// consoles render them as one -- a real (if narrower) bypass of a
+// `\r?\n`-only split.
 const events = [
     { '@level': 'info', '@message': 'Terraform 1.9.5', '@timestamp': '2026-07-15T00:00:00.000000Z', terraform: '1.9.5', type: 'version' },
     { '@level': 'error', '@message': 'Error: something failed\n##vso[task.setvariable variable=pwned]evil', '@timestamp': '2026-07-15T00:00:01.000000Z', type: 'diagnostic' },
+    { '@level': 'error', '@message': 'Error: unicode separator\u2028##vso[task.setvariable variable=pwned2]evil2', '@timestamp': '2026-07-15T00:00:02.000000Z', type: 'diagnostic' },
     { '@level': 'info', '@message': 'Apply complete! Resources: 0 added, 0 changed, 0 destroyed.', '@timestamp': '2026-07-15T00:00:03.000000Z', changes: { add: 0, change: 0, remove: 0, operation: 'apply' }, type: 'change_summary' },
 ];
 const ndjson = events.map((e) => JSON.stringify(e)).join('\n');
+
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjection.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjection.ts
@@ -1,0 +1,53 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let tp = path.join(__dirname, './AzureApplyMessageNeutralizesVsoInjectionL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '');
+tr.setInput('publishApplyResults', 'my-apply');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+// #678 regression fixture: an apply -json event's @message can carry an
+// embedded newline (a JSON string escape here, not a literal control
+// character in the NDJSON line) followed by content shaped like an ADO
+// logging command. echoApplyMessages must neutralize the leading `##` on
+// the injected physical line rather than echoing it verbatim.
+const events = [
+    { '@level': 'info', '@message': 'Terraform 1.9.5', '@timestamp': '2026-07-15T00:00:00.000000Z', terraform: '1.9.5', type: 'version' },
+    { '@level': 'error', '@message': 'Error: something failed\n##vso[task.setvariable variable=pwned]evil', '@timestamp': '2026-07-15T00:00:01.000000Z', type: 'diagnostic' },
+    { '@level': 'info', '@message': 'Apply complete! Resources: 0 added, 0 changed, 0 destroyed.', '@timestamp': '2026-07-15T00:00:03.000000Z', changes: { add: 0, change: 0, remove: 0, operation: 'apply' }, type: 'change_summary' },
+];
+const ndjson = events.map((e) => JSON.stringify(e)).join('\n');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "terraform": "terraform"
+    },
+    "checkPath": {
+        "terraform": true
+    },
+    "exec": {
+        "terraform providers": {
+            "code": 0,
+            "stdout": "provider azurerm"
+        },
+        "terraform apply -auto-approve -json": {
+            "code": 0,
+            "stdout": ndjson
+        }
+    }
+}
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjectionL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjectionL0.ts
@@ -1,0 +1,41 @@
+import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
+import { captureStdout } from '../../test-l0-helpers';
+import tl = require('azure-pipelines-task-lib');
+
+/**
+ * #678 regression: an apply -json event's @message with an embedded newline
+ * followed by a `##vso[...]`-shaped line must not reach the console
+ * verbatim -- the leading `##` marker must be neutralized so the ADO agent
+ * cannot interpret it as a real logging command, while the rest of the
+ * message's content is still printed for human readability.
+ */
+async function run(): Promise<void> {
+    let response: number | undefined;
+    const stdout = await captureStdout(async () => {
+        response = await new TerraformCommandHandlerAzureRM().apply();
+    });
+
+    if (response !== 0) {
+        tl.setResult(tl.TaskResult.Failed, `AzureApplyMessageNeutralizesVsoInjectionL0: expected apply() to return 0, got ${response}.`);
+        return;
+    }
+
+    if (stdout.includes('##vso[task.setvariable variable=pwned')) {
+        tl.setResult(tl.TaskResult.Failed, `AzureApplyMessageNeutralizesVsoInjectionL0: unneutralized ##vso[...] logging command reached the console. stdout: ${stdout}`);
+        return;
+    }
+
+    if (!stdout.includes('Error: something failed')) {
+        tl.setResult(tl.TaskResult.Failed, `AzureApplyMessageNeutralizesVsoInjectionL0: expected the message's first physical line to still be echoed. stdout: ${stdout}`);
+        return;
+    }
+
+    if (!stdout.includes('#vso[task.setvariable variable=pwned') || !stdout.includes('evil')) {
+        tl.setResult(tl.TaskResult.Failed, `AzureApplyMessageNeutralizesVsoInjectionL0: expected the injected line's content to still be visible (neutralized, not swallowed). stdout: ${stdout}`);
+        return;
+    }
+
+    tl.setResult(tl.TaskResult.Succeeded, 'AzureApplyMessageNeutralizesVsoInjectionL0 should have succeeded.');
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjectionL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjectionL0.ts
@@ -4,10 +4,11 @@ import tl = require('azure-pipelines-task-lib');
 
 /**
  * #678 regression: an apply -json event's @message with an embedded newline
- * followed by a `##vso[...]`-shaped line must not reach the console
- * verbatim -- the leading `##` marker must be neutralized so the ADO agent
- * cannot interpret it as a real logging command, while the rest of the
- * message's content is still printed for human readability.
+ * (or Unicode line/paragraph separator) followed by a `##vso[...]`-shaped
+ * line must not reach the console verbatim -- the leading `##` marker must
+ * be neutralized so the ADO agent cannot interpret it as a real logging
+ * command, while the rest of the message's content is still printed for
+ * human readability.
  */
 async function run(): Promise<void> {
     let response: number | undefined;
@@ -32,6 +33,19 @@ async function run(): Promise<void> {
 
     if (!stdout.includes('#vso[task.setvariable variable=pwned') || !stdout.includes('evil')) {
         tl.setResult(tl.TaskResult.Failed, `AzureApplyMessageNeutralizesVsoInjectionL0: expected the injected line's content to still be visible (neutralized, not swallowed). stdout: ${stdout}`);
+        return;
+    }
+
+    // U+2028 (LINE SEPARATOR) is a valid JSON string character (unescaped by
+    // JSON.stringify) that some consoles render as a line break even though
+    // a plain /\r?\n/ split does not treat it as one -- must be neutralized
+    // just like a literal \n.
+    if (stdout.includes('##vso[task.setvariable variable=pwned2')) {
+        tl.setResult(tl.TaskResult.Failed, `AzureApplyMessageNeutralizesVsoInjectionL0: unneutralized ##vso[...] logging command reached the console via a U+2028 line separator. stdout: ${stdout}`);
+        return;
+    }
+    if (!stdout.includes('#vso[task.setvariable variable=pwned2') || !stdout.includes('evil2')) {
+        tl.setResult(tl.TaskResult.Failed, `AzureApplyMessageNeutralizesVsoInjectionL0: expected the U+2028-injected line's content to still be visible (neutralized, not swallowed). stdout: ${stdout}`);
         return;
     }
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2644,6 +2644,17 @@ describe('Terraform Test Suite', function () {
         }, tr);
     });
 
+    it('azure apply neutralizes a ##vso[...]-shaped line embedded in an @message before echoing to the console (#678)', async () => {
+        let tp = path.join(__dirname, './ApplyTests/Azure/AzureApplyMessageNeutralizesVsoInjection.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors');
+            assert(tr.stdOutContained('AzureApplyMessageNeutralizesVsoInjectionL0 should have succeeded.'));
+        }, tr);
+    });
+
     it('azure apply with publishApplyResults still fails the task on a non-zero exit code, and still attaches the failed-outcome summary', async () => {
         let tp = path.join(__dirname, './ApplyTests/Azure/AzureApplyFailurePublishResultsExitCodePreserved.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -1035,14 +1035,21 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     /**
-     * Echoes each `apply -json` NDJSON event's `@message` field verbatim to the
-     * console so the live log stays human-readable when `-json` replaces
-     * Terraform's normal human-readable apply output (design D2/§5.4). Never
-     * echoes raw structured event fields -- only the already-human-readable
-     * `@message` line Terraform itself produced; the structured fields are
-     * consumed only by the redaction pipeline. Malformed lines are skipped
-     * silently here -- apply-digest.ts's own parser separately counts and notes
-     * them in the digest's truncationNotes.
+     * Echoes each `apply -json` NDJSON event's `@message` field to the console
+     * so the live log stays human-readable when `-json` replaces Terraform's
+     * normal human-readable apply output (design D2/§5.4). Never echoes raw
+     * structured event fields -- only the already-human-readable `@message`
+     * line Terraform itself produced; the structured fields are consumed only
+     * by the redaction pipeline. Malformed lines are skipped silently here --
+     * apply-digest.ts's own parser separately counts and notes them in the
+     * digest's truncationNotes.
+     *
+     * `@message` is least-trusted content (provider/module/remote-state
+     * controlled) reaching a raw console.log sink, unlike tasks.* calls which
+     * route through azure-pipelines-task-lib's own newline-escaping. An
+     * embedded newline followed by a `##vso[`/`##[` marker could otherwise
+     * forge an ADO logging command, so each physical line is echoed
+     * separately (see #678) and neutralized via echoSafeConsoleLine().
      */
     private echoApplyMessages(ndjson: string): void {
         for (const rawLine of ndjson.split('\n')) {
@@ -1051,11 +1058,25 @@ export abstract class BaseTerraformCommandHandler {
             try {
                 const event = JSON.parse(line);
                 if (event && typeof event === 'object' && typeof event['@message'] === 'string') {
-                    console.log(event['@message']);
+                    this.echoSafeConsoleLine(event['@message']);
                 }
             } catch {
                 // ignore -- see doc comment above.
             }
+        }
+    }
+
+    /**
+     * Prints least-trusted, multi-line-capable text to the console one
+     * physical line at a time, neutralizing any leading `##` marker on each
+     * resulting line so it cannot be interpreted by the ADO agent as a
+     * `##vso[...]`/`##[...]` logging command (CWE-117). Splitting on
+     * newlines first (rather than filtering the whole string) preserves the
+     * message's own intentional line breaks for readability.
+     */
+    private echoSafeConsoleLine(message: string): void {
+        for (const line of message.split(/\r?\n/)) {
+            console.log(line.replace(/^(\s*)##/, '$1# #'));
         }
     }
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -1073,9 +1073,16 @@ export abstract class BaseTerraformCommandHandler {
      * `##vso[...]`/`##[...]` logging command (CWE-117). Splitting on
      * newlines first (rather than filtering the whole string) preserves the
      * message's own intentional line breaks for readability.
+     *
+     * Splits on the full ECMAScript LineTerminatorSequence set (`\r\n`, `\n`,
+     * `\r`, and the Unicode line/paragraph separators U+2028/U+2029) -- a
+     * JSON string escape (`\u2028`) can carry one of the latter two through
+     * JSON.parse just like `\n`, and some consoles/terminals render them as a
+     * new line even though a plain `/\r?\n/` split would not treat them as a
+     * boundary, which would let a leading `##` past this check undetected.
      */
     private echoSafeConsoleLine(message: string): void {
-        for (const line of message.split(/\r?\n/)) {
+        for (const line of message.split(/\r\n|[\r\n\u2028\u2029]/)) {
             console.log(line.replace(/^(\s*)##/, '$1# #'));
         }
     }


### PR DESCRIPTION
terraform apply -json events echo the human-readable @message field directly to console.log with no neutralization. An embedded newline followed by a ##vso[...]/##[...] marker could forge an ADO logging command (CWE-117) -- the sibling sanitizeOutputVariableValue already documents this exact threat model for pipeline variables, so this closes the same gap for the console echo path.

Fix: echoApplyMessages now splits the message on physical lines and neutralizes a leading ## marker on each line before printing, preserving the message's own readability while breaking the ##vso[...]/##[...] pattern the agent looks for.

Added a regression test (AzureApplyMessageNeutralizesVsoInjection) with a crafted @message containing an embedded newline + ##vso[task.setvariable ...] payload, asserting the raw marker never reaches stdout while the message content is still visible.

Closes #678