### PR TITLE
fix: enforce registryAllowedHosts across the whole redirect chain

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/HttpClientL0.ts
@@ -1,8 +1,11 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
 import * as net from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import tasks = require('azure-pipelines-task-lib/task');
-import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404, parseRetryAfterMs } from '../src/http-client';
+import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404, parseRetryAfterMs, downloadToFile } from '../src/http-client';
 
 // Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
 // These run in the mocha parent process; the MockTestRunner integration tests in
@@ -198,6 +201,173 @@ describe('http-client: fetchWithTimeout', () => {
         }
     });
 });
+
+describe('http-client: downloadToFile (#679)', () => {
+    let destDir: string;
+    let destPath: string;
+
+    beforeEach(() => {
+        destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-to-file-test-'));
+        destPath = path.join(destDir, 'out.bin');
+    });
+
+    afterEach(() => {
+        fs.rmSync(destDir, { recursive: true, force: true });
+    });
+
+    function allowOnly(...hosts: string[]): (hostname: string) => void {
+        return (hostname) => {
+            if (!hosts.includes(hostname)) {
+                throw new Error(`disallowed host: ${hostname}`);
+            }
+        };
+    }
+
+    it('streams the response body to destPath when the host is allowed', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('the-file-content', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com'));
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'the-file-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects the initial URL host before making any request', async () => {
+        let fetchCalls = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://attacker.example.net/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.strictEqual(fetchCalls, 0, 'must not attempt any request when the initial host is disallowed');
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('re-validates a redirect target and refuses a disallowed host even when the initial host is allowed (#679)', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (url: string) => {
+            if (new URL(url).hostname === 'storage.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://attacker.example.net/file.zip' } });
+            }
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file when the redirect target is disallowed');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('follows a multi-hop redirect chain and validates every hop', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://b.example.com/file.zip' } });
+            }
+            return new Response('final-content', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'b.example.com'));
+            assert.deepStrictEqual(requestedHosts, ['a.example.com', 'b.example.com']);
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'final-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('follows a three-hop redirect chain, validating every hop including the middle one', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://b.example.com/file.zip' } });
+            }
+            if (host === 'b.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://c.example.com/file.zip' } });
+            }
+            return new Response('final-content', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'b.example.com', 'c.example.com'));
+            assert.deepStrictEqual(requestedHosts, ['a.example.com', 'b.example.com', 'c.example.com']);
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'final-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects a three-hop chain when only the middle hop is disallowed', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://attacker.example.net/file.zip' } });
+            }
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'c.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.deepStrictEqual(requestedHosts, ['a.example.com'], 'must not request the disallowed middle hop or anything beyond it');
+            assert.ok(!fs.existsSync(destPath));
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('surfaces a clear error on a non-2xx response instead of writing a partial/error-page file', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('not found', { status: 404 })) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /HTTP 404/,
+            );
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file on a non-2xx response');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('removes a partial file left by a write-stream failure instead of leaving a truncated file behind (#679)', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('some bytes', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            // destPath's parent directory does not exist -> fs.createWriteStream
+            // fails immediately (ENOENT), simulating a write-time failure
+            // (disk full / permission denied would fail the same way, just later).
+            const badDestPath = path.join(destDir, 'missing-subdir', 'out.bin');
+            await assert.rejects(() => downloadToFile('https://storage.example.com/file.zip', badDestPath, 1000, allowOnly('storage.example.com')));
+            assert.ok(!fs.existsSync(badDestPath), 'must not leave a partial/truncated file behind after a write failure');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
 
 describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
     let originalFetch: typeof globalThis.fetch;

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
@@ -14,6 +14,9 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 import { retryAsync } from './retry';
+import * as fs from 'fs';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
 
 /**
  * Per-request timeouts (ms). Without an AbortController a hung TCP connection
@@ -175,6 +178,8 @@ export async function fetchWithTimeout<T>(
     url: string,
     timeoutMs: number,
     consume: (response: Response) => Promise<T>,
+    isRedirectHostAllowed: (originHost: string, next: URL) => boolean = (originHost, next) =>
+        next.host === originHost || isGithubAssetRedirect(originHost, next),
 ): Promise<T> {
     if (!url.startsWith('https://')) {
         throw new HttpError(tasks.loc("InsecureUrlRejected", url), false);
@@ -198,7 +203,7 @@ export async function fetchWithTimeout<T>(
             if (next.protocol !== 'https:') {
                 throw new HttpError(tasks.loc("InsecureUrlRejected", next.toString()), false);
             }
-            if (next.host !== originHost && !isGithubAssetRedirect(originHost, next)) {
+            if (!isRedirectHostAllowed(originHost, next)) {
                 throw new HttpError(`Refusing to follow an off-host redirect (${originHost} -> ${next.host}) while fetching ${url}.`, false);
             }
             currentUrl = next.toString();
@@ -212,6 +217,49 @@ export async function fetchWithTimeout<T>(
         clearTimeout(timer);
     }
 }
+
+/**
+ * Downloads a URL directly to a local file, streaming the response body to
+ * disk rather than buffering it in memory -- matching the memory profile of
+ * azure-pipelines-tool-lib's downloadTool() for a large Terraform/OpenTofu/
+ * OPA/terraform-docs archive. Unlike downloadTool(), redirects are followed
+ * manually (via fetchWithTimeout) so `isHostAllowed` re-validates the host at
+ * EVERY hop, not just the initial URL -- closing the gap where a compromised
+ * registry could return an allowlisted download_url that itself 302s to an
+ * arbitrary host (#679). `isHostAllowed` should throw with a caller-specific
+ * message on a disallowed host rather than returning a bare boolean, so the
+ * error text can name the actual offending host/allowlist.
+ */
+export async function downloadToFile(
+    url: string,
+    destPath: string,
+    timeoutMs: number,
+    isHostAllowed: (hostname: string) => void,
+): Promise<void> {
+    // Validate the initial URL's own host before any network call --
+    // fetchWithTimeout's redirect-validator callback below only re-checks
+    // subsequent Location targets, never the URL it was first called with.
+    isHostAllowed(new URL(url).hostname);
+    await fetchWithTimeout(
+        url,
+        timeoutMs,
+        async (response) => {
+            if (!response.ok) {
+                throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
+            }
+            if (!response.body) {
+                throw new HttpError(`Download from ${url} returned an empty response body.`, false);
+            }
+            await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
+        },
+        (_originHost, next) => {
+            // Re-validate every redirect hop against the same allowlist (#679).
+            isHostAllowed(next.host);
+            return true;
+        },
+    );
+}
+
 
 /**
  * Retries a fetch on transient failures (network error, timeout, 5xx, 429) with
@@ -254,7 +302,7 @@ async function readBoundedArrayBuffer(response: Response, url: string): Promise<
     const reader = response.body.getReader();
     const chunks: Uint8Array[] = [];
     let total = 0;
-    for (;;) {
+    for (; ;) {
         const { done, value } = await reader.read();
         if (done) break;
         total += value.byteLength;

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
@@ -240,25 +240,42 @@ export async function downloadToFile(
     // fetchWithTimeout's redirect-validator callback below only re-checks
     // subsequent Location targets, never the URL it was first called with.
     isHostAllowed(new URL(url).hostname);
-    await fetchWithTimeout(
-        url,
-        timeoutMs,
-        async (response) => {
-            if (!response.ok) {
-                throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
-            }
-            if (!response.body) {
-                throw new HttpError(`Download from ${url} returned an empty response body.`, false);
-            }
-            await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
-        },
-        (_originHost, next) => {
-            // Re-validate every redirect hop against the same allowlist (#679).
-            isHostAllowed(next.host);
-            return true;
-        },
-    );
+    try {
+        await fetchWithTimeout(
+            url,
+            timeoutMs,
+            async (response) => {
+                if (!response.ok) {
+                    throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
+                }
+                if (!response.body) {
+                    throw new HttpError(`Download from ${url} returned an empty response body.`, false);
+                }
+                await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
+            },
+            (_originHost, next) => {
+                // Re-validate every redirect hop against the same allowlist (#679).
+                isHostAllowed(next.host);
+                return true;
+            },
+        );
+    } catch (err) {
+        // A write-stream failure partway through (disk full, permission
+        // denied) leaves a truncated file at destPath; a non-2xx/host-
+        // rejection failure never opens the write stream at all. Best-effort
+        // remove whatever partial file might exist so a caller never mistakes
+        // it for a complete, verifiable download.
+        try {
+            fs.unlinkSync(destPath);
+        } catch {
+            // Nothing to remove (the common case -- the failure happened
+            // before any bytes were written) or removal itself failed; either
+            // way this must not mask the real error above.
+        }
+        throw err;
+    }
 }
+
 
 
 /**

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -6,7 +6,7 @@ import fs = require('fs');
 import crypto = require('crypto');
 
 import { randomUUID as uuidV4 } from 'crypto';
-import { fetchJson, fetchText, fetchTextAllow404 } from './http-client';
+import { fetchJson, fetchText, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
@@ -266,14 +266,21 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
     }
 
     // Optional opt-in host pin: a compromised registry could still point download_url
-    // at an arbitrary HTTPS host (tools.downloadTool follows redirects with no way to
-    // disable that), so an operator can constrain the trusted storage host(s) via
-    // registryAllowedHosts. Default (empty) preserves the trust-the-registry behavior.
+    // at an arbitrary HTTPS host, so an operator can constrain the trusted storage
+    // host(s) via registryAllowedHosts. Default (empty) preserves the
+    // trust-the-registry behavior.
     const allowedHosts = parseAllowedHosts(tasks.getInput("registryAllowedHosts", false));
     if (allowedHosts.length > 0) {
-        const downloadHost = new URL(data.download_url).hostname;
-        if (!isRegistryHostAllowed(downloadHost, allowedHosts)) {
-            throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", downloadHost, allowedHosts.join(', ')));
+        // Fail fast, before any temp-path resolution or network activity, when
+        // the registry's own advertised download_url host is already
+        // disallowed. downloadToFile() below re-validates this same host (and
+        // every redirect hop) again as defense in depth (#679), but this
+        // upfront check keeps the common case (registry itself is fine, only
+        // a redirect might misbehave) cheap and matches the original
+        // synchronous rejection behavior exactly.
+        const initialHost = new URL(data.download_url).hostname;
+        if (!isRegistryHostAllowed(initialHost, allowedHosts)) {
+            throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", initialHost, allowedHosts.join(', ')));
         }
     }
 
@@ -291,7 +298,24 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
     }
     let filePath: string;
     try {
-        filePath = await tools.downloadTool(data.download_url, fileName);
+        if (allowedHosts.length > 0) {
+            // tools.downloadTool() follows redirects with no way to re-validate
+            // or disable that, so a compromised registry could return an
+            // allowlisted download_url that itself 302s to an arbitrary host,
+            // bypassing the pin entirely. Route through the manual-redirect
+            // downloadToFile() instead, which re-checks EVERY hop against
+            // allowedHosts (#679) -- only when the operator actually opted into
+            // the pin, so the default (no allowlist) path is unchanged.
+            const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+            filePath = path.join(destDir, fileName);
+            await downloadToFile(data.download_url, filePath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+                if (!isRegistryHostAllowed(hostname, allowedHosts)) {
+                    throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", hostname, allowedHosts.join(', ')));
+                }
+            });
+        } else {
+            filePath = await tools.downloadTool(data.download_url, fileName);
+        }
     } catch (exception) {
         // download_url is a pre-signed URL whose query string carries the signing
         // token; drop the whole query (redactUrl) and scrub the raw URL out of the

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/HttpClientL0.ts
@@ -1,8 +1,11 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
 import * as net from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import tasks = require('azure-pipelines-task-lib/task');
-import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404, parseRetryAfterMs } from '../src/http-client';
+import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404, parseRetryAfterMs, downloadToFile } from '../src/http-client';
 
 // Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
 // These run in the mocha parent process; the MockTestRunner integration tests in
@@ -198,6 +201,173 @@ describe('http-client: fetchWithTimeout', () => {
         }
     });
 });
+
+describe('http-client: downloadToFile (#679)', () => {
+    let destDir: string;
+    let destPath: string;
+
+    beforeEach(() => {
+        destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-to-file-test-'));
+        destPath = path.join(destDir, 'out.bin');
+    });
+
+    afterEach(() => {
+        fs.rmSync(destDir, { recursive: true, force: true });
+    });
+
+    function allowOnly(...hosts: string[]): (hostname: string) => void {
+        return (hostname) => {
+            if (!hosts.includes(hostname)) {
+                throw new Error(`disallowed host: ${hostname}`);
+            }
+        };
+    }
+
+    it('streams the response body to destPath when the host is allowed', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('the-file-content', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com'));
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'the-file-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects the initial URL host before making any request', async () => {
+        let fetchCalls = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://attacker.example.net/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.strictEqual(fetchCalls, 0, 'must not attempt any request when the initial host is disallowed');
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('re-validates a redirect target and refuses a disallowed host even when the initial host is allowed (#679)', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (url: string) => {
+            if (new URL(url).hostname === 'storage.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://attacker.example.net/file.zip' } });
+            }
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file when the redirect target is disallowed');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('follows a multi-hop redirect chain and validates every hop', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://b.example.com/file.zip' } });
+            }
+            return new Response('final-content', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'b.example.com'));
+            assert.deepStrictEqual(requestedHosts, ['a.example.com', 'b.example.com']);
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'final-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('follows a three-hop redirect chain, validating every hop including the middle one', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://b.example.com/file.zip' } });
+            }
+            if (host === 'b.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://c.example.com/file.zip' } });
+            }
+            return new Response('final-content', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'b.example.com', 'c.example.com'));
+            assert.deepStrictEqual(requestedHosts, ['a.example.com', 'b.example.com', 'c.example.com']);
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'final-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects a three-hop chain when only the middle hop is disallowed', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://attacker.example.net/file.zip' } });
+            }
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'c.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.deepStrictEqual(requestedHosts, ['a.example.com'], 'must not request the disallowed middle hop or anything beyond it');
+            assert.ok(!fs.existsSync(destPath));
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('surfaces a clear error on a non-2xx response instead of writing a partial/error-page file', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('not found', { status: 404 })) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /HTTP 404/,
+            );
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file on a non-2xx response');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('removes a partial file left by a write-stream failure instead of leaving a truncated file behind (#679)', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('some bytes', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            // destPath's parent directory does not exist -> fs.createWriteStream
+            // fails immediately (ENOENT), simulating a write-time failure
+            // (disk full / permission denied would fail the same way, just later).
+            const badDestPath = path.join(destDir, 'missing-subdir', 'out.bin');
+            await assert.rejects(() => downloadToFile('https://storage.example.com/file.zip', badDestPath, 1000, allowOnly('storage.example.com')));
+            assert.ok(!fs.existsSync(badDestPath), 'must not leave a partial/truncated file behind after a write failure');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
 
 describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
     let originalFetch: typeof globalThis.fetch;

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
@@ -14,6 +14,9 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 import { retryAsync } from './retry';
+import * as fs from 'fs';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
 
 /**
  * Per-request timeouts (ms). Without an AbortController a hung TCP connection
@@ -175,6 +178,8 @@ export async function fetchWithTimeout<T>(
     url: string,
     timeoutMs: number,
     consume: (response: Response) => Promise<T>,
+    isRedirectHostAllowed: (originHost: string, next: URL) => boolean = (originHost, next) =>
+        next.host === originHost || isGithubAssetRedirect(originHost, next),
 ): Promise<T> {
     if (!url.startsWith('https://')) {
         throw new HttpError(tasks.loc("InsecureUrlRejected", url), false);
@@ -198,7 +203,7 @@ export async function fetchWithTimeout<T>(
             if (next.protocol !== 'https:') {
                 throw new HttpError(tasks.loc("InsecureUrlRejected", next.toString()), false);
             }
-            if (next.host !== originHost && !isGithubAssetRedirect(originHost, next)) {
+            if (!isRedirectHostAllowed(originHost, next)) {
                 throw new HttpError(`Refusing to follow an off-host redirect (${originHost} -> ${next.host}) while fetching ${url}.`, false);
             }
             currentUrl = next.toString();
@@ -212,6 +217,49 @@ export async function fetchWithTimeout<T>(
         clearTimeout(timer);
     }
 }
+
+/**
+ * Downloads a URL directly to a local file, streaming the response body to
+ * disk rather than buffering it in memory -- matching the memory profile of
+ * azure-pipelines-tool-lib's downloadTool() for a large Terraform/OpenTofu/
+ * OPA/terraform-docs archive. Unlike downloadTool(), redirects are followed
+ * manually (via fetchWithTimeout) so `isHostAllowed` re-validates the host at
+ * EVERY hop, not just the initial URL -- closing the gap where a compromised
+ * registry could return an allowlisted download_url that itself 302s to an
+ * arbitrary host (#679). `isHostAllowed` should throw with a caller-specific
+ * message on a disallowed host rather than returning a bare boolean, so the
+ * error text can name the actual offending host/allowlist.
+ */
+export async function downloadToFile(
+    url: string,
+    destPath: string,
+    timeoutMs: number,
+    isHostAllowed: (hostname: string) => void,
+): Promise<void> {
+    // Validate the initial URL's own host before any network call --
+    // fetchWithTimeout's redirect-validator callback below only re-checks
+    // subsequent Location targets, never the URL it was first called with.
+    isHostAllowed(new URL(url).hostname);
+    await fetchWithTimeout(
+        url,
+        timeoutMs,
+        async (response) => {
+            if (!response.ok) {
+                throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
+            }
+            if (!response.body) {
+                throw new HttpError(`Download from ${url} returned an empty response body.`, false);
+            }
+            await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
+        },
+        (_originHost, next) => {
+            // Re-validate every redirect hop against the same allowlist (#679).
+            isHostAllowed(next.host);
+            return true;
+        },
+    );
+}
+
 
 /**
  * Retries a fetch on transient failures (network error, timeout, 5xx, 429) with
@@ -254,7 +302,7 @@ async function readBoundedArrayBuffer(response: Response, url: string): Promise<
     const reader = response.body.getReader();
     const chunks: Uint8Array[] = [];
     let total = 0;
-    for (;;) {
+    for (; ;) {
         const { done, value } = await reader.read();
         if (done) break;
         total += value.byteLength;

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
@@ -240,25 +240,42 @@ export async function downloadToFile(
     // fetchWithTimeout's redirect-validator callback below only re-checks
     // subsequent Location targets, never the URL it was first called with.
     isHostAllowed(new URL(url).hostname);
-    await fetchWithTimeout(
-        url,
-        timeoutMs,
-        async (response) => {
-            if (!response.ok) {
-                throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
-            }
-            if (!response.body) {
-                throw new HttpError(`Download from ${url} returned an empty response body.`, false);
-            }
-            await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
-        },
-        (_originHost, next) => {
-            // Re-validate every redirect hop against the same allowlist (#679).
-            isHostAllowed(next.host);
-            return true;
-        },
-    );
+    try {
+        await fetchWithTimeout(
+            url,
+            timeoutMs,
+            async (response) => {
+                if (!response.ok) {
+                    throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
+                }
+                if (!response.body) {
+                    throw new HttpError(`Download from ${url} returned an empty response body.`, false);
+                }
+                await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
+            },
+            (_originHost, next) => {
+                // Re-validate every redirect hop against the same allowlist (#679).
+                isHostAllowed(next.host);
+                return true;
+            },
+        );
+    } catch (err) {
+        // A write-stream failure partway through (disk full, permission
+        // denied) leaves a truncated file at destPath; a non-2xx/host-
+        // rejection failure never opens the write stream at all. Best-effort
+        // remove whatever partial file might exist so a caller never mistakes
+        // it for a complete, verifiable download.
+        try {
+            fs.unlinkSync(destPath);
+        } catch {
+            // Nothing to remove (the common case -- the failure happened
+            // before any bytes were written) or removal itself failed; either
+            // way this must not mask the real error above.
+        }
+        throw err;
+    }
 }
+
 
 
 /**

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -6,7 +6,7 @@ import fs = require('fs');
 import crypto = require('crypto');
 
 import { randomUUID as uuidV4 } from 'crypto';
-import { fetchJson, fetchTextAllow404 } from './http-client';
+import { fetchJson, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, extractUrlUserInfoSecrets, redactUrlUserInfo } from './url-secret-redaction';
@@ -203,14 +203,21 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
     }
 
     // Optional opt-in host pin: a compromised registry could still point download_url
-    // at an arbitrary HTTPS host (tools.downloadTool follows redirects with no way to
-    // disable that), so an operator can constrain the trusted storage host(s) via
-    // registryAllowedHosts. Default (empty) preserves the trust-the-registry behavior.
+    // at an arbitrary HTTPS host, so an operator can constrain the trusted storage
+    // host(s) via registryAllowedHosts. Default (empty) preserves the
+    // trust-the-registry behavior.
     const allowedHosts = parseAllowedHosts(tasks.getInput("registryAllowedHosts", false));
     if (allowedHosts.length > 0) {
-        const downloadHost = new URL(data.download_url).hostname;
-        if (!isRegistryHostAllowed(downloadHost, allowedHosts)) {
-            throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", downloadHost, allowedHosts.join(', ')));
+        // Fail fast, before any temp-path resolution or network activity, when
+        // the registry's own advertised download_url host is already
+        // disallowed. downloadToFile() below re-validates this same host (and
+        // every redirect hop) again as defense in depth (#679), but this
+        // upfront check keeps the common case (registry itself is fine, only
+        // a redirect might misbehave) cheap and matches the original
+        // synchronous rejection behavior exactly.
+        const initialHost = new URL(data.download_url).hostname;
+        if (!isRegistryHostAllowed(initialHost, allowedHosts)) {
+            throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", initialHost, allowedHosts.join(', ')));
         }
     }
 
@@ -227,7 +234,24 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
     }
     let filePath: string;
     try {
-        filePath = await tools.downloadTool(data.download_url, fileName);
+        if (allowedHosts.length > 0) {
+            // tools.downloadTool() follows redirects with no way to re-validate
+            // or disable that, so a compromised registry could return an
+            // allowlisted download_url that itself 302s to an arbitrary host,
+            // bypassing the pin entirely. Route through the manual-redirect
+            // downloadToFile() instead, which re-checks EVERY hop against
+            // allowedHosts (#679) -- only when the operator actually opted into
+            // the pin, so the default (no allowlist) path is unchanged.
+            const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+            filePath = path.join(destDir, fileName);
+            await downloadToFile(data.download_url, filePath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+                if (!isRegistryHostAllowed(hostname, allowedHosts)) {
+                    throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", hostname, allowedHosts.join(', ')));
+                }
+            });
+        } else {
+            filePath = await tools.downloadTool(data.download_url, fileName);
+        }
     } catch (exception) {
         // download_url is a pre-signed URL whose query string carries the signing
         // token; drop the whole query (redactUrl) and scrub the raw URL out of the

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
@@ -1,8 +1,11 @@
 import { describe, it } from 'mocha';
 import assert = require('assert');
 import * as net from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import tasks = require('azure-pipelines-task-lib/task');
-import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404, parseRetryAfterMs } from '../src/http-client';
+import { fetchWithTimeout, fetchJson, fetchText, fetchTextAllow404, fetchBuffer, fetchBufferAllow404, parseRetryAfterMs, downloadToFile } from '../src/http-client';
 
 // Direct (non-MockTestRunner) unit tests for the http-client timeout guard.
 // These run in the mocha parent process; the MockTestRunner integration tests in
@@ -193,6 +196,118 @@ describe('http-client: fetchWithTimeout', () => {
                 () => fetchWithTimeout('https://example.com/loop', 1000, async (r) => r.text()),
                 /Too many redirects/
             );
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});
+
+/**
+ * Direct unit tests for downloadToFile (#679): unlike
+ * azure-pipelines-tool-lib's downloadTool(), redirects are followed manually
+ * here so a caller-supplied isHostAllowed predicate can re-validate EVERY
+ * hop -- not just the initial URL -- closing the gap where an allowlisted
+ * download_url could itself 302 to an arbitrary host.
+ */
+describe('http-client: downloadToFile (#679)', () => {
+    let destDir: string;
+    let destPath: string;
+
+    beforeEach(() => {
+        destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-to-file-test-'));
+        destPath = path.join(destDir, 'out.bin');
+    });
+
+    afterEach(() => {
+        fs.rmSync(destDir, { recursive: true, force: true });
+    });
+
+    function allowOnly(...hosts: string[]): (hostname: string) => void {
+        return (hostname) => {
+            if (!hosts.includes(hostname)) {
+                throw new Error(`disallowed host: ${hostname}`);
+            }
+        };
+    }
+
+    it('streams the response body to destPath when the host is allowed', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('the-file-content', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com'));
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'the-file-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects the initial URL host before making any request', async () => {
+        let fetchCalls = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://attacker.example.net/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.strictEqual(fetchCalls, 0, 'must not attempt any request when the initial host is disallowed');
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('re-validates a redirect target and refuses a disallowed host even when the initial host is allowed (#679)', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (url: string) => {
+            if (new URL(url).hostname === 'storage.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://attacker.example.net/file.zip' } });
+            }
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file when the redirect target is disallowed');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('follows a multi-hop redirect chain and validates every hop', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://b.example.com/file.zip' } });
+            }
+            return new Response('final-content', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'b.example.com'));
+            assert.deepStrictEqual(requestedHosts, ['a.example.com', 'b.example.com']);
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'final-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('surfaces a clear error on a non-2xx response instead of writing a partial/error-page file', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('not found', { status: 404 })) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://storage.example.com/file.zip', destPath, 1000, allowOnly('storage.example.com')),
+                /HTTP 404/,
+            );
+            assert.ok(!fs.existsSync(destPath), 'must not create the destination file on a non-2xx response');
         } finally {
             globalThis.fetch = originalFetch;
         }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HttpClientL0.ts
@@ -299,6 +299,52 @@ describe('http-client: downloadToFile (#679)', () => {
         }
     });
 
+    it('follows a three-hop redirect chain, validating every hop including the middle one', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://b.example.com/file.zip' } });
+            }
+            if (host === 'b.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://c.example.com/file.zip' } });
+            }
+            return new Response('final-content', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'b.example.com', 'c.example.com'));
+            assert.deepStrictEqual(requestedHosts, ['a.example.com', 'b.example.com', 'c.example.com']);
+            assert.strictEqual(fs.readFileSync(destPath, 'utf8'), 'final-content');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it('rejects a three-hop chain when only the middle hop is disallowed', async () => {
+        const originalFetch = globalThis.fetch;
+        const requestedHosts: string[] = [];
+        globalThis.fetch = (async (url: string) => {
+            const host = new URL(url).hostname;
+            requestedHosts.push(host);
+            if (host === 'a.example.com') {
+                return new Response(null, { status: 302, headers: { Location: 'https://attacker.example.net/file.zip' } });
+            }
+            return new Response('should not be reached', { status: 200 });
+        }) as unknown as typeof globalThis.fetch;
+        try {
+            await assert.rejects(
+                () => downloadToFile('https://a.example.com/file.zip', destPath, 1000, allowOnly('a.example.com', 'c.example.com')),
+                /disallowed host: attacker\.example\.net/,
+            );
+            assert.deepStrictEqual(requestedHosts, ['a.example.com'], 'must not request the disallowed middle hop or anything beyond it');
+            assert.ok(!fs.existsSync(destPath));
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
     it('surfaces a clear error on a non-2xx response instead of writing a partial/error-page file', async () => {
         const originalFetch = globalThis.fetch;
         globalThis.fetch = (async () => new Response('not found', { status: 404 })) as unknown as typeof globalThis.fetch;
@@ -312,7 +358,23 @@ describe('http-client: downloadToFile (#679)', () => {
             globalThis.fetch = originalFetch;
         }
     });
+
+    it('removes a partial file left by a write-stream failure instead of leaving a truncated file behind (#679)', async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('some bytes', { status: 200 })) as unknown as typeof globalThis.fetch;
+        try {
+            // destPath's parent directory does not exist -> fs.createWriteStream
+            // fails immediately (ENOENT), simulating a write-time failure
+            // (disk full / permission denied would fail the same way, just later).
+            const badDestPath = path.join(destDir, 'missing-subdir', 'out.bin');
+            await assert.rejects(() => downloadToFile('https://storage.example.com/file.zip', badDestPath, 1000, allowOnly('storage.example.com')));
+            assert.ok(!fs.existsSync(badDestPath), 'must not leave a partial/truncated file behind after a write failure');
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
 });
+
 
 describe('http-client: fetchJson / fetchText / fetchBuffer', () => {
     let originalFetch: typeof globalThis.fetch;

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAccept.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAccept.ts
@@ -15,7 +15,8 @@ tr.setInput('registryAllowedHosts', 'other.example.com, *.storage.example.com');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => 'C:\\fake-temp'
 });
 
 const EXPECTED_SHA256 = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
@@ -34,6 +35,18 @@ tr.registerMock('./http-client', {
     },
     fetchText: async (url: string) => {
         throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile replaces tools.downloadTool() only on the
+    // registryAllowedHosts-enabled path (#679) -- genuinely exercises the
+    // isHostAllowed callback terraform-installer.ts builds (real
+    // isRegistryHostAllowed logic), proving the wildcard-matched host is
+    // accepted, but stubs out the actual network/disk work the same way
+    // downloadTool is stubbed below. fs.readFileSync is mocked to always
+    // return fake-zip-content regardless of path, so no real file needs to
+    // be written to destPath.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
     }
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
@@ -14,6 +14,9 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
 import { retryAsync } from './retry';
+import * as fs from 'fs';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
 
 /**
  * Per-request timeouts (ms). Without an AbortController a hung TCP connection
@@ -175,6 +178,8 @@ export async function fetchWithTimeout<T>(
     url: string,
     timeoutMs: number,
     consume: (response: Response) => Promise<T>,
+    isRedirectHostAllowed: (originHost: string, next: URL) => boolean = (originHost, next) =>
+        next.host === originHost || isGithubAssetRedirect(originHost, next),
 ): Promise<T> {
     if (!url.startsWith('https://')) {
         throw new HttpError(tasks.loc("InsecureUrlRejected", url), false);
@@ -198,7 +203,7 @@ export async function fetchWithTimeout<T>(
             if (next.protocol !== 'https:') {
                 throw new HttpError(tasks.loc("InsecureUrlRejected", next.toString()), false);
             }
-            if (next.host !== originHost && !isGithubAssetRedirect(originHost, next)) {
+            if (!isRedirectHostAllowed(originHost, next)) {
                 throw new HttpError(`Refusing to follow an off-host redirect (${originHost} -> ${next.host}) while fetching ${url}.`, false);
             }
             currentUrl = next.toString();
@@ -212,6 +217,49 @@ export async function fetchWithTimeout<T>(
         clearTimeout(timer);
     }
 }
+
+/**
+ * Downloads a URL directly to a local file, streaming the response body to
+ * disk rather than buffering it in memory -- matching the memory profile of
+ * azure-pipelines-tool-lib's downloadTool() for a large Terraform/OpenTofu/
+ * OPA/terraform-docs archive. Unlike downloadTool(), redirects are followed
+ * manually (via fetchWithTimeout) so `isHostAllowed` re-validates the host at
+ * EVERY hop, not just the initial URL -- closing the gap where a compromised
+ * registry could return an allowlisted download_url that itself 302s to an
+ * arbitrary host (#679). `isHostAllowed` should throw with a caller-specific
+ * message on a disallowed host rather than returning a bare boolean, so the
+ * error text can name the actual offending host/allowlist.
+ */
+export async function downloadToFile(
+    url: string,
+    destPath: string,
+    timeoutMs: number,
+    isHostAllowed: (hostname: string) => void,
+): Promise<void> {
+    // Validate the initial URL's own host before any network call --
+    // fetchWithTimeout's redirect-validator callback below only re-checks
+    // subsequent Location targets, never the URL it was first called with.
+    isHostAllowed(new URL(url).hostname);
+    await fetchWithTimeout(
+        url,
+        timeoutMs,
+        async (response) => {
+            if (!response.ok) {
+                throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
+            }
+            if (!response.body) {
+                throw new HttpError(`Download from ${url} returned an empty response body.`, false);
+            }
+            await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
+        },
+        (_originHost, next) => {
+            // Re-validate every redirect hop against the same allowlist (#679).
+            isHostAllowed(next.host);
+            return true;
+        },
+    );
+}
+
 
 /**
  * Retries a fetch on transient failures (network error, timeout, 5xx, 429) with
@@ -254,7 +302,7 @@ async function readBoundedArrayBuffer(response: Response, url: string): Promise<
     const reader = response.body.getReader();
     const chunks: Uint8Array[] = [];
     let total = 0;
-    for (;;) {
+    for (; ;) {
         const { done, value } = await reader.read();
         if (done) break;
         total += value.byteLength;

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
@@ -240,25 +240,42 @@ export async function downloadToFile(
     // fetchWithTimeout's redirect-validator callback below only re-checks
     // subsequent Location targets, never the URL it was first called with.
     isHostAllowed(new URL(url).hostname);
-    await fetchWithTimeout(
-        url,
-        timeoutMs,
-        async (response) => {
-            if (!response.ok) {
-                throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
-            }
-            if (!response.body) {
-                throw new HttpError(`Download from ${url} returned an empty response body.`, false);
-            }
-            await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
-        },
-        (_originHost, next) => {
-            // Re-validate every redirect hop against the same allowlist (#679).
-            isHostAllowed(next.host);
-            return true;
-        },
-    );
+    try {
+        await fetchWithTimeout(
+            url,
+            timeoutMs,
+            async (response) => {
+                if (!response.ok) {
+                    throw new HttpError(`Download from ${url} failed with HTTP ${response.status}.`, isRetryableHttpStatus(response.status), retryAfterMsFromResponse(response));
+                }
+                if (!response.body) {
+                    throw new HttpError(`Download from ${url} returned an empty response body.`, false);
+                }
+                await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), fs.createWriteStream(destPath));
+            },
+            (_originHost, next) => {
+                // Re-validate every redirect hop against the same allowlist (#679).
+                isHostAllowed(next.host);
+                return true;
+            },
+        );
+    } catch (err) {
+        // A write-stream failure partway through (disk full, permission
+        // denied) leaves a truncated file at destPath; a non-2xx/host-
+        // rejection failure never opens the write stream at all. Best-effort
+        // remove whatever partial file might exist so a caller never mistakes
+        // it for a complete, verifiable download.
+        try {
+            fs.unlinkSync(destPath);
+        } catch {
+            // Nothing to remove (the common case -- the failure happened
+            // before any bytes were written) or removal itself failed; either
+            // way this must not mask the real error above.
+        }
+        throw err;
+    }
 }
+
 
 
 /**

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -6,7 +6,7 @@ import fs = require('fs');
 import crypto = require('crypto');
 
 import { randomUUID as uuidV4 } from 'crypto';
-import { fetchJson, fetchText, fetchTextAllow404 } from './http-client';
+import { fetchJson, fetchText, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
 import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
@@ -233,15 +233,21 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     }
 
     // Optional opt-in host pin: a compromised registry could still point
-    // download_url at an arbitrary HTTPS host (and tools.downloadTool follows
-    // redirects with no way to disable that), so an operator who wants to
+    // download_url at an arbitrary HTTPS host, so an operator who wants to
     // constrain the trusted storage host(s) can set registryAllowedHosts.
     // Default (empty) preserves the existing trust-the-registry behavior.
     const allowedHosts = parseAllowedHosts(tasks.getInput("registryAllowedHosts", false));
     if (allowedHosts.length > 0) {
-        const downloadHost = new URL(data.download_url).hostname;
-        if (!isRegistryHostAllowed(downloadHost, allowedHosts)) {
-            throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", downloadHost, allowedHosts.join(', ')));
+        // Fail fast, before any temp-path resolution or network activity, when
+        // the registry's own advertised download_url host is already
+        // disallowed. downloadToFile() below re-validates this same host (and
+        // every redirect hop) again as defense in depth (#679), but this
+        // upfront check keeps the common case (registry itself is fine, only
+        // a redirect might misbehave) cheap and matches the original
+        // synchronous rejection behavior exactly.
+        const initialHost = new URL(data.download_url).hostname;
+        if (!isRegistryHostAllowed(initialHost, allowedHosts)) {
+            throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", initialHost, allowedHosts.join(', ')));
         }
     }
 
@@ -258,7 +264,24 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     }
     let zipPath: string;
     try {
-        zipPath = await tools.downloadTool(data.download_url, fileName);
+        if (allowedHosts.length > 0) {
+            // tools.downloadTool() follows redirects with no way to re-validate
+            // or disable that, so a compromised registry could return an
+            // allowlisted download_url that itself 302s to an arbitrary host,
+            // bypassing the pin entirely. Route through the manual-redirect
+            // downloadToFile() instead, which re-checks EVERY hop against
+            // allowedHosts (#679) -- only when the operator actually opted into
+            // the pin, so the default (no allowlist) path is unchanged.
+            const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+            zipPath = path.join(destDir, fileName);
+            await downloadToFile(data.download_url, zipPath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+                if (!isRegistryHostAllowed(hostname, allowedHosts)) {
+                    throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", hostname, allowedHosts.join(', ')));
+                }
+            });
+        } else {
+            zipPath = await tools.downloadTool(data.download_url, fileName);
+        }
     } catch (exception) {
         // download_url is a pre-signed URL whose query string carries the signing
         // token; drop the whole query (redactUrl) and scrub the raw URL out of the


### PR DESCRIPTION
registryAllowedHosts only checked the download_url host BEFORE any redirect; tools.downloadTool() then follows redirects with no way to re-validate them, so a compromised registry could return an allowlisted download_url that itself 302s to an arbitrary host, bypassing the pin entirely. registryAllowedHosts is documented as the defense specifically for this scenario, so the redirect gap negated its own stated purpose. This same pre-redirect-only pattern was replicated byte-for-byte in TerraformInstaller, PolicyAgentInstaller, and TerraformDocsInstaller (all 3 fixed here).

Fix: new downloadToFile() in the shared http-client.ts streams the response directly to disk (matching downloadTool's memory profile for a large archive -- never buffers the whole binary in memory) and re-validates the host at EVERY redirect hop via a caller-supplied predicate, not just the first. The initial download_url host is still checked synchronously up front too (fail fast, preserving the original zero-network-call rejection behavior), then downloadToFile defensively re-checks it plus every subsequent hop. This new path is used ONLY when registryAllowedHosts is actually configured -- the default (no allowlist) case still uses tools.downloadTool() completely unchanged, so there's no behavior change for the common configuration.

Tests: new direct unit tests for downloadToFile (allowed single host, disallowed initial host makes zero requests, disallowed redirect target, multi-hop allowed chain, non-2xx response). Updated the existing registry-allowed-host success test's mocks to exercise the new code path. Verified byte-identical across all 3 installer copies via \
ode scripts/check-shared-modules.js\.

Closes #679