### PR TITLE
fix: close CodeQL-flagged TOCTOU races and command injection

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
@@ -4,9 +4,19 @@ import tasks = require('azure-pipelines-task-lib/task');
 /** Append an article entry to the kb-manifest JSON file. */
 export function appendToManifest(manifestPath: string, entry: Record<string, unknown>): void {
     let entries: unknown[] = [];
-    if (fs.existsSync(manifestPath)) {
+    // Opened once and read via that same descriptor (not an existsSync +
+    // readFileSync pair on the path) so there is no window between the
+    // existence check and the read where the path could be repointed at a
+    // different file (TOCTOU / CWE-367).
+    let fd: number | undefined;
+    try {
+        fd = fs.openSync(manifestPath, 'r');
+    } catch {
+        fd = undefined; // Missing (or otherwise unopenable) -- start from an empty manifest.
+    }
+    if (fd !== undefined) {
         try {
-            entries = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+            entries = JSON.parse(fs.readFileSync(fd, 'utf-8'));
         } catch (e: unknown) {
             // The manifest exists but is unreadable/corrupt. Do NOT silently reset it
             // to [] -- that would overwrite and permanently discard every prior article
@@ -20,6 +30,8 @@ export function appendToManifest(manifestPath: string, entry: Record<string, unk
                 console.warn(tasks.loc('ManifestCorruptNoBackup', manifestPath, e));
             }
             entries = [];
+        } finally {
+            fs.closeSync(fd);
         }
     }
     entries.push(entry);

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -22,19 +22,29 @@ export const MAX_PLAN_JSON_BYTES = 100 * 1024 * 1024; // 100 MB
 // module_locks field; null when absent/unreadable/oversized (the backend then
 // records provenance without locked versions).
 function readModuleLocks(manifestPath: string): unknown {
+    // Opened once and stat/read via that same descriptor (not an existsSync +
+    // statSync + readFileSync sequence on the path) so there is no window
+    // between the size check and the read where the path could be repointed
+    // at a different, larger file (TOCTOU / CWE-367).
+    let fd: number;
     try {
-        if (!fs.existsSync(manifestPath)) {
-            return null;
-        }
+        fd = fs.openSync(manifestPath, 'r');
+    } catch {
+        return null;
+    }
+    try {
         // Skip an implausibly large manifest rather than risk an unbounded read
         // (best-effort field; degrade gracefully, like backend-detection.ts).
-        if (fs.statSync(manifestPath).size > MAX_PLAN_JSON_BYTES) {
+        const size = fs.fstatSync(fd).size;
+        if (size > MAX_PLAN_JSON_BYTES) {
             tasks.debug(`Module manifest ${manifestPath} exceeds the ${MAX_PLAN_JSON_BYTES}-byte guard; skipping module_locks.`);
             return null;
         }
-        return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        return JSON.parse(fs.readFileSync(fd, 'utf8'));
     } catch {
         return null;
+    } finally {
+        fs.closeSync(fd);
     }
 }
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/secure-temp.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/secure-temp.ts
@@ -127,26 +127,43 @@ function applyWindowsRestrictiveAcl(filePath: string): void {
  * can retain the pre-overwrite blocks regardless -- this narrows the ordinary
  * case, not every storage layer.
  *
- * The path is lstat'd (never stat'd) first, and the overwrite is skipped
- * entirely unless lstat reports a plain regular file. A tracked temp path
- * that has been swapped for a symlink (e.g. an attacker racing a shared
- * working directory between write and cleanup) is left alone rather than
- * followed -- opening through it would zero out whatever the link points at
- * instead of the tracked file (CWE-59), matching the symlink-refusal idiom
- * `replaceSecretFile` already uses. `cleanupTempFiles()` still unlinks the
- * link entry itself; only the content-overwrite is skipped here.
+ * The file is opened first (a plain open, which on Windows follows a
+ * symlink -- Node's O_NOFOLLOW is not honored there, confirmed empirically:
+ * it silently follows rather than erroring), and only AFTER that is the path
+ * separately lstat'd to check whether it is currently a symlink. Ordering the
+ * check after the open (rather than the more obvious lstat-then-open) avoids
+ * a check-then-use race window (CWE-367): whatever the open captured is a
+ * fixed reference that a later path swap cannot retarget, so the subsequent
+ * lstat only ever has to answer "was this path a symlink going into (or
+ * immediately after) the open" -- if so, the descriptor is closed WITHOUT
+ * writing through it, so a tracked path swapped for a symlink onto a victim
+ * file (e.g. an attacker racing a shared working directory between write and
+ * cleanup) is never scrubbed, matching the symlink-refusal idiom
+ * `replaceSecretFile` already uses (CWE-59). The worst case on a benign race
+ * (the path is legitimately replaced/removed between the open and the lstat)
+ * is a missed scrub, never a wrong-target write -- the correct fail-closed
+ * tradeoff for a security-sensitive scrub. `cleanupTempFiles()` still unlinks
+ * the link entry itself; only the content-overwrite is skipped here.
  */
 export function scrubFile(filePath: string): void {
-    let stat: fs.Stats;
+    let fd: number;
     try {
-        stat = fs.lstatSync(filePath);
+        fd = fs.openSync(filePath, 'r+');
     } catch {
         return; // Nothing at this path to scrub.
     }
-    if (!stat.isFile()) return; // Symlink or other non-regular entry -- never opened.
-    if (stat.size === 0) return;
-    const fd = fs.openSync(filePath, 'r+');
     try {
+        let linkCheck: fs.Stats;
+        try {
+            linkCheck = fs.lstatSync(filePath);
+        } catch {
+            return; // Path no longer resolves -- do not write through a stale descriptor.
+        }
+        if (linkCheck.isSymbolicLink()) return; // Never write through a (possibly just-followed) symlink.
+
+        const stat = fs.fstatSync(fd);
+        if (!stat.isFile()) return; // Not a regular file -- never written through.
+        if (stat.size === 0) return;
         fs.writeSync(fd, Buffer.alloc(stat.size, 0), 0, stat.size, 0);
         fs.fsyncSync(fd);
     } finally {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/secure-temp.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/secure-temp.ts
@@ -127,26 +127,43 @@ function applyWindowsRestrictiveAcl(filePath: string): void {
  * can retain the pre-overwrite blocks regardless -- this narrows the ordinary
  * case, not every storage layer.
  *
- * The path is lstat'd (never stat'd) first, and the overwrite is skipped
- * entirely unless lstat reports a plain regular file. A tracked temp path
- * that has been swapped for a symlink (e.g. an attacker racing a shared
- * working directory between write and cleanup) is left alone rather than
- * followed -- opening through it would zero out whatever the link points at
- * instead of the tracked file (CWE-59), matching the symlink-refusal idiom
- * `replaceSecretFile` already uses. `cleanupTempFiles()` still unlinks the
- * link entry itself; only the content-overwrite is skipped here.
+ * The file is opened first (a plain open, which on Windows follows a
+ * symlink -- Node's O_NOFOLLOW is not honored there, confirmed empirically:
+ * it silently follows rather than erroring), and only AFTER that is the path
+ * separately lstat'd to check whether it is currently a symlink. Ordering the
+ * check after the open (rather than the more obvious lstat-then-open) avoids
+ * a check-then-use race window (CWE-367): whatever the open captured is a
+ * fixed reference that a later path swap cannot retarget, so the subsequent
+ * lstat only ever has to answer "was this path a symlink going into (or
+ * immediately after) the open" -- if so, the descriptor is closed WITHOUT
+ * writing through it, so a tracked path swapped for a symlink onto a victim
+ * file (e.g. an attacker racing a shared working directory between write and
+ * cleanup) is never scrubbed, matching the symlink-refusal idiom
+ * `replaceSecretFile` already uses (CWE-59). The worst case on a benign race
+ * (the path is legitimately replaced/removed between the open and the lstat)
+ * is a missed scrub, never a wrong-target write -- the correct fail-closed
+ * tradeoff for a security-sensitive scrub. `cleanupTempFiles()` still unlinks
+ * the link entry itself; only the content-overwrite is skipped here.
  */
 export function scrubFile(filePath: string): void {
-    let stat: fs.Stats;
+    let fd: number;
     try {
-        stat = fs.lstatSync(filePath);
+        fd = fs.openSync(filePath, 'r+');
     } catch {
         return; // Nothing at this path to scrub.
     }
-    if (!stat.isFile()) return; // Symlink or other non-regular entry -- never opened.
-    if (stat.size === 0) return;
-    const fd = fs.openSync(filePath, 'r+');
     try {
+        let linkCheck: fs.Stats;
+        try {
+            linkCheck = fs.lstatSync(filePath);
+        } catch {
+            return; // Path no longer resolves -- do not write through a stale descriptor.
+        }
+        if (linkCheck.isSymbolicLink()) return; // Never write through a (possibly just-followed) symlink.
+
+        const stat = fs.fstatSync(fd);
+        if (!stat.isFile()) return; // Not a regular file -- never written through.
+        if (stat.size === 0) return;
         fs.writeSync(fd, Buffer.alloc(stat.size, 0), 0, stat.size, 0);
         fs.fsyncSync(fd);
     } finally {

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/secure-temp.ts
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/secure-temp.ts
@@ -127,26 +127,43 @@ function applyWindowsRestrictiveAcl(filePath: string): void {
  * can retain the pre-overwrite blocks regardless -- this narrows the ordinary
  * case, not every storage layer.
  *
- * The path is lstat'd (never stat'd) first, and the overwrite is skipped
- * entirely unless lstat reports a plain regular file. A tracked temp path
- * that has been swapped for a symlink (e.g. an attacker racing a shared
- * working directory between write and cleanup) is left alone rather than
- * followed -- opening through it would zero out whatever the link points at
- * instead of the tracked file (CWE-59), matching the symlink-refusal idiom
- * `replaceSecretFile` already uses. `cleanupTempFiles()` still unlinks the
- * link entry itself; only the content-overwrite is skipped here.
+ * The file is opened first (a plain open, which on Windows follows a
+ * symlink -- Node's O_NOFOLLOW is not honored there, confirmed empirically:
+ * it silently follows rather than erroring), and only AFTER that is the path
+ * separately lstat'd to check whether it is currently a symlink. Ordering the
+ * check after the open (rather than the more obvious lstat-then-open) avoids
+ * a check-then-use race window (CWE-367): whatever the open captured is a
+ * fixed reference that a later path swap cannot retarget, so the subsequent
+ * lstat only ever has to answer "was this path a symlink going into (or
+ * immediately after) the open" -- if so, the descriptor is closed WITHOUT
+ * writing through it, so a tracked path swapped for a symlink onto a victim
+ * file (e.g. an attacker racing a shared working directory between write and
+ * cleanup) is never scrubbed, matching the symlink-refusal idiom
+ * `replaceSecretFile` already uses (CWE-59). The worst case on a benign race
+ * (the path is legitimately replaced/removed between the open and the lstat)
+ * is a missed scrub, never a wrong-target write -- the correct fail-closed
+ * tradeoff for a security-sensitive scrub. `cleanupTempFiles()` still unlinks
+ * the link entry itself; only the content-overwrite is skipped here.
  */
 export function scrubFile(filePath: string): void {
-    let stat: fs.Stats;
+    let fd: number;
     try {
-        stat = fs.lstatSync(filePath);
+        fd = fs.openSync(filePath, 'r+');
     } catch {
         return; // Nothing at this path to scrub.
     }
-    if (!stat.isFile()) return; // Symlink or other non-regular entry -- never opened.
-    if (stat.size === 0) return;
-    const fd = fs.openSync(filePath, 'r+');
     try {
+        let linkCheck: fs.Stats;
+        try {
+            linkCheck = fs.lstatSync(filePath);
+        } catch {
+            return; // Path no longer resolves -- do not write through a stale descriptor.
+        }
+        if (linkCheck.isSymbolicLink()) return; // Never write through a (possibly just-followed) symlink.
+
+        const stat = fs.fstatSync(fd);
+        if (!stat.isFile()) return; // Not a regular file -- never written through.
+        if (stat.size === 0) return;
         fs.writeSync(fd, Buffer.alloc(stat.size, 0), 0, stat.size, 0);
         fs.fsyncSync(fd);
     } finally {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/backend-detection.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/backend-detection.ts
@@ -54,30 +54,40 @@ const BACKEND_TYPE_TO_CLOUD: Readonly<Record<string, BackendCloud>> = {
 export function detectBackendCloud(workingDirectory: string): BackendCloud | null {
   const tfstatePath = path.join(workingDirectory || '.', '.terraform', 'terraform.tfstate');
 
-  let stats: fs.Stats;
+  // Opened once and stat/read via that same descriptor (not a statSync/
+  // readFileSync pair on the path) so there is no window between the
+  // is-a-file/size check and the read where the path could be repointed at a
+  // different, larger file (TOCTOU / CWE-367).
+  let fd: number;
   try {
-    stats = fs.statSync(tfstatePath);
+    fd = fs.openSync(tfstatePath, 'r');
   } catch {
     tasks.debug(`Backend detection: no ${tfstatePath} found (not yet initialized?); skipping cross-cloud backend credential injection.`);
     return null;
   }
 
-  if (!stats.isFile()) {
-    tasks.debug(`Backend detection: ${tfstatePath} is not a regular file; skipping.`);
-    return null;
-  }
-
-  if (stats.size > MAX_BACKEND_STATE_BYTES) {
-    tasks.debug(`Backend detection: ${tfstatePath} is ${stats.size} bytes, exceeding the ${MAX_BACKEND_STATE_BYTES}-byte guard; skipping rather than risk an unbounded read.`);
-    return null;
-  }
-
   let raw: string;
   try {
-    raw = fs.readFileSync(tfstatePath, 'utf-8');
-  } catch (err) {
-    tasks.debug(`Backend detection: failed to read ${tfstatePath}: ${err instanceof Error ? err.message : err}`);
-    return null;
+    const stats = fs.fstatSync(fd);
+
+    if (!stats.isFile()) {
+      tasks.debug(`Backend detection: ${tfstatePath} is not a regular file; skipping.`);
+      return null;
+    }
+
+    if (stats.size > MAX_BACKEND_STATE_BYTES) {
+      tasks.debug(`Backend detection: ${tfstatePath} is ${stats.size} bytes, exceeding the ${MAX_BACKEND_STATE_BYTES}-byte guard; skipping rather than risk an unbounded read.`);
+      return null;
+    }
+
+    try {
+      raw = fs.readFileSync(fd, 'utf-8');
+    } catch (err) {
+      tasks.debug(`Backend detection: failed to read ${tfstatePath}: ${err instanceof Error ? err.message : err}`);
+      return null;
+    }
+  } finally {
+    fs.closeSync(fd);
   }
 
   let parsed: unknown;

--- a/Tasks/TerraformTask/TerraformTaskV5/src/secure-temp.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/secure-temp.ts
@@ -127,26 +127,43 @@ function applyWindowsRestrictiveAcl(filePath: string): void {
  * can retain the pre-overwrite blocks regardless -- this narrows the ordinary
  * case, not every storage layer.
  *
- * The path is lstat'd (never stat'd) first, and the overwrite is skipped
- * entirely unless lstat reports a plain regular file. A tracked temp path
- * that has been swapped for a symlink (e.g. an attacker racing a shared
- * working directory between write and cleanup) is left alone rather than
- * followed -- opening through it would zero out whatever the link points at
- * instead of the tracked file (CWE-59), matching the symlink-refusal idiom
- * `replaceSecretFile` already uses. `cleanupTempFiles()` still unlinks the
- * link entry itself; only the content-overwrite is skipped here.
+ * The file is opened first (a plain open, which on Windows follows a
+ * symlink -- Node's O_NOFOLLOW is not honored there, confirmed empirically:
+ * it silently follows rather than erroring), and only AFTER that is the path
+ * separately lstat'd to check whether it is currently a symlink. Ordering the
+ * check after the open (rather than the more obvious lstat-then-open) avoids
+ * a check-then-use race window (CWE-367): whatever the open captured is a
+ * fixed reference that a later path swap cannot retarget, so the subsequent
+ * lstat only ever has to answer "was this path a symlink going into (or
+ * immediately after) the open" -- if so, the descriptor is closed WITHOUT
+ * writing through it, so a tracked path swapped for a symlink onto a victim
+ * file (e.g. an attacker racing a shared working directory between write and
+ * cleanup) is never scrubbed, matching the symlink-refusal idiom
+ * `replaceSecretFile` already uses (CWE-59). The worst case on a benign race
+ * (the path is legitimately replaced/removed between the open and the lstat)
+ * is a missed scrub, never a wrong-target write -- the correct fail-closed
+ * tradeoff for a security-sensitive scrub. `cleanupTempFiles()` still unlinks
+ * the link entry itself; only the content-overwrite is skipped here.
  */
 export function scrubFile(filePath: string): void {
-    let stat: fs.Stats;
+    let fd: number;
     try {
-        stat = fs.lstatSync(filePath);
+        fd = fs.openSync(filePath, 'r+');
     } catch {
         return; // Nothing at this path to scrub.
     }
-    if (!stat.isFile()) return; // Symlink or other non-regular entry -- never opened.
-    if (stat.size === 0) return;
-    const fd = fs.openSync(filePath, 'r+');
     try {
+        let linkCheck: fs.Stats;
+        try {
+            linkCheck = fs.lstatSync(filePath);
+        } catch {
+            return; // Path no longer resolves -- do not write through a stale descriptor.
+        }
+        if (linkCheck.isSymbolicLink()) return; // Never write through a (possibly just-followed) symlink.
+
+        const stat = fs.fstatSync(fd);
+        if (!stat.isFile()) return; // Not a regular file -- never written through.
+        if (stat.size === 0) return;
         fs.writeSync(fd, Buffer.alloc(stat.size, 0), 0, stat.size, 0);
         fs.fsyncSync(fd);
     } finally {

--- a/scripts/check-minor-bumps.js
+++ b/scripts/check-minor-bumps.js
@@ -15,7 +15,7 @@
 // `require.main === module` guard at the bottom. The CLI output strings are
 // asserted verbatim by scripts/test-check-minor-bumps.js and must not change.
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { discoverTaskDirs } = require('./lib/task-dirs.js');
 
 // The task list is DERIVED from the Tasks/*/*/task.json directory scan (see
@@ -26,12 +26,19 @@ function getTaskDirs() {
   return discoverTaskDirs(process.cwd());
 }
 
+// Takes an argv array (not a pre-built string) and runs it via execFileSync,
+// which spawns git directly with no intervening shell -- ref/taskDir values
+// (the latter ultimately from a directory-name scan of the checked-out tree,
+// e.g. a PR-introduced Tasks/* folder) are passed through as literal argv
+// elements and can never be interpreted as shell metacharacters, closing the
+// command/argument-injection flagged on the previous execSync(`git ${args}`)
+// template-string form.
 function git(args) {
-  return execSync(`git ${args}`, { encoding: 'utf8' }).trim();
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
 }
 
 function minorAt(ref, taskDir) {
-  const raw = git(`show ${ref}:${taskDir}/task.json`);
+  const raw = git(['show', `${ref}:${taskDir}/task.json`]);
   return parseInt(JSON.parse(raw).version.Minor, 10);
 }
 
@@ -40,8 +47,8 @@ function minorAt(ref, taskDir) {
 // the remaining tags are sorted by version (newest first). Returns undefined
 // when no such tag exists.
 function resolvePrevRef(currRef) {
-  const head = git(`rev-parse ${currRef}`);
-  const tags = git('tag --sort=-v:refname')
+  const head = git(['rev-parse', currRef]);
+  const tags = git(['tag', '--sort=-v:refname'])
     .split('\n')
     .map((t) => t.trim())
     .filter((t) => /^v\d+\.\d+\.\d+$/.test(t));
@@ -49,7 +56,7 @@ function resolvePrevRef(currRef) {
   // being released (which typically already carries this release's own tag).
   return tags.find((t) => {
     try {
-      return git(`rev-list -n1 ${t}`) !== head;
+      return git(['rev-list', '-n1', t]) !== head;
     } catch {
       return false;
     }
@@ -72,7 +79,7 @@ function analyze({ prevRef, currRef, readCurrMinor }) {
   for (const task of getTaskDirs()) {
     let changed;
     try {
-      changed = git(`diff --name-only ${prevRef} ${currRef} -- ${task}/src`);
+      changed = git(['diff', '--name-only', prevRef, currRef, '--', `${task}/src`]);
     } catch (e) {
       results.push({ task, kind: 'diff-error', message: e.message });
       continue;


### PR DESCRIPTION
## Summary

Fixes a batch of CodeQL findings that were genuine check-then-use (TOCTOU) races and a
command/shell-injection pattern in repo tooling. Part of a broader CodeQL alert cleanup;
the remaining alerts (test-only temp-file fixtures, and a few by-design network/file-access
findings) are being resolved as dismissals rather than code changes.

## `js/file-system-race` (7 alerts) — genuine TOCTOU, fixed

A `statSync`/`existsSync`/`lstatSync` check followed by a *separate* `readFileSync`/`openSync`
call on the same path leaves a window where the path could be repointed at a different file
between the check and the use (CWE-367).

- **`secure-temp.ts` `scrubFile`** (4 byte-identical copies: TerraformTaskV5, TerraformDriftReport,
  TerraformPolicyCheck, TerraformProviderMirror) — now opens the file once, then lstats the
  *path* afterward to detect a symlink, closing without writing if one is found.
  - Verified empirically on this machine that Node's `O_NOFOLLOW` is **silently ignored on
    Windows** (`openSync` happily follows the symlink instead of erroring) — an initial fix
    attempt relying on `O_NOFOLLOW` alone regressed the existing "does not follow a symlink onto
    a victim file (CWE-59)" test on Windows. The post-open lstat check is what makes the final
    fix safe cross-platform: whatever the open captured is a fixed reference a later path swap
    can't retarget, and the write is gated on the path still not being a symlink.
- **`backend-detection.ts` `detectBackendCloud`** — opens once, `fstatSync`/`readFileSync` via
  that same descriptor instead of `statSync` + `readFileSync(path)`.
- **TerraformDriftReport `index.ts` `readModuleLocks`** — same pattern.
- **PublishKbArticle `manifest.ts` `appendToManifest`** — same pattern.

All are the same class of fix already applied to `PublishKbArticle`'s `attachments.ts`/
`html-validate.ts` in a previous PR.

## `js/indirect-command-line-injection` + `js/shell-command-injection-from-environment` (2 alerts, same line) — fixed

`scripts/check-minor-bumps.js`'s `git()` helper built a shell command string via template
interpolation (`execSync(\`git ${args}\`)`). Switched to `execFileSync('git', [...argv])` so
`ref`/`taskDir` values (the latter ultimately from a directory-name scan of the checked-out
tree, e.g. a PR-introduced `Tasks/*` folder) are passed as literal argv elements with no shell
to interpret metacharacters in them. In CI today neither workflow passes external args to this
script, but this closes the gap for any future caller and for local/manual use.

## Verification

- `node scripts/test-check-minor-bumps.js` — all cases pass.
- `node scripts/test-bump-minor-versions.js` — all cases pass (depends on `check-minor-bumps.js`'s
  exports).
- `node scripts/check-shared-modules.js` — all 4 `secure-temp.ts` copies remain byte-identical.
- Full `npm test` for all 5 affected tasks, all green:
  - TerraformTaskV5: 549 passing
  - TerraformDriftReport: 59 passing
  - TerraformPolicyCheck: 63 passing
  - TerraformProviderMirror: 58 passing
  - PublishKbArticle: 212 passing
