### PR TITLE
fix: add decorrelated jitter and an optional wall-clock budget to the shared retry backoff (#692)

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RetryL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RetryL0.ts
@@ -54,7 +54,29 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         assert.strictEqual(calls, 3, 'total attempts = retries + 1 (initial attempt + 2 retries)');
     });
 
-    it('grows the default exponential backoff across attempts', async () => {
+    it('applies decorrelated jitter to the default backoff, seeded from an injectable random source (#692)', async () => {
+        const seen: number[] = [];
+        let calls = 0;
+        const randomValues = [0, 1, 0.5];
+        let i = 0;
+        await retryAsync(() => {
+            calls += 1;
+            return calls < 4 ? Promise.reject(new Error('e')) : Promise.resolve('done');
+        }, {
+            retries: 3,
+            baseDelayMs: 5,
+            random: () => randomValues[i++],
+            onRetry: (_attempt, delayMs) => seen.push(delayMs),
+        });
+        // Decorrelated jitter: delay = baseDelayMs + random() * (max(baseDelayMs, previousDelay*3) - baseDelayMs),
+        // with previousDelay seeded at baseDelayMs and updated to the delay just computed.
+        //   attempt 0: bound [5,15],  random()=0   -> 5
+        //   attempt 1: bound [5,15],  random()=1   -> 15
+        //   attempt 2: bound [5,45],  random()=0.5 -> 25
+        assert.deepStrictEqual(seen, [5, 15, 25], 'should follow the documented decorrelated-jitter recurrence exactly');
+    });
+
+    it('keeps the default (non-injected) jittered delay within [baseDelayMs, maxBackoffMs] on every attempt', async () => {
         const seen: number[] = [];
         let calls = 0;
         await retryAsync(() => {
@@ -63,10 +85,25 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         }, {
             retries: 3,
             baseDelayMs: 5,
+            maxBackoffMs: 1000,
             onRetry: (_attempt, delayMs) => seen.push(delayMs),
         });
-        // baseDelayMs * 2**attempt for attempts 0, 1, 2 -- 5, 10, 20.
-        assert.deepStrictEqual(seen, [5, 10, 20], 'each retry should wait longer than the last (exponential backoff)');
+        assert.strictEqual(seen.length, 3);
+        for (const delay of seen) {
+            assert.ok(delay >= 5 && delay <= 1000, `expected each jittered delay within [5,1000], got ${delay}`);
+        }
+    });
+
+    it('gives up immediately once the maxElapsedMs wall-clock budget is exhausted, even with retries remaining (#692)', async () => {
+        let calls = 0;
+        await assert.rejects(
+            retryAsync(() => {
+                calls += 1;
+                return Promise.reject(new Error(`fail-${calls}`));
+            }, { retries: 10, baseDelayMs: 50, maxElapsedMs: 0 }),
+            /fail-1/,
+        );
+        assert.strictEqual(calls, 1, 'a zero-length budget must stop after the very first attempt');
     });
 });
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/retry.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/retry.ts
@@ -12,9 +12,10 @@
 //   Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
 //
 // CI (scripts/check-shared-modules.js) enforces byte-identity across those
-// copies and fails the build on any divergence, so a future hardening change
-// (jitter, a max-total-time cap, ...) can never be applied to one copy and
-// silently missed in the others. EDIT EVERY COPY TOGETHER.
+// copies and fails the build on any divergence, so a hardening change
+// (decorrelated jitter and the optional max-total-elapsed-time budget, added
+// for #692) can never be applied to one copy and silently missed in the
+// others. EDIT EVERY COPY TOGETHER.
 //
 // The retry loops that used to be independently open-coded — the OIDC
 // TokenGenerator (id-token-generator.ts), the registry retryHttp (http.ts), the
@@ -32,7 +33,7 @@
 //   - retryError decides whether a THROWN error is worth retrying. Default:
 //     always. (A pure transport failure carries no server-side state.)
 //   - delayMs overrides the backoff for a single attempt (e.g. honoring a capped
-//     HTTP 429 Retry-After); the default is baseDelayMs * 2**attempt.
+//     HTTP 429 Retry-After); the default is decorrelated jitter (see retryAsync).
 //   - onRetry runs once per retry (never on the final give-up), so each call
 //     site keeps its own log wording.
 //
@@ -48,45 +49,71 @@ export type RetryOutcome<T> =
 export interface RetryController<T> {
     /** Retries AFTER the first attempt (total attempts = retries + 1). Default 3. */
     retries?: number;
-    /** Exponential-backoff base in ms; the nth (0-based) retry waits baseDelayMs * 2**n. Default 500. */
+    /** Exponential-backoff base in ms; the default jittered delay is never below this. Default 500. */
     baseDelayMs?: number;
+    /** Upper bound (ms) on the default jittered delay. Default RETRY_AFTER_CAP_MS (30s). */
+    maxBackoffMs?: number;
+    /** Entropy source for the default jittered delay, injectable for deterministic tests. Default Math.random. */
+    random?: () => number;
+    /**
+     * Optional wall-clock budget (ms) across ALL attempts of this call; once
+     * elapsed, no further retry is scheduled even if attempts/predicates would
+     * otherwise allow one -- the last outcome is returned/thrown immediately
+     * instead (#692). Default: unbounded (only the `retries` count applies).
+     */
+    maxElapsedMs?: number;
     /** Whether a resolved value is worth retrying. Default: never. */
     retryResult?: (result: T) => boolean;
     /** Whether a thrown error is worth retrying. Default: always. */
     retryError?: (error: unknown) => boolean;
-    /** Override the pre-retry delay for one attempt; the default is the exponential backoff. */
+    /** Override the pre-retry delay for one attempt; the default is decorrelated jitter. */
     delayMs?: (attempt: number, backoffMs: number, outcome: RetryOutcome<T>) => number;
     /** Invoked once before each retry's delay (never on the final give-up). */
     onRetry?: (attempt: number, delayMs: number, outcome: RetryOutcome<T>) => void;
 }
 
 /**
- * Run `call` with bounded exponential-backoff retry. `attempt` is 0-based: the
- * first try is attempt 0, and a retry is scheduled only while attempt < retries.
+ * Run `call` with bounded, jittered-backoff retry. `attempt` is 0-based: the
+ * first try is attempt 0, and a retry is scheduled only while attempt < retries
+ * AND (when `maxElapsedMs` is set) the elapsed-time budget has not yet run out.
  * A resolved value is returned as soon as retryResult says it is acceptable (or
  * the budget is spent); a thrown error is rethrown as soon as retryError says it
  * is terminal (or the budget is spent).
+ *
+ * The default per-attempt delay uses decorrelated jitter (AWS's "Exponential
+ * Backoff And Jitter"): `delay = min(maxBackoffMs, baseDelayMs + random() *
+ * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`, with `previousDelay`
+ * seeded at `baseDelayMs`. Unlike a pure `baseDelayMs * 2**attempt` schedule,
+ * this spreads out many concurrent callers retrying the same rate-limited
+ * endpoint instead of having them all wait the same deterministic delay in
+ * lockstep (#692).
  */
 export async function retryAsync<T>(call: () => Promise<T>, controller: RetryController<T> = {}): Promise<T> {
     const retries = controller.retries ?? 3;
     const baseDelayMs = controller.baseDelayMs ?? 500;
+    const maxBackoffMs = controller.maxBackoffMs ?? RETRY_AFTER_CAP_MS;
+    const random = controller.random ?? Math.random;
     const retryResult = controller.retryResult ?? (() => false);
     const retryError = controller.retryError ?? (() => true);
+    const deadline = controller.maxElapsedMs !== undefined ? Date.now() + controller.maxElapsedMs : undefined;
+    let previousDelayMs = baseDelayMs;
     for (let attempt = 0; ; attempt++) {
         let outcome: RetryOutcome<T>;
         try {
             const result = await call();
-            if (attempt >= retries || !retryResult(result)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryResult(result)) {
                 return result;
             }
             outcome = { kind: 'result', result };
         } catch (error) {
-            if (attempt >= retries || !retryError(error)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryError(error)) {
                 throw error;
             }
             outcome = { kind: 'error', error };
         }
-        const backoffMs = baseDelayMs * 2 ** attempt;
+        const upperBound = Math.max(baseDelayMs, previousDelayMs * 3);
+        const backoffMs = Math.min(maxBackoffMs, baseDelayMs + random() * (upperBound - baseDelayMs));
+        previousDelayMs = backoffMs;
         const wait = controller.delayMs ? controller.delayMs(attempt, backoffMs, outcome) : backoffMs;
         controller.onRetry?.(attempt, wait, outcome);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RetryL0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/RetryL0.ts
@@ -6,15 +6,16 @@ import { retryAsync, parseRetryAfterMs } from '../src/retry';
  * Direct unit tests for the shared retry.ts module itself -- retryAsync
  * (bounded exponential-backoff retry) and parseRetryAfterMs (the capped HTTP
  * 429 Retry-After parser). retry.ts is duplicated byte-identically across
- * four tasks (TerraformTaskV5, TerraformModulePublishV1,
- * TerraformDriftReportV1, PublishKbArticleV1; see
+ * seven tasks (TerraformTaskV5, TerraformModulePublishV1,
+ * TerraformDriftReportV1, PublishKbArticleV1, TerraformInstallerV1,
+ * PolicyAgentInstallerV1, TerraformDocsInstallerV1; see
  * scripts/check-shared-modules.js), and before this file existed it was
  * exercised only indirectly through each task's own consumer
- * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts) -- the
- * #497 pattern where a shared module has no test of its own, so a defect in
- * the module itself could hide behind every consumer's mocked/stubbed
- * transport. These call the real exports directly with small real delays --
- * no fake/mocked timers.
+ * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts /
+ * http-client.ts) -- the #497 pattern where a shared module has no test of
+ * its own, so a defect in the module itself could hide behind every
+ * consumer's mocked/stubbed transport. These call the real exports directly
+ * with small real delays -- no fake/mocked timers.
  */
 describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
     it('succeeds after transient failures are retried', async () => {
@@ -51,7 +52,29 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         assert.strictEqual(calls, 3, 'total attempts = retries + 1 (initial attempt + 2 retries)');
     });
 
-    it('grows the default exponential backoff across attempts', async () => {
+    it('applies decorrelated jitter to the default backoff, seeded from an injectable random source (#692)', async () => {
+        const seen: number[] = [];
+        let calls = 0;
+        const randomValues = [0, 1, 0.5];
+        let i = 0;
+        await retryAsync(() => {
+            calls += 1;
+            return calls < 4 ? Promise.reject(new Error('e')) : Promise.resolve('done');
+        }, {
+            retries: 3,
+            baseDelayMs: 5,
+            random: () => randomValues[i++],
+            onRetry: (_attempt, delayMs) => seen.push(delayMs),
+        });
+        // Decorrelated jitter: delay = baseDelayMs + random() * (max(baseDelayMs, previousDelay*3) - baseDelayMs),
+        // with previousDelay seeded at baseDelayMs and updated to the delay just computed.
+        //   attempt 0: bound [5,15],  random()=0   -> 5
+        //   attempt 1: bound [5,15],  random()=1   -> 15
+        //   attempt 2: bound [5,45],  random()=0.5 -> 25
+        assert.deepStrictEqual(seen, [5, 15, 25], 'should follow the documented decorrelated-jitter recurrence exactly');
+    });
+
+    it('keeps the default (non-injected) jittered delay within [baseDelayMs, maxBackoffMs] on every attempt', async () => {
         const seen: number[] = [];
         let calls = 0;
         await retryAsync(() => {
@@ -60,10 +83,25 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         }, {
             retries: 3,
             baseDelayMs: 5,
+            maxBackoffMs: 1000,
             onRetry: (_attempt, delayMs) => seen.push(delayMs),
         });
-        // baseDelayMs * 2**attempt for attempts 0, 1, 2 -- 5, 10, 20.
-        assert.deepStrictEqual(seen, [5, 10, 20], 'each retry should wait longer than the last (exponential backoff)');
+        assert.strictEqual(seen.length, 3);
+        for (const delay of seen) {
+            assert.ok(delay >= 5 && delay <= 1000, `expected each jittered delay within [5,1000], got ${delay}`);
+        }
+    });
+
+    it('gives up immediately once the maxElapsedMs wall-clock budget is exhausted, even with retries remaining (#692)', async () => {
+        let calls = 0;
+        await assert.rejects(
+            retryAsync(() => {
+                calls += 1;
+                return Promise.reject(new Error(`fail-${calls}`));
+            }, { retries: 10, baseDelayMs: 50, maxElapsedMs: 0 }),
+            /fail-1/,
+        );
+        assert.strictEqual(calls, 1, 'a zero-length budget must stop after the very first attempt');
     });
 });
 

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/retry.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/retry.ts
@@ -12,9 +12,10 @@
 //   Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
 //
 // CI (scripts/check-shared-modules.js) enforces byte-identity across those
-// copies and fails the build on any divergence, so a future hardening change
-// (jitter, a max-total-time cap, ...) can never be applied to one copy and
-// silently missed in the others. EDIT EVERY COPY TOGETHER.
+// copies and fails the build on any divergence, so a hardening change
+// (decorrelated jitter and the optional max-total-elapsed-time budget, added
+// for #692) can never be applied to one copy and silently missed in the
+// others. EDIT EVERY COPY TOGETHER.
 //
 // The retry loops that used to be independently open-coded — the OIDC
 // TokenGenerator (id-token-generator.ts), the registry retryHttp (http.ts), the
@@ -32,7 +33,7 @@
 //   - retryError decides whether a THROWN error is worth retrying. Default:
 //     always. (A pure transport failure carries no server-side state.)
 //   - delayMs overrides the backoff for a single attempt (e.g. honoring a capped
-//     HTTP 429 Retry-After); the default is baseDelayMs * 2**attempt.
+//     HTTP 429 Retry-After); the default is decorrelated jitter (see retryAsync).
 //   - onRetry runs once per retry (never on the final give-up), so each call
 //     site keeps its own log wording.
 //
@@ -48,45 +49,71 @@ export type RetryOutcome<T> =
 export interface RetryController<T> {
     /** Retries AFTER the first attempt (total attempts = retries + 1). Default 3. */
     retries?: number;
-    /** Exponential-backoff base in ms; the nth (0-based) retry waits baseDelayMs * 2**n. Default 500. */
+    /** Exponential-backoff base in ms; the default jittered delay is never below this. Default 500. */
     baseDelayMs?: number;
+    /** Upper bound (ms) on the default jittered delay. Default RETRY_AFTER_CAP_MS (30s). */
+    maxBackoffMs?: number;
+    /** Entropy source for the default jittered delay, injectable for deterministic tests. Default Math.random. */
+    random?: () => number;
+    /**
+     * Optional wall-clock budget (ms) across ALL attempts of this call; once
+     * elapsed, no further retry is scheduled even if attempts/predicates would
+     * otherwise allow one -- the last outcome is returned/thrown immediately
+     * instead (#692). Default: unbounded (only the `retries` count applies).
+     */
+    maxElapsedMs?: number;
     /** Whether a resolved value is worth retrying. Default: never. */
     retryResult?: (result: T) => boolean;
     /** Whether a thrown error is worth retrying. Default: always. */
     retryError?: (error: unknown) => boolean;
-    /** Override the pre-retry delay for one attempt; the default is the exponential backoff. */
+    /** Override the pre-retry delay for one attempt; the default is decorrelated jitter. */
     delayMs?: (attempt: number, backoffMs: number, outcome: RetryOutcome<T>) => number;
     /** Invoked once before each retry's delay (never on the final give-up). */
     onRetry?: (attempt: number, delayMs: number, outcome: RetryOutcome<T>) => void;
 }
 
 /**
- * Run `call` with bounded exponential-backoff retry. `attempt` is 0-based: the
- * first try is attempt 0, and a retry is scheduled only while attempt < retries.
+ * Run `call` with bounded, jittered-backoff retry. `attempt` is 0-based: the
+ * first try is attempt 0, and a retry is scheduled only while attempt < retries
+ * AND (when `maxElapsedMs` is set) the elapsed-time budget has not yet run out.
  * A resolved value is returned as soon as retryResult says it is acceptable (or
  * the budget is spent); a thrown error is rethrown as soon as retryError says it
  * is terminal (or the budget is spent).
+ *
+ * The default per-attempt delay uses decorrelated jitter (AWS's "Exponential
+ * Backoff And Jitter"): `delay = min(maxBackoffMs, baseDelayMs + random() *
+ * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`, with `previousDelay`
+ * seeded at `baseDelayMs`. Unlike a pure `baseDelayMs * 2**attempt` schedule,
+ * this spreads out many concurrent callers retrying the same rate-limited
+ * endpoint instead of having them all wait the same deterministic delay in
+ * lockstep (#692).
  */
 export async function retryAsync<T>(call: () => Promise<T>, controller: RetryController<T> = {}): Promise<T> {
     const retries = controller.retries ?? 3;
     const baseDelayMs = controller.baseDelayMs ?? 500;
+    const maxBackoffMs = controller.maxBackoffMs ?? RETRY_AFTER_CAP_MS;
+    const random = controller.random ?? Math.random;
     const retryResult = controller.retryResult ?? (() => false);
     const retryError = controller.retryError ?? (() => true);
+    const deadline = controller.maxElapsedMs !== undefined ? Date.now() + controller.maxElapsedMs : undefined;
+    let previousDelayMs = baseDelayMs;
     for (let attempt = 0; ; attempt++) {
         let outcome: RetryOutcome<T>;
         try {
             const result = await call();
-            if (attempt >= retries || !retryResult(result)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryResult(result)) {
                 return result;
             }
             outcome = { kind: 'result', result };
         } catch (error) {
-            if (attempt >= retries || !retryError(error)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryError(error)) {
                 throw error;
             }
             outcome = { kind: 'error', error };
         }
-        const backoffMs = baseDelayMs * 2 ** attempt;
+        const upperBound = Math.max(baseDelayMs, previousDelayMs * 3);
+        const backoffMs = Math.min(maxBackoffMs, baseDelayMs + random() * (upperBound - baseDelayMs));
+        previousDelayMs = backoffMs;
         const wait = controller.delayMs ? controller.delayMs(attempt, backoffMs, outcome) : backoffMs;
         controller.onRetry?.(attempt, wait, outcome);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RetryL0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RetryL0.ts
@@ -54,7 +54,29 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         assert.strictEqual(calls, 3, 'total attempts = retries + 1 (initial attempt + 2 retries)');
     });
 
-    it('grows the default exponential backoff across attempts', async () => {
+    it('applies decorrelated jitter to the default backoff, seeded from an injectable random source (#692)', async () => {
+        const seen: number[] = [];
+        let calls = 0;
+        const randomValues = [0, 1, 0.5];
+        let i = 0;
+        await retryAsync(() => {
+            calls += 1;
+            return calls < 4 ? Promise.reject(new Error('e')) : Promise.resolve('done');
+        }, {
+            retries: 3,
+            baseDelayMs: 5,
+            random: () => randomValues[i++],
+            onRetry: (_attempt, delayMs) => seen.push(delayMs),
+        });
+        // Decorrelated jitter: delay = baseDelayMs + random() * (max(baseDelayMs, previousDelay*3) - baseDelayMs),
+        // with previousDelay seeded at baseDelayMs and updated to the delay just computed.
+        //   attempt 0: bound [5,15],  random()=0   -> 5
+        //   attempt 1: bound [5,15],  random()=1   -> 15
+        //   attempt 2: bound [5,45],  random()=0.5 -> 25
+        assert.deepStrictEqual(seen, [5, 15, 25], 'should follow the documented decorrelated-jitter recurrence exactly');
+    });
+
+    it('keeps the default (non-injected) jittered delay within [baseDelayMs, maxBackoffMs] on every attempt', async () => {
         const seen: number[] = [];
         let calls = 0;
         await retryAsync(() => {
@@ -63,10 +85,25 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         }, {
             retries: 3,
             baseDelayMs: 5,
+            maxBackoffMs: 1000,
             onRetry: (_attempt, delayMs) => seen.push(delayMs),
         });
-        // baseDelayMs * 2**attempt for attempts 0, 1, 2 -- 5, 10, 20.
-        assert.deepStrictEqual(seen, [5, 10, 20], 'each retry should wait longer than the last (exponential backoff)');
+        assert.strictEqual(seen.length, 3);
+        for (const delay of seen) {
+            assert.ok(delay >= 5 && delay <= 1000, `expected each jittered delay within [5,1000], got ${delay}`);
+        }
+    });
+
+    it('gives up immediately once the maxElapsedMs wall-clock budget is exhausted, even with retries remaining (#692)', async () => {
+        let calls = 0;
+        await assert.rejects(
+            retryAsync(() => {
+                calls += 1;
+                return Promise.reject(new Error(`fail-${calls}`));
+            }, { retries: 10, baseDelayMs: 50, maxElapsedMs: 0 }),
+            /fail-1/,
+        );
+        assert.strictEqual(calls, 1, 'a zero-length budget must stop after the very first attempt');
     });
 });
 

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
@@ -12,9 +12,10 @@
 //   Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
 //
 // CI (scripts/check-shared-modules.js) enforces byte-identity across those
-// copies and fails the build on any divergence, so a future hardening change
-// (jitter, a max-total-time cap, ...) can never be applied to one copy and
-// silently missed in the others. EDIT EVERY COPY TOGETHER.
+// copies and fails the build on any divergence, so a hardening change
+// (decorrelated jitter and the optional max-total-elapsed-time budget, added
+// for #692) can never be applied to one copy and silently missed in the
+// others. EDIT EVERY COPY TOGETHER.
 //
 // The retry loops that used to be independently open-coded — the OIDC
 // TokenGenerator (id-token-generator.ts), the registry retryHttp (http.ts), the
@@ -32,7 +33,7 @@
 //   - retryError decides whether a THROWN error is worth retrying. Default:
 //     always. (A pure transport failure carries no server-side state.)
 //   - delayMs overrides the backoff for a single attempt (e.g. honoring a capped
-//     HTTP 429 Retry-After); the default is baseDelayMs * 2**attempt.
+//     HTTP 429 Retry-After); the default is decorrelated jitter (see retryAsync).
 //   - onRetry runs once per retry (never on the final give-up), so each call
 //     site keeps its own log wording.
 //
@@ -48,45 +49,71 @@ export type RetryOutcome<T> =
 export interface RetryController<T> {
     /** Retries AFTER the first attempt (total attempts = retries + 1). Default 3. */
     retries?: number;
-    /** Exponential-backoff base in ms; the nth (0-based) retry waits baseDelayMs * 2**n. Default 500. */
+    /** Exponential-backoff base in ms; the default jittered delay is never below this. Default 500. */
     baseDelayMs?: number;
+    /** Upper bound (ms) on the default jittered delay. Default RETRY_AFTER_CAP_MS (30s). */
+    maxBackoffMs?: number;
+    /** Entropy source for the default jittered delay, injectable for deterministic tests. Default Math.random. */
+    random?: () => number;
+    /**
+     * Optional wall-clock budget (ms) across ALL attempts of this call; once
+     * elapsed, no further retry is scheduled even if attempts/predicates would
+     * otherwise allow one -- the last outcome is returned/thrown immediately
+     * instead (#692). Default: unbounded (only the `retries` count applies).
+     */
+    maxElapsedMs?: number;
     /** Whether a resolved value is worth retrying. Default: never. */
     retryResult?: (result: T) => boolean;
     /** Whether a thrown error is worth retrying. Default: always. */
     retryError?: (error: unknown) => boolean;
-    /** Override the pre-retry delay for one attempt; the default is the exponential backoff. */
+    /** Override the pre-retry delay for one attempt; the default is decorrelated jitter. */
     delayMs?: (attempt: number, backoffMs: number, outcome: RetryOutcome<T>) => number;
     /** Invoked once before each retry's delay (never on the final give-up). */
     onRetry?: (attempt: number, delayMs: number, outcome: RetryOutcome<T>) => void;
 }
 
 /**
- * Run `call` with bounded exponential-backoff retry. `attempt` is 0-based: the
- * first try is attempt 0, and a retry is scheduled only while attempt < retries.
+ * Run `call` with bounded, jittered-backoff retry. `attempt` is 0-based: the
+ * first try is attempt 0, and a retry is scheduled only while attempt < retries
+ * AND (when `maxElapsedMs` is set) the elapsed-time budget has not yet run out.
  * A resolved value is returned as soon as retryResult says it is acceptable (or
  * the budget is spent); a thrown error is rethrown as soon as retryError says it
  * is terminal (or the budget is spent).
+ *
+ * The default per-attempt delay uses decorrelated jitter (AWS's "Exponential
+ * Backoff And Jitter"): `delay = min(maxBackoffMs, baseDelayMs + random() *
+ * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`, with `previousDelay`
+ * seeded at `baseDelayMs`. Unlike a pure `baseDelayMs * 2**attempt` schedule,
+ * this spreads out many concurrent callers retrying the same rate-limited
+ * endpoint instead of having them all wait the same deterministic delay in
+ * lockstep (#692).
  */
 export async function retryAsync<T>(call: () => Promise<T>, controller: RetryController<T> = {}): Promise<T> {
     const retries = controller.retries ?? 3;
     const baseDelayMs = controller.baseDelayMs ?? 500;
+    const maxBackoffMs = controller.maxBackoffMs ?? RETRY_AFTER_CAP_MS;
+    const random = controller.random ?? Math.random;
     const retryResult = controller.retryResult ?? (() => false);
     const retryError = controller.retryError ?? (() => true);
+    const deadline = controller.maxElapsedMs !== undefined ? Date.now() + controller.maxElapsedMs : undefined;
+    let previousDelayMs = baseDelayMs;
     for (let attempt = 0; ; attempt++) {
         let outcome: RetryOutcome<T>;
         try {
             const result = await call();
-            if (attempt >= retries || !retryResult(result)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryResult(result)) {
                 return result;
             }
             outcome = { kind: 'result', result };
         } catch (error) {
-            if (attempt >= retries || !retryError(error)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryError(error)) {
                 throw error;
             }
             outcome = { kind: 'error', error };
         }
-        const backoffMs = baseDelayMs * 2 ** attempt;
+        const upperBound = Math.max(baseDelayMs, previousDelayMs * 3);
+        const backoffMs = Math.min(maxBackoffMs, baseDelayMs + random() * (upperBound - baseDelayMs));
+        previousDelayMs = backoffMs;
         const wait = controller.delayMs ? controller.delayMs(attempt, backoffMs, outcome) : backoffMs;
         controller.onRetry?.(attempt, wait, outcome);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/RetryL0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/RetryL0.ts
@@ -6,15 +6,16 @@ import { retryAsync, parseRetryAfterMs } from '../src/retry';
  * Direct unit tests for the shared retry.ts module itself -- retryAsync
  * (bounded exponential-backoff retry) and parseRetryAfterMs (the capped HTTP
  * 429 Retry-After parser). retry.ts is duplicated byte-identically across
- * four tasks (TerraformTaskV5, TerraformModulePublishV1,
- * TerraformDriftReportV1, PublishKbArticleV1; see
+ * seven tasks (TerraformTaskV5, TerraformModulePublishV1,
+ * TerraformDriftReportV1, PublishKbArticleV1, TerraformInstallerV1,
+ * PolicyAgentInstallerV1, TerraformDocsInstallerV1; see
  * scripts/check-shared-modules.js), and before this file existed it was
  * exercised only indirectly through each task's own consumer
- * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts) -- the
- * #497 pattern where a shared module has no test of its own, so a defect in
- * the module itself could hide behind every consumer's mocked/stubbed
- * transport. These call the real exports directly with small real delays --
- * no fake/mocked timers.
+ * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts /
+ * http-client.ts) -- the #497 pattern where a shared module has no test of
+ * its own, so a defect in the module itself could hide behind every
+ * consumer's mocked/stubbed transport. These call the real exports directly
+ * with small real delays -- no fake/mocked timers.
  */
 describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
     it('succeeds after transient failures are retried', async () => {
@@ -51,7 +52,29 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         assert.strictEqual(calls, 3, 'total attempts = retries + 1 (initial attempt + 2 retries)');
     });
 
-    it('grows the default exponential backoff across attempts', async () => {
+    it('applies decorrelated jitter to the default backoff, seeded from an injectable random source (#692)', async () => {
+        const seen: number[] = [];
+        let calls = 0;
+        const randomValues = [0, 1, 0.5];
+        let i = 0;
+        await retryAsync(() => {
+            calls += 1;
+            return calls < 4 ? Promise.reject(new Error('e')) : Promise.resolve('done');
+        }, {
+            retries: 3,
+            baseDelayMs: 5,
+            random: () => randomValues[i++],
+            onRetry: (_attempt, delayMs) => seen.push(delayMs),
+        });
+        // Decorrelated jitter: delay = baseDelayMs + random() * (max(baseDelayMs, previousDelay*3) - baseDelayMs),
+        // with previousDelay seeded at baseDelayMs and updated to the delay just computed.
+        //   attempt 0: bound [5,15],  random()=0   -> 5
+        //   attempt 1: bound [5,15],  random()=1   -> 15
+        //   attempt 2: bound [5,45],  random()=0.5 -> 25
+        assert.deepStrictEqual(seen, [5, 15, 25], 'should follow the documented decorrelated-jitter recurrence exactly');
+    });
+
+    it('keeps the default (non-injected) jittered delay within [baseDelayMs, maxBackoffMs] on every attempt', async () => {
         const seen: number[] = [];
         let calls = 0;
         await retryAsync(() => {
@@ -60,10 +83,25 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         }, {
             retries: 3,
             baseDelayMs: 5,
+            maxBackoffMs: 1000,
             onRetry: (_attempt, delayMs) => seen.push(delayMs),
         });
-        // baseDelayMs * 2**attempt for attempts 0, 1, 2 -- 5, 10, 20.
-        assert.deepStrictEqual(seen, [5, 10, 20], 'each retry should wait longer than the last (exponential backoff)');
+        assert.strictEqual(seen.length, 3);
+        for (const delay of seen) {
+            assert.ok(delay >= 5 && delay <= 1000, `expected each jittered delay within [5,1000], got ${delay}`);
+        }
+    });
+
+    it('gives up immediately once the maxElapsedMs wall-clock budget is exhausted, even with retries remaining (#692)', async () => {
+        let calls = 0;
+        await assert.rejects(
+            retryAsync(() => {
+                calls += 1;
+                return Promise.reject(new Error(`fail-${calls}`));
+            }, { retries: 10, baseDelayMs: 50, maxElapsedMs: 0 }),
+            /fail-1/,
+        );
+        assert.strictEqual(calls, 1, 'a zero-length budget must stop after the very first attempt');
     });
 });
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/retry.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/retry.ts
@@ -12,9 +12,10 @@
 //   Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
 //
 // CI (scripts/check-shared-modules.js) enforces byte-identity across those
-// copies and fails the build on any divergence, so a future hardening change
-// (jitter, a max-total-time cap, ...) can never be applied to one copy and
-// silently missed in the others. EDIT EVERY COPY TOGETHER.
+// copies and fails the build on any divergence, so a hardening change
+// (decorrelated jitter and the optional max-total-elapsed-time budget, added
+// for #692) can never be applied to one copy and silently missed in the
+// others. EDIT EVERY COPY TOGETHER.
 //
 // The retry loops that used to be independently open-coded — the OIDC
 // TokenGenerator (id-token-generator.ts), the registry retryHttp (http.ts), the
@@ -32,7 +33,7 @@
 //   - retryError decides whether a THROWN error is worth retrying. Default:
 //     always. (A pure transport failure carries no server-side state.)
 //   - delayMs overrides the backoff for a single attempt (e.g. honoring a capped
-//     HTTP 429 Retry-After); the default is baseDelayMs * 2**attempt.
+//     HTTP 429 Retry-After); the default is decorrelated jitter (see retryAsync).
 //   - onRetry runs once per retry (never on the final give-up), so each call
 //     site keeps its own log wording.
 //
@@ -48,45 +49,71 @@ export type RetryOutcome<T> =
 export interface RetryController<T> {
     /** Retries AFTER the first attempt (total attempts = retries + 1). Default 3. */
     retries?: number;
-    /** Exponential-backoff base in ms; the nth (0-based) retry waits baseDelayMs * 2**n. Default 500. */
+    /** Exponential-backoff base in ms; the default jittered delay is never below this. Default 500. */
     baseDelayMs?: number;
+    /** Upper bound (ms) on the default jittered delay. Default RETRY_AFTER_CAP_MS (30s). */
+    maxBackoffMs?: number;
+    /** Entropy source for the default jittered delay, injectable for deterministic tests. Default Math.random. */
+    random?: () => number;
+    /**
+     * Optional wall-clock budget (ms) across ALL attempts of this call; once
+     * elapsed, no further retry is scheduled even if attempts/predicates would
+     * otherwise allow one -- the last outcome is returned/thrown immediately
+     * instead (#692). Default: unbounded (only the `retries` count applies).
+     */
+    maxElapsedMs?: number;
     /** Whether a resolved value is worth retrying. Default: never. */
     retryResult?: (result: T) => boolean;
     /** Whether a thrown error is worth retrying. Default: always. */
     retryError?: (error: unknown) => boolean;
-    /** Override the pre-retry delay for one attempt; the default is the exponential backoff. */
+    /** Override the pre-retry delay for one attempt; the default is decorrelated jitter. */
     delayMs?: (attempt: number, backoffMs: number, outcome: RetryOutcome<T>) => number;
     /** Invoked once before each retry's delay (never on the final give-up). */
     onRetry?: (attempt: number, delayMs: number, outcome: RetryOutcome<T>) => void;
 }
 
 /**
- * Run `call` with bounded exponential-backoff retry. `attempt` is 0-based: the
- * first try is attempt 0, and a retry is scheduled only while attempt < retries.
+ * Run `call` with bounded, jittered-backoff retry. `attempt` is 0-based: the
+ * first try is attempt 0, and a retry is scheduled only while attempt < retries
+ * AND (when `maxElapsedMs` is set) the elapsed-time budget has not yet run out.
  * A resolved value is returned as soon as retryResult says it is acceptable (or
  * the budget is spent); a thrown error is rethrown as soon as retryError says it
  * is terminal (or the budget is spent).
+ *
+ * The default per-attempt delay uses decorrelated jitter (AWS's "Exponential
+ * Backoff And Jitter"): `delay = min(maxBackoffMs, baseDelayMs + random() *
+ * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`, with `previousDelay`
+ * seeded at `baseDelayMs`. Unlike a pure `baseDelayMs * 2**attempt` schedule,
+ * this spreads out many concurrent callers retrying the same rate-limited
+ * endpoint instead of having them all wait the same deterministic delay in
+ * lockstep (#692).
  */
 export async function retryAsync<T>(call: () => Promise<T>, controller: RetryController<T> = {}): Promise<T> {
     const retries = controller.retries ?? 3;
     const baseDelayMs = controller.baseDelayMs ?? 500;
+    const maxBackoffMs = controller.maxBackoffMs ?? RETRY_AFTER_CAP_MS;
+    const random = controller.random ?? Math.random;
     const retryResult = controller.retryResult ?? (() => false);
     const retryError = controller.retryError ?? (() => true);
+    const deadline = controller.maxElapsedMs !== undefined ? Date.now() + controller.maxElapsedMs : undefined;
+    let previousDelayMs = baseDelayMs;
     for (let attempt = 0; ; attempt++) {
         let outcome: RetryOutcome<T>;
         try {
             const result = await call();
-            if (attempt >= retries || !retryResult(result)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryResult(result)) {
                 return result;
             }
             outcome = { kind: 'result', result };
         } catch (error) {
-            if (attempt >= retries || !retryError(error)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryError(error)) {
                 throw error;
             }
             outcome = { kind: 'error', error };
         }
-        const backoffMs = baseDelayMs * 2 ** attempt;
+        const upperBound = Math.max(baseDelayMs, previousDelayMs * 3);
+        const backoffMs = Math.min(maxBackoffMs, baseDelayMs + random() * (upperBound - baseDelayMs));
+        previousDelayMs = backoffMs;
         const wait = controller.delayMs ? controller.delayMs(attempt, backoffMs, outcome) : backoffMs;
         controller.onRetry?.(attempt, wait, outcome);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RetryL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RetryL0.ts
@@ -54,7 +54,29 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         assert.strictEqual(calls, 3, 'total attempts = retries + 1 (initial attempt + 2 retries)');
     });
 
-    it('grows the default exponential backoff across attempts', async () => {
+    it('applies decorrelated jitter to the default backoff, seeded from an injectable random source (#692)', async () => {
+        const seen: number[] = [];
+        let calls = 0;
+        const randomValues = [0, 1, 0.5];
+        let i = 0;
+        await retryAsync(() => {
+            calls += 1;
+            return calls < 4 ? Promise.reject(new Error('e')) : Promise.resolve('done');
+        }, {
+            retries: 3,
+            baseDelayMs: 5,
+            random: () => randomValues[i++],
+            onRetry: (_attempt, delayMs) => seen.push(delayMs),
+        });
+        // Decorrelated jitter: delay = baseDelayMs + random() * (max(baseDelayMs, previousDelay*3) - baseDelayMs),
+        // with previousDelay seeded at baseDelayMs and updated to the delay just computed.
+        //   attempt 0: bound [5,15],  random()=0   -> 5
+        //   attempt 1: bound [5,15],  random()=1   -> 15
+        //   attempt 2: bound [5,45],  random()=0.5 -> 25
+        assert.deepStrictEqual(seen, [5, 15, 25], 'should follow the documented decorrelated-jitter recurrence exactly');
+    });
+
+    it('keeps the default (non-injected) jittered delay within [baseDelayMs, maxBackoffMs] on every attempt', async () => {
         const seen: number[] = [];
         let calls = 0;
         await retryAsync(() => {
@@ -63,10 +85,25 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         }, {
             retries: 3,
             baseDelayMs: 5,
+            maxBackoffMs: 1000,
             onRetry: (_attempt, delayMs) => seen.push(delayMs),
         });
-        // baseDelayMs * 2**attempt for attempts 0, 1, 2 -- 5, 10, 20.
-        assert.deepStrictEqual(seen, [5, 10, 20], 'each retry should wait longer than the last (exponential backoff)');
+        assert.strictEqual(seen.length, 3);
+        for (const delay of seen) {
+            assert.ok(delay >= 5 && delay <= 1000, `expected each jittered delay within [5,1000], got ${delay}`);
+        }
+    });
+
+    it('gives up immediately once the maxElapsedMs wall-clock budget is exhausted, even with retries remaining (#692)', async () => {
+        let calls = 0;
+        await assert.rejects(
+            retryAsync(() => {
+                calls += 1;
+                return Promise.reject(new Error(`fail-${calls}`));
+            }, { retries: 10, baseDelayMs: 50, maxElapsedMs: 0 }),
+            /fail-1/,
+        );
+        assert.strictEqual(calls, 1, 'a zero-length budget must stop after the very first attempt');
     });
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/retry.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/retry.ts
@@ -12,9 +12,10 @@
 //   Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
 //
 // CI (scripts/check-shared-modules.js) enforces byte-identity across those
-// copies and fails the build on any divergence, so a future hardening change
-// (jitter, a max-total-time cap, ...) can never be applied to one copy and
-// silently missed in the others. EDIT EVERY COPY TOGETHER.
+// copies and fails the build on any divergence, so a hardening change
+// (decorrelated jitter and the optional max-total-elapsed-time budget, added
+// for #692) can never be applied to one copy and silently missed in the
+// others. EDIT EVERY COPY TOGETHER.
 //
 // The retry loops that used to be independently open-coded — the OIDC
 // TokenGenerator (id-token-generator.ts), the registry retryHttp (http.ts), the
@@ -32,7 +33,7 @@
 //   - retryError decides whether a THROWN error is worth retrying. Default:
 //     always. (A pure transport failure carries no server-side state.)
 //   - delayMs overrides the backoff for a single attempt (e.g. honoring a capped
-//     HTTP 429 Retry-After); the default is baseDelayMs * 2**attempt.
+//     HTTP 429 Retry-After); the default is decorrelated jitter (see retryAsync).
 //   - onRetry runs once per retry (never on the final give-up), so each call
 //     site keeps its own log wording.
 //
@@ -48,45 +49,71 @@ export type RetryOutcome<T> =
 export interface RetryController<T> {
     /** Retries AFTER the first attempt (total attempts = retries + 1). Default 3. */
     retries?: number;
-    /** Exponential-backoff base in ms; the nth (0-based) retry waits baseDelayMs * 2**n. Default 500. */
+    /** Exponential-backoff base in ms; the default jittered delay is never below this. Default 500. */
     baseDelayMs?: number;
+    /** Upper bound (ms) on the default jittered delay. Default RETRY_AFTER_CAP_MS (30s). */
+    maxBackoffMs?: number;
+    /** Entropy source for the default jittered delay, injectable for deterministic tests. Default Math.random. */
+    random?: () => number;
+    /**
+     * Optional wall-clock budget (ms) across ALL attempts of this call; once
+     * elapsed, no further retry is scheduled even if attempts/predicates would
+     * otherwise allow one -- the last outcome is returned/thrown immediately
+     * instead (#692). Default: unbounded (only the `retries` count applies).
+     */
+    maxElapsedMs?: number;
     /** Whether a resolved value is worth retrying. Default: never. */
     retryResult?: (result: T) => boolean;
     /** Whether a thrown error is worth retrying. Default: always. */
     retryError?: (error: unknown) => boolean;
-    /** Override the pre-retry delay for one attempt; the default is the exponential backoff. */
+    /** Override the pre-retry delay for one attempt; the default is decorrelated jitter. */
     delayMs?: (attempt: number, backoffMs: number, outcome: RetryOutcome<T>) => number;
     /** Invoked once before each retry's delay (never on the final give-up). */
     onRetry?: (attempt: number, delayMs: number, outcome: RetryOutcome<T>) => void;
 }
 
 /**
- * Run `call` with bounded exponential-backoff retry. `attempt` is 0-based: the
- * first try is attempt 0, and a retry is scheduled only while attempt < retries.
+ * Run `call` with bounded, jittered-backoff retry. `attempt` is 0-based: the
+ * first try is attempt 0, and a retry is scheduled only while attempt < retries
+ * AND (when `maxElapsedMs` is set) the elapsed-time budget has not yet run out.
  * A resolved value is returned as soon as retryResult says it is acceptable (or
  * the budget is spent); a thrown error is rethrown as soon as retryError says it
  * is terminal (or the budget is spent).
+ *
+ * The default per-attempt delay uses decorrelated jitter (AWS's "Exponential
+ * Backoff And Jitter"): `delay = min(maxBackoffMs, baseDelayMs + random() *
+ * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`, with `previousDelay`
+ * seeded at `baseDelayMs`. Unlike a pure `baseDelayMs * 2**attempt` schedule,
+ * this spreads out many concurrent callers retrying the same rate-limited
+ * endpoint instead of having them all wait the same deterministic delay in
+ * lockstep (#692).
  */
 export async function retryAsync<T>(call: () => Promise<T>, controller: RetryController<T> = {}): Promise<T> {
     const retries = controller.retries ?? 3;
     const baseDelayMs = controller.baseDelayMs ?? 500;
+    const maxBackoffMs = controller.maxBackoffMs ?? RETRY_AFTER_CAP_MS;
+    const random = controller.random ?? Math.random;
     const retryResult = controller.retryResult ?? (() => false);
     const retryError = controller.retryError ?? (() => true);
+    const deadline = controller.maxElapsedMs !== undefined ? Date.now() + controller.maxElapsedMs : undefined;
+    let previousDelayMs = baseDelayMs;
     for (let attempt = 0; ; attempt++) {
         let outcome: RetryOutcome<T>;
         try {
             const result = await call();
-            if (attempt >= retries || !retryResult(result)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryResult(result)) {
                 return result;
             }
             outcome = { kind: 'result', result };
         } catch (error) {
-            if (attempt >= retries || !retryError(error)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryError(error)) {
                 throw error;
             }
             outcome = { kind: 'error', error };
         }
-        const backoffMs = baseDelayMs * 2 ** attempt;
+        const upperBound = Math.max(baseDelayMs, previousDelayMs * 3);
+        const backoffMs = Math.min(maxBackoffMs, baseDelayMs + random() * (upperBound - baseDelayMs));
+        previousDelayMs = backoffMs;
         const wait = controller.delayMs ? controller.delayMs(attempt, backoffMs, outcome) : backoffMs;
         controller.onRetry?.(attempt, wait, outcome);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/RetryL0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/RetryL0.ts
@@ -6,15 +6,16 @@ import { retryAsync, parseRetryAfterMs } from '../src/retry';
  * Direct unit tests for the shared retry.ts module itself -- retryAsync
  * (bounded exponential-backoff retry) and parseRetryAfterMs (the capped HTTP
  * 429 Retry-After parser). retry.ts is duplicated byte-identically across
- * four tasks (TerraformTaskV5, TerraformModulePublishV1,
- * TerraformDriftReportV1, PublishKbArticleV1; see
+ * seven tasks (TerraformTaskV5, TerraformModulePublishV1,
+ * TerraformDriftReportV1, PublishKbArticleV1, TerraformInstallerV1,
+ * PolicyAgentInstallerV1, TerraformDocsInstallerV1; see
  * scripts/check-shared-modules.js), and before this file existed it was
  * exercised only indirectly through each task's own consumer
- * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts) -- the
- * #497 pattern where a shared module has no test of its own, so a defect in
- * the module itself could hide behind every consumer's mocked/stubbed
- * transport. These call the real exports directly with small real delays --
- * no fake/mocked timers.
+ * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts /
+ * http-client.ts) -- the #497 pattern where a shared module has no test of
+ * its own, so a defect in the module itself could hide behind every
+ * consumer's mocked/stubbed transport. These call the real exports directly
+ * with small real delays -- no fake/mocked timers.
  */
 describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
     it('succeeds after transient failures are retried', async () => {
@@ -51,7 +52,29 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         assert.strictEqual(calls, 3, 'total attempts = retries + 1 (initial attempt + 2 retries)');
     });
 
-    it('grows the default exponential backoff across attempts', async () => {
+    it('applies decorrelated jitter to the default backoff, seeded from an injectable random source (#692)', async () => {
+        const seen: number[] = [];
+        let calls = 0;
+        const randomValues = [0, 1, 0.5];
+        let i = 0;
+        await retryAsync(() => {
+            calls += 1;
+            return calls < 4 ? Promise.reject(new Error('e')) : Promise.resolve('done');
+        }, {
+            retries: 3,
+            baseDelayMs: 5,
+            random: () => randomValues[i++],
+            onRetry: (_attempt, delayMs) => seen.push(delayMs),
+        });
+        // Decorrelated jitter: delay = baseDelayMs + random() * (max(baseDelayMs, previousDelay*3) - baseDelayMs),
+        // with previousDelay seeded at baseDelayMs and updated to the delay just computed.
+        //   attempt 0: bound [5,15],  random()=0   -> 5
+        //   attempt 1: bound [5,15],  random()=1   -> 15
+        //   attempt 2: bound [5,45],  random()=0.5 -> 25
+        assert.deepStrictEqual(seen, [5, 15, 25], 'should follow the documented decorrelated-jitter recurrence exactly');
+    });
+
+    it('keeps the default (non-injected) jittered delay within [baseDelayMs, maxBackoffMs] on every attempt', async () => {
         const seen: number[] = [];
         let calls = 0;
         await retryAsync(() => {
@@ -60,10 +83,25 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         }, {
             retries: 3,
             baseDelayMs: 5,
+            maxBackoffMs: 1000,
             onRetry: (_attempt, delayMs) => seen.push(delayMs),
         });
-        // baseDelayMs * 2**attempt for attempts 0, 1, 2 -- 5, 10, 20.
-        assert.deepStrictEqual(seen, [5, 10, 20], 'each retry should wait longer than the last (exponential backoff)');
+        assert.strictEqual(seen.length, 3);
+        for (const delay of seen) {
+            assert.ok(delay >= 5 && delay <= 1000, `expected each jittered delay within [5,1000], got ${delay}`);
+        }
+    });
+
+    it('gives up immediately once the maxElapsedMs wall-clock budget is exhausted, even with retries remaining (#692)', async () => {
+        let calls = 0;
+        await assert.rejects(
+            retryAsync(() => {
+                calls += 1;
+                return Promise.reject(new Error(`fail-${calls}`));
+            }, { retries: 10, baseDelayMs: 50, maxElapsedMs: 0 }),
+            /fail-1/,
+        );
+        assert.strictEqual(calls, 1, 'a zero-length budget must stop after the very first attempt');
     });
 });
 

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/retry.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/retry.ts
@@ -12,9 +12,10 @@
 //   Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
 //
 // CI (scripts/check-shared-modules.js) enforces byte-identity across those
-// copies and fails the build on any divergence, so a future hardening change
-// (jitter, a max-total-time cap, ...) can never be applied to one copy and
-// silently missed in the others. EDIT EVERY COPY TOGETHER.
+// copies and fails the build on any divergence, so a hardening change
+// (decorrelated jitter and the optional max-total-elapsed-time budget, added
+// for #692) can never be applied to one copy and silently missed in the
+// others. EDIT EVERY COPY TOGETHER.
 //
 // The retry loops that used to be independently open-coded — the OIDC
 // TokenGenerator (id-token-generator.ts), the registry retryHttp (http.ts), the
@@ -32,7 +33,7 @@
 //   - retryError decides whether a THROWN error is worth retrying. Default:
 //     always. (A pure transport failure carries no server-side state.)
 //   - delayMs overrides the backoff for a single attempt (e.g. honoring a capped
-//     HTTP 429 Retry-After); the default is baseDelayMs * 2**attempt.
+//     HTTP 429 Retry-After); the default is decorrelated jitter (see retryAsync).
 //   - onRetry runs once per retry (never on the final give-up), so each call
 //     site keeps its own log wording.
 //
@@ -48,45 +49,71 @@ export type RetryOutcome<T> =
 export interface RetryController<T> {
     /** Retries AFTER the first attempt (total attempts = retries + 1). Default 3. */
     retries?: number;
-    /** Exponential-backoff base in ms; the nth (0-based) retry waits baseDelayMs * 2**n. Default 500. */
+    /** Exponential-backoff base in ms; the default jittered delay is never below this. Default 500. */
     baseDelayMs?: number;
+    /** Upper bound (ms) on the default jittered delay. Default RETRY_AFTER_CAP_MS (30s). */
+    maxBackoffMs?: number;
+    /** Entropy source for the default jittered delay, injectable for deterministic tests. Default Math.random. */
+    random?: () => number;
+    /**
+     * Optional wall-clock budget (ms) across ALL attempts of this call; once
+     * elapsed, no further retry is scheduled even if attempts/predicates would
+     * otherwise allow one -- the last outcome is returned/thrown immediately
+     * instead (#692). Default: unbounded (only the `retries` count applies).
+     */
+    maxElapsedMs?: number;
     /** Whether a resolved value is worth retrying. Default: never. */
     retryResult?: (result: T) => boolean;
     /** Whether a thrown error is worth retrying. Default: always. */
     retryError?: (error: unknown) => boolean;
-    /** Override the pre-retry delay for one attempt; the default is the exponential backoff. */
+    /** Override the pre-retry delay for one attempt; the default is decorrelated jitter. */
     delayMs?: (attempt: number, backoffMs: number, outcome: RetryOutcome<T>) => number;
     /** Invoked once before each retry's delay (never on the final give-up). */
     onRetry?: (attempt: number, delayMs: number, outcome: RetryOutcome<T>) => void;
 }
 
 /**
- * Run `call` with bounded exponential-backoff retry. `attempt` is 0-based: the
- * first try is attempt 0, and a retry is scheduled only while attempt < retries.
+ * Run `call` with bounded, jittered-backoff retry. `attempt` is 0-based: the
+ * first try is attempt 0, and a retry is scheduled only while attempt < retries
+ * AND (when `maxElapsedMs` is set) the elapsed-time budget has not yet run out.
  * A resolved value is returned as soon as retryResult says it is acceptable (or
  * the budget is spent); a thrown error is rethrown as soon as retryError says it
  * is terminal (or the budget is spent).
+ *
+ * The default per-attempt delay uses decorrelated jitter (AWS's "Exponential
+ * Backoff And Jitter"): `delay = min(maxBackoffMs, baseDelayMs + random() *
+ * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`, with `previousDelay`
+ * seeded at `baseDelayMs`. Unlike a pure `baseDelayMs * 2**attempt` schedule,
+ * this spreads out many concurrent callers retrying the same rate-limited
+ * endpoint instead of having them all wait the same deterministic delay in
+ * lockstep (#692).
  */
 export async function retryAsync<T>(call: () => Promise<T>, controller: RetryController<T> = {}): Promise<T> {
     const retries = controller.retries ?? 3;
     const baseDelayMs = controller.baseDelayMs ?? 500;
+    const maxBackoffMs = controller.maxBackoffMs ?? RETRY_AFTER_CAP_MS;
+    const random = controller.random ?? Math.random;
     const retryResult = controller.retryResult ?? (() => false);
     const retryError = controller.retryError ?? (() => true);
+    const deadline = controller.maxElapsedMs !== undefined ? Date.now() + controller.maxElapsedMs : undefined;
+    let previousDelayMs = baseDelayMs;
     for (let attempt = 0; ; attempt++) {
         let outcome: RetryOutcome<T>;
         try {
             const result = await call();
-            if (attempt >= retries || !retryResult(result)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryResult(result)) {
                 return result;
             }
             outcome = { kind: 'result', result };
         } catch (error) {
-            if (attempt >= retries || !retryError(error)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryError(error)) {
                 throw error;
             }
             outcome = { kind: 'error', error };
         }
-        const backoffMs = baseDelayMs * 2 ** attempt;
+        const upperBound = Math.max(baseDelayMs, previousDelayMs * 3);
+        const backoffMs = Math.min(maxBackoffMs, baseDelayMs + random() * (upperBound - baseDelayMs));
+        previousDelayMs = backoffMs;
         const wait = controller.delayMs ? controller.delayMs(attempt, backoffMs, outcome) : backoffMs;
         controller.onRetry?.(attempt, wait, outcome);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/RetryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/RetryL0.ts
@@ -6,15 +6,16 @@ import { retryAsync, parseRetryAfterMs } from '../src/retry';
  * Direct unit tests for the shared retry.ts module itself -- retryAsync
  * (bounded exponential-backoff retry) and parseRetryAfterMs (the capped HTTP
  * 429 Retry-After parser). retry.ts is duplicated byte-identically across
- * four tasks (TerraformTaskV5, TerraformModulePublishV1,
- * TerraformDriftReportV1, PublishKbArticleV1; see
+ * seven tasks (TerraformTaskV5, TerraformModulePublishV1,
+ * TerraformDriftReportV1, PublishKbArticleV1, TerraformInstallerV1,
+ * PolicyAgentInstallerV1, TerraformDocsInstallerV1; see
  * scripts/check-shared-modules.js), and before this file existed it was
  * exercised only indirectly through each task's own consumer
- * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts) -- the
- * #497 pattern where a shared module has no test of its own, so a defect in
- * the module itself could hide behind every consumer's mocked/stubbed
- * transport. These call the real exports directly with small real delays --
- * no fake/mocked timers.
+ * (id-token-generator.ts / http.ts / callback.ts / servicenow-http.ts /
+ * http-client.ts) -- the #497 pattern where a shared module has no test of
+ * its own, so a defect in the module itself could hide behind every
+ * consumer's mocked/stubbed transport. These call the real exports directly
+ * with small real delays -- no fake/mocked timers.
  */
 describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
     it('succeeds after transient failures are retried', async () => {
@@ -51,7 +52,29 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         assert.strictEqual(calls, 3, 'total attempts = retries + 1 (initial attempt + 2 retries)');
     });
 
-    it('grows the default exponential backoff across attempts', async () => {
+    it('applies decorrelated jitter to the default backoff, seeded from an injectable random source (#692)', async () => {
+        const seen: number[] = [];
+        let calls = 0;
+        const randomValues = [0, 1, 0.5];
+        let i = 0;
+        await retryAsync(() => {
+            calls += 1;
+            return calls < 4 ? Promise.reject(new Error('e')) : Promise.resolve('done');
+        }, {
+            retries: 3,
+            baseDelayMs: 5,
+            random: () => randomValues[i++],
+            onRetry: (_attempt, delayMs) => seen.push(delayMs),
+        });
+        // Decorrelated jitter: delay = baseDelayMs + random() * (max(baseDelayMs, previousDelay*3) - baseDelayMs),
+        // with previousDelay seeded at baseDelayMs and updated to the delay just computed.
+        //   attempt 0: bound [5,15],  random()=0   -> 5
+        //   attempt 1: bound [5,15],  random()=1   -> 15
+        //   attempt 2: bound [5,45],  random()=0.5 -> 25
+        assert.deepStrictEqual(seen, [5, 15, 25], 'should follow the documented decorrelated-jitter recurrence exactly');
+    });
+
+    it('keeps the default (non-injected) jittered delay within [baseDelayMs, maxBackoffMs] on every attempt', async () => {
         const seen: number[] = [];
         let calls = 0;
         await retryAsync(() => {
@@ -60,10 +83,25 @@ describe('retry.ts: retryAsync (shared bounded-backoff retry)', () => {
         }, {
             retries: 3,
             baseDelayMs: 5,
+            maxBackoffMs: 1000,
             onRetry: (_attempt, delayMs) => seen.push(delayMs),
         });
-        // baseDelayMs * 2**attempt for attempts 0, 1, 2 -- 5, 10, 20.
-        assert.deepStrictEqual(seen, [5, 10, 20], 'each retry should wait longer than the last (exponential backoff)');
+        assert.strictEqual(seen.length, 3);
+        for (const delay of seen) {
+            assert.ok(delay >= 5 && delay <= 1000, `expected each jittered delay within [5,1000], got ${delay}`);
+        }
+    });
+
+    it('gives up immediately once the maxElapsedMs wall-clock budget is exhausted, even with retries remaining (#692)', async () => {
+        let calls = 0;
+        await assert.rejects(
+            retryAsync(() => {
+                calls += 1;
+                return Promise.reject(new Error(`fail-${calls}`));
+            }, { retries: 10, baseDelayMs: 50, maxElapsedMs: 0 }),
+            /fail-1/,
+        );
+        assert.strictEqual(calls, 1, 'a zero-length budget must stop after the very first attempt');
     });
 });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/retry.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/retry.ts
@@ -12,9 +12,10 @@
 //   Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts
 //
 // CI (scripts/check-shared-modules.js) enforces byte-identity across those
-// copies and fails the build on any divergence, so a future hardening change
-// (jitter, a max-total-time cap, ...) can never be applied to one copy and
-// silently missed in the others. EDIT EVERY COPY TOGETHER.
+// copies and fails the build on any divergence, so a hardening change
+// (decorrelated jitter and the optional max-total-elapsed-time budget, added
+// for #692) can never be applied to one copy and silently missed in the
+// others. EDIT EVERY COPY TOGETHER.
 //
 // The retry loops that used to be independently open-coded — the OIDC
 // TokenGenerator (id-token-generator.ts), the registry retryHttp (http.ts), the
@@ -32,7 +33,7 @@
 //   - retryError decides whether a THROWN error is worth retrying. Default:
 //     always. (A pure transport failure carries no server-side state.)
 //   - delayMs overrides the backoff for a single attempt (e.g. honoring a capped
-//     HTTP 429 Retry-After); the default is baseDelayMs * 2**attempt.
+//     HTTP 429 Retry-After); the default is decorrelated jitter (see retryAsync).
 //   - onRetry runs once per retry (never on the final give-up), so each call
 //     site keeps its own log wording.
 //
@@ -48,45 +49,71 @@ export type RetryOutcome<T> =
 export interface RetryController<T> {
     /** Retries AFTER the first attempt (total attempts = retries + 1). Default 3. */
     retries?: number;
-    /** Exponential-backoff base in ms; the nth (0-based) retry waits baseDelayMs * 2**n. Default 500. */
+    /** Exponential-backoff base in ms; the default jittered delay is never below this. Default 500. */
     baseDelayMs?: number;
+    /** Upper bound (ms) on the default jittered delay. Default RETRY_AFTER_CAP_MS (30s). */
+    maxBackoffMs?: number;
+    /** Entropy source for the default jittered delay, injectable for deterministic tests. Default Math.random. */
+    random?: () => number;
+    /**
+     * Optional wall-clock budget (ms) across ALL attempts of this call; once
+     * elapsed, no further retry is scheduled even if attempts/predicates would
+     * otherwise allow one -- the last outcome is returned/thrown immediately
+     * instead (#692). Default: unbounded (only the `retries` count applies).
+     */
+    maxElapsedMs?: number;
     /** Whether a resolved value is worth retrying. Default: never. */
     retryResult?: (result: T) => boolean;
     /** Whether a thrown error is worth retrying. Default: always. */
     retryError?: (error: unknown) => boolean;
-    /** Override the pre-retry delay for one attempt; the default is the exponential backoff. */
+    /** Override the pre-retry delay for one attempt; the default is decorrelated jitter. */
     delayMs?: (attempt: number, backoffMs: number, outcome: RetryOutcome<T>) => number;
     /** Invoked once before each retry's delay (never on the final give-up). */
     onRetry?: (attempt: number, delayMs: number, outcome: RetryOutcome<T>) => void;
 }
 
 /**
- * Run `call` with bounded exponential-backoff retry. `attempt` is 0-based: the
- * first try is attempt 0, and a retry is scheduled only while attempt < retries.
+ * Run `call` with bounded, jittered-backoff retry. `attempt` is 0-based: the
+ * first try is attempt 0, and a retry is scheduled only while attempt < retries
+ * AND (when `maxElapsedMs` is set) the elapsed-time budget has not yet run out.
  * A resolved value is returned as soon as retryResult says it is acceptable (or
  * the budget is spent); a thrown error is rethrown as soon as retryError says it
  * is terminal (or the budget is spent).
+ *
+ * The default per-attempt delay uses decorrelated jitter (AWS's "Exponential
+ * Backoff And Jitter"): `delay = min(maxBackoffMs, baseDelayMs + random() *
+ * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`, with `previousDelay`
+ * seeded at `baseDelayMs`. Unlike a pure `baseDelayMs * 2**attempt` schedule,
+ * this spreads out many concurrent callers retrying the same rate-limited
+ * endpoint instead of having them all wait the same deterministic delay in
+ * lockstep (#692).
  */
 export async function retryAsync<T>(call: () => Promise<T>, controller: RetryController<T> = {}): Promise<T> {
     const retries = controller.retries ?? 3;
     const baseDelayMs = controller.baseDelayMs ?? 500;
+    const maxBackoffMs = controller.maxBackoffMs ?? RETRY_AFTER_CAP_MS;
+    const random = controller.random ?? Math.random;
     const retryResult = controller.retryResult ?? (() => false);
     const retryError = controller.retryError ?? (() => true);
+    const deadline = controller.maxElapsedMs !== undefined ? Date.now() + controller.maxElapsedMs : undefined;
+    let previousDelayMs = baseDelayMs;
     for (let attempt = 0; ; attempt++) {
         let outcome: RetryOutcome<T>;
         try {
             const result = await call();
-            if (attempt >= retries || !retryResult(result)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryResult(result)) {
                 return result;
             }
             outcome = { kind: 'result', result };
         } catch (error) {
-            if (attempt >= retries || !retryError(error)) {
+            if (attempt >= retries || (deadline !== undefined && Date.now() >= deadline) || !retryError(error)) {
                 throw error;
             }
             outcome = { kind: 'error', error };
         }
-        const backoffMs = baseDelayMs * 2 ** attempt;
+        const upperBound = Math.max(baseDelayMs, previousDelayMs * 3);
+        const backoffMs = Math.min(maxBackoffMs, baseDelayMs + random() * (upperBound - baseDelayMs));
+        previousDelayMs = backoffMs;
         const wait = controller.delayMs ? controller.delayMs(attempt, backoffMs, outcome) : backoffMs;
         controller.onRetry?.(attempt, wait, outcome);
         await new Promise<void>((resolve) => setTimeout(resolve, wait));


### PR DESCRIPTION
## Summary

Addresses #692 — the shared `retry.ts` module's backoff was a pure deterministic
`baseDelayMs * 2**attempt` schedule, so many concurrent pipeline jobs hitting the
same rate-limited endpoint at the same moment would retry in near-lockstep
(thundering herd) instead of spreading out.

### Decorrelated jitter (default backoff)

Replaced the deterministic formula with AWS's "Exponential Backoff And Jitter"
decorrelated-jitter recurrence:

```
delay = min(maxBackoffMs, baseDelayMs + random() * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))
```

with `previousDelay` seeded at `baseDelayMs`. New `RetryController` fields:

- `maxBackoffMs` — cap on the jittered delay (default `RETRY_AFTER_CAP_MS`, 30s)
- `random` — injectable entropy source, defaults to `Math.random`, so tests can
  supply a deterministic sequence instead of mocking the global

### Optional wall-clock budget

New `maxElapsedMs` field: once the budget elapses, no further retry is
scheduled even if attempts/predicates would otherwise allow one — the last
outcome is returned/thrown immediately. Default is unbounded (only the
`retries` count applies), so this is a zero-behavior-change opt-in for
existing callers.

### Propagation

`retry.ts` is enforced byte-identical across all 7 shared copies by
`scripts/check-shared-modules.js`; applied the same change to all 7 and
re-verified parity right before committing.

### Fixed a pre-existing inaccuracy while touching these files

4 of the 7 `Tests/RetryL0.ts` header comments said retry.ts was "duplicated
byte-identically across four tasks" — stale since #645 added the three
installer tasks to the family (which already had the correct "seven tasks"
wording). Brought all 7 into agreement.

## Testing

The one exact-timing test per copy (`grows the default exponential backoff
across attempts`, asserting `[5, 10, 20]`) is incompatible with genuine
jitter and was replaced with three tests per copy:

1. An injected-`random`-source test proving the decorrelated-jitter
   recurrence exactly (`[5, 15, 25]` for a fixed `[0, 1, 0.5]` sequence).
2. A real-`Math.random` smoke test asserting every delay stays within
   `[baseDelayMs, maxBackoffMs]`.
3. A `maxElapsedMs: 0` test proving an exhausted budget stops retries after
   the very first attempt, even with `retries` remaining.

Searched the repo for any other test asserting an exact default-backoff
value or tight timing that this change could break — none found. (Two
Retry-After-vs-backoff comparison tests only require the honored value to
be much smaller than the default backoff, which still holds under jitter.)

Full suites, all EXIT 0:

| Task | Passing |
| --- | --- |
| TerraformTaskV5 | 555 |
| TerraformModulePublish | 63 |
| TerraformDriftReport | 61 |
| PublishKbArticle | 216 |
| TerraformInstaller | 142 |
| PolicyAgentInstaller | 100 |
| TerraformDocsInstaller | 88 |

`node scripts/check-shared-modules.js` passes (all 7 `retry.ts` copies identical).

Closes #692.
