### PR TITLE
fix: accept OpenTofu's release-branch signing identity for 1.12.x patch releases

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
@@ -14,11 +14,16 @@ describe('cosign-verifier: OpenTofu certificate identity regexp (version-bound, 
     const VERSION = '1.11.6';
     const identityRe = new RegExp(buildOpenTofuCertIdentityRegexp(VERSION));
 
-    // The canonical SAN OpenTofu's keyless release signing produces for THIS version --
-    // confirmed against the real upstream workflow file (opentofu/opentofu's
-    // .github/workflows/release.yml).
+    // The canonical SANs OpenTofu's keyless release signing produces for THIS
+    // version -- confirmed against the real upstream workflow file (opentofu/
+    // opentofu's .github/workflows/release.yml). Both the (older/occasional)
+    // full-version tag ref and the (current, 1.12.x-line) major.minor release
+    // branch ref must be accepted -- confirmed directly against the real
+    // Fulcio certificate for the current upstream release (tofu_1.12.4_
+    // SHA256SUMS.pem's SAN is .../release.yml@refs/heads/v1.12).
     const accepted = [
         `https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v${VERSION}`,
+        'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v1.11',
     ];
 
     // Each of these satisfied the previous any-version `@refs/tags/v[0-9].*` pattern
@@ -33,6 +38,14 @@ describe('cosign-verifier: OpenTofu certificate identity regexp (version-bound, 
         // anchored, so a longer numeric tail cannot slip past.
         'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.11.60',
         'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1x11x6',
+        // A DIFFERENT major.minor release branch must still be rejected (cross-
+        // release-line replay via the branch alternative).
+        'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v1.10',
+        'https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v1.12',
+        // The branch alternative only ever encodes major.minor -- a branch ref
+        // carrying the full patch version is not a real OpenTofu ref and must
+        // still be rejected.
+        `https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v${VERSION}`,
         // #697: the workflow-file segment is now bound to the exact, real signing
         // workflow (release.yml) instead of a permissive `.+` -- a look-alike or
         // otherwise-named workflow file on the SAME repo and exact tag ref must
@@ -71,6 +84,24 @@ describe('cosign-verifier: OpenTofu certificate identity regexp (version-bound, 
         assert.ok(
             !re.test('https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v1.7.0-alpha2'),
             'should reject a different prerelease tag',
+        );
+        // A prerelease version still carries a real major.minor, so its own
+        // release-branch ref must also be accepted.
+        assert.ok(
+            re.test('https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v1.7'),
+            'should accept the prerelease version\'s own major.minor branch ref',
+        );
+    });
+
+    it('falls back to a tag-only pattern for a version with no leading major.minor', () => {
+        const re = new RegExp(buildOpenTofuCertIdentityRegexp('unusual-version'));
+        assert.ok(
+            re.test('https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/vunusual-version'),
+            'should still accept the exact tag ref for the literal version string',
+        );
+        assert.ok(
+            !re.test('https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/vunusual-version'),
+            'should not accept a branch ref when no major.minor could be extracted',
         );
     });
 });
@@ -153,8 +184,11 @@ describe('cosign-verifier: verifyCosignSignature behavior', () => {
         const idIdx = args.indexOf('--certificate-identity-regexp');
         assert.ok(idIdx >= 0, 'the --certificate-identity-regexp flag should be passed');
         assert.strictEqual(args[idIdx + 1], buildOpenTofuCertIdentityRegexp(VERSION));
-        // The passed regexp must bind the exact version (with escaped dots), not any tag.
-        assert.ok(args[idIdx + 1].includes('v1\\.11\\.6$'), 'the identity regexp must anchor the exact requested version');
+        // The passed regexp must bind the exact version (with escaped dots) on the
+        // tag alternative, not any tag.
+        assert.ok(args[idIdx + 1].includes('tags/v1\\.11\\.6'), 'the identity regexp must anchor the exact requested version on the tag alternative');
+        // ...and must bind only VERSION's own major.minor on the branch alternative.
+        assert.ok(args[idIdx + 1].includes('heads/v1\\.11)$'), 'the identity regexp must anchor the requested version\'s major.minor on the branch alternative');
         const issIdx = args.indexOf('--certificate-oidc-issuer');
         assert.ok(issIdx >= 0, 'the --certificate-oidc-issuer flag should be passed');
         assert.strictEqual(args[issIdx + 1], 'https://token.actions.githubusercontent.com');

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
@@ -20,29 +20,56 @@ function escapeRegExp(value: string): string {
 /**
  * Builds the anchored, escaped regular expression for the Fulcio certificate
  * identity (SAN) that OpenTofu's keyless release signing produces for the
- * SPECIFIC requested version. OpenTofu signs each release's SHA256SUMS from its
- * `release.yml` workflow on that release's tag ref, yielding a SAN of the form
- * `https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v<version>`.
+ * SPECIFIC requested version.
+ *
+ * OpenTofu's actual signing ref depends on the release: some releases sign from
+ * a version TAG ref (`refs/tags/v<version>`), but as of the 1.12.x line OpenTofu
+ * cuts patch releases from a long-lived per-minor release-maintenance BRANCH, and
+ * the release.yml run that performs the keyless signing is triggered on that
+ * branch push — so the Fulcio certificate's SAN carries `refs/heads/v<major>.<minor>`
+ * (no patch component) instead of a tag ref. Confirmed directly against the real,
+ * current upstream certificate (`tofu_1.12.4_SHA256SUMS.pem`'s SAN is
+ * `https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v1.12`)
+ * after the weekly cosign trust-root canary caught the previous tag-only pattern
+ * rejecting every current release (#734-era incident). The pattern therefore
+ * accepts EITHER form: the full-version tag ref, or the major.minor branch ref —
+ * both bound to the requested version (the branch alternative to its major.minor
+ * only, since that is all the ref itself encodes; the SHA256SUMS content is still
+ * independently bound to the exact patch version by `parseSha256`'s exact
+ * `tofu_<version>_<file>` filename lookup in the caller, so a same-branch
+ * cross-patch substitution is still caught even though the identity alone cannot
+ * distinguish patch versions on the same branch).
  *
  * cosign matches `--certificate-identity-regexp` unanchored (Go
  * `regexp.MatchString`), so the pattern is anchored with `^`/`$` and its dots are
  * escaped. Anchoring alone prevents a look-alike certificate whose SAN merely
- * *contains* the OpenTofu identity (or sits on a different host/org/repo, a branch
- * ref, or http) from satisfying the match. Interpolating the exact version
- * (regex-escaped) additionally binds the signed SHA256SUMS to the version being
- * installed, so a validly-signed SHA256SUMS from a DIFFERENT OpenTofu release can
- * no longer satisfy the identity — closing the cross-version replay gap that the
- * previous `@refs/tags/v[0-9].*` (any tag) pattern left to URL-path binding alone.
- * The workflow-file segment is pinned to the literal, escaped `release.yml` (the
- * actual, currently-stable signing workflow at
- * github.com/opentofu/opentofu/.github/workflows/release.yml, confirmed against
- * the upstream repo) rather than a permissive `.+`, so a Fulcio certificate for
- * any OTHER workflow file in the repo — even one on the exact release tag ref —
- * no longer satisfies the identity (#697). If OpenTofu ever renames or splits its
- * signing workflow, this constant needs updating alongside it.
+ * *contains* the OpenTofu identity (or sits on a different host/org/repo, an
+ * unrelated branch, or http) from satisfying the match. Binding to the requested
+ * version (tag) / its major.minor (branch) means a validly-signed SHA256SUMS from
+ * a DIFFERENT OpenTofu release line can no longer satisfy the identity — closing
+ * the cross-version replay gap that the original `@refs/tags/v[0-9].*` (any tag)
+ * pattern left to URL-path binding alone. The workflow-file segment is pinned to
+ * the literal, escaped `release.yml` (the actual, currently-stable signing
+ * workflow at github.com/opentofu/opentofu/.github/workflows/release.yml,
+ * confirmed against the upstream repo) rather than a permissive `.+`, so a Fulcio
+ * certificate for any OTHER workflow file in the repo — even one on an otherwise
+ * matching ref — no longer satisfies the identity (#697). If OpenTofu ever
+ * renames or splits its signing workflow, or changes its branching scheme again,
+ * this constant needs updating alongside it.
  */
 export function buildOpenTofuCertIdentityRegexp(version: string): string {
-    return `^https://github\\.com/opentofu/opentofu/\\.github/workflows/release\\.yml@refs/tags/v${escapeRegExp(version)}$`;
+    const workflowPrefix = 'https://github\\.com/opentofu/opentofu/\\.github/workflows/release\\.yml@refs/';
+    const tagAlternative = `tags/v${escapeRegExp(version)}`;
+    const majorMinorMatch = version.match(/^(\d+\.\d+)/);
+    if (!majorMinorMatch) {
+        // Version string doesn't look like <major>.<minor>[.<patch>...] (e.g. an
+        // unusual operator-supplied 'version' input) — fall back to the
+        // tag-only pattern rather than emitting a malformed/absent branch
+        // alternative.
+        return `^${workflowPrefix}${tagAlternative}$`;
+    }
+    const branchAlternative = `heads/v${escapeRegExp(majorMinorMatch[1])}`;
+    return `^${workflowPrefix}(${tagAlternative}|${branchAlternative})$`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the weekly "OpenTofu cosign trust-root canary" job (#714 — Scheduled build failed) by updating the OpenTofu certificate-identity check to accept OpenTofu's real, current release-signing ref.

## Root cause

OpenTofu's 1.12.x patch releases (confirmed against the real, current `v1.12.4` release) are signed from a per-minor **release-maintenance branch** (`refs/heads/v1.12`), not a version **tag**. `buildOpenTofuCertIdentityRegexp()` only ever accepted `refs/tags/v<version>`, so with `requireCosignVerification` at its fail-closed default, cosign verification would reject every current OpenTofu release's signature — a real, live break, not a test-only gap. Verified directly against the real upstream Fulcio certificate (`tofu_1.12.4_SHA256SUMS.pem`) before touching this trust boundary:

```
SAN: https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v1.12
```

## Fix

`buildOpenTofuCertIdentityRegexp(version)` now accepts **either** the full-version tag ref or the version's major.minor branch ref — mirroring the same tag-or-branch alternation this repo's own `release.yml` already uses for its own cosign identity check. The branch alternative only binds to major.minor (that's all the ref itself encodes); the exact patch version is still independently bound downstream by the caller's `tofu_<version>_<file>` filename lookup inside the signed SHA256SUMS content, so a same-branch cross-patch substitution is still caught even though the certificate identity alone can't distinguish patch versions on the same branch.

## Testing

- Updated `CosignVerifierL0.ts`: new accept case for the major.minor branch ref, new reject cases for a wrong-branch and a full-version-as-branch-name, updated the argv-assertion test for the new pattern shape, and a new fallback test for a non-numeric version input.
- `npm test` green in `TerraformInstallerV1` (153 passing).

Closes #714
