### PR TITLE
docs: correct stale retry-family task count and Key Dependencies HTML sanitizer entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ azure-pipelines-terraform/
 | `secure-file-loader.ts`              | Downloads secure var files from ADO Secure Files library                                       |
 | `id-token-generator.ts`              | Generates OIDC ID tokens for Workload Identity Federation fallback                             |
 | `secure-temp.ts`                     | Secure temp-file primitives: owner-only 0600 + O_EXCL on Unix, a restrictive icacls DACL on Windows (both fail closed), plus symlink-guarded `scrubFile()` zero-overwrite-before-unlink (#595) — canonical source; byte-identical copy also in TerraformDriftReportV1 and TerraformPolicyCheckV1, gated by `scripts/check-shared-modules.js` |
-| `retry.ts`                           | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all four tasks in this retry family, gated by `scripts/check-shared-modules.js` |
+| `retry.ts`                           | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
 
 ### Structured plan/apply results (`src/results/`)
 
@@ -312,7 +312,7 @@ Source: `Tasks/TerraformDriftReport/TerraformDriftReportV1/src/`. Parses a Terra
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `index.ts`        | Entry point — computes drift counts, orchestrates the callback and SARIF report                                                    |
 | `callback.ts`     | POSTs the drift summary to TSM; retries transport failures/5xx only, never after a received response (`callbackToken` is one-shot) |
-| `retry.ts`        | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all four tasks in this retry family, gated by `scripts/check-shared-modules.js` |
+| `retry.ts`        | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
 | `sarif.ts`        | Generates a SARIF 2.1.0 report of drift findings (opt-in)                                                                          |
 | `https-client.ts` | Shared HTTPS client, HTTPS-only (shared with TerraformModulePublish)                                                               |
 
@@ -328,7 +328,7 @@ Source: `Tasks/TerraformModulePublish/TerraformModulePublishV1/src/`. Publishes 
 | `hcp-publisher.ts`     | Publishes via the HCP Terraform module registry API; polls ingest status                                |
 | `private-publisher.ts` | Publishes to a private registry via its API (`apiKey` auth); auto-creates the module if absent          |
 | `http.ts`              | Shared HTTP client with bounded retry (`retryHttp()` — the reference implementation other tasks mirror) |
-| `retry.ts`             | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all four tasks in this retry family, gated by `scripts/check-shared-modules.js` |
+| `retry.ts`             | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
 | `https-client.ts`      | Shared HTTPS client, HTTPS-only (shared with TerraformDriftReport)                                      |
 | `types.ts`             | Shared type definitions for both publishers                                                             |
 
@@ -359,7 +359,7 @@ Source: `Tasks/PublishKbArticle/PublishKbArticleV1/src/`. Publishes or updates a
 | `auth.ts`              | OAuth client-credentials and Basic auth; masks secrets including derived/encoded forms                                     |
 | `servicenow-client.ts` | ServiceNow Table API client — every `sysparm_query` interpolation goes through `assertQueryValueSafe()`                    |
 | `servicenow-http.ts`   | Shared HTTP client with bounded retry (transport + 5xx only, never a received 4xx)                                         |
-| `retry.ts`             | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all four tasks in this retry family, gated by `scripts/check-shared-modules.js` |
+| `retry.ts`             | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
 | `attachments.ts`       | Image-attachment upload/list/sync                                                                                          |
 | `image-rewrite.ts`     | Rewrites local `<img src>` references to uploaded attachment URLs                                                          |
 | `html-validate.ts`     | Security gate for article HTML before publish; `force` only bypasses the content-loss heuristic, never the security checks |
@@ -433,7 +433,8 @@ Tests are organized by command x provider: `InitTests/`, `PlanTests/`, `ApplyTes
 | `azure-pipelines-tasks-securefiles-common` | Secure file download — TerraformTaskV5 (`secureVarsFile` input)                        |
 | `openpgp`                                  | GPG signature verification for installer downloads                                     |
 | `undici`                                   | HTTP/proxy client — TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller   |
-| `cheerio`                                  | HTML sanitize/validate — Markdown2Html, PublishKbArticle                               |
+| `sanitize-html`                             | Primary allowlist HTML sanitizer (final stored-XSS defense) — Markdown2Html            |
+| `cheerio`                                  | Markdown2Html: defense-in-depth pre-filter parsing ahead of `sanitize-html`; PublishKbArticle: independent `html-validate.ts` content-inspection gate |
 | `markdown-it`                              | Markdown parser — Markdown2Html                                                        |
 | `highlight.js`                             | Syntax highlighting — Markdown2Html                                                    |
 | `js-yaml`                                  | YAML front-matter parsing — Markdown2Html                                              |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,15 +206,17 @@ runCommand(new TerraformCommandHandlerAWS(), 'init', 'AWSInitFailL0', false);
 
 ### Retry/backoff helper parity
 
-Three tasks each implement their own bounded exponential-backoff HTTP retry helper, independently of one another and outside `scripts/check-shared-modules.js`'s automated byte-identity enforcement:
+`retry.ts` (`retryAsync()`) is the single canonical, CI-enforced-byte-identical bounded-retry implementation, duplicated across all **seven** tasks that need it (Tasks can't cross-import, so `scripts/check-shared-modules.js` gates byte-identity across the copies instead):
 
-- `Tasks/TerraformModulePublish/TerraformModulePublishV1/src/http.ts` — `retryHttp()` (the reference implementation the other two mirror)
-- `Tasks/TerraformDriftReport/TerraformDriftReportV1/src/callback.ts` — `postJsonWithRetry()`
-- `Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts` — `withRetry()`
+- `Tasks/TerraformTask/TerraformTaskV5/src/retry.ts`
+- `Tasks/TerraformModulePublish/TerraformModulePublishV1/src/retry.ts` (consumed by `http.ts`'s `retryHttp()`)
+- `Tasks/TerraformDriftReport/TerraformDriftReportV1/src/retry.ts` (consumed by `callback.ts`'s `postJsonWithRetry()`)
+- `Tasks/PublishKbArticle/PublishKbArticleV1/src/retry.ts` (consumed by `servicenow-http.ts`'s `withRetry()`)
+- `Tasks/TerraformInstaller/TerraformInstallerV1/src/retry.ts`, `Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/retry.ts`, `Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/retry.ts` (the installer family's shared `http-client.ts` fetch client)
 
-All three share the same `{ retries?, baseDelayMs?, log? }` options shape and `baseDelayMs * 2 ** attempt` backoff. **When hardening the retry/backoff behavior (timeout, backoff formula, retry predicate, etc.) in any one of these, review the other two in the same change** and update them together if the hardening applies equally.
+The default backoff is AWS-style decorrelated jitter (`delay = min(maxBackoffMs, baseDelayMs + random() * (max(baseDelayMs, previousDelay * 3) - baseDelayMs))`), not a fixed `baseDelayMs * 2 ** attempt` schedule, and each call site supplies its own `retryResult`/`retryError` predicates rather than sharing one hardcoded policy. An optional `maxElapsedMs` wall-clock budget across all attempts is also available (#692). **When hardening the retry/backoff behavior (the backoff formula, a retry predicate, a new option, etc.), edit `retry.ts` and update every one of the seven copies together in the same change** — `scripts/check-shared-modules.js`'s `Check Shared Module Parity` CI job fails the build on any divergence, so this is enforced, not just a convention to remember.
 
-`callback.ts`'s `postJsonWithRetry()` deliberately diverges from the other two: it never retries after a *received* HTTP response, including a 5xx, and only retries transport-level failures. This is intentional, not an oversight — `TerraformDriftReport`'s TSM callback token is one-shot, so retrying after the server has already seen (and possibly consumed) the token risks a spurious duplicate-submission error on the retry rather than a real recovery. Keep this divergence when syncing the other two helpers' behavior into `callback.ts`.
+`callback.ts`'s `postJsonWithRetry()` deliberately supplies a `retryResult` that never retries after a *received* HTTP response, including a 5xx, and only retries transport-level failures via the default `retryError`. This is intentional, not an oversight — `TerraformDriftReport`'s TSM callback token is one-shot, so retrying after the server has already seen (and possibly consumed) the token risks a spurious duplicate-submission error on the retry rather than a real recovery. Keep this divergence (via its own predicate, not a fork of `retry.ts` itself) when hardening the other call sites' behavior.
 
 ## Terraform results tab (build-results-tab)
 


### PR DESCRIPTION
## Summary

Two documentation accuracy fixes found by the 2026-07-20 blind audit — both low/info severity, bundled together since they touch the same two files.

## #725 — stale retry-helper architecture description

CONTRIBUTING.md's "Retry/backoff helper parity" section (and 4 spots in CLAUDE.md) described the **pre-#501** architecture: three independently-open-coded retry helpers, outside any CI parity gate, with a plain `baseDelayMs * 2 ** attempt` backoff. None of that has been true since #501 unified them into a single `retry.ts`, byte-identity-gated by `scripts/check-shared-modules.js` — and the family grew by 3 more tasks (the installer trio) in #645, which CLAUDE.md's "four tasks" wording never picked up. A contributor following the old guidance would edit the wrong surface (a thin per-task wrapper that no longer exists) and could still fail the `Check Shared Module Parity` CI job by missing 4 of the 7 required copies.

Rewrote both docs to describe the current architecture: `retry.ts` is the single canonical, CI-enforced byte-identical implementation across 7 task directories, with decorrelated-jitter backoff and the `#692` `maxElapsedMs` wall-clock budget option.

## #733 — CLAUDE.md Key Dependencies table missing sanitize-html

Per render.ts's own comments and CHANGELOG's 1.10.5 entry (#672, closes #552), `sanitize-html` is now the primary, final HTML sanitizer for the ServiceNow KB stored-XSS defense — `cheerio` was demoted to an earlier defense-in-depth pre-filter there. The table had no `sanitize-html` row at all and described `cheerio` as if it were still the sanitizer. THIRD_PARTY_NOTICES.md already lists `sanitize-html` correctly, so this was purely a CLAUDE.md completeness gap.

Added the missing row and updated `cheerio`'s description to cover both of its real, current roles: Markdown2Html's defense-in-depth pre-filter, and PublishKbArticle's independent `html-validate.ts` content-inspection gate (confirmed cheerio is actually imported by both).

## Testing

Docs-only change; no code/test impact. `get_errors` shows only pre-existing MD060/MD040/MD038 markdownlint diagnostics on unrelated lines (this repo has no markdownlint CI job — confirmed no such workflow exists), nothing new introduced by this diff.

Closes #725
Closes #733
