### PR TITLE
refactor: resolve DigestMeta name collision, gate HTTP hardening constants, dedupe az login exec

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
@@ -20,10 +20,11 @@
  * because this API needs JSON-body encoding, query-string params, and
  * axios-like non-2xx rejection that the other client's callers don't — see the
  * tracking note in check-shared-modules.js for the split: the ProxyTunnelAgent
- * class below is byte-identity-gated automatically via that script's
- * REGION_FAMILIES (the `#region shared:ProxyTunnelAgent` markers bracketing it
- * here and in both https-client.ts copies), while the remaining parallels
- * (https-only guard, request timeout, response size cap) stay in sync by hand.
+ * class below, and the request-timeout/response-cap constants, are both
+ * byte-identity-gated automatically via that script's REGION_FAMILIES (the
+ * `#region shared:ProxyTunnelAgent` / `#region shared:HttpHardeningConstants`
+ * markers bracketing them here and in both https-client.ts copies) — only the
+ * https-only guard itself remains a hand-tracked parallel (#722).
  */
 
 import * as https from 'https';
@@ -35,11 +36,18 @@ import { URL } from 'url';
 import type * as TaskLib from 'azure-pipelines-task-lib/task';
 import { retryAsync, parseRetryAfterMs } from './retry';
 
+/**
+ * Per-request socket timeout (ms) and the upper bound on the response body
+ * buffered in memory (ServiceNow table/attachment responses are small JSON, so
+ * this only guards against a misbehaving/hostile endpoint). Byte-identical
+ * with both https-client.ts copies via the `HttpHardeningConstants` region
+ * below (#722) — this used to be a hand-tracked parallel; edit every copy
+ * together.
+ */
+// #region shared:HttpHardeningConstants -- byte-identical across ModulePublish/DriftReport https-client.ts and PublishKbArticle servicenow-http.ts; enforced by scripts/check-shared-modules.js (REGION_FAMILIES). Edit every copy together.
 export const DEFAULT_REQUEST_TIMEOUT_MS = 100_000;
-
-// Bound how much of a response we buffer; ServiceNow table/attachment responses
-// are small JSON, so this only guards against a misbehaving/hostile endpoint.
 const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+// #endregion shared:HttpHardeningConstants
 
 /**
  * An https.Agent that tunnels every connection through the agent's configured

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts
@@ -7,19 +7,21 @@ import { URL } from 'url';
 import type * as TaskLib from 'azure-pipelines-task-lib/task';
 
 /**
- * Per-request socket timeout (ms). Without it a hung TCP connection makes the
- * caller's own timeout silently ineffective until the agent job timeout.
+ * Per-request socket timeout (ms) and the upper bound on the response body
+ * buffered in memory. The timeout is an *inactivity* timer (a hung connection
+ * makes the caller's own timeout silently ineffective until the agent job
+ * timeout); the byte cap guards against an endpoint that streams continuously
+ * without ever going idle (which the timeout alone can't catch), exhausting
+ * the agent's memory. Byte-identical across the module-publish/drift-report
+ * https-client.ts copies (FAMILIES) AND PublishKbArticleV1's servicenow-http.ts
+ * (REGION_FAMILIES, #722) via the `HttpHardeningConstants` region below — this
+ * used to be a hand-tracked parallel with servicenow-http.ts; edit every copy
+ * together.
  */
+// #region shared:HttpHardeningConstants -- byte-identical across ModulePublish/DriftReport https-client.ts and PublishKbArticle servicenow-http.ts; enforced by scripts/check-shared-modules.js (REGION_FAMILIES). Edit every copy together.
 export const DEFAULT_REQUEST_TIMEOUT_MS = 100_000;
-
-/**
- * Upper bound on the response body buffered in memory. The socket timeout above
- * is an *inactivity* timer, so an endpoint that streams bytes continuously never
- * trips it and could exhaust the agent's memory; this cap makes such a response
- * fail fast instead. Mirrors servicenow-http.ts and is kept byte-identical
- * across the module-publish and drift-report copies by check-shared-modules.js.
- */
 const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+// #endregion shared:HttpHardeningConstants
 
 export interface HttpResponse {
     status: number;

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts
@@ -7,19 +7,21 @@ import { URL } from 'url';
 import type * as TaskLib from 'azure-pipelines-task-lib/task';
 
 /**
- * Per-request socket timeout (ms). Without it a hung TCP connection makes the
- * caller's own timeout silently ineffective until the agent job timeout.
+ * Per-request socket timeout (ms) and the upper bound on the response body
+ * buffered in memory. The timeout is an *inactivity* timer (a hung connection
+ * makes the caller's own timeout silently ineffective until the agent job
+ * timeout); the byte cap guards against an endpoint that streams continuously
+ * without ever going idle (which the timeout alone can't catch), exhausting
+ * the agent's memory. Byte-identical across the module-publish/drift-report
+ * https-client.ts copies (FAMILIES) AND PublishKbArticleV1's servicenow-http.ts
+ * (REGION_FAMILIES, #722) via the `HttpHardeningConstants` region below — this
+ * used to be a hand-tracked parallel with servicenow-http.ts; edit every copy
+ * together.
  */
+// #region shared:HttpHardeningConstants -- byte-identical across ModulePublish/DriftReport https-client.ts and PublishKbArticle servicenow-http.ts; enforced by scripts/check-shared-modules.js (REGION_FAMILIES). Edit every copy together.
 export const DEFAULT_REQUEST_TIMEOUT_MS = 100_000;
-
-/**
- * Upper bound on the response body buffered in memory. The socket timeout above
- * is an *inactivity* timer, so an endpoint that streams bytes continuously never
- * trips it and could exhaust the agent's memory; this cap makes such a response
- * fail fast instead. Mirrors servicenow-http.ts and is kept byte-identical
- * across the module-publish and drift-report copies by check-shared-modules.js.
- */
 const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+// #endregion shared:HttpHardeningConstants
 
 export interface HttpResponse {
     status: number;

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/ApplyDigestL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/ApplyDigestL0.ts
@@ -1,9 +1,9 @@
 import * as assert from 'assert';
 import { buildApplyDigest } from '../../src/results/apply-digest';
-import { DigestMeta } from '../../src/results/plan-digest';
+import { DigestBuildMeta } from '../../src/results/plan-digest';
 import { MAX_DIAGNOSTICS, MAX_OUTPUTS, MAX_RESOURCES } from '../../src/results/caps';
 
-const META: DigestMeta = {
+const META: DigestBuildMeta = {
   taskVersion: '0.0.0-test',
   toolName: 'terraform',
   name: 'terraform-apply',

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/PlanDigestL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/PlanDigestL0.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
-import { buildPlanDigest, DigestMeta, capNotes } from '../../src/results/plan-digest';
+import { buildPlanDigest, DigestBuildMeta, capNotes } from '../../src/results/plan-digest';
 import { MAX_RESOURCES, MAX_ATTR_CHANGES_PER_RESOURCE, MAX_OUTPUTS, MAX_DRIFT, MAX_NOTES } from '../../src/results/caps';
 
-const META: DigestMeta = {
+const META: DigestBuildMeta = {
   taskVersion: '0.0.0-test',
   toolName: 'terraform',
   name: 'terraform-plan',

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/StateDigestL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/StateDigestL0.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { buildStateDigest } from '../../src/results/state-digest';
-import { DigestMeta } from '../../src/results/plan-digest';
+import { DigestBuildMeta } from '../../src/results/plan-digest';
 import { serializeDigest } from '../../src/results/redact';
 import { MAX_STATE_RESOURCES, MAX_STATE_ATTRS_PER_RESOURCE, MAX_OUTPUTS } from '../../src/results/caps';
 
@@ -10,7 +10,7 @@ import { MAX_STATE_RESOURCES, MAX_STATE_ATTRS_PER_RESOURCE, MAX_OUTPUTS } from '
 // mismatch rule, the module-flattening walk, the mode split, the caps, and
 // determinism each have a direct assertion.
 
-const META: DigestMeta = {
+const META: DigestBuildMeta = {
   taskVersion: '0.0.0-test',
   toolName: 'terraform',
   name: 'terraform-state',

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/golden-fixtures.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/golden-fixtures.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildPlanDigest, DigestMeta } from '../../src/results/plan-digest';
+import { buildPlanDigest, DigestBuildMeta } from '../../src/results/plan-digest';
 import { buildApplyDigest } from '../../src/results/apply-digest';
 import { serializeDigest } from '../../src/results/redact';
 
@@ -12,7 +12,7 @@ export const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
 
 // FIXED meta so goldens never churn: never Date.now(), never the real task
 // version (§2.6 determinism).
-export const PLAN_META: DigestMeta = {
+export const PLAN_META: DigestBuildMeta = {
   taskVersion: '0.0.0-test',
   toolName: 'terraform',
   name: 'terraform-plan',
@@ -20,7 +20,7 @@ export const PLAN_META: DigestMeta = {
   createdIso: '2026-07-15T00:00:00Z',
 };
 
-export const APPLY_META: DigestMeta = {
+export const APPLY_META: DigestBuildMeta = {
   taskVersion: '0.0.0-test',
   toolName: 'terraform',
   name: 'terraform-apply',

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/phase5-golden-fixtures.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/phase5-golden-fixtures.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildPlanDigest, DigestMeta } from '../../src/results/plan-digest';
+import { buildPlanDigest, DigestBuildMeta } from '../../src/results/plan-digest';
 import { buildStateDigest } from '../../src/results/state-digest';
 import { serializeDigest } from '../../src/results/redact';
 
@@ -14,7 +14,7 @@ export const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
 
 // FIXED meta so goldens never churn: never Date.now(), never the real task
 // version (§2.6 determinism).
-export const STATE_META: DigestMeta = {
+export const STATE_META: DigestBuildMeta = {
   taskVersion: '0.0.0-test',
   toolName: 'terraform',
   name: 'terraform-state',
@@ -22,7 +22,7 @@ export const STATE_META: DigestMeta = {
   createdIso: '2026-07-15T00:00:00Z',
 };
 
-export const PLAN_META: DigestMeta = {
+export const PLAN_META: DigestBuildMeta = {
   taskVersion: '0.0.0-test',
   toolName: 'terraform',
   name: 'terraform-plan',

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -171,10 +171,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                     "--allow-no-subscriptions",
                     "--federated-token", oidcToken]);
 
-                const loginResult = await loginTool.execAsync(<IExecOptions>{ silent: true });
-                if (loginResult !== 0) {
-                    throw new Error(`az login failed with exit code ${loginResult}`);
-                }
+                await this.execAzLogin(loginTool);
                 break;
             }
             case AuthorizationScheme.ServicePrincipal: {
@@ -189,10 +186,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                     "--tenant", tenantId,
                     "--allow-no-subscriptions"]);
 
-                const loginResult = await loginTool.execAsync(<IExecOptions>{ silent: true });
-                if (loginResult !== 0) {
-                    throw new Error(`az login failed with exit code ${loginResult}`);
-                }
+                await this.execAzLogin(loginTool);
                 break;
             }
             case AuthorizationScheme.ManagedServiceIdentity: {
@@ -207,10 +201,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                 }
                 loginTool.arg(loginArgs);
 
-                const loginResult = await loginTool.execAsync(<IExecOptions>{ silent: true });
-                if (loginResult !== 0) {
-                    throw new Error(`az login failed with exit code ${loginResult}`);
-                }
+                await this.execAzLogin(loginTool);
                 break;
             }
         }
@@ -223,6 +214,20 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
         tasks.debug("az login completed successfully.");
     }
+
+    /**
+     * Runs an already-argv-built `az login` ToolRunner and throws on a non-zero
+     * exit code. Factored out of runAzLogin's three AuthorizationScheme branches,
+     * which build different login argv but otherwise repeated this exact
+     * exec-and-check sequence verbatim (#732).
+     */
+    private async execAzLogin(loginTool: ToolRunner): Promise<void> {
+        const loginResult = await loginTool.execAsync(<IExecOptions>{ silent: true });
+        if (loginResult !== 0) {
+            throw new Error(`az login failed with exit code ${loginResult}`);
+        }
+    }
+
 
     private async setCommonVariables(authorizationScheme: AuthorizationScheme, serviceConnectionID: string, fallbackToIdTokenGeneration: boolean, useCliFlagsForBackend: boolean): Promise<void> {
         EnvironmentVariableHelper.setEnvironmentVariable("ARM_TENANT_ID", tasks.getEndpointAuthorizationParameter(serviceConnectionID, "tenantid", false) ?? '');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -3,7 +3,7 @@ import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformBaseCommandInitializer, TerraformAuthorizationCommandInitializer } from './terraform-commands';
 import { getSecureVarFileArgs, SecureFileLoader } from './secure-file-loader';
 import { replaceSecretFile, scrubFile, writeSecretFile } from './secure-temp';
-import { buildPlanDigest, DigestMeta } from './results/plan-digest';
+import { buildPlanDigest, DigestBuildMeta } from './results/plan-digest';
 import { buildApplyDigest, ApplyDigestOptions } from './results/apply-digest';
 import { buildStateDigest } from './results/state-digest';
 import { Digest } from './results/digest-schema';
@@ -1031,7 +1031,7 @@ export abstract class BaseTerraformCommandHandler {
      * Builds the DigestMeta identity/provenance fields (design §4.1) shared by
      * both the plan and apply structured attachments.
      */
-    private buildDigestMeta(publishName: string, workingDirectory: string): DigestMeta {
+    private buildDigestMeta(publishName: string, workingDirectory: string): DigestBuildMeta {
         return {
             taskVersion: getTaskVersion(),
             toolName: 'terraform',

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/apply-digest.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/apply-digest.ts
@@ -14,7 +14,7 @@ import { ApplyDigest, ApplyResource, Diagnostic, OutputChange } from './digest-s
 import { MAX_RESOURCES, MAX_DIAGNOSTICS, MAX_OUTPUTS, SOFT_MAX_DIGEST_BYTES, HARD_MAX_DIGEST_BYTES } from './caps';
 import { redactValue, newRedactContext, capDigestBytes, RedactContext } from './redact';
 import { scrubSecrets, sanitizeAttachmentName } from './secret-scrub';
-import { DigestMeta, DigestByteLimits, capNotes } from './plan-digest';
+import { DigestBuildMeta, DigestByteLimits, capNotes } from './plan-digest';
 
 /** Apply-specific build options (diagnostic handling + the byte-cap test seam). */
 export interface ApplyDigestOptions extends DigestByteLimits {
@@ -60,7 +60,7 @@ interface ResAcc {
  * @param meta    provenance/identity supplied by the caller
  * @param options diagnostic-detail toggle, known secrets, byte-cap test seam
  */
-export function buildApplyDigest(ndjson: string, meta: DigestMeta, options?: ApplyDigestOptions): ApplyDigest {
+export function buildApplyDigest(ndjson: string, meta: DigestBuildMeta, options?: ApplyDigestOptions): ApplyDigest {
   const ctx = newRedactContext();
   const includeDiagnostics = options?.includeDiagnostics !== false;
   const includeDetail = options?.includeDiagnosticDetail === true;

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/plan-digest.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/plan-digest.ts
@@ -31,7 +31,7 @@ import { redactValue, newRedactContext, deepEqual, capDigestBytes, RedactContext
 import { sanitizeAttachmentName } from './secret-scrub';
 
 /** Identity/provenance a caller supplies; kept out of the raw Terraform JSON. */
-export interface DigestMeta {
+export interface DigestBuildMeta {
   taskVersion: string;
   toolName: 'terraform' | 'opentofu';
   name: string;
@@ -86,7 +86,7 @@ const KNOWN_ACTIONS = new Set(['no-op', 'create', 'read', 'update', 'delete', 'r
  * @param meta    provenance/identity supplied by the caller
  * @param options destroy marker (`mode`) + the soft/hard byte-ceiling test seam
  */
-export function buildPlanDigest(plan: unknown, meta: DigestMeta, options?: PlanDigestOptions): PlanDigest {
+export function buildPlanDigest(plan: unknown, meta: DigestBuildMeta, options?: PlanDigestOptions): PlanDigest {
   const ctx = newRedactContext();
   const p = (plan && typeof plan === 'object' ? (plan as Record<string, unknown>) : {}) as Record<string, unknown>;
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/state-digest.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/state-digest.ts
@@ -29,7 +29,7 @@ import {
   HARD_MAX_DIGEST_BYTES,
 } from './caps';
 import { redactValue, newRedactContext, capDigestBytes, RedactContext } from './redact';
-import { DigestMeta, DigestByteLimits, capNotes } from './plan-digest';
+import { DigestBuildMeta, DigestByteLimits, capNotes } from './plan-digest';
 import { sanitizeAttachmentName } from './secret-scrub';
 
 // State has no unknown/after-apply values — everything is materialized (spec
@@ -49,7 +49,7 @@ const UNSAFE_ATTR_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
  * @param meta    provenance/identity supplied by the caller
  * @param options optional test seam for the soft/hard byte ceilings
  */
-export function buildStateDigest(state: unknown, meta: DigestMeta, options?: DigestByteLimits): StateDigest {
+export function buildStateDigest(state: unknown, meta: DigestBuildMeta, options?: DigestByteLimits): StateDigest {
   const ctx = newRedactContext();
   const s = obj(state);
   const values = obj(s.values);

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -252,15 +252,15 @@ const FAMILIES = [
 // MAX_RESPONSE_BYTES response cap (see truncate()/truncateBody()). It stays a
 // separate module rather than reusing https-client.ts because its call sites
 // need JSON-body encoding, query-string params, and axios-like non-2xx
-// rejection that the module-publish/drift-report clients don't. Its most
-// complex shared piece, the CONNECT-tunneling ProxyTunnelAgent class, IS gated
-// automatically: it is byte-compared against the two https-client.ts copies by
-// the REGION_FAMILIES mechanism below, via the '#region shared:ProxyTunnelAgent'
-// / '#endregion shared:ProxyTunnelAgent' markers bracketing the class in all
-// three files. The remaining hand-tracked parallels (the https-only guard, the
-// request timeout, the response cap) are scalar constants outside any region; a
-// future hardening change to those in https-client.ts should still be mirrored
-// into servicenow-http.ts by hand.
+// rejection that the module-publish/drift-report clients don't. Its two most
+// hardening-sensitive shared pieces are gated automatically via the
+// REGION_FAMILIES mechanism below: the CONNECT-tunneling ProxyTunnelAgent class
+// (`#region shared:ProxyTunnelAgent`) and, as of #722, the request-timeout /
+// response-cap constants (`#region shared:HttpHardeningConstants`) — both
+// byte-compared against the two https-client.ts copies. Only the https-only
+// guard itself remains a hand-tracked parallel: a future hardening change to
+// it in https-client.ts should still be mirrored into servicenow-http.ts by
+// hand.
 
 // Region families: unlike FAMILIES (whole-file byte-identity), each entry names a
 // marked region that must stay byte-identical across files that are otherwise NOT
@@ -277,6 +277,17 @@ const REGION_FAMILIES = [
         // https-client.ts copies (already whole-file-gated as a FAMILY above) and
         // the ServiceNow transport servicenow-http.ts (not a whole-file copy).
         region: 'ProxyTunnelAgent',
+        files: [
+            'Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts',
+            'Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts',
+            'Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts',
+        ],
+    },
+    {
+        // The per-request socket timeout and response-body byte cap, previously a
+        // hand-tracked parallel outside any parity gate (#722) -- now byte-
+        // compared the same way as ProxyTunnelAgent above.
+        region: 'HttpHardeningConstants',
         files: [
             'Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts',
             'Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts',


### PR DESCRIPTION
## Summary

Three low/info code-quality fixes from the 2026-07-20 blind audit, bundled together since they're all small, independent, behavior-preserving refactors.

## #721 — duplicate `DigestMeta` type name

`plan-digest.ts` and `digest-schema.ts` each exported an unrelated interface named `DigestMeta` — the former a wider "builder input" shape (`taskVersion`/`toolName`/etc., actually used as the parameter type for `buildPlanDigest`/`buildApplyDigest`/`buildStateDigest`), the latter the frozen, tab-consumed output-envelope shape. A future contributor extending the digest system could easily import the wrong one by name/autocomplete, with TypeScript only surfacing the resulting shape mismatch at the call site, not at the import.

Renamed `plan-digest.ts`'s version to `DigestBuildMeta` (via a semantic rename across all references — 9 files, 20 call sites) to remove the collision. No behavior change.

## #722 — servicenow-http.ts's HTTP hardening constants were hand-tracked, not parity-gated

`scripts/check-shared-modules.js`'s own comment already flagged this as the one remaining manual-parity gap: the two `https-client.ts` copies (ModulePublish/DriftReport, already whole-file byte-identity gated) and `servicenow-http.ts` (a credential-bearing ServiceNow transport, not a whole-file copy) kept their `DEFAULT_REQUEST_TIMEOUT_MS`/`MAX_RESPONSE_BYTES` constants in sync by hand — a future hardening change to one could silently miss the other.

Wrapped both constants in a `// #region shared:HttpHardeningConstants` / `// #endregion` marker pair (mirroring the existing `ProxyTunnelAgent` region convention) in all 3 files, and added a matching `REGION_FAMILIES` entry to `check-shared-modules.js` so a future divergence fails CI instead of silently drifting. Only the https-only guard itself remains a hand-tracked parallel (unchanged, out of scope here).

## #732 — `runAzLogin`'s repeated exec+throw block

The three `AuthorizationScheme` branches in `azure-terraform-command-handler.ts`'s `runAzLogin` build different `az login` argv but then repeated an identical exec/check/throw sequence verbatim. Factored the shared piece into a small private `execAzLogin(loginTool)` helper, called from each branch after building just its own differing `arg()` list. Purely an in-file readability change — the security-relevant residual on this method (WIF token/SP secret on argv) is unaffected.

## Testing

- `node scripts/check-shared-modules.js` passes, including the new `HttpHardeningConstants` region check.
- `npm test` green on TerraformTaskV5, TerraformModulePublishV1, TerraformDriftReportV1, PublishKbArticleV1 (the 4 tasks touched).

Closes #721
Closes #722
Closes #732
