### PR TITLE
test: add missing skipTlsVerify warning and drift-callback host-handling coverage

### DIFF
--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/HttpsClientHostHandlingByDesignL0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/HttpsClientHostHandlingByDesignL0.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import { createHttpsClient } from '../src/https-client';
+
+// Confirms createHttpsClient's ONLY validation gate on the destination is the
+// https:// scheme check -- there is no destination-host allowlist/denylist on
+// this sink (audit id30/#730). PublishKbArticleV1 has dedicated SSRF-restriction
+// tests for its analogous ServiceNow instance sink (InstanceSsrfDotDotReject.ts /
+// InstanceSsrfEmbeddedHostReject.ts); this test pins down that the drift-callback
+// sink's *design* is instead to accept any https host, so a future change that
+// silently narrows or widens this is visible in a diff here instead of only in
+// runtime behavior.
+describe('drift callback https-client: destination-host handling (by design, no restriction)', () => {
+  it('rejects a non-https URL before any network attempt, regardless of host', async () => {
+    const client = createHttpsClient(true, 2000);
+    await assert.rejects(
+      () => client('POST', 'http://tsm.example.com/drift', {}, '{}'),
+      /Refusing to send credentials over a non-HTTPS URL/,
+    );
+  });
+
+  it('does not reject an unusual/unexpected https host at a scheme-check layer (no host allowlist exists)', async () => {
+    // A .invalid TLD (RFC 6761) is guaranteed to never resolve, so the request
+    // fails at the network/DNS layer, never at a host-validation layer --
+    // proving no such layer exists for this sink.
+    const client = createHttpsClient(true, 2000);
+    await assert.rejects(
+      () => client('POST', 'https://internal-service.invalid/drift', {}, '{}'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(
+          !/Refusing to send credentials over a non-HTTPS URL/.test(err.message),
+          'an https:// URL to any host must not be rejected as a scheme violation',
+        );
+        return true;
+      },
+    );
+  });
+});

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -13,6 +13,8 @@ import { startConnectProxy, startRefusingConnectProxy, startHangingConnectProxy 
 
 // Direct unit tests for the fail-secure rejectUnauthorized default.
 import './RejectUnauthorizedDefaultL0';
+// Direct unit tests confirming the https-client destination-host is unrestricted by design (#730).
+import './HttpsClientHostHandlingByDesignL0';
 // Direct unit tests for the fail-secure failOnCallbackError default.
 import './FailOnCallbackErrorDefaultL0';
 // Direct unit tests for the secure-temp writeSecretFile/replaceSecretFile copy (#607).

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
@@ -696,6 +696,25 @@ describe('index orchestrator (setSecret masking + publisher routing)', () => {
         }
     });
 
+    it('emits the SkipTlsVerifyEnabled warning when skipTlsVerify is true (audit id31/#731)', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'PublishSkipTlsVerifyWarning.js'));
+        await tr.runAsync();
+        try {
+            assert.ok(tr.succeeded, 'task should have succeeded');
+            // The mock task-lib environment resolves tasks.loc() to a
+            // `loc_mock_<Key>` placeholder rather than the real resource string
+            // (no setResourcePath call in this fixture), so assert on the loc key.
+            assert.ok(
+                tr.warningIssues.some((w) => w.includes('SkipTlsVerifyEnabled')),
+                'should have warned that skipTlsVerify is enabled and TLS validation is disabled',
+            );
+        } catch (error) {
+            console.log('STDERR', tr.stderr);
+            console.log('STDOUT', tr.stdout);
+            throw error;
+        }
+    });
+
     it('masks the hcpToken and routes to the HCP publisher', async () => {
         const tr = new ttm.MockTestRunner(path.join(__dirname, 'PublishHcpToken.js'));
         await tr.runAsync();

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/PublishSkipTlsVerifyWarning.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/PublishSkipTlsVerifyWarning.ts
@@ -1,0 +1,46 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// Drives src/index.ts down the PRIVATE-registry path with skipTlsVerify=true, so
+// the SkipTlsVerifyEnabled warning path is actually exercised (audit id31/#731 --
+// no prior test set skipTlsVerify to true and asserted the warning fires). The
+// publisher and http transport are stubbed so no real network call is made.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('registryType', 'private');
+tr.setInput('namespace', 'aceo');
+tr.setInput('name', 'networking-vpc');
+tr.setInput('provider', 'aws');
+tr.setInput('version', '1.0.0');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('apiKey', 'super-secret-api-key');
+tr.setInput('skipTlsVerify', 'true');
+tr.setInput('waitForPublish', 'false');
+tr.setInput('timeoutSeconds', '180');
+
+// Stub the HTTPS transport so createHttpsClient never opens a socket.
+tr.registerMock('./http', {
+  createHttpsClient: () => () => Promise.resolve({ status: 200, body: '{}' }),
+});
+
+// Stub the private publisher: the constructor returns an object whose publish()
+// resolves a fake success result matching the real PublishResult shape.
+tr.registerMock('./private-publisher', {
+  PrivateRegistryPublisher: class {
+    publish() {
+      return Promise.resolve({ published: true, message: 'Sync triggered for version 1.0.0.' });
+    }
+  },
+});
+
+// Stub HCP too so the wrong branch can never touch the network if routing regresses.
+tr.registerMock('./hcp-publisher', {
+  HcpPublisher: class {
+    publish() {
+      return Promise.resolve({ published: true, message: 'should not be called' });
+    }
+  },
+});
+
+tr.run();


### PR DESCRIPTION
## Summary

Two low/enhancement test-coverage gaps from the 2026-07-20 blind audit, bundled together since both are pure test additions with no behavior change.

## #731 — no test proves the `skipTlsVerify` warning actually fires

`TerraformModulePublishV1`'s `SkipTlsVerifyEnabled` warning ("TLS certificate validation is DISABLED for the private registry connection...") is the only in-band signal a pipeline author gets when this task's TLS-bypass escape hatch is enabled. Existing tests only exercised the safe `skipTlsVerify=false` default and a dedicated https-only-guard test — nothing set it to `true` and asserted the warning is actually emitted, so a future refactor could silently drop the call with no test failing.

Added `PublishSkipTlsVerifyWarning.ts` (mirrors the existing `PublishPrivateApiKey.ts` fixture with `skipTlsVerify: 'true'`) and an `L0.ts` assertion on `tr.warningIssues`. Note: the mock task-lib harness resolves `tasks.loc()` to a `loc_mock_<Key>` placeholder rather than the real resource string (no `setResourcePath` call in this fixture), so the assertion matches on the loc key rather than the real English text.

## #730 — drift-callback sink has no test for destination-host handling

`TerraformDriftReportV1`'s `https-client.ts` backs the TSM drift-callback POST (an operator-configured URL carrying a bearer token) but had zero test coverage of its destination-host behavior — unlike `PublishKbArticleV1`'s analogous ServiceNow instance sink, which has dedicated `InstanceSsrfDotDotReject.ts`/`InstanceSsrfEmbeddedHostReject.ts` tests. Read `createHttpsClient` in full to confirm its actual, current design: the **only** validation is the `https://` scheme (synchronous rejection before any network attempt); there is no destination-host allowlist/denylist.

Added `HttpsClientHostHandlingByDesignL0.ts` pinning down that exact design: a non-https URL is rejected synchronously regardless of host, and an unusual/unexpected https host is **not** rejected at a validation layer — it reaches the network layer instead (proven via a guaranteed-unresolvable `.invalid` TLD per RFC 6761, so the test is fast and has zero real network dependency). This makes a future change that silently narrows or widens the host-handling behavior visible in a diff here, rather than only in runtime behavior.

## Testing

- `npm test` green on both `TerraformModulePublishV1` (64 passing) and `TerraformDriftReportV1` (63 passing).
- Both new tests were verified failing-then-passing during authoring (the skipTlsVerify one caught the `loc_mock_` placeholder quirk; the host-handling one completed in ~240ms, no flakiness observed).

Closes #730
Closes #731
