### PR TITLE
fix: distinguish stale-docs failure from crash, and warn on real getArticle errors in dry-run

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Strings/resources.resjson/en-US/resources.resjson
@@ -33,6 +33,7 @@
   "loc.messages.ArticleInfoSaved": "Article information saved to %s",
   "loc.messages.ArticleInfoSaveFailed": "Could not save article information to the KB JSON file: %s. A later run may fail to resolve this article and create a duplicate.",
   "loc.messages.MultipleKbJsonFilesFound": "Warning: multiple KB article JSON files found (%s); using the most recently modified.",
+  "loc.messages.DryRunGetArticleFailed": "Warning: could not fetch the existing article's current state (not a plain not-found): %s",
   "loc.messages.FoundKbJsonFile": "Found KB article JSON file: %s",
   "loc.messages.ImageNotFound": "Image not found, leaving src unchanged: '%s' (resolved to '%s')",
   "loc.messages.ImageTooLarge": "Image '%s' is %s bytes, exceeding the %s-byte attachment size limit; refusing to read it into memory.",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/DryRunGetArticleAuthErrorWarns.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/DryRunGetArticleAuthErrorWarns.ts
@@ -1,0 +1,44 @@
+// Full-task test: dryRun=true with an existing articleId, but getArticle() fails
+// with a genuine auth error (401), not a plain not-found. Confirms the dry-run
+// path surfaces this loudly (a console warning naming the real error) instead of
+// silently normalizing it to "unknown current state" the same way a real 404
+// would be treated (audit id27/#727).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('instance', 'my-valid-instance');
+tr.setInput('authType', 'basic');
+tr.setInput('username', 'svc-user');
+tr.setInput('password', 'svc-pass');
+tr.setInput('articleId', 'art-123');
+tr.setInput('workflowState', 'draft');
+tr.setInput('dryRun', 'true');
+tr.setInput('skipJsonLookup', 'true');
+tr.setInput('force', 'false');
+tr.setInput('uploadImages', 'false');
+
+tr.registerMock('./servicenow-http', {
+  ServiceNowHttpError: class ServiceNowHttpError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'ServiceNowHttpError';
+      this.status = status;
+    }
+  },
+});
+tr.registerMock('./servicenow-client', {
+  getArticle: async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { ServiceNowHttpError } = require('./servicenow-http');
+    throw new ServiceNowHttpError('Unauthorized', 401);
+  },
+});
+
+const a: ma.TaskLibAnswers = {};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -2349,6 +2349,19 @@ describe('PublishKbArticle full-task: instance SSRF guard', () => {
         }, tr);
     });
 
+    it('DryRunGetArticleAuthErrorWarns — a genuine auth failure fetching the current article warns instead of being silently normalized (audit id27/#727)', async () => {
+        const tp = nodePath.join(__dirname, 'DryRunGetArticleAuthErrorWarns.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'a dry run should still succeed even when the current-state lookup fails');
+            assert.ok(
+                tr.warningIssues.some((w) => w.includes('DryRunGetArticleFailed') || w.includes('Unauthorized')),
+                `should have warned about the real (non-404) getArticle failure: ${tr.warningIssues}`,
+            );
+        }, tr);
+    });
+
     it('SourceKeyMissFallsBackToJson — a source-key miss falls through to the KB*.json lookup instead of creating a duplicate', async () => {
         const tp = nodePath.join(__dirname, 'SourceKeyMissFallsBackToJson.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
@@ -14,6 +14,7 @@ import { emitArticleOutput, findKbArticleJson, readFrontMatterKey, sanitizeForSi
 import { DryRunPlan, PlannedAction, formatDryRunReport } from './dry-run';
 import { processArticleImages } from './attachments';
 import { updateArticleBody } from './servicenow-client';
+import { ServiceNowHttpError } from './servicenow-http';
 
 interface ResolvedAuth {
     instance: string;
@@ -271,9 +272,20 @@ async function run() {
                 try {
                     const existing = await getArticle(instance, headers, articleId);
                     currentWorkflowState = existing.workflow_state;
-                } catch {
-                    // Non-fatal in dry-run: report what we can without the current state.
+                } catch (error) {
+                    // A genuine 404 (the article truly doesn't exist under this ID) is
+                    // non-fatal in dry-run: report what we can without the current
+                    // state. Any OTHER failure (401/403 auth, 5xx, transport) is a real
+                    // connectivity/misconfiguration problem masquerading as "unknown" --
+                    // surface it loudly (#727) instead of silently normalizing every
+                    // failure the same way, since dryRun is explicitly documented as a
+                    // way to catch misconfiguration early.
                     currentWorkflowState = undefined;
+                    const is404 = error instanceof ServiceNowHttpError && error.status === 404;
+                    if (!is404) {
+                        const message = error instanceof Error ? error.message : String(error);
+                        tasks.warning(tasks.loc('DryRunGetArticleFailed', message));
+                    }
                 }
             } else if (plannedAction === 'create') {
                 // Surface the same required-field problems a real create would hit,

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -286,6 +286,7 @@
         "ArticleInfoSaved": "Article information saved to %s",
         "ArticleInfoSaveFailed": "Could not save article information to the KB JSON file: %s. A later run may fail to resolve this article and create a duplicate.",
         "MultipleKbJsonFilesFound": "Warning: multiple KB article JSON files found (%s); using the most recently modified.",
+        "DryRunGetArticleFailed": "Warning: could not fetch the existing article's current state (not a plain not-found): %s",
         "FoundKbJsonFile": "Found KB article JSON file: %s",
         "ImageNotFound": "Image not found, leaving src unchanged: '%s' (resolved to '%s')",
         "ImageAttached": "Attached image '%s' -> sys_attachment.do?sys_id=%s",

--- a/Tasks/TerraformDocs/TerraformDocsV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Strings/resources.resjson/en-US/resources.resjson
@@ -24,5 +24,6 @@
   "loc.input.label.additionalArgs": "Additional arguments",
   "loc.input.help.additionalArgs": "Additional command-line arguments passed verbatim to terraform-docs (e.g. --hide-empty --show inputs).",
   "loc.messages.TerraformDocsFailed": "terraform-docs failed with exit code %s.",
+  "loc.messages.TerraformDocsOutdated": "Generated documentation is out of date (outputCheck is enabled) for '%s'. Run terraform-docs locally with the same formatter/config and commit the update.",
   "loc.messages.GeneratedFile": "terraform-docs documentation written to: %s"
 }

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
@@ -44,9 +44,16 @@ async function run() {
 
         // ignoreReturnCode lets us surface a precise message. terraform-docs exits
         // non-zero on a genuine error and, with --output-check, when the target file
-        // is out of date — both should fail the task.
+        // is out of date -- both should fail the task, but they are surfaced with
+        // DIFFERENT messages (#726) so a build-summary-only view (e.g. a
+        // notification, or the pipeline's Result column) can tell 'the docs are
+        // stale, regenerate them' apart from 'terraform-docs crashed' without
+        // needing the interleaved raw tool stdout/stderr above in the log.
         const exitCode = await toolRunner.execAsync(<IExecOptions>{ ignoreReturnCode: true });
         if (exitCode !== 0) {
+            if (config.outputCheck) {
+                throw new Error(tasks.loc('TerraformDocsOutdated', config.outputFile || config.modulePath));
+            }
             throw new Error(tasks.loc('TerraformDocsFailed', exitCode));
         }
 

--- a/Tasks/TerraformDocs/TerraformDocsV1/task.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/task.json
@@ -152,6 +152,7 @@
   ],
   "messages": {
     "TerraformDocsFailed": "terraform-docs failed with exit code %s.",
+    "TerraformDocsOutdated": "Generated documentation is out of date (outputCheck is enabled) for '%s'. Run terraform-docs locally with the same formatter/config and commit the update.",
     "GeneratedFile": "terraform-docs documentation written to: %s"
   }
 }


### PR DESCRIPTION
## Summary

Two low-severity error-handling clarity fixes from the 2026-07-20 blind audit.

## #726 — terraform-docs generic exit-code message doesn't distinguish stale docs from a crash

terraform-docs exits non-zero both on a genuine error and, when `--output-check` is set, purely because the generated documentation is out of date — both cases mapped to the same generic `terraform-docs failed with exit code %s.` message. A build-summary-only view (a notification, or the pipeline's Result column) couldn't tell "the docs are stale, regenerate them" apart from "terraform-docs crashed" without digging into the interleaved raw tool stdout/stderr in the log.

Added a `TerraformDocsOutdated` message, thrown instead of the generic one when `outputCheck` is enabled and the exit is non-zero.

## #727 — PublishKbArticle's dry-run mode swallows getArticle() failures indiscriminately

The dry-run path's `getArticle()` call had a bare `catch` that discarded every failure mode alike — a genuine 401/403 (bad credentials), a 5xx, a network timeout, or a real 404 — always reporting `currentWorkflowState: unknown`. Since `dryRun` is explicitly documented as a way to "catch misconfiguration early", an operator relying on a dry run in a PR/validation build to confirm the ServiceNow connection is correct would get a clean-looking report even when auth is actually broken.

Now distinguishes a definitive 404 (`ServiceNowHttpError` with `status === 404`, still non-fatal and silent as before) from any other failure, which now emits a `DryRunGetArticleFailed` warning naming the real error.

## Testing

- New regression test `DryRunGetArticleAuthErrorWarns` (mocks a 401 `ServiceNowHttpError` from `getArticle()`, asserts the task still succeeds but warns).
- Real `npm test` green: TerraformDocsV1 (35 passing), PublishKbArticleV1 (217 passing).

Closes #726
Closes #727
