### PR TITLE
fix(deps): update tar to patch critical PAX path-confusion/DoS CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9343,9 +9343,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.17",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
-            "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
+            "version": "7.5.20",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+            "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "optional": true,
@@ -17200,9 +17200,9 @@
             "dev": true
         },
         "tar": {
-            "version": "7.5.17",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
-            "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
+            "version": "7.5.20",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+            "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
             "dev": true,
             "optional": true,
             "requires": {


### PR DESCRIPTION
## Summary

`npm audit --audit-level=high` started failing on `main` and every open PR (unrelated to
their own diffs) after a new **critical**-severity advisory was published for `tar`.

## Root cause

Root `package.json` has no `dependencies` — only `devDependencies` (tfx-cli, webpack,
cyclonedx-npm, jest, …) — so the per-task `--omit=dev` audits never see it. The
`Build and Test Tab` job is the one place that installs and audits the root toolchain, and
it gates on `npm audit --audit-level=high` with no `--omit=dev`.

`tar <=7.5.18` was flagged as critical, reached via:

```
@cyclonedx/cyclonedx-npm -> libxmljs2 -> node-gyp -> make-fetch-happen -> cacache -> tar
```

- GHSA-w8wr-v893-vjvp — process crash via PAX numeric path type confusion
- GHSA-23hp-3jrh-7fpw — decompression/parse DoS via unlimited input
- GHSA-8x88-c5mf-7j5w — negative tar entry size causes infinite loop in archive replace

This is a devDependency-only chain (SBOM generation tooling used at build/release time), not
something shipped in any task's runtime, but it still fails the CI gate for everyone.

## Fix

`npm update tar` (7.5.17 → 7.5.20) — within `node-gyp`'s existing `^7.5.x` dependency range,
so no `overrides` entry was needed.

## Verification

- `npm audit --audit-level=high` → 0 vulnerabilities.
- `npx tsc -p src/tab/tsconfig.json --noEmit` → clean.
- `npm run test:tab` → 17 suites / 238 tests passing (unchanged).

No tracking issue filed — caught live via CI failures on #741/#743 (both fail identically
on `main`, confirming it's pre-existing/unrelated to either PR's diff).
