### PR TITLE
fix(installer): stream SHA256 hashing + reject private/link-local hosts by default

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitReverifyMismatch.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitReverifyMismatch.ts
@@ -41,6 +41,10 @@ tr.registerMock('fs', {
         }
         return Buffer.from('cached-binary-content');
     },
+    createReadStream: (p: string) => {
+        const content = p.includes('opa-fresh-binary') ? 'fresh-binary-content' : 'cached-binary-content';
+        return require('stream').Readable.from(Buffer.from(content));
+    },
     writeFileSync: () => {
         throw new Error('writeFileSync should not be called when re-verification rejects the cached copy');
     },
@@ -51,11 +55,17 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({
-        update: (data: any) => ({
-            digest: () => data.toString() === 'fresh-binary-content' ? FRESH_HASH : CACHED_HASH
-        })
-    })
+    createHash: () => {
+        const chunks: Buffer[] = [];
+        const hash: any = new (require('stream').Writable)({
+            write(chunk: any, _e: any, cb: any) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                cb();
+            }
+        });
+        hash.digest = () => Buffer.concat(chunks).toString() === 'fresh-binary-content' ? FRESH_HASH : CACHED_HASH;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitReverifyPass.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitReverifyPass.ts
@@ -34,6 +34,7 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 tr.registerMock('fs', {
     existsSync: (_p: string) => false, // no stored integrity marker
     readFileSync: (_p: string, _enc?: string) => Buffer.from('shared-binary-content'),
+    createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('shared-binary-content')),
     writeFileSync: (p: string, _data: any, _enc?: string) => {
         console.log('MARKER_WRITTEN:' + p);
     },
@@ -44,13 +45,19 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({
-        update: (data: any) => ({
-            digest: () => data.toString() === 'shared-binary-content'
-                ? BINARY_HASH
-                : 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233'
-        })
-    })
+    createHash: () => {
+        const chunks: Buffer[] = [];
+        const hash: any = new (require('stream').Writable)({
+            write(chunk: any, _e: any, cb: any) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                cb();
+            }
+        });
+        hash.digest = () => Buffer.concat(chunks).toString() === 'shared-binary-content'
+            ? BINARY_HASH
+            : 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitVerifyFail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitVerifyFail.ts
@@ -30,6 +30,7 @@ tr.registerMock('fs', {
         }
         return Buffer.from('tampered-exe-content');
     },
+    createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('tampered-exe-content')),
     writeFileSync: () => { throw new Error('writeFileSync should not be called on a cache hit'); },
     chmodSync: () => { },
     mkdirSync: () => undefined,
@@ -38,7 +39,11 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122' }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitVerifyPass.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitVerifyPass.ts
@@ -33,6 +33,7 @@ tr.registerMock('fs', {
         }
         return Buffer.from('cached-exe-content');
     },
+    createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('cached-exe-content')),
     writeFileSync: () => { throw new Error('writeFileSync should not be called on a cache hit'); },
     chmodSync: () => { },
     mkdirSync: () => undefined,
@@ -41,7 +42,11 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => CACHED_EXE_HASH }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => CACHED_EXE_HASH;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorOpaSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorOpaSuccess.ts
@@ -29,14 +29,18 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 
 tr.registerMock('fs', {
     chmodSync: () => { },
-    readFileSync: () => Buffer.from('fake-binary'),
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-binary')),
     mkdirSync: () => undefined,
     copyFileSync: () => { }
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinelSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinelSuccess.ts
@@ -40,12 +40,16 @@ tr.registerMock('./gpg-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: () => { },
-    readFileSync: () => Buffer.from('fake-zip')
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-zip'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaLatestSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaLatestSuccess.ts
@@ -34,14 +34,18 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 
 tr.registerMock('fs', {
     chmodSync: () => { },
-    readFileSync: () => Buffer.from('fake-binary'),
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-binary')),
     mkdirSync: () => undefined,
     copyFileSync: () => { }
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaOfficialSuccess.ts
@@ -29,14 +29,18 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 
 tr.registerMock('fs', {
     chmodSync: () => { },
-    readFileSync: () => Buffer.from('fake-binary'),
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-binary')),
     mkdirSync: () => undefined,
     copyFileSync: () => { }
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistrySuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistrySuccess.ts
@@ -31,14 +31,18 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 
 tr.registerMock('fs', {
     chmodSync: () => { },
-    readFileSync: () => Buffer.from('fake-binary'),
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-binary')),
     mkdirSync: () => undefined,
     copyFileSync: () => { }
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -57,12 +57,16 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { throw new 
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  readFileSync: () => Buffer.from('fake-zip')
+  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-zip'))
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => EXPECTED_SHA256;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistrySentinelSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistrySentinelSuccess.ts
@@ -30,12 +30,16 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { throw new 
 
 tr.registerMock('fs', {
     chmodSync: () => { },
-    readFileSync: () => Buffer.from('fake-zip')
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-zip'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelCacheHitReverifyMismatch.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelCacheHitReverifyMismatch.ts
@@ -43,6 +43,15 @@ tr.registerMock('fs', {
         }
         return Buffer.from('cached-exe-content');
     },
+    createReadStream: (p: string) => {
+        let content = 'cached-exe-content';
+        if (p.includes('sentinel-reverify')) {
+            content = 'fresh-zip-content';
+        } else if (p.includes('sentinel-fresh')) {
+            content = 'fresh-exe-content';
+        }
+        return require('stream').Readable.from(Buffer.from(content));
+    },
     writeFileSync: () => {
         throw new Error('writeFileSync should not be called when re-verification rejects the cached copy');
     },
@@ -53,16 +62,22 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({
-        update: (data: any) => ({
-            digest: () => {
-                const s = data.toString();
-                if (s === 'fresh-zip-content') return ZIP_HASH;
-                if (s === 'fresh-exe-content') return FRESH_EXE_HASH;
-                return CACHED_EXE_HASH;
+    createHash: () => {
+        const chunks: Buffer[] = [];
+        const hash: any = new (require('stream').Writable)({
+            write(chunk: any, _e: any, cb: any) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                cb();
             }
-        })
-    })
+        });
+        hash.digest = () => {
+            const s = Buffer.concat(chunks).toString();
+            if (s === 'fresh-zip-content') return ZIP_HASH;
+            if (s === 'fresh-exe-content') return FRESH_EXE_HASH;
+            return CACHED_EXE_HASH;
+        };
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelOfficialSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelOfficialSuccess.ts
@@ -28,12 +28,16 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 
 tr.registerMock('fs', {
     chmodSync: () => { },
-    readFileSync: () => Buffer.from('fake-zip')
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-zip'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
-    createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -4,10 +4,11 @@ import path = require('path');
 import os = require('os');
 import fs = require('fs');
 import crypto = require('crypto');
+import { pipeline } from 'stream/promises';
 
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchText, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
-import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
+import { parseAllowedHosts, isRegistryHostAllowed, isPrivateOrLinkLocalHost } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from './url-secret-redaction';
@@ -75,12 +76,12 @@ export async function downloadPolicyAgent(inputVersion: string): Promise<string>
         // was originally downloaded and verified — see verifyCachedTool — and, when
         // no marker exists (cached before markers, or cached with verification
         // disabled), re-verify against a freshly downloaded, verified release.
-        const markerVerified = verifyCachedTool(cachedToolPath, exePath, `${agent} ${version}`);
+        const markerVerified = await verifyCachedTool(cachedToolPath, exePath, `${agent} ${version}`);
         if (!markerVerified) {
             await reverifyUnmarkedCacheEntry(agent, downloadSource, version, cachedToolPath, exePath);
         }
     } else if (verified) {
-        writeCacheIntegrityMarker(cachedToolPath, exePath);
+        await writeCacheIntegrityMarker(cachedToolPath, exePath);
     }
 
     tasks.setVariable('policyAgentLocation', exePath);
@@ -245,6 +246,7 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
     // host(s) via registryAllowedHosts. Default (empty) preserves the
     // trust-the-registry behavior.
     const allowedHosts = parseAllowedHosts(tasks.getInput("registryAllowedHosts", false));
+    const initialHost = new URL(data.download_url).hostname;
     if (allowedHosts.length > 0) {
         // Fail fast, before any temp-path resolution or network activity, when
         // the registry's own advertised download_url host is already
@@ -253,10 +255,19 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
         // upfront check keeps the common case (registry itself is fine, only
         // a redirect might misbehave) cheap and matches the original
         // synchronous rejection behavior exactly.
-        const initialHost = new URL(data.download_url).hostname;
         if (!isRegistryHostAllowed(initialHost, allowedHosts)) {
             throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", initialHost, allowedHosts.join(', ')));
         }
+    } else if (isPrivateOrLinkLocalHost(initialHost)) {
+        // Baseline protection even on the DEFAULT (no explicit allowlist) path
+        // (#729): a compromised or misconfigured registry pointing download_url
+        // straight at a loopback/link-local/private address (notably the cloud
+        // metadata service, conventionally at 169.254.169.254) is refused
+        // without requiring the operator to opt into registryAllowedHosts.
+        // Does not apply once an explicit allowlist is configured, so an
+        // operator who deliberately points at a private-IP mirror for an
+        // air-gapped environment is unaffected.
+        throw new Error(tasks.loc("RegistryDownloadHostIsPrivate", initialHost));
     }
 
     const ext = agent === "sentinel" ? ".zip" : (isWindows ? ".exe" : "");
@@ -441,16 +452,28 @@ export function parseFirstSha256(content: string): string {
 }
 
 export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
-    const fileBuffer = fs.readFileSync(filePath);
-    const actualHash = crypto.createHash('sha256').update(fileBuffer).digest('hex');
+    const actualHash = await computeSha256Streaming(filePath);
     if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
         throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
     }
     tasks.debug(`SHA256 verification passed: ${actualHash}`);
 }
 
-function hashFile(filePath: string): string {
-    return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+/**
+ * Computes a file's SHA256 via a streaming read (fs.createReadStream piped into
+ * the hash) instead of buffering the whole file into memory at once (#728).
+ * A compromised/malicious registry or mirror serving an oversized artifact
+ * would otherwise drive the agent toward memory exhaustion at this step; the
+ * streaming approach keeps memory usage constant regardless of file size.
+ */
+async function computeSha256Streaming(filePath: string): Promise<string> {
+    const hash = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(filePath), hash);
+    return hash.digest('hex');
+}
+
+async function hashFile(filePath: string): Promise<string> {
+    return computeSha256Streaming(filePath);
 }
 
 /**
@@ -461,9 +484,9 @@ function hashFile(filePath: string): string {
  * only means a future cache hit for this tool degrades to the pre-existing
  * trust-the-cache behavior.
  */
-function writeCacheIntegrityMarker(toolDir: string, exePath: string): void {
+async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
     try {
-        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), hashFile(exePath), 'utf8');
+        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), await hashFile(exePath), 'utf8');
     } catch (err) {
         tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
     }
@@ -490,14 +513,14 @@ function writeCacheIntegrityMarker(toolDir: string, exePath: string): void {
  * cross-job verification-policy mixing, not against an attacker who already has
  * write access to the agent's tool cache (who effectively owns the agent).
  */
-function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): boolean {
+async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
     const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
     if (!fs.existsSync(markerPath)) {
         tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
         return false;
     }
     const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
-    const actualHash = hashFile(exePath).toLowerCase();
+    const actualHash = (await hashFile(exePath)).toLowerCase();
     if (actualHash !== storedHash) {
         throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
     }
@@ -563,12 +586,12 @@ async function reverifyUnmarkedCacheEntry(agent: string, downloadSource: string,
         // OPA ships as the raw binary itself — compare it directly.
         freshExePath = artifact.path;
     }
-    const freshHash = hashFile(freshExePath).toLowerCase();
-    const cachedHash = hashFile(cachedExePath).toLowerCase();
+    const freshHash = (await hashFile(freshExePath)).toLowerCase();
+    const cachedHash = (await hashFile(cachedExePath)).toLowerCase();
     if (freshHash !== cachedHash) {
         throw new Error(tasks.loc("CachedToolReverificationMismatch", toolLabel, freshHash, cachedHash));
     }
-    writeCacheIntegrityMarker(toolDir, cachedExePath);
+    await writeCacheIntegrityMarker(toolDir, cachedExePath);
     console.log(tasks.loc("CachedToolReverified", toolLabel));
 }
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-allowlist.ts
@@ -25,3 +25,42 @@ export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]):
     allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
   );
 }
+
+/**
+ * Returns true when `hostname` is a loopback, link-local, or RFC1918/ULA
+ * private-range literal IP, or the `localhost` alias — the common SSRF
+ * targets (notably the cloud-provider instance-metadata service conventionally
+ * reachable at 169.254.169.254) that a compromised or misconfigured registry
+ * could steer a download toward even on the DEFAULT (registryAllowedHosts
+ * unset) path (#729). This is a baseline, always-on check on the initial
+ * advertised host; it does not replace the stronger, explicit
+ * registryAllowedHosts pin (which also re-validates every redirect hop) and is
+ * only applied when the operator has NOT configured that pin, so an operator
+ * who deliberately allowlists a private-IP mirror for an air-gapped
+ * environment is unaffected.
+ */
+export function isPrivateOrLinkLocalHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost') {
+    return true;
+  }
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    return (
+      a === 127 || // loopback
+      a === 10 || // RFC1918
+      (a === 172 && b >= 16 && b <= 31) || // RFC1918
+      (a === 192 && b === 168) || // RFC1918
+      (a === 169 && b === 254) || // link-local, incl. cloud metadata services
+      a === 0 // "this network"
+    );
+  }
+  if (host === '::1' || host === '::') {
+    return true;
+  }
+  // IPv6 link-local (fe80::/10) and unique local (fc00::/7).
+  return /^fe[89ab][0-9a-f]:/.test(host) || /^f[cd][0-9a-f]{2}:/.test(host);
+}
+

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -152,6 +152,7 @@
         "ResolvingLatestFromRegistry": "Resolving latest version from registry: %s",
         "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s",
         "RegistryDownloadHostNotAllowed": "Registry download_url host '%s' is not in registryAllowedHosts: %s",
+        "RegistryDownloadHostIsPrivate": "Registry download_url host '%s' is a private/link-local address, which is refused by default (a common SSRF target, e.g. the cloud metadata service). Set registryAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
         "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
         "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
         "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitReverifyMismatch.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitReverifyMismatch.ts
@@ -43,6 +43,15 @@ tr.registerMock('fs', {
     }
     return Buffer.from('cached-exe-content');
   },
+  createReadStream: (p: string) => {
+    let content = 'cached-exe-content';
+    if (p.includes('terraform-docs-reverify')) {
+      content = 'fresh-archive-content';
+    } else if (p.includes('terraform-docs-fresh')) {
+      content = 'fresh-exe-content';
+    }
+    return require('stream').Readable.from(Buffer.from(content));
+  },
   writeFileSync: () => {
     throw new Error('writeFileSync should not be called when re-verification rejects the cached copy');
   },
@@ -51,16 +60,22 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({
-    update: (data: any) => ({
-      digest: () => {
-        const s = data.toString();
-        if (s === 'fresh-archive-content') return ARCHIVE_HASH;
-        if (s === 'fresh-exe-content') return FRESH_EXE_HASH;
-        return CACHED_EXE_HASH;
+  createHash: () => {
+    const chunks: Buffer[] = [];
+    const hash: any = new (require('stream').Writable)({
+      write(chunk: any, _e: any, cb: any) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        cb();
       }
-    })
-  })
+    });
+    hash.digest = () => {
+      const s = Buffer.concat(chunks).toString();
+      if (s === 'fresh-archive-content') return ARCHIVE_HASH;
+      if (s === 'fresh-exe-content') return FRESH_EXE_HASH;
+      return CACHED_EXE_HASH;
+    };
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitReverifyPass.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitReverifyPass.ts
@@ -40,6 +40,10 @@ tr.registerMock('fs', {
     // same bytes — the cached entry matches the verified release.
     return Buffer.from('shared-exe-content');
   },
+  createReadStream: (p: string) => {
+    const content = p.includes('terraform-docs-reverify') ? 'fresh-archive-content' : 'shared-exe-content';
+    return require('stream').Readable.from(Buffer.from(content));
+  },
   writeFileSync: (p: string, _data: any, _enc?: string) => {
     console.log('MARKER_WRITTEN:' + p);
   },
@@ -48,11 +52,17 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({
-    update: (data: any) => ({
-      digest: () => data.toString() === 'fresh-archive-content' ? ARCHIVE_HASH : EXE_HASH
-    })
-  })
+  createHash: () => {
+    const chunks: Buffer[] = [];
+    const hash: any = new (require('stream').Writable)({
+      write(chunk: any, _e: any, cb: any) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        cb();
+      }
+    });
+    hash.digest = () => Buffer.concat(chunks).toString() === 'fresh-archive-content' ? ARCHIVE_HASH : EXE_HASH;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitVerifyFail.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitVerifyFail.ts
@@ -28,13 +28,18 @@ tr.registerMock('fs', {
     }
     return Buffer.from('tampered-exe-content');
   },
+  createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('tampered-exe-content')),
   writeFileSync: () => { throw new Error('writeFileSync should not be called on a cache hit'); },
   chmodSync: () => { }
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122' }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitVerifyPass.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitVerifyPass.ts
@@ -31,13 +31,18 @@ tr.registerMock('fs', {
     }
     return Buffer.from('cached-exe-content');
   },
+  createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('cached-exe-content')),
   writeFileSync: () => { throw new Error('writeFileSync should not be called on a cache hit'); },
   chmodSync: () => { }
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => CACHED_EXE_HASH }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => CACHED_EXE_HASH;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/LatestSuccess.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/LatestSuccess.ts
@@ -31,12 +31,16 @@ tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  readFileSync: () => Buffer.from('fake-archive')
+  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-archive'))
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => EXPECTED_SHA256;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorSuccess.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorSuccess.ts
@@ -27,12 +27,16 @@ tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  readFileSync: () => Buffer.from('fake-archive')
+  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-archive'))
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => EXPECTED_SHA256;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/OfficialSuccess.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/OfficialSuccess.ts
@@ -26,12 +26,16 @@ tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  readFileSync: () => Buffer.from('fake-archive')
+  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-archive'))
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => EXPECTED_SHA256;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -55,12 +55,16 @@ tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  readFileSync: () => Buffer.from('fake-archive')
+  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-archive'))
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => EXPECTED_SHA256;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistrySuccess.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistrySuccess.ts
@@ -28,12 +28,16 @@ tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  readFileSync: () => Buffer.from('fake-archive')
+  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-archive'))
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => EXPECTED_SHA256 }) })
+  createHash: () => {
+    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+    hash.digest = () => EXPECTED_SHA256;
+    return hash;
+  }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-allowlist.ts
@@ -25,3 +25,42 @@ export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]):
     allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
   );
 }
+
+/**
+ * Returns true when `hostname` is a loopback, link-local, or RFC1918/ULA
+ * private-range literal IP, or the `localhost` alias — the common SSRF
+ * targets (notably the cloud-provider instance-metadata service conventionally
+ * reachable at 169.254.169.254) that a compromised or misconfigured registry
+ * could steer a download toward even on the DEFAULT (registryAllowedHosts
+ * unset) path (#729). This is a baseline, always-on check on the initial
+ * advertised host; it does not replace the stronger, explicit
+ * registryAllowedHosts pin (which also re-validates every redirect hop) and is
+ * only applied when the operator has NOT configured that pin, so an operator
+ * who deliberately allowlists a private-IP mirror for an air-gapped
+ * environment is unaffected.
+ */
+export function isPrivateOrLinkLocalHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost') {
+    return true;
+  }
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    return (
+      a === 127 || // loopback
+      a === 10 || // RFC1918
+      (a === 172 && b >= 16 && b <= 31) || // RFC1918
+      (a === 192 && b === 168) || // RFC1918
+      (a === 169 && b === 254) || // link-local, incl. cloud metadata services
+      a === 0 // "this network"
+    );
+  }
+  if (host === '::1' || host === '::') {
+    return true;
+  }
+  // IPv6 link-local (fe80::/10) and unique local (fc00::/7).
+  return /^fe[89ab][0-9a-f]:/.test(host) || /^f[cd][0-9a-f]{2}:/.test(host);
+}
+

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -4,10 +4,11 @@ import path = require('path');
 import os = require('os');
 import fs = require('fs');
 import crypto = require('crypto');
+import { pipeline } from 'stream/promises';
 
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
-import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
+import { parseAllowedHosts, isRegistryHostAllowed, isPrivateOrLinkLocalHost } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from './url-secret-redaction';
 import { VerificationFailure, isVerificationFailure } from './verification-failure';
@@ -72,12 +73,12 @@ export async function downloadTerraformDocs(inputVersion: string): Promise<strin
         // was originally downloaded and verified — see verifyCachedTool — and, when
         // no marker exists (cached before markers, or cached with verification
         // disabled), re-verify against a freshly downloaded, verified release.
-        const markerVerified = verifyCachedTool(cachedToolPath, exePath, `terraform-docs ${version}`);
+        const markerVerified = await verifyCachedTool(cachedToolPath, exePath, `terraform-docs ${version}`);
         if (!markerVerified) {
             await reverifyUnmarkedCacheEntry(downloadSource, version, cachedToolPath, exePath);
         }
     } else if (verified) {
-        writeCacheIntegrityMarker(cachedToolPath, exePath);
+        await writeCacheIntegrityMarker(cachedToolPath, exePath);
     }
 
     tasks.setVariable('terraformDocsLocation', exePath);
@@ -182,6 +183,7 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
     // host(s) via registryAllowedHosts. Default (empty) preserves the
     // trust-the-registry behavior.
     const allowedHosts = parseAllowedHosts(tasks.getInput("registryAllowedHosts", false));
+    const initialHost = new URL(data.download_url).hostname;
     if (allowedHosts.length > 0) {
         // Fail fast, before any temp-path resolution or network activity, when
         // the registry's own advertised download_url host is already
@@ -190,10 +192,19 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
         // upfront check keeps the common case (registry itself is fine, only
         // a redirect might misbehave) cheap and matches the original
         // synchronous rejection behavior exactly.
-        const initialHost = new URL(data.download_url).hostname;
         if (!isRegistryHostAllowed(initialHost, allowedHosts)) {
             throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", initialHost, allowedHosts.join(', ')));
         }
+    } else if (isPrivateOrLinkLocalHost(initialHost)) {
+        // Baseline protection even on the DEFAULT (no explicit allowlist) path
+        // (#729): a compromised or misconfigured registry pointing download_url
+        // straight at a loopback/link-local/private address (notably the cloud
+        // metadata service, conventionally at 169.254.169.254) is refused
+        // without requiring the operator to opt into registryAllowedHosts.
+        // Does not apply once an explicit allowlist is configured, so an
+        // operator who deliberately points at a private-IP mirror for an
+        // air-gapped environment is unaffected.
+        throw new Error(tasks.loc("RegistryDownloadHostIsPrivate", initialHost));
     }
 
     const fileName = `terraform-docs-${version}-${uuidV4()}.${getArchiveExtension()}`;
@@ -326,16 +337,28 @@ export function parseSha256(sha256SumsContent: string, fileName: string): string
 }
 
 export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
-    const fileBuffer = fs.readFileSync(filePath);
-    const actualHash = crypto.createHash('sha256').update(fileBuffer).digest('hex');
+    const actualHash = await computeSha256Streaming(filePath);
     if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
         throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
     }
     tasks.debug(`SHA256 verification passed: ${actualHash}`);
 }
 
-function hashFile(filePath: string): string {
-    return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+/**
+ * Computes a file's SHA256 via a streaming read (fs.createReadStream piped into
+ * the hash) instead of buffering the whole file into memory at once (#728).
+ * A compromised/malicious registry or mirror serving an oversized artifact
+ * would otherwise drive the agent toward memory exhaustion at this step; the
+ * streaming approach keeps memory usage constant regardless of file size.
+ */
+async function computeSha256Streaming(filePath: string): Promise<string> {
+    const hash = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(filePath), hash);
+    return hash.digest('hex');
+}
+
+async function hashFile(filePath: string): Promise<string> {
+    return computeSha256Streaming(filePath);
 }
 
 /**
@@ -346,9 +369,9 @@ function hashFile(filePath: string): string {
  * only means a future cache hit for this tool degrades to the pre-existing
  * trust-the-cache behavior.
  */
-function writeCacheIntegrityMarker(toolDir: string, exePath: string): void {
+async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
     try {
-        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), hashFile(exePath), 'utf8');
+        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), await hashFile(exePath), 'utf8');
     } catch (err) {
         tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
     }
@@ -375,14 +398,14 @@ function writeCacheIntegrityMarker(toolDir: string, exePath: string): void {
  * cross-job verification-policy mixing, not against an attacker who already has
  * write access to the agent's tool cache (who effectively owns the agent).
  */
-function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): boolean {
+async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
     const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
     if (!fs.existsSync(markerPath)) {
         tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
         return false;
     }
     const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
-    const actualHash = hashFile(exePath).toLowerCase();
+    const actualHash = (await hashFile(exePath)).toLowerCase();
     if (actualHash !== storedHash) {
         throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
     }
@@ -441,12 +464,12 @@ async function reverifyUnmarkedCacheEntry(downloadSource: string, version: strin
     if (!freshExePath) {
         throw new Error(tasks.loc("TerraformDocsNotFoundInFolder", freshDir));
     }
-    const freshHash = hashFile(freshExePath).toLowerCase();
-    const cachedHash = hashFile(cachedExePath).toLowerCase();
+    const freshHash = (await hashFile(freshExePath)).toLowerCase();
+    const cachedHash = (await hashFile(cachedExePath)).toLowerCase();
     if (freshHash !== cachedHash) {
         throw new Error(tasks.loc("CachedToolReverificationMismatch", toolLabel, freshHash, cachedHash));
     }
-    writeCacheIntegrityMarker(toolDir, cachedExePath);
+    await writeCacheIntegrityMarker(toolDir, cachedExePath);
     console.log(tasks.loc("CachedToolReverified", toolLabel));
 }
 

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -131,6 +131,7 @@
     "ResolvingLatestFromRegistry": "Resolving latest version from registry: %s",
     "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s",
     "RegistryDownloadHostNotAllowed": "Registry download_url host '%s' is not in registryAllowedHosts: %s",
+    "RegistryDownloadHostIsPrivate": "Registry download_url host '%s' is a private/link-local address, which is refused by default (a common SSRF target, e.g. the cloud metadata service). Set registryAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
     "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
     "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
     "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyMismatch.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyMismatch.ts
@@ -56,6 +56,15 @@ tr.registerMock('fs', {
         }
         return Buffer.from('cached-exe-content');
     },
+    createReadStream: (p: string) => {
+        let content = 'cached-exe-content';
+        if (p.includes('terraform-reverify')) {
+            content = 'fresh-zip-content';
+        } else if (p.includes('terraform-fresh')) {
+            content = 'fresh-exe-content';
+        }
+        return require('stream').Readable.from(Buffer.from(content));
+    },
     writeFileSync: () => {
         throw new Error('writeFileSync should not be called when re-verification rejects the cached copy');
     },
@@ -64,16 +73,22 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (data: any) => ({
-            digest: (_encoding: string) => {
-                const s = data.toString();
-                if (s === 'fresh-zip-content') return ZIP_HASH;
-                if (s === 'fresh-exe-content') return FRESH_EXE_HASH;
-                return CACHED_EXE_HASH;
+    createHash: (_algorithm: string) => {
+        const chunks: Buffer[] = [];
+        const hash: any = new (require('stream').Writable)({
+            write(chunk: any, _enc: any, cb: any) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                cb();
             }
-        })
-    })
+        });
+        hash.digest = (_encoding: string) => {
+            const s = Buffer.concat(chunks).toString();
+            if (s === 'fresh-zip-content') return ZIP_HASH;
+            if (s === 'fresh-exe-content') return FRESH_EXE_HASH;
+            return CACHED_EXE_HASH;
+        };
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyPass.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyPass.ts
@@ -52,6 +52,10 @@ tr.registerMock('fs', {
         // same bytes — the cached entry matches the verified release.
         return Buffer.from('shared-exe-content');
     },
+    createReadStream: (p: string) => {
+        const content = p.includes('terraform-reverify') ? 'fresh-zip-content' : 'shared-exe-content';
+        return require('stream').Readable.from(Buffer.from(content));
+    },
     writeFileSync: (p: string, _data: any, _enc?: string) => {
         console.log('MARKER_WRITTEN:' + p);
     },
@@ -60,15 +64,21 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (data: any) => ({
-            digest: (_encoding: string) => {
-                const s = data.toString();
-                if (s === 'fresh-zip-content') return ZIP_HASH;
-                return EXE_HASH;
+    createHash: (_algorithm: string) => {
+        const chunks: Buffer[] = [];
+        const hash: any = new (require('stream').Writable)({
+            write(chunk: any, _enc: any, cb: any) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                cb();
             }
-        })
-    })
+        });
+        hash.digest = (_encoding: string) => {
+            const s = Buffer.concat(chunks).toString();
+            if (s === 'fresh-zip-content') return ZIP_HASH;
+            return EXE_HASH;
+        };
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitVerifyFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitVerifyFail.ts
@@ -43,6 +43,7 @@ tr.registerMock('fs', {
         }
         return Buffer.from('tampered-exe-content');
     },
+    createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('tampered-exe-content')),
     writeFileSync: () => {
         throw new Error('writeFileSync should not be called on a cache hit');
     },
@@ -51,11 +52,11 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122'
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitVerifyPass.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitVerifyPass.ts
@@ -46,6 +46,7 @@ tr.registerMock('fs', {
         }
         return Buffer.from('cached-exe-content');
     },
+    createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('cached-exe-content')),
     writeFileSync: () => {
         throw new Error('writeFileSync should not be called on a cache hit');
     },
@@ -54,11 +55,11 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => CACHED_EXE_HASH
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => CACHED_EXE_HASH;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CachedInstallSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CachedInstallSuccess.ts
@@ -35,6 +35,7 @@ tr.registerMock('fs', {
         }
         return Buffer.from('cached-exe-content');
     },
+    createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('cached-exe-content')),
     writeFileSync: () => {
         throw new Error('writeFileSync should not be called on a marker-verified cache hit');
     },
@@ -43,11 +44,11 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => CACHED_EXE_HASH
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => CACHED_EXE_HASH;
+        return hash;
+    }
 });
 tr.registerMock('undici', { ProxyAgent: class { } });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
@@ -45,16 +45,16 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccess.ts
@@ -40,16 +40,16 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccess.ts
@@ -46,17 +46,17 @@ tr.registerMock('./cosign-verifier', {
 // fs: readFileSync for verifySha256, chmodSync skipped on Windows
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccess.ts
@@ -42,17 +42,17 @@ tr.registerMock('./cosign-verifier', {
 // fs: readFileSync for verifySha256, chmodSync skipped on Windows
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccess.ts
@@ -38,6 +38,7 @@ tr.registerMock('fs', {
         }
         return Buffer.from('cached-exe-content');
     },
+    createReadStream: (_p: string) => require('stream').Readable.from(Buffer.from('cached-exe-content')),
     writeFileSync: () => {
         throw new Error('writeFileSync should not be called on a marker-verified cache hit');
     },
@@ -46,11 +47,11 @@ tr.registerMock('fs', {
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => CACHED_EXE_HASH
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => CACHED_EXE_HASH;
+        return hash;
+    }
 });
 tr.registerMock('undici', { ProxyAgent: class { } });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccess.ts
@@ -50,7 +50,7 @@ tr.registerMock('./cosign-verifier', {
 // fs: readFileSync for verifySha256, chmodSync skipped on Windows
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content'),
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content')),
     writeFileSync: (_path: string, _content: any) => { },
     unlinkSync: (_path: string) => { }
 });
@@ -58,11 +58,11 @@ tr.registerMock('fs', {
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccess.ts
@@ -43,18 +43,18 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content'),
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content')),
     writeFileSync: (_path: string, _content: any) => { },
     unlinkSync: (_path: string) => { }
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/PathPrependedOnInstall.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/PathPrependedOnInstall.ts
@@ -39,16 +39,16 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 // prependPath logs a distinctive marker so the L0 test can assert it was

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAccept.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAccept.ts
@@ -62,16 +62,16 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -68,16 +68,16 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
@@ -49,17 +49,17 @@ tr.registerMock('./cosign-verifier', {
 // fs: mock readFileSync (for verifySha256) and chmodSync (no-op, Windows mock)
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content'))
 });
 
 // crypto: return the expected hash so SHA256 verification passes
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/TofuPathPrependedOnInstall.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/TofuPathPrependedOnInstall.ts
@@ -42,18 +42,18 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('fake-zip-content'),
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('fake-zip-content')),
     writeFileSync: (_path: string, _content: any) => { },
     unlinkSync: (_path: string) => { }
 });
 
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => EXPECTED_SHA256
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => EXPECTED_SHA256;
+        return hash;
+    }
 });
 
 // prependPath logs a distinctive marker so the L0 test can assert it was

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-allowlist.ts
@@ -25,3 +25,42 @@ export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]):
     allowed.startsWith('*.') ? host.endsWith(allowed.slice(1)) : host === allowed,
   );
 }
+
+/**
+ * Returns true when `hostname` is a loopback, link-local, or RFC1918/ULA
+ * private-range literal IP, or the `localhost` alias — the common SSRF
+ * targets (notably the cloud-provider instance-metadata service conventionally
+ * reachable at 169.254.169.254) that a compromised or misconfigured registry
+ * could steer a download toward even on the DEFAULT (registryAllowedHosts
+ * unset) path (#729). This is a baseline, always-on check on the initial
+ * advertised host; it does not replace the stronger, explicit
+ * registryAllowedHosts pin (which also re-validates every redirect hop) and is
+ * only applied when the operator has NOT configured that pin, so an operator
+ * who deliberately allowlists a private-IP mirror for an air-gapped
+ * environment is unaffected.
+ */
+export function isPrivateOrLinkLocalHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost') {
+    return true;
+  }
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    return (
+      a === 127 || // loopback
+      a === 10 || // RFC1918
+      (a === 172 && b >= 16 && b <= 31) || // RFC1918
+      (a === 192 && b === 168) || // RFC1918
+      (a === 169 && b === 254) || // link-local, incl. cloud metadata services
+      a === 0 // "this network"
+    );
+  }
+  if (host === '::1' || host === '::') {
+    return true;
+  }
+  // IPv6 link-local (fe80::/10) and unique local (fc00::/7).
+  return /^fe[89ab][0-9a-f]:/.test(host) || /^f[cd][0-9a-f]{2}:/.test(host);
+}
+

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -4,10 +4,11 @@ import path = require('path');
 import os = require('os');
 import fs = require('fs');
 import crypto = require('crypto');
+import { pipeline } from 'stream/promises';
 
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchText, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
-import { parseAllowedHosts, isRegistryHostAllowed } from './registry-allowlist';
+import { parseAllowedHosts, isRegistryHostAllowed, isPrivateOrLinkLocalHost } from './registry-allowlist';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';
@@ -111,7 +112,7 @@ export async function downloadTerraform(inputVersion: string): Promise<string> {
         // was originally downloaded and verified — see verifyCachedTool — and, when
         // no marker exists (cached before markers, or cached with verification
         // disabled), re-verify against a freshly downloaded, verified release.
-        const markerVerified = verifyCachedTool(cachedToolPath, terraformPath, `terraform ${version}`);
+        const markerVerified = await verifyCachedTool(cachedToolPath, terraformPath, `terraform ${version}`);
         if (!markerVerified) {
             await reverifyUnmarkedCacheEntry(
                 `terraform ${version}`,
@@ -122,7 +123,7 @@ export async function downloadTerraform(inputVersion: string): Promise<string> {
             );
         }
     } else if (verified) {
-        writeCacheIntegrityMarker(cachedToolPath, terraformPath);
+        await writeCacheIntegrityMarker(cachedToolPath, terraformPath);
     }
 
     // PipelineTerraformTask locates the binary via tasks.which() (a PATH lookup),
@@ -211,6 +212,7 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     // constrain the trusted storage host(s) can set registryAllowedHosts.
     // Default (empty) preserves the existing trust-the-registry behavior.
     const allowedHosts = parseAllowedHosts(tasks.getInput("registryAllowedHosts", false));
+    const initialHost = new URL(data.download_url).hostname;
     if (allowedHosts.length > 0) {
         // Fail fast, before any temp-path resolution or network activity, when
         // the registry's own advertised download_url host is already
@@ -219,10 +221,19 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
         // upfront check keeps the common case (registry itself is fine, only
         // a redirect might misbehave) cheap and matches the original
         // synchronous rejection behavior exactly.
-        const initialHost = new URL(data.download_url).hostname;
         if (!isRegistryHostAllowed(initialHost, allowedHosts)) {
             throw new Error(tasks.loc("RegistryDownloadHostNotAllowed", initialHost, allowedHosts.join(', ')));
         }
+    } else if (isPrivateOrLinkLocalHost(initialHost)) {
+        // Baseline protection even on the DEFAULT (no explicit allowlist) path
+        // (#729): a compromised or misconfigured registry pointing download_url
+        // straight at a loopback/link-local/private address (notably the cloud
+        // metadata service, conventionally at 169.254.169.254) is refused
+        // without requiring the operator to opt into registryAllowedHosts.
+        // Does not apply once an explicit allowlist is configured, so an
+        // operator who deliberately points at a private-IP mirror for an
+        // air-gapped environment is unaffected.
+        throw new Error(tasks.loc("RegistryDownloadHostIsPrivate", initialHost));
     }
 
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
@@ -369,16 +380,28 @@ export function parseSha256(sha256SumsContent: string, zipFileName: string): str
 }
 
 export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
-    const fileBuffer = fs.readFileSync(filePath);
-    const actualHash = crypto.createHash('sha256').update(fileBuffer).digest('hex');
+    const actualHash = await computeSha256Streaming(filePath);
     if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
         throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
     }
     tasks.debug(`SHA256 verification passed: ${actualHash}`);
 }
 
-function hashFile(filePath: string): string {
-    return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+/**
+ * Computes a file's SHA256 via a streaming read (fs.createReadStream piped into
+ * the hash) instead of buffering the whole file into memory at once (#728).
+ * A compromised/malicious registry or mirror serving an oversized artifact
+ * would otherwise drive the agent toward memory exhaustion at this step; the
+ * streaming approach keeps memory usage constant regardless of file size.
+ */
+async function computeSha256Streaming(filePath: string): Promise<string> {
+    const hash = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(filePath), hash);
+    return hash.digest('hex');
+}
+
+async function hashFile(filePath: string): Promise<string> {
+    return computeSha256Streaming(filePath);
 }
 
 /**
@@ -389,9 +412,9 @@ function hashFile(filePath: string): string {
  * only means a future cache hit for this tool degrades to the pre-existing
  * trust-the-cache behavior.
  */
-function writeCacheIntegrityMarker(toolDir: string, exePath: string): void {
+async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
     try {
-        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), hashFile(exePath), 'utf8');
+        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), await hashFile(exePath), 'utf8');
     } catch (err) {
         tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
     }
@@ -418,14 +441,14 @@ function writeCacheIntegrityMarker(toolDir: string, exePath: string): void {
  * cross-job verification-policy mixing, not against an attacker who already has
  * write access to the agent's tool cache (who effectively owns the agent).
  */
-function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): boolean {
+async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
     const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
     if (!fs.existsSync(markerPath)) {
         tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
         return false;
     }
     const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
-    const actualHash = hashFile(exePath).toLowerCase();
+    const actualHash = (await hashFile(exePath)).toLowerCase();
     if (actualHash !== storedHash) {
         throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
     }
@@ -484,12 +507,12 @@ async function reverifyUnmarkedCacheEntry(
     if (!freshExePath) {
         throw new Error(tasks.loc("TerraformNotFoundInFolder", freshDir));
     }
-    const freshHash = hashFile(freshExePath).toLowerCase();
-    const cachedHash = hashFile(cachedExePath).toLowerCase();
+    const freshHash = (await hashFile(freshExePath)).toLowerCase();
+    const cachedHash = (await hashFile(cachedExePath)).toLowerCase();
     if (freshHash !== cachedHash) {
         throw new Error(tasks.loc("CachedToolReverificationMismatch", toolLabel, freshHash, cachedHash));
     }
-    writeCacheIntegrityMarker(toolDir, cachedExePath);
+    await writeCacheIntegrityMarker(toolDir, cachedExePath);
     console.log(tasks.loc("CachedToolReverified", toolLabel));
 }
 
@@ -589,7 +612,7 @@ async function downloadTofu(inputVersion: string): Promise<string> {
 
     if (cacheHit) {
         // See the matching comment in downloadTerraform.
-        const markerVerified = verifyCachedTool(cachedToolPath, tofuPath, `tofu ${version}`);
+        const markerVerified = await verifyCachedTool(cachedToolPath, tofuPath, `tofu ${version}`);
         if (!markerVerified) {
             await reverifyUnmarkedCacheEntry(
                 `tofu ${version}`,
@@ -602,7 +625,7 @@ async function downloadTofu(inputVersion: string): Promise<string> {
     } else {
         // downloadZipFromOpenTofu always verifies the zip's SHA256 unconditionally
         // (cosign only gates authenticity of the SHA256SUMS itself).
-        writeCacheIntegrityMarker(cachedToolPath, tofuPath);
+        await writeCacheIntegrityMarker(cachedToolPath, tofuPath);
     }
 
     // See the matching comment in downloadTerraform: PipelineTerraformTask finds

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -163,6 +163,7 @@
         "ResolvingLatestFromRegistry": "Resolving latest Terraform version from registry: %s",
         "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s",
         "RegistryDownloadHostNotAllowed": "Registry download_url host '%s' is not in registryAllowedHosts: %s",
+        "RegistryDownloadHostIsPrivate": "Registry download_url host '%s' is a private/link-local address, which is refused by default (a common SSRF target, e.g. the cloud metadata service). Set registryAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
         "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
         "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
         "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",


### PR DESCRIPTION
## Summary

Hardens all 3 installer tasks (TerraformInstallerV1, PolicyAgentInstallerV1,
TerraformDocsInstallerV1) against two related issues in their shared cache/verification
logic: an oversized-artifact memory DoS (#728) and a default-path SSRF residual (#729).

## #728 — SHA256 verification buffered the whole artifact into memory

`verifySha256`/`hashFile` read the entire downloaded artifact via `fs.readFileSync` before
hashing. A compromised or misconfigured source (registry, mirror, or HashiCorp/OpenTofu/OPA
official release) serving an oversized artifact could drive the agent toward memory
exhaustion at this step.

**Fix:** switched to a streaming read — `fs.createReadStream` piped into the hash via
`stream/promises`' `pipeline()` — so memory usage stays constant regardless of file size.
Applied identically to all 3 tasks (same function names/shapes: `verifySha256`, `hashFile`,
`writeCacheIntegrityMarker`, `verifyCachedTool`).

## #729 — default path trusts the registry to steer the download to any host

With `registryAllowedHosts` unset (the default), a compromised registry's `download_url`
was trusted at face value, with no restriction on the resolved host — including loopback,
link-local, or private-range addresses (notably the cloud-provider instance-metadata service
conventionally reachable at `169.254.169.254`).

**Fix:** added `isPrivateOrLinkLocalHost()` to the shared `registry-allowlist.ts` (byte-identical
across all 3 tasks, enforced by `scripts/check-shared-modules.js`). The registry download path
now rejects the initial advertised host by default when it's a loopback/link-local/RFC1918
literal IP or `localhost` — **only** on the default (no explicit allowlist) path, so an operator
who has already opted into `registryAllowedHosts` (e.g. deliberately pointing at a private-IP
mirror for an air-gapped environment) is unaffected.

## Verification

- `npm test` in all 3 task directories: zero regressions, matching each task's pre-change
  passing count exactly (TerraformInstallerV1: 153, PolicyAgentInstallerV1: 105,
  TerraformDocsInstallerV1: 93).
- `node scripts/check-shared-modules.js`: passes (registry-allowlist.ts stays byte-identical
  across all 3 tasks).
- Updated 39 test fixtures across the 3 tasks whose `fs`/`crypto` mocks assumed the old
  `readFileSync` + `update/digest`-chain shape — added `createReadStream` mocks mirroring
  existing `readFileSync` branching, and upgraded `crypto.createHash` mocks to a real
  `Writable`-compatible object (`pipeline()` needs a genuine stream destination).

Closes #728
Closes #729
