### PR TITLE
docs: clarify Node 24 is the sole behavioral test gate, Node 20 is load-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,19 @@ Verified tooling snapshot (periodically re-verified rather than tracked to an ex
 
 CI and local development both target Node 24 LTS (Active LTS, EOL April 2028). Node 20 is EOL as of April 2026.
 
+**Node 20 is load-only, not a behavioral gate (#720):** every task ships a `Node20_1` fallback
+handler (see above), and each task's CI leg has a "Set up Node 20 for Node20_1 handler smoke
+test" step that runs the already-compiled `src/index.js` under Node 20 with no ADO inputs
+supplied — this proves the compiled module graph parses and loads under Node 20 (a real,
+useful check: a Node-20-incompatible dependency or syntax construct would fail it), but the
+task's own try/catch converts the resulting "input required" error into a caught failure
+before any real command, credential, or verification logic executes. The full mocha/L0
+assertion suite only ever runs under Node 24 — **Node 24 is the sole behavioral gate**;
+Node 20 is deliberately load-only. This is an intentional scope decision (not an oversight):
+running the full test suite twice per task would roughly double CI time for every task, and
+Node 20 is already EOL, so the fallback handler exists purely for agents that haven't yet
+upgraded their runner, not as a second fully-verified execution path.
+
 ## Supported Providers
 
 | Provider  | Handler class                    | Auth method                                                                                   |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,15 @@ Two throw styles coexist across the tasks: `throw new Error(tasks.loc('Key', ...
 
 ## Testing
 
+Node 24 is the sole behavioral test gate (`npm test` in every task directory runs the full
+mocha/L0 assertion suite under Node 24 only). Every task also ships a `Node20_1` fallback
+handler for agents that haven't upgraded their runner yet, and each task's CI leg includes a
+load-only smoke step (compiled `src/index.js` run under Node 20 with no inputs) proving the
+module graph parses/loads there — but that step never exercises real command, credential, or
+verification logic. This is an intentional scope decision (#720), not a gap to fill by
+duplicating the full suite under Node 20: doing so would roughly double CI time per task for a
+runtime that's already EOL (April 2026).
+
 ### TerraformTaskV5
 
 ```bash


### PR DESCRIPTION
## Summary

Documents an existing, intentional scope decision that was previously only implicit in a CI
step comment: **Node 24 is the sole behavioral test gate**; the Node 20 CI leg is deliberately
load-only.

## Background

Every task ships a `Node20_1` fallback handler for agents that haven't upgraded their runner
yet. Each task's CI leg includes a "Set up Node 20 for Node20_1 handler smoke test" step that
runs the already-compiled `src/index.js` under Node 20 with no ADO inputs supplied — this
proves the compiled module graph parses/loads under Node 20 (a real, useful check), but the
task's own try/catch converts the resulting "input required" error into a caught failure
before any real command, credential, or verification logic executes. The full mocha/L0
assertion suite only ever runs under Node 24.

This was always an intentional choice (#654's own recommendation asked for "at minimum
running the compiled output under Node 20," which that fix delivered) — not an oversight —
but it wasn't documented as a stated policy anywhere, so a future contributor or auditor could
reasonably read the smoke-test step as full Node 20 coverage.

## Change

Docs-only. Adds an explicit note to both `CLAUDE.md` and `CONTRIBUTING.md` stating Node 24 is
the sole behavioral gate and Node 20 is load-only, with the rationale (duplicating the full
suite under Node 20 would roughly double CI time per task for a runtime that's already EOL as
of April 2026).

No code or CI changes.

Closes #720
