### PR TITLE
feat(v5): real-terraform smoke harness -- Workstream 1 of #719

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -113,6 +113,52 @@ jobs:
       - name: Verify compiled output runs under Node 20 (Node20_1 handler)
         run: node src/index.js
 
+  # Real-terraform behavioral smoke harness (#719). Kept as a SEPARATE job from
+  # build-and-test-v5 above (not folded into test:coverage) so the normal mock
+  # suite stays terraform-free and fast, and local devs without terraform on
+  # PATH still run it. See docs/initiatives/smoke-fuzz-testing-plan.md
+  # Workstream 1 for the full design/rationale, and
+  # Tests/SmokeL0.ts/Tests/SmokeTests/** for the scenarios themselves.
+  build-and-test-v5-smoke:
+    name: Build and Test V5 Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-2025]
+    defaults:
+      run:
+        working-directory: Tasks/TerraformTask/TerraformTaskV5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.15.7"
+          terraform_wrapper: false
+      - name: Run real-terraform smoke tests
+        run: npm run test:smoke
+
+  # Stable required-status-check context for the V5 smoke matrix, mirroring
+  # build-and-test-tab-gate's identical rationale: branch protection pins a
+  # bare context, but an OS matrix job only reports OS-suffixed contexts.
+  build-and-test-v5-smoke-gate:
+    name: Build and Test V5 Smoke
+    needs: build-and-test-v5-smoke
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all V5 smoke matrix legs passed
+        if: needs.build-and-test-v5-smoke.result != 'success'
+        run: exit 1
+
   build-and-test-installer-v1:
     name: Build and Test Installer V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeL0.ts
@@ -1,0 +1,158 @@
+import * as assert from 'assert';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import * as path from 'path';
+
+/**
+ * Real-terraform smoke harness (#719). Kept as a SEPARATE suite/CI job from
+ * L0.ts's mock-runner suite (not folded into test:coverage) so the normal
+ * suite stays terraform-free and fast, and local devs without terraform on
+ * PATH still run the mock suite. Requires a real terraform (or tofu) binary
+ * on PATH -- see docs/initiatives/smoke-fuzz-testing-plan.md for the full
+ * design and rationale.
+ *
+ * Unlike L0.ts's mock-runner scenarios (where ToolRunner exec answers are
+ * keyed by the exact command-line string the code currently emits -- so a
+ * WRONG argv shape the test wasn't told to expect is invisible), every
+ * scenario here runs a real terraform binary against a real local-backend
+ * fixture (Tests/SmokeTests/fixtures/local-data/main.tf) with no mocking at
+ * all (TaskMockRunner.run(true)), and asserts on the real exit code and real
+ * on-disk artifacts.
+ */
+describe('TerraformTaskV5 Smoke Test Suite (real terraform, #719)', function () {
+  this.timeout(60000);
+
+  function runValidations(validator: () => void, tr: ttm.MockTestRunner) {
+    try {
+      validator();
+    } catch (error) {
+      console.log('STDERR', tr.stderr);
+      console.log('STDOUT', tr.stdout);
+      throw error;
+    }
+  }
+
+  describe('Regression floor', () => {
+    it('#612 plan: user-supplied -out is honored, no task-injected second -out shadows it', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'Regression612Plan.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('Regression612PlanL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('#612 destroy: user-supplied -out is honored, no task-injected second -out shadows it', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'Regression612Destroy.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('Regression612DestroyL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('#613 apply: -json is emitted before the positional saved-plan path, not after', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'Regression613Apply.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('Regression613ApplyL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('#613 stderr-surfacing: a real terraform failure message reaches the thrown error under publishApplyResults', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'Regression613Stderr.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('Regression613StderrL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+  });
+
+  describe('Baseline command matrix', () => {
+    it('plan: no additional options', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'BaselinePlainPlan.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('BaselinePlainPlanL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('plan + publishPlanSummary: task-owned tempfile -out', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'BaselinePlanSummary.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('BaselinePlanSummaryL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('apply: fresh (no saved plan) + publishApplyResults', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'BaselineApplyResults.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('BaselineApplyResultsL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('show: current state + publishStateResults', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'BaselineShowStateResults.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('BaselineShowStateResultsL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('output -json', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'BaselineOutputJson.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('BaselineOutputJsonL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('validate (auth-free)', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'BaselineValidate.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('BaselineValidateL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+
+    it('fmt -check (auth-free)', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'BaselineFmt.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('BaselineFmtL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineApplyResults.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineApplyResults.ts
@@ -1,0 +1,19 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/** Baseline matrix: fresh apply (no saved plan) + publishApplyResults (-json structured path). */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'BaselineApplyResultsL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('publishApplyResults', 'my-apply-results');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineApplyResultsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineApplyResultsL0.ts
@@ -1,0 +1,22 @@
+import tl = require('azure-pipelines-task-lib');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        const handler = new TerraformCommandHandlerAzureRM();
+        const response = await handler.apply();
+        if (response !== 0) {
+            tl.setResult(tl.TaskResult.Failed, `BaselineApplyResultsL0: expected apply() to return 0, got ${response}.`);
+            return;
+        }
+        handler.cleanupTempFiles();
+        tl.setResult(tl.TaskResult.Succeeded, 'BaselineApplyResultsL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineFmt.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineFmt.ts
@@ -1,0 +1,16 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture } from './smoke-helpers';
+
+/** Baseline matrix: fmt -check (auth-free, createBaseCommand). */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'BaselineFmtL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'fmt');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('fmtCheck', 'true');
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineFmtL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineFmtL0.ts
@@ -1,0 +1,21 @@
+import tl = require('azure-pipelines-task-lib');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        const handler = new TerraformCommandHandlerAzureRM();
+        const response = await handler.fmt();
+        if (response !== 0) {
+            tl.setResult(tl.TaskResult.Failed, `BaselineFmtL0: expected fmt() to return 0 (fixture is already canonically formatted), got ${response}.`);
+            return;
+        }
+        tl.setResult(tl.TaskResult.Succeeded, 'BaselineFmtL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineOutputJson.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineOutputJson.ts
@@ -1,0 +1,18 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/** Baseline matrix: output -json. */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'BaselineOutputJsonL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'output');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineOutputJsonL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineOutputJsonL0.ts
@@ -1,0 +1,38 @@
+import tl = require('azure-pipelines-task-lib');
+import fs = require('fs');
+import { execFileSync } from 'child_process';
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        execFileSync('terraform', ['apply', '-auto-approve', '-no-color'], { cwd: workingDirectory, stdio: 'pipe' });
+
+        const handler = new TerraformCommandHandlerAzureRM();
+        const response = await handler.output();
+        if (response !== 0) {
+            tl.setResult(tl.TaskResult.Failed, `BaselineOutputJsonL0: expected output() to return 0, got ${response}.`);
+            return;
+        }
+
+        const outputFilePath = tl.getVariable('jsonOutputVariablesPath');
+        if (!outputFilePath || !fs.existsSync(outputFilePath)) {
+            tl.setResult(tl.TaskResult.Failed, 'BaselineOutputJsonL0: jsonOutputVariablesPath was not set to a real file.');
+            return;
+        }
+        const outputJson = JSON.parse(fs.readFileSync(outputFilePath, 'utf-8'));
+        if (!outputJson.env_output || outputJson.env_output.value !== 'staging') {
+            tl.setResult(tl.TaskResult.Failed, `BaselineOutputJsonL0: expected env_output.value === 'staging', got: ${JSON.stringify(outputJson)}`);
+            return;
+        }
+
+        handler.cleanupTempFiles();
+        tl.setResult(tl.TaskResult.Succeeded, 'BaselineOutputJsonL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlainPlan.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlainPlan.ts
@@ -1,0 +1,18 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/** Baseline matrix: plan with no additional options (real terraform, no mocks). */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'BaselinePlainPlanL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlainPlanL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlainPlanL0.ts
@@ -1,0 +1,22 @@
+import tl = require('azure-pipelines-task-lib');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+  const workingDirectory = tl.getInput('workingDirectory')!;
+  try {
+    realTerraformInit(workingDirectory);
+    const handler = new TerraformCommandHandlerAzureRM();
+    const response = await handler.plan();
+    if (response !== 2) {
+      tl.setResult(tl.TaskResult.Failed, `BaselinePlainPlanL0: expected plan() to return 2 (changes present), got ${response}.`);
+      return;
+    }
+    handler.cleanupTempFiles();
+    tl.setResult(tl.TaskResult.Succeeded, 'BaselinePlainPlanL0 should have succeeded.');
+  } finally {
+    cleanupScratchFixture(workingDirectory);
+  }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlanSummary.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlanSummary.ts
@@ -1,0 +1,19 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/** Baseline matrix: plan + publishPlanSummary, task-owned tempfile -out (no user -out). */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'BaselinePlanSummaryL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('publishPlanSummary', 'my-summary');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlanSummaryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselinePlanSummaryL0.ts
@@ -1,0 +1,30 @@
+import tl = require('azure-pipelines-task-lib');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+  const workingDirectory = tl.getInput('workingDirectory')!;
+  try {
+    realTerraformInit(workingDirectory);
+    const handler = new TerraformCommandHandlerAzureRM();
+    const response = await handler.plan();
+    if (response !== 2) {
+      tl.setResult(tl.TaskResult.Failed, `BaselinePlanSummaryL0: expected plan() to return 2 (changes present), got ${response}.`);
+      return;
+    }
+    // No user -out was supplied, so the task must have injected its own
+    // tempfile -out (Agent.TempDirectory falls back to os.tmpdir() when
+    // unset) and built a real plan-summary digest from it -- proven by the
+    // real ##vso[task.addattachment] logging command real task-lib emits.
+    if (!tl.getVariable('changesPresent') || tl.getVariable('changesPresent') !== 'true') {
+      tl.setResult(tl.TaskResult.Failed, "BaselinePlanSummaryL0: expected changesPresent variable to be 'true'.");
+      return;
+    }
+    handler.cleanupTempFiles();
+    tl.setResult(tl.TaskResult.Succeeded, 'BaselinePlanSummaryL0 should have succeeded.');
+  } finally {
+    cleanupScratchFixture(workingDirectory);
+  }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineShowStateResults.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineShowStateResults.ts
@@ -1,0 +1,21 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/** Baseline matrix: show current state + publishStateResults (structured state-inventory path). */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'BaselineShowStateResultsL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'show');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('outputTo', 'console');
+tr.setInput('outputFormat', 'json');
+tr.setInput('publishStateResults', 'my-state-results');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineShowStateResultsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineShowStateResultsL0.ts
@@ -1,0 +1,27 @@
+import tl = require('azure-pipelines-task-lib');
+import { execFileSync } from 'child_process';
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        // Real state to show, created directly (bypassing the task) so this
+        // scenario tests ONLY show()'s own argv-build.
+        execFileSync('terraform', ['apply', '-auto-approve', '-no-color'], { cwd: workingDirectory, stdio: 'pipe' });
+
+        const handler = new TerraformCommandHandlerAzureRM();
+        const response = await handler.show();
+        if (response !== 0) {
+            tl.setResult(tl.TaskResult.Failed, `BaselineShowStateResultsL0: expected show() to return 0, got ${response}.`);
+            return;
+        }
+        handler.cleanupTempFiles();
+        tl.setResult(tl.TaskResult.Succeeded, 'BaselineShowStateResultsL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineValidate.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineValidate.ts
@@ -1,0 +1,15 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture } from './smoke-helpers';
+
+/** Baseline matrix: validate (auth-free, createBaseCommand). */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'BaselineValidateL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'validate');
+tr.setInput('workingDirectory', scratchDir);
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineValidateL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/BaselineValidateL0.ts
@@ -1,0 +1,21 @@
+import tl = require('azure-pipelines-task-lib');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        const handler = new TerraformCommandHandlerAzureRM();
+        const response = await handler.validate();
+        if (response !== 0) {
+            tl.setResult(tl.TaskResult.Failed, `BaselineValidateL0: expected validate() to return 0, got ${response}.`);
+            return;
+        }
+        tl.setResult(tl.TaskResult.Succeeded, 'BaselineValidateL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612Destroy.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612Destroy.ts
@@ -1,0 +1,31 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/**
+ * Baseline destroy scenario (real terraform, no mocks): auto-approve +
+ * commandOptions forwarding against real state.
+ *
+ * NOTE: this deliberately does NOT combine destroy with publishPlanSummary --
+ * building this harness discovered that combination is currently broken
+ * against real terraform (destroy() unconditionally injects `-out=`, which
+ * real `terraform destroy` -- a convenience alias for `apply -destroy` --
+ * rejects outright: "flag provided but not defined: -out"). Filed as #749;
+ * a publishPlanSummary+destroy scenario belongs in this suite once that's
+ * fixed, as a real regression guard.
+ */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'Regression612DestroyL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'destroy');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '-var=env=prod');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);
+

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612DestroyL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612DestroyL0.ts
@@ -1,0 +1,46 @@
+import tl = require('azure-pipelines-task-lib');
+import { execFileSync } from 'child_process';
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        // Real state to destroy: apply directly (bypassing the task) so this
+        // scenario tests ONLY destroy()'s own argv-build (commandOptions
+        // forwarding + auto-approve), not apply()'s.
+        execFileSync('terraform', ['apply', '-auto-approve', '-no-color'], { cwd: workingDirectory, stdio: 'pipe' });
+
+        const stateBefore = JSON.parse(execFileSync('terraform', ['show', '-json'], { cwd: workingDirectory, encoding: 'utf-8' }));
+        if (!stateBefore.values || !stateBefore.values.root_module || !stateBefore.values.root_module.resources || stateBefore.values.root_module.resources.length !== 1) {
+            tl.setResult(tl.TaskResult.Failed, 'Regression612DestroyL0: sanity check failed -- expected exactly 1 real resource in state before destroy.');
+            return;
+        }
+
+        const handler = new TerraformCommandHandlerAzureRM();
+        const response = await handler.destroy();
+        if (response !== 0) {
+            tl.setResult(tl.TaskResult.Failed, `Regression612DestroyL0: expected destroy() to return 0, got ${response}.`);
+            return;
+        }
+
+        // commandOptions (-var=env=prod) must have been forwarded and accepted
+        // (a wrong argv shape would have made this whole command fail above).
+        // An empty state's `terraform show -json` still has a top-level
+        // format_version key, just no `values` key at all.
+        const stateAfter = JSON.parse(execFileSync('terraform', ['show', '-json'], { cwd: workingDirectory, encoding: 'utf-8' }));
+        if (stateAfter.values !== undefined) {
+            tl.setResult(tl.TaskResult.Failed, `Regression612DestroyL0: expected no resources left in state after destroy, got: ${JSON.stringify(stateAfter)}`);
+            return;
+        }
+
+        handler.cleanupTempFiles();
+        tl.setResult(tl.TaskResult.Succeeded, 'Regression612DestroyL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();
+

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612Plan.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612Plan.ts
@@ -1,0 +1,31 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/**
+ * #612 regression floor (real terraform, no mocks): the user already saves
+ * the plan via their own `-out=userplan.tfplan` in commandOptions AND enables
+ * publishPlanSummary. The task must NOT inject a second `-out=` -- terraform
+ * honors only the LAST `-out=` on the command line, so a task-injected
+ * tempfile would silently shadow the user's file and userplan.tfplan would
+ * never be written. Unlike the mock-runner sibling test (which proves this by
+ * an exec-answer keyed on the exact expected command line -- itself unable to
+ * catch a WRONG argv shape it wasn't told to expect), this scenario runs a
+ * real terraform binary against a real fixture and asserts on the real
+ * on-disk file.
+ */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'Regression612PlanL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'plan');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', '-out=userplan.tfplan');
+tr.setInput('publishPlanSummary', 'my-summary');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612PlanL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression612PlanL0.ts
@@ -1,0 +1,36 @@
+import tl = require('azure-pipelines-task-lib');
+import fs = require('fs');
+import path = require('path');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        const handler = new TerraformCommandHandlerAzureRM();
+
+        const response = await handler.plan();
+        if (response !== 2) {
+            tl.setResult(tl.TaskResult.Failed, `Regression612PlanL0: expected plan() to return 2 (changes present), got ${response}.`);
+            return;
+        }
+
+        // The USER's own -out path must exist -- proves no second, task-owned
+        // -out= was injected (the broken code would have appended one AFTER the
+        // user's, and terraform honors only the last -out= on the line, so
+        // userplan.tfplan would never be written).
+        const userPlanPath = path.join(workingDirectory, 'userplan.tfplan');
+        if (!fs.existsSync(userPlanPath)) {
+            tl.setResult(tl.TaskResult.Failed, "Regression612PlanL0: userplan.tfplan was not written -- a task-injected -out shadowed the user's own -out (the #612 regression).");
+            return;
+        }
+
+        handler.cleanupTempFiles();
+        tl.setResult(tl.TaskResult.Succeeded, 'Regression612PlanL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613Apply.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613Apply.ts
@@ -1,0 +1,31 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/**
+ * #613 regression floor (real terraform, no mocks): the standard saved-plan
+ * apply pattern -- `commandOptions` is a POSITIONAL plan-file path (not a
+ * flag). Pre-fix, applyAutoApprove() appended `-json` AFTER commandOptions,
+ * producing `apply -auto-approve x.tfplan -json`, which terraform's flag
+ * parser rejects as "Too many command line arguments" (it stops parsing flags
+ * at the first positional argument). The fix emits `-json` BEFORE the
+ * positional. This can only be proven with a REAL terraform binary -- a mock
+ * exec answer keyed on the current (already-fixed) command line can't detect
+ * that the fixed code would have failed against a real CLI parser if the
+ * ordering regressed.
+ */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'Regression613ApplyL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', 'x.tfplan');
+tr.setInput('publishApplyResults', 'my-apply-results');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613ApplyL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613ApplyL0.ts
@@ -1,0 +1,30 @@
+import tl = require('azure-pipelines-task-lib');
+import { execFileSync } from 'child_process';
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+        // Real saved plan to apply, created directly (bypassing the task) so
+        // this scenario tests ONLY apply()'s own argv-build.
+        execFileSync('terraform', ['plan', '-out=x.tfplan', '-no-color'], { cwd: workingDirectory, stdio: 'pipe' });
+
+        const handler = new TerraformCommandHandlerAzureRM();
+        const response = await handler.apply();
+        if (response !== 0) {
+            tl.setResult(tl.TaskResult.Failed, `Regression613ApplyL0: expected apply() to return 0, got ${response}.`);
+            return;
+        }
+
+        handler.cleanupTempFiles();
+        tl.setResult(tl.TaskResult.Succeeded, 'Regression613ApplyL0 should have succeeded.');
+    } catch (error) {
+        tl.setResult(tl.TaskResult.Failed, `Regression613ApplyL0: apply() threw -- ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613Stderr.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613Stderr.ts
@@ -1,0 +1,32 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/**
+ * #613 stderr-surfacing (real terraform, no mocks): apply() against a
+ * nonexistent saved-plan file, with publishApplyResults set (the structured
+ * path runs with `silent:true`, so ToolRunner's own stderr echo is
+ * suppressed). Asserts the task fails closed (never silently succeeds).
+ *
+ * Building this harness found that under -json (publishApplyResults),
+ * terraform's own error for this exact case is an NDJSON diagnostic on
+ * STDOUT, not stderr -- so apply()'s stderr-fold (#613's original fix) does
+ * not surface it, and the thrown message is currently just the bare loc
+ * string. Filed as #750; see the L0 driver's comment for the exact assertion
+ * this test currently makes pending that fix.
+ */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'Regression613StderrL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'apply');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('commandOptions', 'missing.tfplan');
+tr.setInput('publishApplyResults', 'my-apply-results');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613StderrL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613StderrL0.ts
@@ -1,0 +1,41 @@
+import tl = require('azure-pipelines-task-lib');
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+    const workingDirectory = tl.getInput('workingDirectory')!;
+    try {
+        realTerraformInit(workingDirectory);
+
+        const handler = new TerraformCommandHandlerAzureRM();
+        try {
+            await handler.apply();
+            tl.setResult(tl.TaskResult.Failed, 'Regression613StderrL0: expected apply() to throw for a missing plan file, but it succeeded.');
+            return;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            // NOTE: under publishApplyResults (-json), terraform's own error
+            // for a missing/unreadable plan file is an NDJSON diagnostic event
+            // on STDOUT, not stderr (confirmed empirically) -- apply()'s
+            // stderr-fold (#613) does not cover this, so the message is
+            // currently just the bare loc string with no diagnostic detail.
+            // Filed as #750; this assertion only proves the task still FAILS
+            // CLOSED (does not silently succeed) for this real failure -- once
+            // #750 is fixed, tighten this to also assert the message contains
+            // the real diagnostic text (mirrors Regression612Destroy.ts's note
+            // about #749).
+            if (!message.includes('TerraformApplyFailed')) {
+                tl.setResult(tl.TaskResult.Failed, `Regression613StderrL0: unexpected failure message shape: ${message}`);
+                return;
+            }
+        }
+
+        handler.cleanupTempFiles();
+        tl.setResult(tl.TaskResult.Succeeded, 'Regression613StderrL0 should have succeeded.');
+    } finally {
+        cleanupScratchFixture(workingDirectory);
+    }
+}
+
+run();
+

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/fixtures/local-data/main.tf
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/fixtures/local-data/main.tf
@@ -1,0 +1,26 @@
+// Smoke-harness fixture (#719): backend "local" + the built-in terraform_data
+// resource (Terraform core >= 1.4, no external provider) so `terraform init`
+// is fully offline -- no registry.terraform.io dependency in CI. Deliberately
+// declares NO cloud provider block, so the ARM_*/AWS_*/GOOGLE_*/etc.
+// environment variables the task's handleProvider() writes are simply never
+// consumed by terraform -- this is what lets the harness exercise the task's
+// real argv-build + real-terraform-exec path with zero cloud calls.
+//
+// Do NOT use null_resource/random -- both require a provider download.
+
+terraform {
+  backend "local" {}
+}
+
+variable "env" {
+  type    = string
+  default = "staging"
+}
+
+resource "terraform_data" "example" {
+  input = var.env
+}
+
+output "env_output" {
+  value = var.env
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/smoke-helpers.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/smoke-helpers.ts
@@ -1,0 +1,61 @@
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+import { execFileSync } from 'child_process';
+
+/**
+ * Copies the shared local-backend `terraform_data` fixture into a fresh
+ * scratch directory (under os.tmpdir()) and returns its path. Each scenario
+ * gets its own directory so parallel/sequential scenarios never collide over
+ * `.terraform/`, state, or lock files -- and a fresh `terraform init` (fully
+ * offline: the fixture declares no provider) is required per scratch dir.
+ */
+export function prepareScratchFixture(): string {
+    const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tf-smoke-'));
+    const fixtureSrc = path.join(__dirname, 'fixtures', 'local-data', 'main.tf');
+    fs.copyFileSync(fixtureSrc, path.join(scratchDir, 'main.tf'));
+    return scratchDir;
+}
+
+/** Best-effort recursive removal of a scratch directory created by {@link prepareScratchFixture}. */
+export function cleanupScratchFixture(scratchDir: string): void {
+    try {
+        fs.rmSync(scratchDir, { recursive: true, force: true });
+    } catch {
+        // best-effort -- os.tmpdir() is periodically reaped by the OS/agent anyway.
+    }
+}
+
+/**
+ * Runs a real, direct `terraform init` in workingDirectory -- deliberately
+ * NOT via the task's own `handler.init()`, which unconditionally calls
+ * handleBackend() and requires a `backendServiceArm`/equivalent input
+ * regardless of what backend block the .tf actually declares (it builds
+ * `-backend-config=` args assuming a cloud remote backend). This harness's
+ * fixture uses `backend "local" {}`, and #719/the argv-injection bugs this
+ * harness targets (#612/#613) live entirely in plan/apply/destroy/show, not
+ * init/backend-credential wiring -- so bypassing the task's init path here
+ * keeps the harness focused on the argv surface in scope, without needing to
+ * fake cloud backend credentials that would only be rejected by a local
+ * backend's own arg validation anyway.
+ */
+export function realTerraformInit(workingDirectory: string): void {
+    execFileSync('terraform', ['init', '-no-color'], { cwd: workingDirectory, stdio: 'pipe' });
+}
+
+/**
+ * Sets the fake Azure ServicePrincipal service-connection env vars every
+ * scenario needs for handleProvider() to complete without a real network call
+ * (setCommonVariables() only WRITES ARM_* environment variables from these --
+ * it never validates or calls out anywhere). The fixture's main.tf declares no
+ * `azurerm` provider block, so terraform never reads/consumes the resulting
+ * ARM_* variables either -- this is what makes the whole scenario network-free.
+ */
+export function setFakeAzureServiceConnectionEnv(): void {
+    process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+    process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = '00000000-0000-0000-0000-000000000000';
+    process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+    process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+    process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = '00000000-0000-0000-0000-000000000000';
+}
+

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
     "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
+    "test:smoke": "npm run compile:all && mocha --timeout 60000 --require ts-node/register Tests/SmokeL0.ts",
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",

--- a/scripts/check-task-list.js
+++ b/scripts/check-task-list.js
@@ -97,6 +97,11 @@ function taskDirsFromDependabot() {
 // run at repo root), so keying off `working-directory: Tasks/...` naturally
 // excludes them (and any future non-task job) exactly like the `cd Tasks/...`
 // key excludes release.yml's non-task 'Generate SBOM for tab' step above.
+// A task dir may legitimately have MORE than one job pointing at it (e.g.
+// TerraformTaskV5's real-terraform smoke-test job, `build-and-test-v5-smoke`,
+// alongside its main `build-and-test-v5` job, #719) -- mirrors the extension
+// manifest's own "two contribution ids, one task dir" dedup above, so compare
+// the deduplicated set of dirs, not the raw occurrence count.
 function taskDirsFromUnitTestJobs() {
     const text = readText('.github/workflows/unit-test.yml');
     const re = /working-directory:\s*(Tasks\/\S+)/g;
@@ -105,7 +110,7 @@ function taskDirsFromUnitTestJobs() {
     while ((m = re.exec(text))) {
         dirs.push(m[1]);
     }
-    return dirs.sort();
+    return [...new Set(dirs)].sort();
 }
 
 // .github/workflows/release.yml: the sbom-and-sign job's 'Generate SBOM for


### PR DESCRIPTION
## Summary

Implements **Workstream 1** of `docs/initiatives/smoke-fuzz-testing-plan.md`: a real-terraform
behavioral smoke harness for `TerraformTaskV5`, closing the structural gap that let #612/#613
(argv-ordering/stream-handling bugs) escape four consecutive audits and reach production within
hours of the feature being enabled.

## Root cause this closes

The entire test suite is mock-runner unit tests, where `ToolRunner` exec answers are keyed by
the exact command-line string the code currently emits — so the mock happily answers whatever
argv the code emits, and a wrong argv order is invisible. CI never ran a real terraform binary
anywhere in this repo.

## What's added

- `Tests/SmokeTests/fixtures/local-data/main.tf` — `backend "local" {}` + the built-in
  `terraform_data` resource (Terraform core ≥1.4, no external provider), so `terraform init` is
  fully offline.
- `Tests/SmokeTests/smoke-helpers.ts` — scratch-fixture prep/cleanup + fake Azure
  ServicePrincipal env vars (pure env-var writes, zero network calls, matching the existing
  mock-runner tests' own fixture pattern).
- 11 scenarios (each: outer `.ts` sets real inputs/env + calls `TaskMockRunner.run(true)` —
  **no mocking at all**; inner `L0.ts` driver calls the real handler method against real
  terraform):
  - **Regression floor:** #612 plan, #612 destroy, #613 apply (argv ordering), #613
    stderr-surfacing.
  - **Baseline command matrix:** plain plan, plan+publishPlanSummary, fresh
    apply+publishApplyResults, show+publishStateResults, output -json, validate, fmt -check.
- `Tests/SmokeL0.ts` — new mocha aggregator (kept separate from `L0.ts`/`test:coverage`).
- `package.json`: new `test:smoke` script.
- `.github/workflows/unit-test.yml`: new `build-and-test-v5-smoke` job (both OS legs, via
  SHA-pinned `hashicorp/setup-terraform`) + a `build-and-test-v5-smoke-gate` stable-context
  wrapper (mirrors the existing Tab gate pattern).

## Proven to catch the real bug (acceptance test)

Per the plan's own verification section: temporarily reverted the #613 fix (swapped
`extraFlags`/`commandOptions` emission order in `applyAutoApprove`), re-ran `test:smoke` — the
`#613 apply` scenario failed with terraform's **exact real error from the original incident**:

```
Error: Too many command line arguments
Expected at most one positional argument.
```

Restored the fix, re-ran — all 11 scenarios green again.

## Two new real bugs found (filed separately, not fixed here)

Building this harness surfaced two genuine, previously-undetected bugs — exactly the class this
harness exists to catch. Kept out of this PR to stay scoped to test infrastructure:

- #749 — `destroy()` + `publishPlanSummary` unconditionally injects `-out=`, which real
  `terraform destroy` (an alias for `apply -destroy`) rejects outright
  (`flag provided but not defined: -out`). The `#612 destroy` regression scenario here
  deliberately does **not** combine destroy with `publishPlanSummary` as a result.
- #750 — `apply()`'s `-json` failure path only folds captured `stderr` into the thrown error,
  but a real terraform CLI-level failure under `-json` surfaces as an NDJSON diagnostic on
  **stdout**, not stderr — so the fold never sees it. The `#613 stderr-surfacing` scenario
  currently only asserts the task fails closed, not that the message contains the real
  diagnostic (tightened once #750 lands).

## Verification

- `npm run test:smoke` (real terraform v1.15.7): 11 passing.
- `npm test` (existing mock suite): 564 passing, unaffected.
- `npx eslint src/ Tests/`: 0 errors (24 pre-existing warnings, unrelated).
- `actionlint .github/workflows/unit-test.yml`: clean.
- `zizmor .github/workflows/unit-test.yml`: "No findings to report."

## Manual follow-up required (flagged, needs admin)

Per the plan: register `Build and Test V5 Smoke` as a required branch-protection status check
once this merges (same process CLAUDE.md documents for existing required checks).
