### PR TITLE
fix: destroy+publishPlanSummary against real terraform, and surface apply's -json diagnostic on failure (#749, #750)

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformTask/TerraformTaskV5/Strings/resources.resjson/en-US/resources.resjson
@@ -65,6 +65,7 @@
   "loc.messages.TerraformToolNotFound": "Could not locate the terraform/tofu binary. Run PipelineTerraformInstaller in the same job as this task, or ensure the binary is installed on the agent's PATH.",
   "loc.messages.TerraformApplyFailed": "Terraform apply failed with exit code %s",
   "loc.messages.TerraformDestroyFailed": "Terraform destroy failed with exit code %s",
+  "loc.messages.TerraformDestroyPlanForSummaryFailed": "Could not build the destroy plan summary: 'terraform plan -destroy' failed with exit code %s. The real destroy was not attempted.",
   "loc.messages.OidcRequestUriHostNotAllowed": "SYSTEM_OIDCREQUESTURI host '%s' is not a recognized Azure DevOps host (expected dev.azure.com, *.dev.azure.com, *.visualstudio.com, or the host of System.CollectionUri); refusing to send the job access token to it.",
   "loc.messages.GcpTokenUriNotAllowed": "GCP service connection field 'Audience' (used as the credential token_uri) must be an https:// URL on oauth2.googleapis.com or *.googleapis.com, got '%s'.",
   "loc.messages.OutputSensitiveOutputsStrictFailure": "%s contains %d sensitive Terraform output(s) in cleartext (%s) and 'failOnSensitiveOutputs' is enabled; the file will be deleted at the end of this step. Set 'cleanupOutputFile' to true to delete the file automatically instead of failing, or disable 'failOnSensitiveOutputs' to downgrade this to a warning.",

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroyFailurePublishSummaryExitCodePreserved.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroyFailurePublishSummaryExitCodePreserved.ts
@@ -30,11 +30,12 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 
-// Terraform writes -out during the PLANNING phase, before the auto-approved
-// apply phase runs -- so the plan file exists even when the apply portion of
-// destroy fails partway through. The mocked show -json below simulates that:
-// the plan file's content is available for the digest despite the destroy
-// command itself exiting non-zero.
+// #749: the destroy-plan digest is now built by a SEPARATE, real
+// `terraform plan -destroy -out=<file>` BEFORE the real (auto-approved,
+// -out-free) destroy runs -- real `terraform destroy` (a convenience alias
+// for `apply -destroy`) does not accept `-out=` at all. So the plan file
+// exists (and the digest can be attached) even when the real destroy that
+// follows fails outright.
 const destroyPlanJson = JSON.stringify({
     format_version: '1.2',
     terraform_version: '1.9.5',
@@ -69,7 +70,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "provider azurerm"
         },
-        [`terraform destroy -auto-approve -out=${planFilePath}`]: {
+        [`terraform plan -destroy -out=${planFilePath}`]: {
+            "code": 0,
+            "stdout": "Plan: 0 to add, 0 to change, 1 to destroy."
+        },
+        "terraform destroy -auto-approve": {
             "code": 1,
             "stdout": "Error: A resource could not be destroyed."
         },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessPublishSummary.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessPublishSummary.ts
@@ -4,10 +4,13 @@ import path = require('path');
 import os = require('os');
 import crypto = require('crypto');
 
-// destroy()'s structured-summary path adds `-out=<planfile>` to the destroy
-// command and later runs `terraform show -json <planfile>` on the SAME path
-// (mirroring plan()'s AzurePlanSuccessPublishSummary.ts), so the mock exec
-// answers below must know that path ahead of time. Pin crypto.randomUUID() to
+// destroy()'s structured-summary path (#749) runs a SEPARATE, real
+// `terraform plan -destroy -out=<planfile>` BEFORE the real (auto-approved,
+// -out-free) destroy, then runs `terraform show -json <planfile>` on that
+// same path to build the digest -- real `terraform destroy` (a convenience
+// alias for `apply -destroy`) does not accept `-out=` at all, unlike
+// plan()'s single-command `-out=` injection (AzurePlanSuccessPublishSummary.ts).
+// The mock exec answers below must know that path ahead of time. Pin crypto.randomUUID() to
 // a fixed value for EVERY call (not just the first) -- call-order-independent,
 // because azure-pipelines-task-lib >=5.276 also calls crypto.randomUUID()
 // internally (Vault.genKey(), constructed before task code runs) against this
@@ -70,7 +73,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "provider azurerm"
         },
-        [`terraform destroy -auto-approve -out=${planFilePath}`]: {
+        [`terraform plan -destroy -out=${planFilePath}`]: {
+            "code": 0,
+            "stdout": "Plan: 0 to add, 0 to change, 1 to destroy."
+        },
+        "terraform destroy -auto-approve": {
             "code": 0,
             "stdout": "Destroy complete! Resources: 1 destroyed."
         },

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessPublishSummaryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/Azure/AzureDestroySuccessPublishSummaryL0.ts
@@ -6,11 +6,13 @@ import fs = require('fs');
 /**
  * Structured destroy-summary attach path (Phase 5 §5.5): destroy REUSES
  * PlanDigest -- a destroy plan is a plan whose resource_changes are all
- * deletes. publishPlanSummary set on `destroy` must add `-out=<planfile>` to
- * the auto-approved destroy invocation, run `terraform show -json` on it, and
- * attach a redacted `terraform-plan-summary` digest with `planMode: "destroy"`
- * so the tab can label the view. Destroy still auto-approves and the exit
- * code (0) is unaffected by publishing the summary.
+ * deletes. publishPlanSummary set on `destroy` runs a SEPARATE, real
+ * `terraform plan -destroy -out=<planfile>` (#749 -- real destroy itself
+ * does not accept `-out=`), runs `terraform show -json` on that plan file,
+ * and attaches a redacted `terraform-plan-summary` digest with
+ * `planMode: "destroy"` so the tab can label the view. Destroy still
+ * auto-approves and the exit code (0) is unaffected by publishing the
+ * summary.
  */
 async function run(): Promise<void> {
     let response: number | undefined;

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeL0.ts
@@ -75,6 +75,17 @@ describe('TerraformTaskV5 Smoke Test Suite (real terraform, #719)', function () 
         assert(tr.stdOutContained('Regression613StderrL0 should have succeeded.'), 'expected the L0 driver to report success');
       }, tr);
     });
+
+    it('#749 destroy + publishPlanSummary: a real destroy-plan digest is built and the real destroy still succeeds', async () => {
+      const tp = path.join(__dirname, 'SmokeTests', 'Regression749DestroyPlanSummary.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        assert(tr.stdOutContained('Regression749DestroyPlanSummaryL0 should have succeeded.'), 'expected the L0 driver to report success');
+      }, tr);
+    });
   });
 
   describe('Baseline command matrix', () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613Stderr.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613Stderr.ts
@@ -6,14 +6,15 @@ import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke
  * #613 stderr-surfacing (real terraform, no mocks): apply() against a
  * nonexistent saved-plan file, with publishApplyResults set (the structured
  * path runs with `silent:true`, so ToolRunner's own stderr echo is
- * suppressed). Asserts the task fails closed (never silently succeeds).
+ * suppressed). Asserts the task fails closed (never silently succeeds) AND
+ * that the real terraform diagnostic text is present in the thrown error.
  *
  * Building this harness found that under -json (publishApplyResults),
  * terraform's own error for this exact case is an NDJSON diagnostic on
- * STDOUT, not stderr -- so apply()'s stderr-fold (#613's original fix) does
- * not surface it, and the thrown message is currently just the bare loc
- * string. Filed as #750; see the L0 driver's comment for the exact assertion
- * this test currently makes pending that fix.
+ * STDOUT, not stderr -- so apply()'s original stderr-fold (#613's fix) did
+ * not surface it, and the thrown message was just the bare loc string with
+ * no cause. Filed and fixed as #750: error-severity diagnostic summaries
+ * from the NDJSON stdout are now folded into the failure alongside stderr.
  */
 const scratchDir = prepareScratchFixture();
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613StderrL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression613StderrL0.ts
@@ -3,38 +3,35 @@ import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-comman
 import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
 
 async function run(): Promise<void> {
-    const workingDirectory = tl.getInput('workingDirectory')!;
+  const workingDirectory = tl.getInput('workingDirectory')!;
+  try {
+    realTerraformInit(workingDirectory);
+
+    const handler = new TerraformCommandHandlerAzureRM();
     try {
-        realTerraformInit(workingDirectory);
-
-        const handler = new TerraformCommandHandlerAzureRM();
-        try {
-            await handler.apply();
-            tl.setResult(tl.TaskResult.Failed, 'Regression613StderrL0: expected apply() to throw for a missing plan file, but it succeeded.');
-            return;
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            // NOTE: under publishApplyResults (-json), terraform's own error
-            // for a missing/unreadable plan file is an NDJSON diagnostic event
-            // on STDOUT, not stderr (confirmed empirically) -- apply()'s
-            // stderr-fold (#613) does not cover this, so the message is
-            // currently just the bare loc string with no diagnostic detail.
-            // Filed as #750; this assertion only proves the task still FAILS
-            // CLOSED (does not silently succeed) for this real failure -- once
-            // #750 is fixed, tighten this to also assert the message contains
-            // the real diagnostic text (mirrors Regression612Destroy.ts's note
-            // about #749).
-            if (!message.includes('TerraformApplyFailed')) {
-                tl.setResult(tl.TaskResult.Failed, `Regression613StderrL0: unexpected failure message shape: ${message}`);
-                return;
-            }
-        }
-
-        handler.cleanupTempFiles();
-        tl.setResult(tl.TaskResult.Succeeded, 'Regression613StderrL0 should have succeeded.');
-    } finally {
-        cleanupScratchFixture(workingDirectory);
+      await handler.apply();
+      tl.setResult(tl.TaskResult.Failed, 'Regression613StderrL0: expected apply() to throw for a missing plan file, but it succeeded.');
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Under publishApplyResults (-json), terraform's own error for a
+      // missing/unreadable plan file is an NDJSON diagnostic event on
+      // STDOUT, not stderr (confirmed empirically) -- apply()'s
+      // stderr-fold (#613) alone never covered this path. #750 folds
+      // error-severity diagnostic summaries from the NDJSON stdout
+      // alongside stderr, so the real terraform diagnostic text
+      // ("Failed to load ... as a plan file") must now be present.
+      if (!message.includes('missing.tfplan')) {
+        tl.setResult(tl.TaskResult.Failed, `Regression613StderrL0: the thrown error did not include terraform's real diagnostic text (expected to mention 'missing.tfplan'). Got: ${message}`);
+        return;
+      }
     }
+
+    handler.cleanupTempFiles();
+    tl.setResult(tl.TaskResult.Succeeded, 'Regression613StderrL0 should have succeeded.');
+  } finally {
+    cleanupScratchFixture(workingDirectory);
+  }
 }
 
 run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression749DestroyPlanSummary.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression749DestroyPlanSummary.ts
@@ -1,0 +1,29 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import { prepareScratchFixture, setFakeAzureServiceConnectionEnv } from './smoke-helpers';
+
+/**
+ * #749 regression floor (real terraform, no mocks): destroy() +
+ * publishPlanSummary. Real `terraform destroy` (a convenience alias for
+ * `apply -destroy`) does not accept `-out=` at all -- a prior fix
+ * unconditionally injected `-out=` on the real destroy command anyway, which
+ * real terraform rejected outright ("flag provided but not defined: -out")
+ * every time. The fix runs a SEPARATE, real `terraform plan -destroy -out=`
+ * to build the digest, then the real (auto-approved, -out-free) destroy.
+ * This scenario proves the whole combination now succeeds end-to-end against
+ * real terraform.
+ */
+const scratchDir = prepareScratchFixture();
+
+const tp = path.join(__dirname, 'Regression749DestroyPlanSummaryL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'destroy');
+tr.setInput('workingDirectory', scratchDir);
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+tr.setInput('publishPlanSummary', 'my-destroy-summary');
+
+setFakeAzureServiceConnectionEnv();
+
+tr.run(true);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression749DestroyPlanSummaryL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SmokeTests/Regression749DestroyPlanSummaryL0.ts
@@ -1,0 +1,67 @@
+import tl = require('azure-pipelines-task-lib');
+import fs = require('fs');
+import { execFileSync } from 'child_process';
+import { TerraformCommandHandlerAzureRM } from '../../src/azure-terraform-command-handler';
+import { captureStdout, findAttachmentCommand } from '../test-l0-helpers';
+import { cleanupScratchFixture, realTerraformInit } from './smoke-helpers';
+
+async function run(): Promise<void> {
+  const workingDirectory = tl.getInput('workingDirectory')!;
+  try {
+    realTerraformInit(workingDirectory);
+    // Real state to destroy, created directly (bypassing the task) so this
+    // scenario tests ONLY destroy()'s own argv-build + digest mechanism.
+    execFileSync('terraform', ['apply', '-auto-approve', '-no-color'], { cwd: workingDirectory, stdio: 'pipe' });
+
+    const handler = new TerraformCommandHandlerAzureRM();
+    let response: number | undefined;
+    const stdout = await captureStdout(async () => {
+      response = await handler.destroy();
+    });
+
+    if (response !== 0) {
+      tl.setResult(tl.TaskResult.Failed, `Regression749DestroyPlanSummaryL0: expected destroy() to return 0, got ${response}.`);
+      return;
+    }
+
+    // The real destroy must have actually happened (state is empty).
+    const stateAfter = JSON.parse(execFileSync('terraform', ['show', '-json'], { cwd: workingDirectory, encoding: 'utf-8' }));
+    if (stateAfter.values !== undefined) {
+      tl.setResult(tl.TaskResult.Failed, `Regression749DestroyPlanSummaryL0: expected no resources left in state after destroy, got: ${JSON.stringify(stateAfter)}`);
+      return;
+    }
+
+    // The destroy-plan digest must have been built and attached for real.
+    const summaryAttachment = findAttachmentCommand(stdout, 'terraform-plan-summary');
+    if (!summaryAttachment) {
+      tl.setResult(tl.TaskResult.Failed, 'Regression749DestroyPlanSummaryL0: no terraform-plan-summary attachment was emitted.');
+      return;
+    }
+    if (summaryAttachment.name !== 'my-destroy-summary') {
+      tl.setResult(tl.TaskResult.Failed, `Regression749DestroyPlanSummaryL0: expected attachment name 'my-destroy-summary', got '${summaryAttachment.name}'.`);
+      return;
+    }
+
+    let digest: { kind: string; planMode?: string; resources: Array<{ address: string; actions: string[] }> };
+    try {
+      digest = JSON.parse(fs.readFileSync(summaryAttachment.path, 'utf-8'));
+    } catch (error) {
+      tl.setResult(tl.TaskResult.Failed, `Regression749DestroyPlanSummaryL0: attachment file was not valid JSON: ${error}`);
+      return;
+    } finally {
+      try { fs.unlinkSync(summaryAttachment.path); } catch { /* ignore */ }
+    }
+
+    if (digest.kind !== 'plan' || digest.planMode !== 'destroy' || digest.resources.length !== 1 || digest.resources[0].address !== 'terraform_data.example') {
+      tl.setResult(tl.TaskResult.Failed, `Regression749DestroyPlanSummaryL0: digest did not describe the real destroy plan: ${JSON.stringify(digest)}`);
+      return;
+    }
+
+    handler.cleanupTempFiles();
+    tl.setResult(tl.TaskResult.Succeeded, 'Regression749DestroyPlanSummaryL0 should have succeeded.');
+  } finally {
+    cleanupScratchFixture(workingDirectory);
+  }
+}
+
+run();

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -8,6 +8,7 @@ import { buildApplyDigest, ApplyDigestOptions } from './results/apply-digest';
 import { buildStateDigest } from './results/state-digest';
 import { Digest } from './results/digest-schema';
 import { serializeDigest, maskHasSensitiveLeaf } from './results/redact';
+import { scrubSecrets } from './results/secret-scrub';
 import { EnvironmentVariableHelper } from './environment-variables';
 import tasks = require('azure-pipelines-task-lib/task');
 import path = require('path');
@@ -1141,8 +1142,18 @@ export abstract class BaseTerraformCommandHandler {
             // the -json NDJSON stdout stream the digest consumes. Fold the captured
             // stderr into the failure so the cause is never swallowed (the incident
             // showed only a bare "exit code 1" with an empty log).
-            throw new Error(stderr
-                ? `${tasks.loc("TerraformApplyFailed", commandOutput.code)}\n${stderr}`
+            //
+            // #750: under -json, a real terraform CLI-level failure (e.g. an
+            // unreadable saved plan file) is instead reported as a `diagnostic`
+            // event on STDOUT, not stderr -- the stderr-fold above alone never
+            // sees it, reproducing the exact "bare exit code, no cause" problem
+            // #613 fixed, just via the one path that fix didn't cover. Fold any
+            // error-severity diagnostic summaries from the NDJSON alongside
+            // stderr.
+            const errorDiagnostics = this.extractApplyErrorDiagnostics(commandOutput.stdout);
+            const detailLines = [...errorDiagnostics, ...(stderr ? [stderr] : [])];
+            throw new Error(detailLines.length > 0
+                ? `${tasks.loc("TerraformApplyFailed", commandOutput.code)}\n${detailLines.join('\n')}`
                 : tasks.loc("TerraformApplyFailed", commandOutput.code));
         }
         // A successful apply may still write warnings to stderr; pass them through
@@ -1151,6 +1162,45 @@ export abstract class BaseTerraformCommandHandler {
             tasks.debug(stderr);
         }
         return commandOutput.code;
+    }
+
+    /**
+     * Extracts error-severity diagnostic summaries from apply's `-json` NDJSON
+     * stdout (#750). Mirrors apply-digest.ts's own NDJSON line-parsing and
+     * `diagnostic` event shape (`{diagnostic: {severity, summary, ...}}`), kept
+     * intentionally lighter-weight here: this is a one-shot extraction for an
+     * error message, not the full digest, so no caps or detail-toggle plumbing.
+     * Malformed lines are skipped silently, same as the digest builder's own
+     * tolerance for a partial/truncated NDJSON stream.
+     *
+     * Each summary is scrubbed via scrubSecrets() with the SAME knownSecrets
+     * source (EnvironmentVariableHelper.getTrackedSecretValues()) the production
+     * digest call site uses -- this text reaches the thrown error unconditionally
+     * (unlike the digest attachment's own includeDiagnostics opt-in gate, #613's
+     * stderr-fold precedent is likewise unconditional), so it must carry the same
+     * redaction guarantee the digest's `summary` field always gets.
+     */
+    private extractApplyErrorDiagnostics(ndjson: string): string[] {
+        const knownSecrets = EnvironmentVariableHelper.getTrackedSecretValues();
+        const summaries: string[] = [];
+        for (const rawLine of ndjson.split('\n')) {
+            const line = rawLine.replace(/\r$/, '').trim();
+            if (!line) continue;
+            let event: unknown;
+            try {
+                event = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            if (!event || typeof event !== 'object') continue;
+            const diagnostic = (event as Record<string, unknown>).diagnostic;
+            if (!diagnostic || typeof diagnostic !== 'object') continue;
+            const d = diagnostic as Record<string, unknown>;
+            if (d.severity === 'error' && typeof d.summary === 'string' && d.summary) {
+                summaries.push(scrubSecrets(d.summary, knownSecrets));
+            }
+        }
+        return summaries;
     }
 
     /**
@@ -1273,19 +1323,36 @@ export abstract class BaseTerraformCommandHandler {
         // neither publish input set has a byte-for-byte unchanged command line
         // (backward-compat, design §12.3 applied to destroy).
         //
-        // #612 (sibling): destroy DOES forward commandOptions -- applyAutoApprove()
-        // above emits them via `terraformTool.line(commandOptions)` -- so the same
-        // last-`-out=`-wins collision applies here. Honor a user-supplied `-out=`
-        // identically to plan(): reuse it for the show -json digest and inject no
-        // second `-out=`.
+        // #749: unlike plan(), destroy() cannot inject its OWN `-out=` on the
+        // real destroy command -- real `terraform destroy` is a convenience
+        // alias for `terraform apply -destroy`, and apply does not accept
+        // `-out=` at all (a plan-only concept: -out SAVES a new plan file;
+        // apply/destroy CONSUME one or run interactively, neither ever produces
+        // one). A prior fix injected `-out=` here anyway, which real terraform
+        // rejected outright ("flag provided but not defined: -out") every time
+        // destroy + publishPlanSummary were used together.
+        //
+        // #612 (sibling): honor a user-supplied `-out=` in commandOptions
+        // identically to plan() -- reuse it for the show -json digest and run
+        // no separate plan of our own. (Real terraform destroy would itself
+        // reject a user's own `-out=` the same way, so this only matters if an
+        // operator is relying on destroy silently ignoring an `-out=` they
+        // also pass to other commands via a shared commandOptions value.)
         let planFilePath: string | undefined;
         if (publishPlanSummary) {
             const userOutPath = extractOutFlagPath(this.getCommandOptions());
             if (userOutPath) {
                 planFilePath = userOutPath;
             } else {
+                // Run a SEPARATE, real `terraform plan -destroy -out=<file>` to
+                // produce a genuine destroy-plan file for the digest -- the same
+                // shape of extra, independent terraform invocation
+                // publishStateSummaryAttachment() already runs for show(). Runs
+                // BEFORE the real destroy below, using the same leading args
+                // (var files/target resources/secure var file) so the preview
+                // matches what destroy is about to do.
                 planFilePath = path.join(tempDir, `terraform-destroy-${uuidV4()}.tfplan`);
-                terraformTool.arg(`-out=${planFilePath}`);
+                await this.runDestroyPlanForSummary(planFilePath, destroyCommand.workingDirectory);
             }
         }
 
@@ -1295,13 +1362,12 @@ export abstract class BaseTerraformCommandHandler {
             });
         }
 
-        // ignoreReturnCode is needed ONLY so a FAILED destroy's already-written
-        // plan file (terraform writes -out during planning, before the
-        // auto-approved apply phase runs) is still available to build+attach the
-        // structured summary below -- mirrors apply()'s identical
-        // ignoreReturnCode/manual-throw pattern for the same reason (design D2).
-        // Destroy still auto-approves and still fails the task on a non-zero exit
-        // exactly as the non-structured path above.
+        // ignoreReturnCode: a FAILED destroy should still get its
+        // pre-destroy plan digest attached below (useful context for the
+        // failure) -- mirrors apply()'s identical ignoreReturnCode/manual-throw
+        // pattern for the same reason (design D2). Destroy still auto-approves
+        // and still fails the task on a non-zero exit exactly as the
+        // non-structured path above.
         const result = await terraformTool.execAsync(<IExecOptions>{
             cwd: destroyCommand.workingDirectory,
             ignoreReturnCode: true,
@@ -1313,6 +1379,41 @@ export abstract class BaseTerraformCommandHandler {
             throw new Error(tasks.loc("TerraformDestroyFailed", result));
         }
         return result;
+    }
+
+    /**
+     * Runs a SEPARATE, real `terraform plan -destroy -out=<planFilePath>` to
+     * produce a genuine destroy-plan file for destroy()'s publishPlanSummary
+     * digest (#749). Real `terraform destroy` (a convenience alias for `apply
+     * -destroy`) does not accept `-out=` at all, unlike plan()'s single-command
+     * `-out=` injection -- destroy's structured summary needs this independent
+     * plan invocation before the real (auto-approved, `-out`-free) destroy runs.
+     * Uses the same leading args (var files/target resources/secure var file)
+     * destroy() itself applies, so the preview matches what destroy is about to
+     * do; deliberately does NOT forward destroy's own commandOptions (which may
+     * carry destroy-specific flags plan doesn't accept) beyond that.
+     *
+     * Fails loudly (throws) rather than silently degrading like
+     * publishPlanSummaryAttachment's own `show -json` failures do: a failure
+     * here means the working directory itself can't produce a valid plan (bad
+     * HCL, backend issue), and proceeding to a real destroy blind would be
+     * unsafe.
+     */
+    private async runDestroyPlanForSummary(planFilePath: string, workingDirectory: string): Promise<void> {
+        const planCommand = this.createBaseCommand("plan", `-destroy -out=${planFilePath}`);
+        const planTool = this.terraformToolHandler.createToolRunner(planCommand);
+        this.applyTokens(planTool, await this.buildLeadingArgs({
+            varFiles: true, targetResources: true, secureVarFile: true,
+        }));
+        this.appendTerraformVariables(planTool);
+
+        const result = await planTool.execAsync(<IExecOptions>{
+            cwd: workingDirectory,
+            ignoreReturnCode: true,
+        });
+        if (result !== 0 && result !== 2) {
+            throw new Error(tasks.loc("TerraformDestroyPlanForSummaryFailed", result));
+        }
     }
 
     /**

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -15,7 +15,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "284",
+        "Minor": "285",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",
@@ -1037,6 +1037,7 @@
         "TerraformPlanFailed": "Terraform plan failed with exit code %s",
         "TerraformApplyFailed": "Terraform apply failed with exit code %s",
         "TerraformDestroyFailed": "Terraform destroy failed with exit code %s",
+        "TerraformDestroyPlanForSummaryFailed": "Could not build the destroy plan summary: 'terraform plan -destroy' failed with exit code %s. The real destroy was not attempted.",
         "PlanJsonFlagNotSupportedWithPublishPlanResults": "'commandOptions' contains a -json flag, which is not supported together with 'publishPlanResults': terraform plan -json output carries real sensitive values in cleartext (masked only by a parallel after_sensitive flag meant for a redacting consumer to apply), unlike the human-readable format's own '(sensitive value)' redaction that 'publishPlanResults' relies on being safe to echo to the console. Remove -json from 'commandOptions', or use 'publishPlanSummary' instead for a redacted, structured JSON summary.",
         "OidcRequestUriHostNotAllowed": "SYSTEM_OIDCREQUESTURI host '%s' is not a recognized Azure DevOps host (expected dev.azure.com, *.dev.azure.com, *.visualstudio.com, or the host of System.CollectionUri); refusing to send the job access token to it.",
         "GcpTokenUriNotAllowed": "GCP service connection field 'Audience' (used as the credential token_uri) must be an https:// URL on oauth2.googleapis.com or *.googleapis.com, got '%s'.",


### PR DESCRIPTION
## Summary

Fixes the 2 bugs discovered while building the real-terraform smoke harness (#719/#751):

- **#749**: `destroy()` + `publishPlanSummary` failed against **real** terraform every time. The task unconditionally injected `-out=<tempfile>` onto the real destroy command, but real `terraform destroy` (a convenience alias for `terraform apply -destroy`) does not accept `-out=` at all -- that's a plan-only concept. This was invisible to the existing mock-based test suite (every mock exec answer is canned/always-successful regardless of actual argv shape), and was exactly the kind of regression the new real-terraform smoke harness was built to catch.
- **#750**: apply()'s failure path only ever folded captured **stderr** into the thrown error (the #613 fix). Under `-json` (`publishApplyResults`), a real terraform CLI-level failure (e.g. an unreadable saved plan file) is reported as a `diagnostic` event on **stdout**, not stderr -- so #613's fold never saw it, reproducing the exact "bare exit code, no cause" problem via the one path that fix didn't cover.

## Changes

### #749 fix
- When `publishPlanSummary` is set and `commandOptions` has no user `-out=`, `destroy()` now runs a separate, real `terraform plan -destroy -out=<file>` **before** the real (auto-approved, `-out`-free) destroy -- mirroring the existing `show()` / `publishStateSummaryAttachment` pattern of an independent auxiliary command.
- A user-supplied `-out=` in `commandOptions` is still honored unchanged (no separate plan is run in that case) -- this path (#612) was already correct and is untouched.
- Added `TerraformDestroyPlanForSummaryFailed` loc string (`task.json` + `resources.resjson`) for the new plan step's own failure case.

### #750 fix
- New `extractApplyErrorDiagnostics()` helper parses apply's `-json` NDJSON stdout for error-severity `diagnostic` events (mirroring `apply-digest.ts`'s own event shape) and folds their `summary` text into the thrown error alongside stderr.
- Each summary is scrubbed via `scrubSecrets()` using the same `knownSecrets` source the production digest attachment uses (`EnvironmentVariableHelper.getTrackedSecretValues()`) -- this text now reaches the console/error surface **unconditionally**, matching the #613 stderr-fold's own unconditional precedent (not gated behind the `includeDiagnostics` opt-in, which only governs the separate build-attachment surface).

### Test fallout + additions
- Fixed 2 mock-runner fixtures whose exec answers assumed the old (incorrect) destroy+publishPlanSummary command line: `AzureDestroyFailurePublishSummaryExitCodePreserved`, `AzureDestroySuccessPublishSummary`.
- Added `Regression749DestroyPlanSummary` (+ L0 driver): a new real-terraform smoke scenario proving destroy+publishPlanSummary now succeeds end-to-end, including asserting the real destroy-plan digest attachment content.
- Tightened `Regression613Stderr`'s assertion to check for terraform's real diagnostic text (`missing.tfplan`) instead of only the bare loc-string key.
- Bumped `TerraformTaskV5` to `5.285.0` (real behavior change).

## Verification

- Real-terraform smoke suite (`npm run test:smoke`): **12/12 passing**, including the new #749 scenario and the tightened #750 scenario.
- Mock-based unit suite (`npm test`): **564/564 passing**, zero regressions from either fix.

Closes #749
Closes #750
