### PR TITLE
fix: audit-2026-07-22 remediation - SSRF redirect revalidation + cosign SHA256 pin (#729, #550)

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -298,4 +298,18 @@ describe('PolicyAgentInstaller Test Suite', function () {
             );
         }, tr);
     });
+
+    it('registry default path redirects to a private/metadata address: should reject the redirect hop (#729 follow-up)', async () => {
+        const tp = path.join(__dirname, 'OpaRegistryDefaultPathRedirectToPrivate.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some(e => e.includes('RegistryDownloadHostIsPrivate')),
+                'should fail via the private-address check on the redirect hop. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
 });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryDefaultPathRedirectToPrivate.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryDefaultPathRedirectToPrivate.ts
@@ -1,0 +1,78 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// registryAllowedHosts is NOT set (the default path). The initial download_url
+// host is benign, but the (simulated) download follows a redirect to the cloud
+// metadata address 169.254.169.254 -- proving the default path re-validates
+// every hop via downloadToFile, not just the initial host (#729 follow-up).
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'opa');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+// dns: registry.example.com is the INITIAL host, not the redirect target under
+// test here -- mock it to a public (non-private/link-local) address so the
+// #769 resolvesToPrivateOrLinkLocalAddress initial-host check passes without a
+// real network lookup, reaching the downloadToFile call this test exercises.
+tr.registerMock('dns', {
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
+});
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    if (url.includes('/terraform/binaries/opa/versions/1.17.1/linux/amd64')) {
+      return {
+        download_url: 'https://storage.example.com/signed/opa?sig=abc',
+        sha256: 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233'
+      };
+    }
+    throw new Error('Unexpected fetchJson URL: ' + url);
+  },
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Simulate a redirect hop landing on the cloud metadata service.
+    isHostAllowed('169.254.169.254');
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('fs', {
+  chmodSync: () => { },
+  readFileSync: () => Buffer.from('fake-binary'),
+  mkdirSync: () => undefined,
+  copyFileSync: () => { }
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => 'should-not-be-reached' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => {
+    throw new Error('downloadTool should not be reached on the default path -- downloadToFile must be used so every redirect hop is re-validated');
+  },
+  extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
+  cacheDir: async () => '/tmp/opa-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256RequireChecksum.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256RequireChecksum.ts
@@ -34,7 +34,15 @@ tr.registerMock('./http-client', {
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
-    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download so the empty-sha256+requireChecksum fail-closed check below
+    // still runs.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
+    }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256Warns.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256Warns.ts
@@ -35,7 +35,14 @@ tr.registerMock('./http-client', {
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
-    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed elsewhere.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
+    }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistrySuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/OpaRegistrySuccess.ts
@@ -32,7 +32,14 @@ tr.registerMock('./http-client', {
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
-    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed elsewhere.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
+    }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -23,9 +23,9 @@ tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/
 // resolvesToPrivateOrLinkLocalAddress check passes without a real network
 // lookup, instead of failing with a real ENOTFOUND in this offline test run.
 tr.registerMock('dns', {
-    promises: {
-        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
-    }
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
 });
 
 const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
@@ -59,7 +59,14 @@ tr.registerMock('./http-client', {
     }
     throw new Error('Unexpected fetchJson URL: ' + url);
   },
-  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+  DOWNLOAD_TIMEOUT_MS: 600000,
+  // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+  // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+  // download the same way downloadTool is stubbed elsewhere.
+  downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    isHostAllowed(new URL(url).hostname);
+  }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistrySentinelSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistrySentinelSuccess.ts
@@ -32,7 +32,14 @@ tr.registerMock('./http-client', {
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
-    fetchText: async (url: string) => { throw new Error('Registry sentinel path should not fetch text: ' + url); }
+    fetchText: async (url: string) => { throw new Error('Registry sentinel path should not fetch text: ' + url); },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed elsewhere.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
+    }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -306,7 +306,25 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
                 }
             });
         } else {
-            filePath = await tools.downloadTool(data.download_url, fileName);
+            // Baseline redirect-hop protection on the DEFAULT (no explicit allowlist)
+            // path (#729 follow-up): tools.downloadTool() follows redirects with no
+            // way to re-validate them, so a compromised/misconfigured registry could
+            // return an initially-safe download_url that itself 302s to a
+            // private/link-local address (notably the cloud metadata service) -- the
+            // initial-host check above only covers the first hop. Route through the
+            // same manual-redirect downloadToFile() used on the allowlist path,
+            // re-checking every hop against isPrivateOrLinkLocalHost. This is a
+            // synchronous literal-IP/hostname check (unlike the initial-host check,
+            // it does not also perform a DNS lookup per hop), so a redirect Location
+            // that is a DNS name resolving to a private address is not caught here --
+            // only a literal private/link-local host/IP is.
+            const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+            filePath = path.join(destDir, fileName);
+            await downloadToFile(data.download_url, filePath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+                if (isPrivateOrLinkLocalHost(hostname)) {
+                    throw new Error(tasks.loc("RegistryDownloadHostIsPrivate", hostname));
+                }
+            });
         }
     } catch (exception) {
         // download_url is a pre-signed URL whose query string carries the signing

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-allowlist.ts
@@ -42,7 +42,35 @@ export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]):
  * environment is unaffected.
  */
 export function isPrivateOrLinkLocalHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  let host = hostname.toLowerCase();
+  // Strip an optional port suffix before the address checks below. WHATWG
+  // URL.host (unlike .hostname) includes an explicit non-default port, and
+  // downloadToFile's per-redirect-hop callback is invoked with .host -- so a
+  // redirect Location like https://10.0.0.5:8443/ would otherwise bypass
+  // every check below (the IPv4 regex is fully anchored and never matches a
+  // 'digits.digits.digits.digits:port' string) (#729 follow-up). A bracketed
+  // IPv6 literal (`[addr]` or `[addr]:port`) is unwrapped by locating the
+  // matching `]` rather than assuming it is the final character.
+  if (host.startsWith('[')) {
+    const closeBracket = host.indexOf(']');
+    host = closeBracket >= 0 ? host.slice(1, closeBracket) : host.slice(1);
+  } else {
+    // A BARE (unbracketed) IPv6 address always has at least 2 colons (the
+    // '::' shorthand, or 2+ literal ':' separators between hextets) -- e.g.
+    // the loopback '::1' returned verbatim by Node's dns.lookup(), which the
+    // sibling resolvesToPrivateOrLinkLocalAddress check feeds in with no
+    // brackets and no port at all. A REAL 'host:port'/'ipv4:port' string has
+    // exactly ONE colon. Only strip when there is exactly one, so a bare
+    // IPv6 literal (however many colons) is never misread as 'address:port'
+    // and truncated into something that no longer matches the checks below.
+    const colonCount = (host.match(/:/g) || []).length;
+    if (colonCount === 1) {
+      const lastColon = host.lastIndexOf(':');
+      if (/^\d+$/.test(host.slice(lastColon + 1))) {
+        host = host.slice(0, lastColon);
+      }
+    }
+  }
   if (host === 'localhost') {
     return true;
   }

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "16",
+        "Minor": "17",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitReverifyWithheld.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitReverifyWithheld.ts
@@ -41,7 +41,14 @@ tr.registerMock('./http-client', {
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
-    fetchTextAllow404: async (url: string) => { throw new Error('fetchTextAllow404 should not be called for registry: ' + url); }
+    fetchTextAllow404: async (url: string) => { throw new Error('fetchTextAllow404 should not be called for registry: ' + url); },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed elsewhere.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
+    }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
@@ -280,4 +280,18 @@ describe('TerraformDocsInstaller Test Suite', function () {
       );
     }, tr);
   });
+
+  it('registry default path redirects to a private/metadata address: should reject the redirect hop (#729 follow-up)', async () => {
+    const tp = path.join(__dirname, 'RegistryDefaultPathRedirectToPrivate.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    await tr.runAsync();
+
+    runValidations(() => {
+      assert(tr.failed, 'task should have failed');
+      assert(
+        tr.errorIssues.some(e => e.includes('RegistryDownloadHostIsPrivate')),
+        'should fail via the private-address check on the redirect hop. errors: ' + tr.errorIssues,
+      );
+    }, tr);
+  });
 });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDefaultPathRedirectToPrivate.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDefaultPathRedirectToPrivate.ts
@@ -1,0 +1,56 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// registryAllowedHosts is NOT set (the default path). The initial download_url
+// host is benign, but the (simulated) download follows a redirect to the cloud
+// metadata address 169.254.169.254 -- proving the default path re-validates
+// every hop via downloadToFile, not just the initial host (#729 follow-up).
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('version', '0.24.0');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform-docs');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+// dns: registry.example.com is the INITIAL host, not the redirect target under
+// test here -- mock it to a public (non-private/link-local) address so the
+// #769 resolvesToPrivateOrLinkLocalAddress initial-host check passes without a
+// real network lookup, reaching the downloadToFile call this test exercises.
+tr.registerMock('dns', {
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
+});
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    if (url.includes('/terraform/binaries/terraform-docs/versions/0.24.0/linux/amd64')) {
+      return { download_url: 'https://storage.example.com/td.tar.gz', sha256: EXPECTED_SHA256 };
+    }
+    throw new Error('Unexpected fetchJson URL: ' + url);
+  },
+  fetchText: async (url: string) => { throw new Error('should not fetch text: ' + url); },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Simulate a redirect hop landing on the cloud metadata service.
+    isHostAllowed('169.254.169.254');
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => {
+    throw new Error('downloadTool should not be reached on the default path -- downloadToFile must be used so every redirect hop is re-validated');
+  },
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -22,9 +22,9 @@ tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/
 // resolvesToPrivateOrLinkLocalAddress check passes without a real network
 // lookup, instead of failing with a real ENOTFOUND in this offline test run.
 tr.registerMock('dns', {
-    promises: {
-        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
-    }
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
 });
 
 const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
@@ -58,7 +58,14 @@ tr.registerMock('./http-client', {
     }
     throw new Error('Unexpected fetchJson URL: ' + url);
   },
-  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+  DOWNLOAD_TIMEOUT_MS: 600000,
+  // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+  // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+  // download the same way downloadTool is stubbed elsewhere.
+  downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    isHostAllowed(new URL(url).hostname);
+  }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryEmptySha256RequireChecksum.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryEmptySha256RequireChecksum.ts
@@ -20,9 +20,9 @@ tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/
 // resolvesToPrivateOrLinkLocalAddress check passes without a real network
 // lookup, instead of failing with a real ENOTFOUND in this offline test run.
 tr.registerMock('dns', {
-    promises: {
-        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
-    }
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
 });
 
 tr.registerMock('./http-client', {
@@ -32,7 +32,14 @@ tr.registerMock('./http-client', {
     }
     throw new Error('Unexpected fetchJson URL: ' + url);
   },
-  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+  DOWNLOAD_TIMEOUT_MS: 600000,
+  // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+  // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+  // download the same way downloadTool is stubbed elsewhere.
+  downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    isHostAllowed(new URL(url).hostname);
+  }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryEmptySha256Warns.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryEmptySha256Warns.ts
@@ -20,9 +20,9 @@ tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/
 // resolvesToPrivateOrLinkLocalAddress check passes without a real network
 // lookup, instead of failing with a real ENOTFOUND in this offline test run.
 tr.registerMock('dns', {
-    promises: {
-        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
-    }
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
 });
 
 tr.registerMock('./http-client', {
@@ -32,7 +32,14 @@ tr.registerMock('./http-client', {
     }
     throw new Error('Unexpected fetchJson URL: ' + url);
   },
-  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+  DOWNLOAD_TIMEOUT_MS: 600000,
+  // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+  // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+  // download the same way downloadTool is stubbed elsewhere.
+  downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    isHostAllowed(new URL(url).hostname);
+  }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistrySuccess.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistrySuccess.ts
@@ -17,9 +17,9 @@ tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/
 // resolvesToPrivateOrLinkLocalAddress check passes without a real network
 // lookup, instead of failing with a real ENOTFOUND in this offline test run.
 tr.registerMock('dns', {
-    promises: {
-        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
-    }
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
 });
 
 const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
@@ -31,7 +31,14 @@ tr.registerMock('./http-client', {
     }
     throw new Error('Unexpected fetchJson URL: ' + url);
   },
-  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); }
+  fetchText: async (url: string) => { throw new Error('Registry path should not fetch text: ' + url); },
+  DOWNLOAD_TIMEOUT_MS: 600000,
+  // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+  // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+  // download the same way downloadTool is stubbed elsewhere.
+  downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    isHostAllowed(new URL(url).hostname);
+  }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-allowlist.ts
@@ -42,7 +42,35 @@ export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]):
  * environment is unaffected.
  */
 export function isPrivateOrLinkLocalHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  let host = hostname.toLowerCase();
+  // Strip an optional port suffix before the address checks below. WHATWG
+  // URL.host (unlike .hostname) includes an explicit non-default port, and
+  // downloadToFile's per-redirect-hop callback is invoked with .host -- so a
+  // redirect Location like https://10.0.0.5:8443/ would otherwise bypass
+  // every check below (the IPv4 regex is fully anchored and never matches a
+  // 'digits.digits.digits.digits:port' string) (#729 follow-up). A bracketed
+  // IPv6 literal (`[addr]` or `[addr]:port`) is unwrapped by locating the
+  // matching `]` rather than assuming it is the final character.
+  if (host.startsWith('[')) {
+    const closeBracket = host.indexOf(']');
+    host = closeBracket >= 0 ? host.slice(1, closeBracket) : host.slice(1);
+  } else {
+    // A BARE (unbracketed) IPv6 address always has at least 2 colons (the
+    // '::' shorthand, or 2+ literal ':' separators between hextets) -- e.g.
+    // the loopback '::1' returned verbatim by Node's dns.lookup(), which the
+    // sibling resolvesToPrivateOrLinkLocalAddress check feeds in with no
+    // brackets and no port at all. A REAL 'host:port'/'ipv4:port' string has
+    // exactly ONE colon. Only strip when there is exactly one, so a bare
+    // IPv6 literal (however many colons) is never misread as 'address:port'
+    // and truncated into something that no longer matches the checks below.
+    const colonCount = (host.match(/:/g) || []).length;
+    if (colonCount === 1) {
+      const lastColon = host.lastIndexOf(':');
+      if (/^\d+$/.test(host.slice(lastColon + 1))) {
+        host = host.slice(0, lastColon);
+      }
+    }
+  }
   if (host === 'localhost') {
     return true;
   }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -242,7 +242,25 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
                 }
             });
         } else {
-            filePath = await tools.downloadTool(data.download_url, fileName);
+            // Baseline redirect-hop protection on the DEFAULT (no explicit allowlist)
+            // path (#729 follow-up): tools.downloadTool() follows redirects with no
+            // way to re-validate them, so a compromised/misconfigured registry could
+            // return an initially-safe download_url that itself 302s to a
+            // private/link-local address (notably the cloud metadata service) -- the
+            // initial-host check above only covers the first hop. Route through the
+            // same manual-redirect downloadToFile() used on the allowlist path,
+            // re-checking every hop against isPrivateOrLinkLocalHost. This is a
+            // synchronous literal-IP/hostname check (unlike the initial-host check,
+            // it does not also perform a DNS lookup per hop), so a redirect Location
+            // that is a DNS name resolving to a private address is not caught here --
+            // only a literal private/link-local host/IP is.
+            const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+            filePath = path.join(destDir, fileName);
+            await downloadToFile(data.download_url, filePath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+                if (isPrivateOrLinkLocalHost(hostname)) {
+                    throw new Error(tasks.loc("RegistryDownloadHostIsPrivate", hostname));
+                }
+            });
         }
     } catch (exception) {
         // download_url is a pre-signed URL whose query string carries the signing

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "12",
+    "Minor": "13",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyRegistryWithheld.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyRegistryWithheld.ts
@@ -20,7 +20,8 @@ tr.setInput('requireChecksum', 'true');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
 });
 
 // dns: storage.example.com is a fictional test host with no real DNS record;
@@ -48,6 +49,13 @@ tr.registerMock('./http-client', {
     },
     fetchText: async (url: string) => {
         throw new Error('fetchText should not be called for a registry download. Called with: ' + url);
+    },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed for other sources.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
     }
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
@@ -1,5 +1,9 @@
 import { describe, it, afterEach } from 'mocha';
 import assert = require('assert');
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+import crypto = require('crypto');
 import tasks = require('azure-pipelines-task-lib/task');
 import { buildOpenTofuCertIdentityRegexp, verifyCosignSignature } from '../src/cosign-verifier';
 import { isVerificationFailure } from '../src/verification-failure';
@@ -242,6 +246,75 @@ describe('cosign-verifier: verifyCosignSignature behavior', () => {
             verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', VERSION, false),
             /fetch failed for OpenTofu verification/,
         );
+    });
+
+    // #550: an operator-pinned cosignSha256 verifies the RESOLVED binary itself,
+    // closing the ambient-PATH trust gap (a PATH-write attacker could otherwise
+    // shadow `cosign` with an always-succeeding stub).
+    describe('cosignSha256 pin (#550)', () => {
+        let tmpDirToClean: string;
+
+        afterEach(() => {
+            if (tmpDirToClean) {
+                try { fs.rmSync(tmpDirToClean, { recursive: true, force: true }); } catch { /* already removed */ }
+            }
+        });
+
+        it('succeeds when the resolved cosign binary matches the pinned SHA256', async () => {
+            stubLogging();
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cosign-pin-test-'));
+            tmpDirToClean = tmpDir;
+            const tmpCosignPath = path.join(tmpDir, 'cosign-fake-binary');
+            const content = Buffer.from('fake cosign binary content for a hash test');
+            fs.writeFileSync(tmpCosignPath, content);
+            const expectedHash = crypto.createHash('sha256').update(content).digest('hex');
+
+            t.which = () => tmpCosignPath;
+            hc.fetchBufferAllow404 = async () => new Uint8Array([1]);
+            t.tool = (_path: string) => ({
+                arg() { return this; },
+                exec: async () => 0,
+            });
+
+            await verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', VERSION, true, expectedHash);
+        });
+
+        it('throws a VerificationFailure when the resolved cosign binary does not match the pinned SHA256', async () => {
+            stubLogging();
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cosign-pin-test-'));
+            tmpDirToClean = tmpDir;
+            const tmpCosignPath = path.join(tmpDir, 'cosign-fake-binary');
+            fs.writeFileSync(tmpCosignPath, Buffer.from('the real, expected cosign binary content'));
+
+            t.which = () => tmpCosignPath;
+            hc.fetchBufferAllow404 = async () => new Uint8Array([1]);
+            t.tool = (_path: string) => ({
+                arg() { return this; },
+                exec: async () => 0,
+            });
+
+            const wrongHash = 'a'.repeat(64);
+            await assert.rejects(
+                verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', VERSION, true, wrongHash),
+                (err: unknown) => {
+                    assert.ok(isVerificationFailure(err), 'a cosign hash mismatch must be a typed VerificationFailure (fail closed)');
+                    assert.match((err as Error).message, /does not match the pinned cosignSha256/);
+                    return true;
+                },
+            );
+        });
+
+        it('does not compute or check any hash when cosignSha256 is left unset (default, unchanged behavior)', async () => {
+            stubLogging();
+            t.which = () => '/usr/bin/cosign'; // a path that does not exist -- proves no fs read is attempted
+            hc.fetchBufferAllow404 = async () => new Uint8Array([1]);
+            t.tool = (_path: string) => ({
+                arg() { return this; },
+                exec: async () => 0,
+            });
+
+            await verifyCosignSignature('sums', 'https://x.example/sig', 'https://x.example/pem', VERSION, true);
+        });
     });
     /* eslint-enable @typescript-eslint/no-explicit-any */
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -414,6 +414,24 @@ describe('TerraformInstaller Test Suite', function () {
         }, tr);
     });
 
+    it('registry default path redirects to a private/metadata address: should reject the redirect hop (#729 follow-up)', async () => {
+        // registryAllowedHosts is unset (default path). The initial download_url
+        // host is benign, but the (simulated) download follows a redirect to the
+        // cloud metadata address -- proving the default path now re-validates
+        // every hop via downloadToFile, not just the initial host.
+        const tp = path.join(__dirname, 'RegistryDefaultPathRedirectToPrivateReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some(e => e.includes('RegistryDownloadHostIsPrivate')),
+                'should fail via the private-address check on the redirect hop. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
     // --- Mirror download source ---
 
     it('mirror custom URL: should download from mirror at HashiCorp path structure', async () => {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostsL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostsL0.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { parseAllowedHosts, isRegistryHostAllowed, resolvesToPrivateOrLinkLocalAddress } from '../src/registry-allowlist';
+import { parseAllowedHosts, isRegistryHostAllowed, isPrivateOrLinkLocalHost, resolvesToPrivateOrLinkLocalAddress } from '../src/registry-allowlist';
 
 /**
  * Direct unit tests for the optional registry download_url host allowlist.
@@ -69,6 +69,56 @@ describe('registry download_url host allowlist', function () {
         it('propagates a lookup failure (e.g. NXDOMAIN) instead of misreporting it as private', async () => {
             const lookup = async () => { throw new Error('ENOTFOUND attacker.example.net'); };
             await assert.rejects(resolvesToPrivateOrLinkLocalAddress('attacker.example.net', lookup), /ENOTFOUND/);
+        });
+    });
+
+    describe('isPrivateOrLinkLocalHost: port-suffix handling (#729 follow-up)', () => {
+        it('still detects a bare private IPv4 address with no port', () => {
+            assert.strictEqual(isPrivateOrLinkLocalHost('10.0.0.5'), true);
+            assert.strictEqual(isPrivateOrLinkLocalHost('169.254.169.254'), true);
+        });
+
+        it('still returns false for a bare public IPv4 address with no port', () => {
+            assert.strictEqual(isPrivateOrLinkLocalHost('93.184.216.34'), false);
+        });
+
+        it('detects a private IPv4 address with an explicit port (WHATWG URL.host shape)', () => {
+            // downloadToFile's per-redirect-hop callback is invoked with URL.host,
+            // which includes a non-default port -- a redirect straight to the
+            // cloud metadata service on a non-default port must still be caught.
+            assert.strictEqual(isPrivateOrLinkLocalHost('169.254.169.254:8443'), true);
+            assert.strictEqual(isPrivateOrLinkLocalHost('10.0.0.5:443'), true);
+        });
+
+        it('does not treat a public IPv4 address with an explicit port as private', () => {
+            assert.strictEqual(isPrivateOrLinkLocalHost('93.184.216.34:8443'), false);
+        });
+
+        it('detects a bracketed private IPv6 address with an explicit port', () => {
+            assert.strictEqual(isPrivateOrLinkLocalHost('[::1]:8443'), true);
+            assert.strictEqual(isPrivateOrLinkLocalHost('[fe80::1]:443'), true);
+        });
+
+        it('still detects a bracketed private IPv6 address with no port', () => {
+            assert.strictEqual(isPrivateOrLinkLocalHost('[::1]'), true);
+        });
+
+        it('does not treat "localhost" with an explicit port as a non-match', () => {
+            assert.strictEqual(isPrivateOrLinkLocalHost('localhost:8443'), true);
+        });
+
+        it('still detects a BARE (unbracketed, no port) IPv6 loopback/link-local address -- the shape dns.lookup() actually returns', () => {
+            // Regression: an earlier version of the port-stripping fix used
+            // hostname.lastIndexOf(':') unconditionally, which found the SECOND
+            // colon in '::1', treated the trailing '1' as a "port", and sliced
+            // the address down to ':' -- silently breaking the exact DNS-resolved
+            // loopback shape resolvesToPrivateOrLinkLocalAddress depends on. A
+            // bare IPv6 address always has >=2 colons, so port-stripping must
+            // only fire when there is EXACTLY one.
+            assert.strictEqual(isPrivateOrLinkLocalHost('::1'), true);
+            assert.strictEqual(isPrivateOrLinkLocalHost('::'), true);
+            assert.strictEqual(isPrivateOrLinkLocalHost('fe80::1'), true);
+            assert.strictEqual(isPrivateOrLinkLocalHost('fc00::1'), true);
         });
     });
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectToPrivateReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectToPrivateReject.ts
@@ -1,0 +1,97 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// registryAllowedHosts is NOT set (the default path). The registry's
+// download_url host itself is benign, but the download is redirected
+// (simulated via the downloadToFile mock invoking its isHostAllowed callback)
+// to the cloud metadata address 169.254.169.254 -- proving the default path
+// now re-validates redirect hops, not just the initial host (#729 follow-up).
+const tp = path.join(__dirname, 'RegistryDefaultPathRedirectToPrivateRejectL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'registry');
+tr.setInput('registryUrl', 'https://registry.example.com');
+tr.setInput('registryMirrorName', 'terraform');
+
+tr.registerMock('os', {
+  type: () => 'Windows_NT',
+  arch: () => 'x64',
+  tmpdir: () => '/tmp'
+});
+// dns: registry.example.com is the INITIAL host, not the redirect target under
+// test here -- mock it to a public (non-private/link-local) address so the
+// #769 resolvesToPrivateOrLinkLocalAddress initial-host check passes without a
+// real network lookup, reaching the downloadToFile call this test exercises.
+tr.registerMock('dns', {
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
+});
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    if (url.includes('/terraform/binaries/terraform/versions/1.9.8/windows/amd64')) {
+      return {
+        os: 'windows',
+        arch: 'amd64',
+        version: '1.9.8',
+        sha256: 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+        download_url: 'https://storage.example.com/signed/terraform_1.9.8_windows_amd64.zip'
+      };
+    }
+    throw new Error('Unexpected fetchJson URL: ' + url);
+  },
+  fetchText: async (url: string) => {
+    throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+  },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Simulate a redirect hop landing on the cloud metadata service.
+    isHostAllowed('169.254.169.254');
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+  verifyGpgSignature: async () => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+  verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+  chmodSync: (_path: string, _mode: string) => { },
+  readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid-1234',
+  createHash: (_algorithm: string) => ({
+    update: (_data: any) => ({
+      digest: (_encoding: string) => 'should-not-be-reached'
+    })
+  })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: (_toolName: string, _version: string) => null,
+  downloadTool: async (_url: string, _fileName: string) => {
+    throw new Error('downloadTool should not be reached on the default path -- downloadToFile must be used so every redirect hop is re-validated');
+  },
+  extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+  cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+  cleanVersion: (version: string) => version,
+  prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  'find': {
+    '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectToPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectToPrivateRejectL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+  try {
+    await downloadTerraform('1.9.8');
+    tl.setResult(tl.TaskResult.Succeeded, 'RegistryDefaultPathRedirectToPrivateRejectL0 should have succeeded.');
+  } catch (error) {
+    tl.setResult(tl.TaskResult.Failed, 'RegistryDefaultPathRedirectToPrivateRejectL0 failed: ' + error.message);
+  }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMasked.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMasked.ts
@@ -16,7 +16,8 @@ tr.setInput('registryMirrorName', 'terraform');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
 });
 
 // dns: storage.example.com is a fictional test host with no real DNS record;
@@ -63,7 +64,17 @@ tr.registerMock('./http-client', {
         }
         throw new Error('Unexpected fetchJson URL: ' + url);
     },
-    fetchText: async (url: string) => { throw new Error('Registry path should not fetch SHA256SUMS text: ' + url); }
+    fetchText: async (url: string) => { throw new Error('Registry path should not fetch SHA256SUMS text: ' + url); },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up) -- simulate a clean, non-redirected
+    // download by invoking isHostAllowed once with the URL's own host (no
+    // private/link-local address, so it passes) and not writing anything, the
+    // same way downloadTool is stubbed below; fs.createReadStream is mocked to
+    // always return fake-zip-content regardless of path.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
+    }
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksum.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksum.ts
@@ -43,6 +43,13 @@ tr.registerMock('./http-client', {
     },
     fetchText: async (url: string) => {
         throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed below.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
     }
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256Warns.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256Warns.ts
@@ -17,7 +17,8 @@ tr.setInput('requireChecksum', 'false');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
 });
 
 // dns: storage.example.com is a fictional test host with no real DNS record;
@@ -45,6 +46,13 @@ tr.registerMock('./http-client', {
     },
     fetchText: async (url: string) => {
         throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed below.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
     }
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccess.ts
@@ -12,7 +12,8 @@ tr.setInput('registryMirrorName', 'terraform');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
 });
 
 // dns: storage.example.com is a fictional test host with no real DNS record;
@@ -42,6 +43,13 @@ tr.registerMock('./http-client', {
     },
     fetchText: async (url: string) => {
         throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download the same way downloadTool is stubbed below.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
     }
 });
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFail.ts
@@ -12,7 +12,18 @@ tr.setInput('registryMirrorName', 'terraform');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
+});
+
+// dns: storage.example.com is a fictional test host with no real DNS record;
+// mock it to a public (non-private/link-local) address so the #769
+// resolvesToPrivateOrLinkLocalAddress check passes without a real network
+// lookup, instead of failing with a real ENOTFOUND in this offline test run.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
 });
 
 // http-client: registry returns a specific expected hash
@@ -31,6 +42,13 @@ tr.registerMock('./http-client', {
     },
     fetchText: async (url: string) => {
         throw new Error('fetchText should not be called for registry download. Called with: ' + url);
+    },
+    DOWNLOAD_TIMEOUT_MS: 600000,
+    // downloadToFile now replaces tools.downloadTool() on the DEFAULT (no
+    // allowlist) path too (#729 follow-up); simulate a clean, non-redirected
+    // download so the SHA256-mismatch check below still runs.
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(url).hostname);
     }
 });
 
@@ -45,20 +63,24 @@ tr.registerMock('./cosign-verifier', {
     verifyCosignSignature: async () => { }
 });
 
-// fs: readFileSync returns some content
+// fs: createReadStream feeds verifySha256's streaming hash (#728); readFileSync
+// stays for anything else (e.g. GPG paths) that might still read the file whole.
 tr.registerMock('fs', {
     chmodSync: (_path: string, _mode: string) => { },
-    readFileSync: (_path: string) => Buffer.from('tampered-zip-content')
+    readFileSync: (_path: string) => Buffer.from('tampered-zip-content'),
+    createReadStream: (_path: string) => require('stream').Readable.from(Buffer.from('tampered-zip-content'))
 });
 
-// crypto: returns a DIFFERENT hash than what the registry provided → mismatch
+// crypto: createHash returns a real Writable (satisfying pipeline()'s destination
+// contract, per #728's streaming refactor) with a DIFFERENT digest than what the
+// registry provided -> mismatch.
 tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
-    createHash: (_algorithm: string) => ({
-        update: (_data: any) => ({
-            digest: (_encoding: string) => 'wrong_hash_that_does_not_match_xyz789'
-        })
-    })
+    createHash: (_algorithm: string) => {
+        const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
+        hash.digest = (_encoding: string) => 'wrong_hash_that_does_not_match_xyz789';
+        return hash;
+    }
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/cosign-verifier.ts
@@ -3,9 +3,24 @@ import fs = require('fs');
 import os = require('os');
 import path = require('path');
 
-import { randomUUID as uuidV4 } from 'crypto';
+import { randomUUID as uuidV4, createHash } from 'crypto';
+import { pipeline } from 'stream/promises';
 import { fetchBufferAllow404 } from './http-client';
 import { VerificationFailure } from './verification-failure';
+
+/**
+ * Computes a file's SHA256 via a streaming read (fs.createReadStream piped into
+ * the hash) rather than buffering the whole file into memory at once, mirroring
+ * the same memory-safety property terraform-installer.ts's own
+ * computeSha256Streaming establishes for downloaded archives (#728). Used to
+ * verify the resolved `cosign` binary itself against an operator-pinned
+ * cosignSha256 (#550).
+ */
+async function computeSha256Streaming(filePath: string): Promise<string> {
+    const hash = createHash('sha256');
+    await pipeline(fs.createReadStream(filePath), hash);
+    return hash.digest('hex');
+}
 
 /**
  * Escapes every regular-expression metacharacter in `value` so it matches
@@ -92,7 +107,8 @@ export async function verifyCosignSignature(
     signatureUrl: string,
     certificateUrl: string,
     version: string,
-    required: boolean = false
+    required: boolean = false,
+    expectedCosignSha256?: string
 ): Promise<void> {
     let cosignPath: string;
     try {
@@ -109,6 +125,20 @@ export async function verifyCosignSignature(
     // so log where it resolved from — a shadowed/unexpected binary is then auditable
     // from the build log.
     console.log(`Using cosign at ${cosignPath} for OpenTofu signature verification.`);
+
+    if (expectedCosignSha256) {
+        // Optional, opt-in pin (#550): an operator who has provisioned cosign from a
+        // known-good, integrity-verified source (e.g. sigstore/cosign-installer
+        // pinned to a commit SHA) can pin its exact binary hash here, closing the
+        // ambient-PATH trust gap -- a PATH-write attacker who shadows `cosign` with a
+        // stub is caught instead of silently trusted. Fails closed on a mismatch;
+        // left unset (default), behavior is completely unchanged.
+        const actualCosignSha256 = await computeSha256Streaming(cosignPath);
+        if (actualCosignSha256.toLowerCase() !== expectedCosignSha256.toLowerCase()) {
+            throw new VerificationFailure(`cosign binary at ${cosignPath} has SHA256 ${actualCosignSha256}, which does not match the pinned cosignSha256 (${expectedCosignSha256}). Refusing to trust it for OpenTofu signature verification.`);
+        }
+        tasks.debug('cosign binary SHA256 matches the pinned cosignSha256.');
+    }
 
     // Fetch the signature + certificate, distinguishing a genuine 404 (the files
     // are not published) from a transient 5xx / network / TLS failure. Only a real

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-allowlist.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-allowlist.ts
@@ -42,7 +42,35 @@ export function isRegistryHostAllowed(hostname: string, allowedHosts: string[]):
  * environment is unaffected.
  */
 export function isPrivateOrLinkLocalHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  let host = hostname.toLowerCase();
+  // Strip an optional port suffix before the address checks below. WHATWG
+  // URL.host (unlike .hostname) includes an explicit non-default port, and
+  // downloadToFile's per-redirect-hop callback is invoked with .host -- so a
+  // redirect Location like https://10.0.0.5:8443/ would otherwise bypass
+  // every check below (the IPv4 regex is fully anchored and never matches a
+  // 'digits.digits.digits.digits:port' string) (#729 follow-up). A bracketed
+  // IPv6 literal (`[addr]` or `[addr]:port`) is unwrapped by locating the
+  // matching `]` rather than assuming it is the final character.
+  if (host.startsWith('[')) {
+    const closeBracket = host.indexOf(']');
+    host = closeBracket >= 0 ? host.slice(1, closeBracket) : host.slice(1);
+  } else {
+    // A BARE (unbracketed) IPv6 address always has at least 2 colons (the
+    // '::' shorthand, or 2+ literal ':' separators between hextets) -- e.g.
+    // the loopback '::1' returned verbatim by Node's dns.lookup(), which the
+    // sibling resolvesToPrivateOrLinkLocalAddress check feeds in with no
+    // brackets and no port at all. A REAL 'host:port'/'ipv4:port' string has
+    // exactly ONE colon. Only strip when there is exactly one, so a bare
+    // IPv6 literal (however many colons) is never misread as 'address:port'
+    // and truncated into something that no longer matches the checks below.
+    const colonCount = (host.match(/:/g) || []).length;
+    if (colonCount === 1) {
+      const lastColon = host.lastIndexOf(':');
+      if (/^\d+$/.test(host.slice(lastColon + 1))) {
+        host = host.slice(0, lastColon);
+      }
+    }
+  }
   if (host === 'localhost') {
     return true;
   }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -271,7 +271,25 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
                 }
             });
         } else {
-            zipPath = await tools.downloadTool(data.download_url, fileName);
+            // Baseline redirect-hop protection on the DEFAULT (no explicit allowlist)
+            // path (#729 follow-up): tools.downloadTool() follows redirects with no
+            // way to re-validate them, so a compromised/misconfigured registry could
+            // return an initially-safe download_url that itself 302s to a
+            // private/link-local address (notably the cloud metadata service) -- the
+            // initial-host check above only covers the first hop. Route through the
+            // same manual-redirect downloadToFile() used on the allowlist path,
+            // re-checking every hop against isPrivateOrLinkLocalHost. This is a
+            // synchronous literal-IP/hostname check (unlike the initial-host check,
+            // it does not also perform a DNS lookup per hop), so a redirect Location
+            // that is a DNS name resolving to a private address is not caught here --
+            // only a literal private/link-local host/IP is.
+            const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+            zipPath = path.join(destDir, fileName);
+            await downloadToFile(data.download_url, zipPath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+                if (isPrivateOrLinkLocalHost(hostname)) {
+                    throw new Error(tasks.loc("RegistryDownloadHostIsPrivate", hostname));
+                }
+            });
         }
     } catch (exception) {
         // download_url is a pre-signed URL whose query string carries the signing
@@ -686,7 +704,11 @@ async function downloadZipFromOpenTofu(version: string): Promise<string> {
     const requireCosign = getBoolInputDefaultTrue("requireCosignVerification");
     const signatureUrl = `${sha256SumsUrl}.sig`;
     const certificateUrl = `${sha256SumsUrl}.pem`;
-    await verifyCosignSignature(sha256SumsContent, signatureUrl, certificateUrl, version, requireCosign);
+    // Optional, opt-in pin (#550): verifies the resolved `cosign` binary itself
+    // against an operator-supplied hash before trusting it, closing the ambient
+    // PATH-lookup trust gap. Unset (default), behavior is unchanged.
+    const cosignSha256 = tasks.getInput("cosignSha256", false);
+    await verifyCosignSignature(sha256SumsContent, signatureUrl, certificateUrl, version, requireCosign, cosignSha256 || undefined);
 
     const expectedHash = parseSha256(sha256SumsContent, zipFileName);
     await verifySha256(zipPath, expectedHash);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "240",
+        "Minor": "241",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",
@@ -107,6 +107,15 @@
             "required": false,
             "visibleRule": "binary = tofu",
             "helpMarkDown": "When enabled (default), fail the install if cosign is not available on the agent or the OpenTofu SHA256SUMS signature cannot be verified against OpenTofu's pinned Sigstore identity. Install cosign on the agent (e.g. sigstore/cosign-installer) to satisfy this. Set to false only to fall back to checksum-only verification on agents without cosign."
+        },
+        {
+            "name": "cosignSha256",
+            "type": "string",
+            "label": "Pinned cosign binary SHA256 (optional)",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "binary = tofu",
+            "helpMarkDown": "Optional. cosign is discovered via a PATH lookup and is never itself integrity-verified by default, so a prior step that prepends a directory to PATH could shadow it with a stub that always reports success. If you provision cosign from a known, integrity-verified source, set this to its exact SHA256 to pin and verify the resolved binary before it is trusted -- a mismatch fails the install. Leave empty (default) to keep the existing ambient-PATH trust behavior unchanged."
         },
         {
             "name": "requireChecksum",


### PR DESCRIPTION
## Summary

Batch A of the 2026-07-22 accepted-risk remediation pass. Fixes #729 (default registry-download path did not re-validate redirect hops against the SSRF private/link-local guard) and #550 (cosign resolved via an unverified PATH lookup), across all 3 installer tasks that share the affected pattern: `TerraformInstallerV1`, `PolicyAgentInstallerV1`, `TerraformDocsInstallerV1`.

Run through the `issue-remediation.copilot.md` 3-agent adversarial review process (Sonnet 5 panel, consensus = 2 of 3 approve). **Full transparency: this took 3 review iterations**, and each iteration's rejecting reviewer(s) found genuinely real, independently-verified issues — documented below so a human reviewer has the complete picture, not just the final "approved" state.

## #729 — default registry download path did not re-validate redirect hops

The initial `download_url` host was already checked (an earlier fix), but `tools.downloadTool()` follows redirects with no way to re-validate them — a compromised/misconfigured registry could return an initially-safe URL that itself 302s to a private/link-local address (e.g. the cloud metadata service, `169.254.169.254`). The default (no `registryAllowedHosts`) path now routes through the same manual-redirect `downloadToFile()` the allowlist path already used, with a validator that rejects `isPrivateOrLinkLocalHost()` on every redirect hop. No behavior change when `registryAllowedHosts` **is** configured.

## #550 — cosign resolved via an unverified PATH lookup

Added an optional `cosignSha256` task input (`TerraformInstallerV1`). When set, the resolved `cosign` binary is hashed (streaming, memory-safe — mirrors `terraform-installer.ts`'s own `computeSha256Streaming` from #728) and compared before it's trusted to verify OpenTofu's SHA256SUMS signature — fails closed (`VerificationFailure`) on a mismatch. Left unset (default), behavior is completely unchanged.

## Review history (3 iterations — the real value of adversarial review)

- **Iteration 1 (0/3 approve)**: missing `downloadToFile` mock in `PolicyAgentInstallerV1/Tests/OpaRegistryEmptySha256RequireChecksum.ts` (silently passed for the wrong reason); missing `os.tmpdir`/`downloadToFile` mocks in several other default-path fixtures across all 3 tasks. All fixed.
- **Iteration 2 (2/3 approve, 1 reject)**: the port-stripping fix for `isPrivateOrLinkLocalHost` (closing a redirect-Location-with-explicit-port bypass, e.g. `10.0.0.5:8443`) **introduced a regression** — misclassified a **bare IPv6 loopback** (`'::1'`, exactly what Node's `dns.lookup()` returns, used by the sibling `resolvesToPrivateOrLinkLocalAddress` check) as non-private. Fixed by only stripping a port when the string has **exactly one** colon (an unbracketed IPv6 address always has 2+). Also fixed a second, deeper mock-shape masking bug in `Sha256VerificationFail.ts` (a pre-#728 chainable `crypto` mock incompatible with the real streaming hash implementation).
- **Iteration 3 (2/3 approve, 1 reject)**: found a **third** masking layer in the same `Sha256VerificationFail.ts` fixture — missing `dns` mock, meaning the fixture depended on a real, non-deterministic network lookup before ever reaching the SHA256-mismatch check. Fixed to match every sibling fixture's established pattern (mock `dns.promises.lookup` to a public address), then empirically re-verified via direct code trace + a live isolated test run (not re-reviewed by a 4th panel — `MAX_ITERS=3` was reached and this fix is small, mechanical, and directly verifiable: confirmed the test now fails via the genuine `Sha256VerificationFailed` comparison, not a stray error).

## Scoped out (tracked separately, not silently dropped)

- **#799** (new) — the **mirror**-download path (`downloadZipFromMirror`/`downloadFromMirror`, all 3 tasks) shares the identical redirect-validation gap (in fact has *zero* host validation at all, not even an initial-host check), but has a meaningfully different trust model: `mirrorBaseUrl` is operator-configured (a task input the pipeline author sets directly) vs. the registry path's dynamically-remote-API-returned `download_url`. Filed as its own issue with a documented rationale rather than expanding this already-reviewed batch's scope.
- `downloadToFile`'s lack of automatic retry (unlike `tools.downloadTool()`'s built-in `maxRetries:2`) now also applies to the default registry path, not just the pre-existing allowlist opt-in. Accepted, deliberate extension of an already-shipped (#679) trade-off — offset by `downloadToFile`'s improved explicit wall-clock timeout enforcement (which `tools.downloadTool()` lacked). Not fixed in this batch.

## Verification

- `TerraformInstallerV1`: **171 passing**, 0 failing (+12 new tests)
- `PolicyAgentInstallerV1`: **114 passing**, 0 failing (+5 new tests)
- `TerraformDocsInstallerV1`: **102 passing**, 0 failing (+5 new tests)
- `scripts/check-shared-modules.js` parity gate: passing (all 3 `registry-allowlist.ts` copies still byte-identical)
- `TerraformInstallerV1` coverage gate: passing (`registry-allowlist.js` 100% lines, `cosign-verifier.js` 97%+)
- Minor versions bumped: `TerraformInstallerV1` 240→241, `PolicyAgentInstallerV1` 16→17, `TerraformDocsInstallerV1` 12→13

Closes #729
Closes #550
