### PR TITLE
fix: audit-2026-07-22 remediation - output-file auto-cleanup + WIF token help (#650, #761)

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2156,6 +2156,44 @@ describe('Terraform Test Suite', function () {
         fs.rmSync(agentTempDirectory, { recursive: true, force: true });
     });
 
+    it('aws output with a sensitive output is auto-cleaned up at normal step end by default (#650)', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputSensitiveAutoCleanup.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        const workingDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-test');
+        const agentTempDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-agenttemp');
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(
+                tr.warningIssues.some((w) => w.includes('sensitive output') && w.includes('db_password')),
+                'should still warn about the sensitive output. warnings: ' + tr.warningIssues
+            );
+            const remaining = (fs.existsSync(agentTempDirectory) ? fs.readdirSync(agentTempDirectory) : []).filter((f) => f !== '.taskkey');
+            assert.strictEqual(remaining.length, 0, `expected the sensitive output JSON file to be auto-cleaned up by default (#650), found: ${remaining.join(', ')}`);
+        }, tr);
+        fs.rmSync(workingDirectory, { recursive: true, force: true });
+        fs.rmSync(agentTempDirectory, { recursive: true, force: true });
+    });
+
+    it('aws output with cleanupOutputFileIfSensitive=false retains a sensitive output file at normal step end (#650 opt-out)', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputSensitiveAutoCleanupOptOut.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        const workingDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-optout-test');
+        const agentTempDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-optout-agenttemp');
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            const files = (fs.existsSync(agentTempDirectory) ? fs.readdirSync(agentTempDirectory) : []).filter((f) => f !== '.taskkey');
+            assert.strictEqual(files.length, 1, `expected the sensitive output file to be retained when opted out (#650), found: ${files.join(', ')}`);
+        }, tr);
+        fs.rmSync(workingDirectory, { recursive: true, force: true });
+        fs.rmSync(agentTempDirectory, { recursive: true, force: true });
+    });
+
     /* terraform custom tests */
 
     it('azure custom command to console should succeed', async () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanup.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanup.ts
@@ -1,0 +1,60 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// #650: a sensitive Terraform output in the `output -json` file is now
+// auto-registered for NORMAL-completion scrub+delete by default
+// (cleanupOutputFileIfSensitive defaults to true in task.json), even though
+// the general cleanupOutputFile input is left off -- closing the residual
+// window where the cleartext value was previously retained until the
+// agent's end-of-job purge. Uses ParentCommandHandler (via
+// runViaParentHandler) since cleanupTempFiles() only runs from execute()'s
+// finally block.
+//
+// cleanupOutputFileIfSensitive is set explicitly to 'true' here even though
+// that's its task.json default: mock-task's getBoolInput() only reads the
+// INPUT_* env var tr.setInput() sets and never consults task.json defaults
+// (that resolution is the real ADO agent's job, done before the task
+// process starts) -- leaving it unset here would incorrectly evaluate to
+// false under the mock harness, unlike a real pipeline run.
+const workingDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-test');
+fs.rmSync(workingDirectory, { recursive: true, force: true });
+fs.mkdirSync(workingDirectory, { recursive: true });
+// The file is written under Agent.TempDirectory (#492), so point it at a
+// scrubbed per-scenario directory the L0 assertions can inspect.
+const agentTempDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-agenttemp');
+fs.rmSync(agentTempDirectory, { recursive: true, force: true });
+fs.mkdirSync(agentTempDirectory, { recursive: true });
+process.env['AGENT_TEMPDIRECTORY'] = agentTempDirectory;
+
+let tp = path.join(__dirname, './AWSOutputSensitiveAutoCleanupL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', workingDirectory);
+// cleanupOutputFile intentionally left unset -- must default to false.
+tr.setInput('cleanupOutputFileIfSensitive', 'true');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"db_password\": { \"value\": \"hunter2\", \"sensitive\": true }, \"safe_output\": { \"value\": \"hello\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanupL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanupL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../test-l0-helpers';
+
+runViaParentHandler('AWSOutputSensitiveAutoCleanupL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanupOptOut.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanupOptOut.ts
@@ -1,0 +1,46 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// #650: an operator can opt OUT of the new auto-cleanup-if-sensitive default
+// (cleanupOutputFileIfSensitive=false) when a downstream step in the SAME job
+// still needs to read the sensitive value from disk -- the file must then be
+// retained after a normal completion exactly like the pre-#650-fix behavior.
+const workingDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-optout-test');
+fs.rmSync(workingDirectory, { recursive: true, force: true });
+fs.mkdirSync(workingDirectory, { recursive: true });
+const agentTempDirectory = path.join(os.tmpdir(), 'tf-output-sensitive-autocleanup-optout-agenttemp');
+fs.rmSync(agentTempDirectory, { recursive: true, force: true });
+fs.mkdirSync(agentTempDirectory, { recursive: true });
+process.env['AGENT_TEMPDIRECTORY'] = agentTempDirectory;
+
+let tp = path.join(__dirname, './AWSOutputSensitiveAutoCleanupOptOutL0.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('cleanupOutputFileIfSensitive', 'false');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": { "terraform": "terraform" },
+    "checkPath": { "terraform": true },
+    "exec": {
+        "terraform output -json": {
+            "code": 0,
+            "stdout": "{ \"db_password\": { \"value\": \"hunter2\", \"sensitive\": true }, \"safe_output\": { \"value\": \"hello\" } }"
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanupOptOutL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputSensitiveAutoCleanupOptOutL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../test-l0-helpers';
+
+runViaParentHandler('AWSOutputSensitiveAutoCleanupOptOutL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -211,10 +211,13 @@ export abstract class BaseTerraformCommandHandler {
     backendConfig: Map<string, string>;
     protected tempFiles: string[];
     // Files scrubbed+deleted ONLY on a SIGTERM/cancellation (emergencyCleanupTempFiles),
-    // never on normal step completion: the retained `terraform output -json` file
+    // never on normal step completion: a retained `terraform output -json` file
     // when cleanupOutputFile is off, which downstream steps still read via
     // jsonOutputVariablesPath during the same job but has no legitimate reader once
-    // the job is cancelled (#650).
+    // the job is cancelled (#650). Since #650's auto-cleanup fix, this now only holds
+    // the output file when it has NO sensitive values, or the operator explicitly
+    // opted out via cleanupOutputFileIfSensitive=false -- a sensitive-containing file
+    // is registered in `tempFiles` instead (normal-completion cleanup) by default.
     protected emergencyOnlyTempFiles: string[] = [];
     private secureFileId: string | null = null;
     // Path of the downloaded secure var file, retained so it can be scrubbed
@@ -570,9 +573,10 @@ export abstract class BaseTerraformCommandHandler {
      * End-of-step cleanup (normal completion). Scrubs+deletes every tracked temp
      * file and the secure var file. Deliberately does NOT touch
      * {@link emergencyOnlyTempFiles} -- those (a retained `terraform output -json`
-     * file when cleanupOutputFile is off) must survive a normal step so
-     * downstream steps can still read them via the documented output-variable
-     * contract; they are cleaned only on cancellation (#650).
+     * file when cleanupOutputFile is off AND it either has no sensitive values or
+     * the operator opted out via cleanupOutputFileIfSensitive=false) must survive
+     * a normal step so downstream steps can still read them via the documented
+     * output-variable contract; they are cleaned only on cancellation (#650).
      */
     public cleanupTempFiles(): void {
         this.scrubAndUnlink(this.tempFiles);
@@ -585,7 +589,7 @@ export abstract class BaseTerraformCommandHandler {
      * ParentCommandHandler.emergencyCleanup). Cleans everything
      * {@link cleanupTempFiles} does, PLUS {@link emergencyOnlyTempFiles}: on a
      * cancellation there is no legitimate downstream reader left for a retained
-     * output file, so its cleartext (possibly `sensitive = true`) values are
+     * (non-sensitive, or explicitly opted-out) output file, so its values are
      * scrubbed+deleted then rather than left on a reused self-hosted agent's
      * temp dir until job end (#650).
      */
@@ -841,17 +845,23 @@ export abstract class BaseTerraformCommandHandler {
 
         this.writeCommandOutputFile(jsonOutputVariablesFilePath, commandOutput.stdout);
         tasks.setVariable('jsonOutputVariablesPath', jsonOutputVariablesFilePath, false, true);
-        this.warnIfSensitiveOutputFile(commandOutput.stdout, jsonOutputVariablesFilePath);
+        const hasSensitiveOutputs = this.warnIfSensitiveOutputFile(commandOutput.stdout, jsonOutputVariablesFilePath);
 
-        if (tasks.getBoolInput('cleanupOutputFile', false)) {
+        // #650: a file containing sensitive output values is auto-registered for
+        // NORMAL-completion scrub+delete (cleanupOutputFileIfSensitive, default
+        // true) even when the general-purpose cleanupOutputFile wasn't requested
+        // -- unless the operator explicitly opts out (e.g. a downstream step in
+        // the SAME job still needs to read this specific sensitive value from
+        // disk). Otherwise, cleanupOutputFile is off: the file must survive a
+        // NORMAL step so downstream steps can still read it via the
+        // jsonOutputVariablesPath contract, but on a cancellation there is no
+        // legitimate downstream reader left -- register it for the
+        // emergency-only scrub+delete path so its cleartext values aren't left
+        // on a reused self-hosted agent's temp dir until job end.
+        if (tasks.getBoolInput('cleanupOutputFile', false) ||
+            (hasSensitiveOutputs && tasks.getBoolInput('cleanupOutputFileIfSensitive', false))) {
             this.tempFiles.push(jsonOutputVariablesFilePath);
         } else {
-            // cleanupOutputFile is off: the file must survive a NORMAL step so
-            // downstream steps can still read it via the jsonOutputVariablesPath
-            // contract, but on a cancellation there is no legitimate downstream
-            // reader left -- register it for the emergency-only scrub+delete path
-            // so its cleartext (possibly `sensitive = true`) values aren't left on
-            // a reused self-hosted agent's temp dir until job end (#650).
             this.emergencyOnlyTempFiles.push(jsonOutputVariablesFilePath);
         }
 
@@ -1896,30 +1906,44 @@ export abstract class BaseTerraformCommandHandler {
      * file is registered for end-of-step deletion first so the failure
      * doesn't leave the cleartext values behind. With `cleanupOutputFile` set
      * the file is deleted at step end anyway, so strict mode stays a warning.
+     *
+     * Returns whether the parsed output contained at least one `sensitive =
+     * true` value (and this call did not already throw) -- the caller (the
+     * `output()` command) uses this to decide whether to also auto-register
+     * the file for normal-completion cleanup via `cleanupOutputFileIfSensitive`
+     * (#650), independent of this function's own warn/throw behavior.
      */
-    private warnIfSensitiveOutputFile(jsonOutput: string, filePath: string): void {
+    private warnIfSensitiveOutputFile(jsonOutput: string, filePath: string): boolean {
         let outputs: unknown;
         try {
             outputs = JSON.parse(jsonOutput);
         } catch (error) {
             tasks.debug(`Could not parse terraform output as JSON for sensitive-output detection: ${error}`);
-            return;
+            return false;
         }
-        if (!outputs || typeof outputs !== 'object') return;
+        if (!outputs || typeof outputs !== 'object') return false;
 
         const sensitiveKeys = Object.entries(outputs)
             .filter(([, def]) => (def as { sensitive?: boolean }).sensitive === true)
             .map(([key]) => key);
-        if (sensitiveKeys.length === 0) return;
+        if (sensitiveKeys.length === 0) return false;
 
         if (tasks.getBoolInput('failOnSensitiveOutputs', false) && !tasks.getBoolInput('cleanupOutputFile', false)) {
             this.tempFiles.push(filePath);
             throw new Error(tasks.loc('OutputSensitiveOutputsStrictFailure', filePath, sensitiveKeys.length, sensitiveKeys.join(', ')));
         }
+        // #650: state the actual outcome accurately -- with cleanupOutputFileIfSensitive
+        // defaulting to true, this file is normally already slated for deletion, so telling
+        // every caller to "set cleanupOutputFile" regardless would be stale/misleading now
+        // that cleanup is opt-OUT rather than opt-in for the sensitive case.
+        const willAutoCleanup = tasks.getBoolInput('cleanupOutputFile', false) || tasks.getBoolInput('cleanupOutputFileIfSensitive', false);
         tasks.warning(
             `${filePath} contains ${sensitiveKeys.length} sensitive output(s) in cleartext (${sensitiveKeys.join(', ')}). ` +
-            `Ensure this file is not published as a pipeline artifact. Set 'cleanupOutputFile' to remove it automatically ` +
-            `at the end of this step if downstream steps don't need to read it from disk.`
+            `Ensure this file is not published as a pipeline artifact. ` +
+            (willAutoCleanup
+                ? `This file will be deleted automatically at the end of this step.`
+                : `Set 'cleanupOutputFileIfSensitive' (or 'cleanupOutputFile') to remove it automatically at the end of this step if downstream steps don't need to read it from disk.`)
         );
+        return true;
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -15,7 +15,7 @@
     "demands": [],
     "version": {
         "Major": "5",
-        "Minor": "286",
+        "Minor": "287",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",
@@ -449,7 +449,16 @@
             "defaultValue": "false",
             "required": false,
             "visibleRule": "command = output",
-            "helpMarkDown": "Delete the JSON file written by the output command (containing every output's real value, including any marked sensitive) when this step finishes. The file is written under the agent temp directory (`Agent.TempDirectory`), which the agent purges at the end of the job; it is retained until then by default so downstream steps can read it via the `jsonOutputVariablesPath` output variable. Enable this to delete it at the end of this step instead, e.g. when the step only needs the auto-set `TF_OUT_*` pipeline variables and not the file itself."
+            "helpMarkDown": "Delete the JSON file written by the output command (containing every output's real value, including any marked sensitive) when this step finishes. The file is written under the agent temp directory (`Agent.TempDirectory`), which the agent purges at the end of the job; it is retained until then by default so downstream steps can read it via the `jsonOutputVariablesPath` output variable -- unless it contains a Terraform output declared `sensitive = true`, see 'Delete the output JSON file at task end if it contains sensitive values' below. Enable this to delete it at the end of this step instead, e.g. when the step only needs the auto-set `TF_OUT_*` pipeline variables and not the file itself."
+        },
+        {
+            "name": "cleanupOutputFileIfSensitive",
+            "type": "boolean",
+            "label": "Delete the output JSON file at task end if it contains sensitive values",
+            "defaultValue": "true",
+            "required": false,
+            "visibleRule": "command = output",
+            "helpMarkDown": "When the output command's JSON file is detected to contain one or more Terraform outputs declared `sensitive = true` (see the sensitive-output warning), delete it automatically at the end of this step -- even though 'Delete the output JSON file at task end' (cleanupOutputFile) is off -- rather than leaving cleartext sensitive values on disk for the rest of the job relying solely on the agent's end-of-job temp directory purge. Has no effect when cleanupOutputFile is already enabled (the file is always deleted then) or when the output contains no sensitive values (the general retain-by-default behavior described above is unchanged). Disable this only if a downstream step in the SAME job still needs to read this specific file's sensitive value from disk via jsonOutputVariablesPath."
         },
         {
             "name": "failOnSensitiveOutputs",
@@ -509,7 +518,7 @@
             "type": "boolean",
             "defaultValue": "false",
             "label": "Use ID Token Generation as a fallback for older provider versions",
-            "helpMarkDown": "Choose whether to use ID Token generation as a fallback for older provider versions. Warning this setting may result in unexpected timeouts.",
+            "helpMarkDown": "Choose whether to use ID Token generation as a fallback for older provider versions. Warning this setting may result in unexpected timeouts.<br><br>Security note: when **false** (the default), the task exports the broader ADO pipeline OIDC access token (`ARM_OIDC_REQUEST_TOKEN`) into the terraform process environment for the whole run so the provider can refresh it as needed -- inherited by any `local-exec` provisioner or `external` data source the configuration runs. Setting this to **true** instead generates a single-use, narrower-scoped `ARM_OIDC_TOKEN` up front. For pipelines running untrusted or third-party modules/providers on shared agents, prefer **true**. See [Token modes and exposure](https://github.com/sethbacon/azure-pipelines-terraform/blob/main/docs/setup/azure-wif-setup.md#token-modes-and-exposure).",
             "groupName": "providerAzureRm"
         },
         {
@@ -702,7 +711,7 @@
             "type": "boolean",
             "defaultValue": "false",
             "label": "Use ID Token Generation as a fallback for older backend versions",
-            "helpMarkDown": "Choose whether to use ID Token generation as a fallback for older backend versions. Warning this setting may result in unexpected timeouts.",
+            "helpMarkDown": "Choose whether to use ID Token generation as a fallback for older backend versions. Warning this setting may result in unexpected timeouts.<br><br>Security note: when **false** (the default), the task exports the broader ADO pipeline OIDC access token (`ARM_OIDC_REQUEST_TOKEN`) into the terraform process environment for the whole run so the backend can refresh it as needed -- inherited by any `local-exec` provisioner or `external` data source the configuration runs. Setting this to **true** instead generates a single-use, narrower-scoped `ARM_OIDC_TOKEN` up front. For pipelines running untrusted or third-party modules/providers on shared agents, prefer **true**. See [Token modes and exposure](https://github.com/sethbacon/azure-pipelines-terraform/blob/main/docs/setup/azure-wif-setup.md#token-modes-and-exposure).",
             "groupName": "backendAzureRm"
         },
         {


### PR DESCRIPTION
## Summary

Batch B of the 2026-07-22 accepted-risk remediation pass. Fixes #650 (cleartext `terraform output -json` file, including sensitive outputs, retained on disk unless opt-in cleanup was enabled) and #761 (default Azure WIF path exports the broad `System.AccessToken` into the terraform child-process environment, undocumented in the task's own authoring-UI help text). Both are scoped to `TerraformTaskV5` only — bundled into one PR to avoid a double Minor-version-bump conflict on the same `task.json`.

Run through the `issue-remediation.copilot.md` 3-agent adversarial review process (Sonnet 5 panel, consensus = 2 of 3 approve). **2 of 3 approved on the first round**, but the rejecting reviewer found a real, valid issue that's been fixed (see below) — full transparency on that, plus one reviewer-raised finding that was investigated and found to be **incorrect** (also documented, since validating findings before acting on them is part of the process).

## #650 — cleartext output file retained on disk unless opt-in cleanup enabled

Added a new opt-out input, `cleanupOutputFileIfSensitive` (default **`true`**). When `terraform output -json`'s file is detected to contain one or more `sensitive = true` values, it's now auto-registered for **normal-completion** scrub+delete — closing the window where the file previously relied solely on the agent's own end-of-job temp-directory purge (not guaranteed mid-run on a reused self-hosted agent). The general, non-sensitive case is completely unaffected; `cleanupOutputFile`'s own existing behavior/default is unchanged. An operator can still opt back out (e.g. a downstream step in the same job needs to read the sensitive value from disk) via `cleanupOutputFileIfSensitive=false`.

## #761 — WIF token-mode trade-off undocumented in the task's own UI

The default ("ID token refresh") Azure WIF path exports the broad ADO pipeline OIDC access token into the terraform process environment for the whole run; a narrower, one-shot token mode already existed (`environmentAzureRmUseIdTokenGeneration`/`backendAzureRmUseIdTokenGeneration` = `true`) but the trade-off was only documented in an external markdown doc and a source-code comment — neither of which the ADO pipeline-authoring UI surfaces. Enriched both inputs' `helpMarkDown` directly, with a link to the existing `docs/setup/azure-wif-setup.md#token-modes-and-exposure` section. **Documentation-only — no default or behavior change** (deliberately not flipping the default, since the input's own pre-existing help text already warns of timeout risk).

## Review history

- **Round 1 (2/3 approve)**: `correctness` and `test-adequacy-siblings` approved. `regression-conventions` **rejected** — found that `warnIfSensitiveOutputFile()`'s existing warning message still said *"Set 'cleanupOutputFile' to remove it automatically..."*, which is now stale/misleading given the new default already auto-cleans the file. **Fixed**: the warning now states the actual outcome (computed from the real current input values) — "this file will be deleted automatically" when it will be, or names both the new and old opt-in inputs when it won't.
- A **separate** `newFindings` item from `test-adequacy-siblings` (suggesting `getBoolInput('cleanupOutputFileIfSensitive', false)`'s second argument should be `true` to "match the task.json default") was investigated and found **incorrect** — that parameter means `required` (whether to throw if unset), not "default value"; changing it as suggested would make the input mandatory and break every pipeline that doesn't explicitly set it. Rejected per the process's "validate findings before folding them in" step; verified directly against the real `azure-pipelines-task-lib/task.js` source.
- The same reviewer also noted `show()`'s `outputTo=file` path has an analogous "retained by default" gap for sensitive outputs, but flagged it themselves as likely out of scope (issue #650's own evidence/recommendation are both specific to the `output` command). Agreed and left out of this batch — filed as a follow-up rather than silently dropped (see below).

## Scoped out (tracked separately)

- **#802** (new) — `show()`'s `outputTo=file` sensitive-output path has the same "retained-by-default unless `failOnSensitiveOutputs` strict-fails" shape as #650 had, but is a structurally distinct code path (`warnIfSensitiveOutputs`, plural, not `warnIfSensitiveOutputFile`) that the original issue text never named. Filed as its own issue with rationale rather than expanding this already-reviewed batch's scope.

## Verification

- `TerraformTaskV5`: **582 passing**, 0 failing (+2 new tests)
- `npm run test:coverage`: per-file coverage gate passes for every file; `azure-terraform-command-handler.js` (SECURITY_TIER) unaffected at 99.38% since #761 is a `task.json`-only change
- Confirmed via direct `node -e` inspection that all 5 touched/new `task.json` inputs parse with the correct `defaultValue`s

Closes #650
Closes #761
