### PR TITLE
fix: mirror download SSRF/redirect-to-private-address protection (#799)

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -69,6 +69,9 @@ describe('PolicyAgentInstaller Test Suite', function () {
     expectSuccess('RegistrySentinelSuccess');
     expectSuccess('MirrorSentinelSuccess');
     expectSuccess('MirrorOpaSuccess');
+    // #799: a private-IP mirror host explicitly pinned via mirrorAllowedHosts is
+    // accepted (the air-gapped escape hatch), not refused by the default baseline.
+    expectSuccess('MirrorAllowedHostAccept');
 
     it('OpaOfficialChecksumSkip warns when the .sha256 is unavailable', async () => {
         const tp = path.join(__dirname, 'OpaOfficialChecksumSkip.js');
@@ -309,6 +312,34 @@ describe('PolicyAgentInstaller Test Suite', function () {
             assert(
                 tr.errorIssues.some(e => e.includes('RegistryDownloadHostIsPrivate')),
                 'should fail via the private-address check on the redirect hop. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
+    it('mirror host is a private/link-local address: should reject before downloading (#799)', async () => {
+        const tp = path.join(__dirname, 'MirrorHostIsPrivateReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some(e => e.includes('MirrorDownloadHostIsPrivate')),
+                'should fail via the mirror private-address check. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
+    it('mirror download redirects to a private/metadata address: should reject the redirect hop (#799)', async () => {
+        const tp = path.join(__dirname, 'MirrorRedirectToPrivateReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some(e => e.includes('MirrorDownloadHostIsPrivate')),
+                'should fail via the mirror private-address check on the redirect hop. errors: ' + tr.errorIssues,
             );
         }, tr);
     });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorAllowedHostAccept.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorAllowedHostAccept.ts
@@ -1,0 +1,61 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #799 follow-up: mirrorAllowedHosts is set and the mirror host is a PRIVATE IP
+// address that would otherwise be refused by the default baseline check --
+// proving an operator running a legitimate mirror on a private/internal
+// address (e.g. an air-gapped environment) can opt back in, mirroring the
+// registry path's registryAllowedHosts escape hatch exactly.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://10.0.5.10');
+tr.setInput('mirrorAllowedHosts', '10.0.5.10');
+tr.setInput('requireChecksum', 'false');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('Mirror path should not call fetchJson: ' + url); },
+  fetchTextAllow404: async () => null, // no .sha256; requireChecksum=false -> warn + proceed
+  downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Genuinely exercises the isHostAllowed callback against
+    // mirrorAllowedHosts, proving the pinned private-IP host is accepted.
+    isHostAllowed(new URL(url).hostname);
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('fs', {
+  chmodSync: () => { },
+  readFileSync: () => Buffer.from('fake-binary'),
+  mkdirSync: () => undefined,
+  copyFileSync: () => { }
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => 'unused' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => {
+    throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
+  },
+  extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
+  cacheDir: async () => '/tmp/opa-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = { find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] } };
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorHostIsPrivateReject.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorHostIsPrivateReject.ts
@@ -1,0 +1,50 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #799 (follow-up to #729): mirrorBaseUrl's host is a literal private/link-local
+// address (the cloud metadata service). Unlike the registry path's download_url
+// (dynamically returned by a remote API), mirrorBaseUrl is operator-configured --
+// but the task must still refuse it outright before ever attempting a download.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://169.254.169.254');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('Mirror path should not call fetchJson: ' + url); },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, _isHostAllowed: (hostname: string) => void) => {
+    throw new Error('downloadToFile should not be reached for a mirror host that is a literal private/link-local address');
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => 'should-not-be-reached' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => {
+    throw new Error('downloadTool should not be reached for a mirror host that is a private/link-local address');
+  },
+  extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
+  cacheDir: async () => '/tmp/opa-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorOpaSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorOpaSuccess.ts
@@ -12,6 +12,15 @@ tr.setInput('mirrorBaseUrl', 'https://mirror.example.com');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
+});
+
 const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
 
 tr.registerMock('./http-client', {
@@ -21,7 +30,13 @@ tr.registerMock('./http-client', {
             return `${EXPECTED_SHA256}  opa_linux_amd64\n`;
         }
         throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
-    }
+    },
+    downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        // Mirror downloads now go through downloadToFile (#799), not
+        // tools.downloadTool -- simulate a benign successful download.
+        isHostAllowed(new URL(_url).hostname);
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });
@@ -45,7 +60,9 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: () => null,
-    downloadTool: async () => '/tmp/opa-download',
+    downloadTool: async () => {
+        throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
+    },
     extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
     cacheDir: async () => '/tmp/opa-cached',
     cleanVersion: (v: string) => v,

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorRedirectToPrivateReject.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorRedirectToPrivateReject.ts
@@ -2,37 +2,34 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
+// #799 (follow-up to #729): mirrorBaseUrl's own host is benign, but the (simulated)
+// download follows a redirect to the cloud metadata address 169.254.169.254 --
+// proving the mirror path re-validates every redirect hop via downloadToFile, not
+// just the initial host (mirrors the registry path's #729 follow-up fix).
 const tp = path.join(__dirname, 'RunInstaller.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
-tr.setInput('policyAgent', 'sentinel');
-tr.setInput('version', '0.40.0');
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
 tr.setInput('downloadSource', 'mirror');
 tr.setInput('mirrorBaseUrl', 'https://mirror.example.com');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
-// dns: the mirror host is a fake test domain; mock it to a public (non-private/
-// link-local) address so the #799 initial-host check passes without a real
-// network lookup, reaching the checksum-fetch failure this test exercises.
+// dns: the mirror host itself is benign (this test is about the REDIRECT hop,
+// not the initial host); mock it to a public address so the initial-host check
+// passes without a real network lookup, reaching the downloadToFile call.
 tr.registerMock('dns', {
   promises: {
     lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
   }
 });
 
-// A NON-404 mirror SHA256SUMS fetch failure (e.g. a 5xx after http-client retries)
-// must be FATAL, not treated as "checksum absent". fetchTextAllow404 returns null
-// ONLY for a genuine 404; here it throws, so the Sentinel install must fail closed.
 tr.registerMock('./http-client', {
   fetchJson: async (url: string) => { throw new Error('Mirror path should not call fetchJson: ' + url); },
-  fetchTextAllow404: async () => {
-    throw new Error('HTTP 503 fetching SHA256SUMS (server error, exhausted retries)');
-  },
   downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
-    // Mirror downloads now go through downloadToFile (#799); simulate a benign
-    // successful download so the checksum-fetch failure under test is reached.
-    isHostAllowed(new URL(_url).hostname);
+    // Simulate a redirect hop landing on the cloud metadata service.
+    isHostAllowed('169.254.169.254');
   },
   DOWNLOAD_TIMEOUT_MS: 30000
 });
@@ -42,27 +39,27 @@ tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  readFileSync: () => Buffer.from('fake-zip')
+  readFileSync: () => Buffer.from('fake-binary')
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => ({ update: () => ({ digest: () => 'deadbeef' }) })
+  createHash: () => ({ update: () => ({ digest: () => 'should-not-be-reached' }) })
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
   findLocalTool: () => null,
   downloadTool: async () => {
-    throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
+    throw new Error('downloadTool should not be reached -- downloadToFile must be used so every redirect hop is re-validated');
   },
-  extractZip: async () => '/tmp/sentinel-extracted',
-  cacheDir: async () => '/tmp/sentinel-cached',
+  extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
+  cacheDir: async () => '/tmp/opa-cached',
   cleanVersion: (v: string) => v,
   prependPath: () => { }
 });
 
 const a: ma.TaskLibAnswers = {
-  find: { '/tmp/sentinel-cached': ['/tmp/sentinel-cached/sentinel'] }
+  find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
 };
 tr.setAnswers(a);
 tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinelSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorSentinelSuccess.ts
@@ -12,6 +12,15 @@ tr.setInput('mirrorBaseUrl', 'https://mirror.example.com');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
+});
+
 const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
 
 tr.registerMock('./http-client', {
@@ -21,7 +30,13 @@ tr.registerMock('./http-client', {
             return `${EXPECTED_SHA256}  sentinel_0.40.0_linux_amd64.zip\n`;
         }
         throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
-    }
+    },
+    downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        // Mirror downloads now go through downloadToFile (#799); simulate a
+        // benign successful download.
+        isHostAllowed(new URL(_url).hostname);
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });
@@ -54,7 +69,9 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: () => null,
-    downloadTool: async () => '/tmp/sentinel.zip',
+    downloadTool: async () => {
+        throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
+    },
     extractZip: async () => '/tmp/sentinel-extracted',
     cacheDir: async () => '/tmp/sentinel-cached',
     cleanVersion: (v: string) => v,

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorUserInfoRedacted.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/MirrorUserInfoRedacted.ts
@@ -18,9 +18,26 @@ tr.setInput('requireChecksum', 'false');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
+});
+
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => { throw new Error('Mirror path should not call fetchJson: ' + url); },
-    fetchTextAllow404: async () => null // no .sha256; requireChecksum=false -> warn + proceed
+    fetchTextAllow404: async () => null, // no .sha256; requireChecksum=false -> warn + proceed
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        // The actual download must retain the credential to reach the mirror.
+        if (!url.includes('user:s3cr3t@mirror.example.com')) {
+            throw new Error('mirror download URL must retain the basic-auth userinfo; got: ' + url);
+        }
+        isHostAllowed(new URL(url).hostname);
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });
@@ -40,12 +57,8 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: () => null,
-    downloadTool: async (url: string) => {
-        // The actual download must retain the credential to reach the mirror.
-        if (!url.includes('user:s3cr3t@mirror.example.com')) {
-            throw new Error('mirror download URL must retain the basic-auth userinfo; got: ' + url);
-        }
-        return '/tmp/opa-download';
+    downloadTool: async () => {
+        throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
     },
     extractZip: async () => { throw new Error('extractZip should not be called for OPA'); },
     cacheDir: async () => '/tmp/opa-cached',

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -368,7 +368,7 @@ async function downloadFromMirror(agent: string, version: string, mirrorBaseUrl:
     if (agent === "sentinel") {
         const zipFileName = `sentinel_${version}_${osPlatform}_${arch}.zip`;
         const downloadUrl = `${mirrorBaseUrl}/${version}/${zipFileName}`;
-        const zipPath = await downloadTo(downloadUrl, `sentinel-${version}-${uuidV4()}.zip`);
+        const zipPath = await downloadFromMirrorUrl(downloadUrl, `sentinel-${version}-${uuidV4()}.zip`);
 
         const sha256SumsUrl = `${mirrorBaseUrl}/${version}/sentinel_${version}_SHA256SUMS`;
         const verified = await verifyMirrorChecksum(zipPath, sha256SumsUrl, zipFileName);
@@ -377,7 +377,7 @@ async function downloadFromMirror(agent: string, version: string, mirrorBaseUrl:
 
     const assetName = getOpaAssetName();
     const downloadUrl = `${mirrorBaseUrl}/${version}/${assetName}`;
-    const binaryPath = await downloadTo(downloadUrl, `opa-${version}-${uuidV4()}${isWindows ? '.exe' : ''}`);
+    const binaryPath = await downloadFromMirrorUrl(downloadUrl, `opa-${version}-${uuidV4()}${isWindows ? '.exe' : ''}`);
 
     const requireChecksum = getBoolInputDefaultTrue("requireChecksum");
     const sha256Url = `${downloadUrl}.sha256`;
@@ -437,6 +437,51 @@ async function downloadTo(url: string, fileName: string): Promise<string> {
         // the interpolated message (no-op for the official releases/GitHub URLs) (#586).
         throw new Error(tasks.loc("PolicyAgentDownloadFailed", redactUrlUserInfo(url), exception));
     }
+}
+
+/**
+ * Mirror-only download path (#799, follow-up to #729). mirrorBaseUrl is an
+ * operator-configured input (unlike the registry path's dynamically-returned
+ * download_url), but a compromised/misconfigured mirror SERVICE could still
+ * redirect the actual download at a private/link-local address (notably the
+ * cloud metadata service). Checks the initial host up front, then re-validates
+ * every redirect hop via downloadToFile() -- unlike downloadTo() above (used
+ * for the official/GitHub path, left unchanged), which calls
+ * tools.downloadTool() and follows redirects with no way to re-validate them,
+ * the same underlying gap #729 closed for the registry path. An operator
+ * running a legitimate mirror on a private/internal address (a real,
+ * pre-existing use case -- the registry path's own registryAllowedHosts
+ * exists for exactly this reason) can opt in via mirrorAllowedHosts,
+ * mirroring the registry path's allowlist shape exactly.
+ */
+async function downloadFromMirrorUrl(url: string, fileName: string): Promise<string> {
+    const mirrorAllowedHosts = parseAllowedHosts(tasks.getInput("mirrorAllowedHosts", false));
+    const initialHost = new URL(url).hostname;
+    if (mirrorAllowedHosts.length > 0) {
+        if (!isRegistryHostAllowed(initialHost, mirrorAllowedHosts)) {
+            throw new Error(tasks.loc("MirrorDownloadHostNotAllowed", initialHost, mirrorAllowedHosts.join(', ')));
+        }
+    } else if (isPrivateOrLinkLocalHost(initialHost) || await resolvesToPrivateOrLinkLocalAddress(initialHost)) {
+        throw new Error(tasks.loc("MirrorDownloadHostIsPrivate", initialHost));
+    }
+    const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+    const destPath = path.join(destDir, fileName);
+    try {
+        await downloadToFile(url, destPath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+            if (mirrorAllowedHosts.length > 0) {
+                if (!isRegistryHostAllowed(hostname, mirrorAllowedHosts)) {
+                    throw new Error(tasks.loc("MirrorDownloadHostNotAllowed", hostname, mirrorAllowedHosts.join(', ')));
+                }
+            } else if (isPrivateOrLinkLocalHost(hostname)) {
+                throw new Error(tasks.loc("MirrorDownloadHostIsPrivate", hostname));
+            }
+        });
+    } catch (exception) {
+        // A mirror download URL can embed operator basic-auth userinfo; strip it from
+        // the interpolated message (#586).
+        throw new Error(tasks.loc("PolicyAgentDownloadFailed", redactUrlUserInfo(url), exception));
+    }
+    return destPath;
 }
 
 /** Copies a raw downloaded binary into a fresh directory under its canonical name. */

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -90,6 +90,15 @@
             "helpMarkDown": "Base URL of your binary mirror. Must use HTTPS. Must serve files at the same path structure as the official releases for the selected agent."
         },
         {
+            "name": "mirrorAllowedHosts",
+            "type": "string",
+            "label": "Allowed mirror download hosts",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "downloadSource = mirror",
+            "helpMarkDown": "Optional comma- or newline-separated allowlist of hostnames the mirror download is permitted to use (e.g. mirror.example.com, or *.internal.example.com to allow any subdomain). When empty (default), a mirror host that is a private/link-local address (e.g. the cloud metadata service) is refused. Set this to explicitly allow a legitimate private/internal mirror -- including one on a private IP -- for an air-gapped or otherwise network-isolated environment."
+        },
+        {
             "name": "requireGpgSignature",
             "type": "boolean",
             "label": "Require GPG signature verification",
@@ -153,6 +162,8 @@
         "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s",
         "RegistryDownloadHostNotAllowed": "Registry download_url host '%s' is not in registryAllowedHosts: %s",
         "RegistryDownloadHostIsPrivate": "Registry download_url host '%s' is a private/link-local address, which is refused by default (a common SSRF target, e.g. the cloud metadata service). Set registryAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
+        "MirrorDownloadHostIsPrivate": "Mirror download host '%s' is a private/link-local address, which is refused (a common SSRF target, e.g. the cloud metadata service). Set mirrorAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
+        "MirrorDownloadHostNotAllowed": "Mirror download host '%s' is not in mirrorAllowedHosts: %s",
         "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
         "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
         "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
@@ -64,6 +64,9 @@ describe('TerraformDocsInstaller Test Suite', function () {
   expectSuccess('LatestSuccess');
   expectSuccess('RegistrySuccess');
   expectSuccess('MirrorSuccess');
+  // #799: a private-IP mirror host explicitly pinned via mirrorAllowedHosts is
+  // accepted (the air-gapped escape hatch), not refused by the default baseline.
+  expectSuccess('MirrorAllowedHostAccept');
 
   it('OfficialChecksumSkip warns when the sha256sum is unavailable', async () => {
     const tp = path.join(__dirname, 'OfficialChecksumSkip.js');
@@ -291,6 +294,34 @@ describe('TerraformDocsInstaller Test Suite', function () {
       assert(
         tr.errorIssues.some(e => e.includes('RegistryDownloadHostIsPrivate')),
         'should fail via the private-address check on the redirect hop. errors: ' + tr.errorIssues,
+      );
+    }, tr);
+  });
+
+  it('mirror host is a private/link-local address: should reject before downloading (#799)', async () => {
+    const tp = path.join(__dirname, 'MirrorHostIsPrivateReject.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    await tr.runAsync();
+
+    runValidations(() => {
+      assert(tr.failed, 'task should have failed');
+      assert(
+        tr.errorIssues.some(e => e.includes('MirrorDownloadHostIsPrivate')),
+        'should fail via the mirror private-address check. errors: ' + tr.errorIssues,
+      );
+    }, tr);
+  });
+
+  it('mirror download redirects to a private/metadata address: should reject the redirect hop (#799)', async () => {
+    const tp = path.join(__dirname, 'MirrorRedirectToPrivateReject.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    await tr.runAsync();
+
+    runValidations(() => {
+      assert(tr.failed, 'task should have failed');
+      assert(
+        tr.errorIssues.some(e => e.includes('MirrorDownloadHostIsPrivate')),
+        'should fail via the mirror private-address check on the redirect hop. errors: ' + tr.errorIssues,
       );
     }, tr);
   });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorAllowedHostAccept.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorAllowedHostAccept.ts
@@ -2,38 +2,29 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
+// #799 follow-up: mirrorAllowedHosts is set and the mirror host is a PRIVATE IP
+// address that would otherwise be refused by the default baseline check --
+// proving an operator running a legitimate mirror on a private/internal
+// address (e.g. an air-gapped environment) can opt back in, mirroring the
+// registry path's registryAllowedHosts escape hatch exactly.
 const tp = path.join(__dirname, 'RunInstaller.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('version', '0.24.0');
 tr.setInput('downloadSource', 'mirror');
-tr.setInput('mirrorBaseUrl', 'https://artifacts.example.com/terraform-docs');
+tr.setInput('mirrorBaseUrl', 'https://10.0.5.10/terraform-docs');
+tr.setInput('mirrorAllowedHosts', '10.0.5.10');
+tr.setInput('requireChecksum', 'false');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
-// dns: the mirror host is a fake test domain; mock it to a public (non-private/
-// link-local) address so the #799 initial-host check passes without a real
-// network lookup.
-tr.registerMock('dns', {
-  promises: {
-    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
-  }
-});
-
-const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
-
 tr.registerMock('./http-client', {
   fetchJson: async (url: string) => { throw new Error('Mirror path should not fetch json: ' + url); },
-  fetchTextAllow404: async (url: string) => {
-    if (url.endsWith('.sha256sum')) {
-      return `${EXPECTED_SHA256}  terraform-docs-v0.24.0-linux-amd64.tar.gz\n`;
-    }
-    throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
-  },
-  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
-    // Mirror downloads now go through downloadToFile (#799); simulate a benign
-    // successful download.
-    isHostAllowed(new URL(_url).hostname);
+  fetchTextAllow404: async () => null, // no .sha256sum; requireChecksum=false -> warn + proceed
+  downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Genuinely exercises the isHostAllowed callback against mirrorAllowedHosts,
+    // proving the pinned private-IP host is accepted.
+    isHostAllowed(new URL(url).hostname);
   },
   DOWNLOAD_TIMEOUT_MS: 30000
 });
@@ -42,16 +33,12 @@ tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-archive'))
+  readFileSync: () => Buffer.from('fake-archive')
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => {
-    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
-    hash.digest = () => EXPECTED_SHA256;
-    return hash;
-  }
+  createHash: () => ({ update: () => ({ digest: () => 'unused' }) })
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorChecksumFetch5xxFail.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorChecksumFetch5xxFail.ts
@@ -11,6 +11,15 @@ tr.setInput('mirrorBaseUrl', 'https://artifacts.example.com/terraform-docs');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup, reaching the checksum-fetch failure this test exercises.
+tr.registerMock('dns', {
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
+});
+
 // A NON-404 mirror .sha256sum fetch failure (e.g. a 5xx after http-client retries)
 // must be FATAL, not treated as "checksum absent". fetchTextAllow404 returns null
 // ONLY for a genuine 404; here it throws, so the install must fail closed rather
@@ -20,7 +29,13 @@ tr.registerMock('./http-client', {
   fetchJson: async (url: string) => { throw new Error('Mirror path should not fetch json: ' + url); },
   fetchTextAllow404: async () => {
     throw new Error('HTTP 503 fetching .sha256sum (server error, exhausted retries)');
-  }
+  },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Mirror downloads now go through downloadToFile (#799); simulate a benign
+    // successful download so the checksum-fetch failure under test is reached.
+    isHostAllowed(new URL(_url).hostname);
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });
@@ -37,7 +52,9 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
   findLocalTool: () => null,
-  downloadTool: async () => '/tmp/terraform-docs-download.tar.gz',
+  downloadTool: async () => {
+    throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
+  },
   extractTar: async () => '/tmp/terraform-docs-extracted',
   extractZip: async () => { throw new Error('extractZip should not be called on Linux'); },
   cacheDir: async () => '/tmp/terraform-docs-cached',

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorHostIsPrivateReject.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorHostIsPrivateReject.ts
@@ -1,0 +1,49 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #799 (follow-up to #729): mirrorBaseUrl's host is a literal private/link-local
+// address (the cloud metadata service). Unlike the registry path's download_url
+// (dynamically returned by a remote API), mirrorBaseUrl is operator-configured --
+// but the task must still refuse it outright before ever attempting a download.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('version', '0.24.0');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://169.254.169.254/terraform-docs');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('Mirror path should not fetch json: ' + url); },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, _isHostAllowed: (hostname: string) => void) => {
+    throw new Error('downloadToFile should not be reached for a mirror host that is a literal private/link-local address');
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid',
+  createHash: () => ({ update: () => ({ digest: () => 'should-not-be-reached' }) })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => null,
+  downloadTool: async () => {
+    throw new Error('downloadTool should not be reached for a mirror host that is a private/link-local address');
+  },
+  extractTar: async () => { throw new Error('extractTar should not be reached'); },
+  extractZip: async () => { throw new Error('extractZip should not be reached'); },
+  cacheDir: async () => '/tmp/terraform-docs-cached',
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/terraform-docs-cached': ['/tmp/terraform-docs-cached/terraform-docs'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorRedirectToPrivateReject.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorRedirectToPrivateReject.ts
@@ -2,6 +2,10 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
+// #799 (follow-up to #729): mirrorBaseUrl's own host is benign, but the (simulated)
+// download follows a redirect to the cloud metadata address 169.254.169.254 --
+// proving the mirror path re-validates every redirect hop via downloadToFile, not
+// just the initial host (mirrors the registry path's #729 follow-up fix).
 const tp = path.join(__dirname, 'RunInstaller.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
@@ -11,29 +15,20 @@ tr.setInput('mirrorBaseUrl', 'https://artifacts.example.com/terraform-docs');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
-// dns: the mirror host is a fake test domain; mock it to a public (non-private/
-// link-local) address so the #799 initial-host check passes without a real
-// network lookup.
+// dns: the mirror host itself is benign (this test is about the REDIRECT hop,
+// not the initial host); mock it to a public address so the initial-host check
+// passes without a real network lookup, reaching the downloadToFile call.
 tr.registerMock('dns', {
   promises: {
     lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
   }
 });
 
-const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
-
 tr.registerMock('./http-client', {
   fetchJson: async (url: string) => { throw new Error('Mirror path should not fetch json: ' + url); },
-  fetchTextAllow404: async (url: string) => {
-    if (url.endsWith('.sha256sum')) {
-      return `${EXPECTED_SHA256}  terraform-docs-v0.24.0-linux-amd64.tar.gz\n`;
-    }
-    throw new Error('Unexpected fetchTextAllow404 URL: ' + url);
-  },
   downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
-    // Mirror downloads now go through downloadToFile (#799); simulate a benign
-    // successful download.
-    isHostAllowed(new URL(_url).hostname);
+    // Simulate a redirect hop landing on the cloud metadata service.
+    isHostAllowed('169.254.169.254');
   },
   DOWNLOAD_TIMEOUT_MS: 30000
 });
@@ -42,25 +37,21 @@ tr.registerMock('undici', { ProxyAgent: class { } });
 
 tr.registerMock('fs', {
   chmodSync: () => { },
-  createReadStream: () => require('stream').Readable.from(Buffer.from('fake-archive'))
+  readFileSync: () => Buffer.from('fake-archive')
 });
 
 tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
-  createHash: () => {
-    const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
-    hash.digest = () => EXPECTED_SHA256;
-    return hash;
-  }
+  createHash: () => ({ update: () => ({ digest: () => 'should-not-be-reached' }) })
 });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
   findLocalTool: () => null,
   downloadTool: async () => {
-    throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
+    throw new Error('downloadTool should not be reached -- downloadToFile must be used so every redirect hop is re-validated');
   },
-  extractTar: async () => '/tmp/terraform-docs-extracted',
-  extractZip: async () => { throw new Error('extractZip should not be called on Linux'); },
+  extractTar: async () => { throw new Error('extractTar should not be reached'); },
+  extractZip: async () => { throw new Error('extractZip should not be reached'); },
   cacheDir: async () => '/tmp/terraform-docs-cached',
   cleanVersion: (v: string) => v,
   prependPath: () => { }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorUserInfoRedacted.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/MirrorUserInfoRedacted.ts
@@ -17,9 +17,26 @@ tr.setInput('requireChecksum', 'false');
 
 tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
 
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
+});
+
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => { throw new Error('Mirror path should not fetch json: ' + url); },
-    fetchTextAllow404: async () => null // no .sha256sum; requireChecksum=false -> warn + proceed
+    fetchTextAllow404: async () => null, // no .sha256sum; requireChecksum=false -> warn + proceed
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        // The actual download must retain the credential to reach the mirror.
+        if (!url.includes('user:s3cr3t@artifacts.example.com')) {
+            throw new Error('mirror download URL must retain the basic-auth userinfo; got: ' + url);
+        }
+        isHostAllowed(new URL(url).hostname);
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });
@@ -36,12 +53,8 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: () => null,
-    downloadTool: async (url: string) => {
-        // The actual download must retain the credential to reach the mirror.
-        if (!url.includes('user:s3cr3t@artifacts.example.com')) {
-            throw new Error('mirror download URL must retain the basic-auth userinfo; got: ' + url);
-        }
-        return '/tmp/terraform-docs-download.tar.gz';
+    downloadTool: async () => {
+        throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
     },
     extractTar: async () => '/tmp/terraform-docs-extracted',
     extractZip: async () => { throw new Error('extractZip should not be called on Linux'); },

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -300,7 +300,7 @@ async function downloadFromMirror(version: string, mirrorBaseUrl: string): Promi
     }
     const assetName = getAssetName(version);
     const downloadUrl = `${mirrorBaseUrl}/${version}/${assetName}`;
-    const archivePath = await downloadTo(downloadUrl, `terraform-docs-${version}-${uuidV4()}.${getArchiveExtension()}`);
+    const archivePath = await downloadFromMirrorUrl(downloadUrl, `terraform-docs-${version}-${uuidV4()}.${getArchiveExtension()}`);
 
     const sha256Url = `${mirrorBaseUrl}/${version}/terraform-docs-v${version}.sha256sum`;
     const verified = await verifyChecksumOrSkip(archivePath, sha256Url, assetName, "mirror");
@@ -344,6 +344,51 @@ async function downloadTo(url: string, fileName: string): Promise<string> {
         // the interpolated message (no-op for the official GitHub release URLs) (#586).
         throw new Error(tasks.loc("TerraformDocsDownloadFailed", redactUrlUserInfo(url), exception));
     }
+}
+
+/**
+ * Mirror-only download path (#799, follow-up to #729). mirrorBaseUrl is an
+ * operator-configured input (unlike the registry path's dynamically-returned
+ * download_url), but a compromised/misconfigured mirror SERVICE could still
+ * redirect the actual download at a private/link-local address (notably the
+ * cloud metadata service). Checks the initial host up front, then re-validates
+ * every redirect hop via downloadToFile() -- unlike downloadTo() above (used
+ * for the official/GitHub path, left unchanged), which calls
+ * tools.downloadTool() and follows redirects with no way to re-validate them,
+ * the same underlying gap #729 closed for the registry path. An operator
+ * running a legitimate mirror on a private/internal address (a real,
+ * pre-existing use case -- the registry path's own registryAllowedHosts
+ * exists for exactly this reason) can opt in via mirrorAllowedHosts,
+ * mirroring the registry path's allowlist shape exactly.
+ */
+async function downloadFromMirrorUrl(url: string, fileName: string): Promise<string> {
+    const mirrorAllowedHosts = parseAllowedHosts(tasks.getInput("mirrorAllowedHosts", false));
+    const initialHost = new URL(url).hostname;
+    if (mirrorAllowedHosts.length > 0) {
+        if (!isRegistryHostAllowed(initialHost, mirrorAllowedHosts)) {
+            throw new Error(tasks.loc("MirrorDownloadHostNotAllowed", initialHost, mirrorAllowedHosts.join(', ')));
+        }
+    } else if (isPrivateOrLinkLocalHost(initialHost) || await resolvesToPrivateOrLinkLocalAddress(initialHost)) {
+        throw new Error(tasks.loc("MirrorDownloadHostIsPrivate", initialHost));
+    }
+    const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+    const destPath = path.join(destDir, fileName);
+    try {
+        await downloadToFile(url, destPath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+            if (mirrorAllowedHosts.length > 0) {
+                if (!isRegistryHostAllowed(hostname, mirrorAllowedHosts)) {
+                    throw new Error(tasks.loc("MirrorDownloadHostNotAllowed", hostname, mirrorAllowedHosts.join(', ')));
+                }
+            } else if (isPrivateOrLinkLocalHost(hostname)) {
+                throw new Error(tasks.loc("MirrorDownloadHostIsPrivate", hostname));
+            }
+        });
+    } catch (exception) {
+        // A mirror download URL can embed operator basic-auth userinfo; strip it from
+        // the interpolated message (#586).
+        throw new Error(tasks.loc("TerraformDocsDownloadFailed", redactUrlUserInfo(url), exception));
+    }
+    return destPath;
 }
 
 export function parseSha256(sha256SumsContent: string, fileName: string): string {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -78,6 +78,15 @@
       "helpMarkDown": "Base URL of your binary mirror. Must use HTTPS. Must serve files at the same path structure as the official releases (e.g. https://artifacts.example.com/terraform-docs, serving {base}/{version}/terraform-docs-v{version}-{os}-{arch}.{ext})."
     },
     {
+      "name": "mirrorAllowedHosts",
+      "type": "string",
+      "label": "Allowed mirror download hosts",
+      "defaultValue": "",
+      "required": false,
+      "visibleRule": "downloadSource = mirror",
+      "helpMarkDown": "Optional comma- or newline-separated allowlist of hostnames the mirror download is permitted to use (e.g. mirror.example.com, or *.internal.example.com to allow any subdomain). When empty (default), a mirror host that is a private/link-local address (e.g. the cloud metadata service) is refused. Set this to explicitly allow a legitimate private/internal mirror -- including one on a private IP -- for an air-gapped or otherwise network-isolated environment."
+    },
+    {
       "name": "requireChecksum",
       "type": "boolean",
       "label": "Require checksum verification",
@@ -132,6 +141,8 @@
     "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s",
     "RegistryDownloadHostNotAllowed": "Registry download_url host '%s' is not in registryAllowedHosts: %s",
     "RegistryDownloadHostIsPrivate": "Registry download_url host '%s' is a private/link-local address, which is refused by default (a common SSRF target, e.g. the cloud metadata service). Set registryAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
+    "MirrorDownloadHostIsPrivate": "Mirror download host '%s' is a private/link-local address, which is refused (a common SSRF target, e.g. the cloud metadata service). Set mirrorAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
+    "MirrorDownloadHostNotAllowed": "Mirror download host '%s' is not in mirrorAllowedHosts: %s",
     "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
     "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
     "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyMirrorWithheld.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitReverifyMirrorWithheld.ts
@@ -20,7 +20,17 @@ tr.setInput('requireGpgSignature', 'true');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
+});
+
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup, reaching the reverify-classification logic under test.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
 });
 
 tr.registerMock('./http-client', {
@@ -31,7 +41,13 @@ tr.registerMock('./http-client', {
         throw new Error('fetchText should not be called: use fetchTextAllow404. Called with: ' + url);
     },
     // Genuine 404 for the required SHA256SUMS -> reachable mirror withholding material.
-    fetchTextAllow404: async (_url: string) => null
+    fetchTextAllow404: async (_url: string) => null,
+    // Mirror downloads now go through downloadToFile (#799); simulate a benign
+    // successful download so the reverify-classification logic under test runs.
+    downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        isHostAllowed(new URL(_url).hostname);
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('undici', { ProxyAgent: class { } });
@@ -56,7 +72,9 @@ tr.registerMock('crypto', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => '/tmp/terraform-cached',
-    downloadTool: async (_url: string, _fileName: string) => '/tmp/terraform-reverify.zip',
+    downloadTool: async (_url: string, _fileName: string) => {
+        throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
+    },
     extractZip: async (_zipPath: string) => {
         throw new Error('extractZip must not be reached when required material is withheld');
     },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -459,6 +459,59 @@ describe('TerraformInstaller Test Suite', function () {
         }, tr);
     });
 
+    it('mirror host is a private/link-local address: should reject before downloading (#799)', async () => {
+        const tp = path.join(__dirname, 'MirrorHostIsPrivateReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some((e) => e.includes('MirrorDownloadHostIsPrivate')),
+                'should fail via the mirror private-address check. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
+    it('mirror host resolves to a private address: should reject via DNS-resolution check, not just literal-IP (#799)', async () => {
+        const tp = path.join(__dirname, 'MirrorHostResolvesPrivateReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some((e) => e.includes('MirrorDownloadHostIsPrivate')),
+                'should fail via the mirror private-address check on the resolved address. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
+    it('mirror download redirects to a private/metadata address: should reject the redirect hop (#799)', async () => {
+        const tp = path.join(__dirname, 'MirrorRedirectToPrivateReject.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some((e) => e.includes('MirrorDownloadHostIsPrivate')),
+                'should fail via the mirror private-address check on the redirect hop. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
+    it('mirror allowed host: should succeed when a private-IP mirror host is explicitly pinned via mirrorAllowedHosts (#799)', async () => {
+        const tp = path.join(__dirname, 'MirrorAllowedHostAccept.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
     it('registry insecure download_url: should reject a non-https pre-signed URL', async () => {
         const tp = path.join(__dirname, 'RegistryInsecureUrlReject.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorAllowedHostAccept.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorAllowedHostAccept.ts
@@ -2,13 +2,20 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-// Reuses the generic MirrorCustomUrlSuccessL0 entry (runs downloadTerraform).
-const tp = path.join(__dirname, 'MirrorCustomUrlSuccessL0.js');
+// #799 follow-up: mirrorAllowedHosts is set and the mirror host is a PRIVATE IP
+// address that would otherwise be refused by the default baseline check --
+// proving an operator running a legitimate mirror on a private/internal
+// address (e.g. an air-gapped environment) can opt back in, mirroring the
+// registry path's registryAllowedHosts escape hatch exactly.
+const tp = path.join(__dirname, 'MirrorAllowedHostAcceptL0.js');
 const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('terraformVersion', '1.9.8');
 tr.setInput('downloadSource', 'mirror');
-tr.setInput('mirrorBaseUrl', 'https://artifacts.example.com/hashicorp/terraform');
+tr.setInput('mirrorBaseUrl', 'https://10.0.5.10/hashicorp/terraform');
+tr.setInput('mirrorAllowedHosts', '10.0.5.10');
+tr.setInput('requireChecksum', 'false');
+tr.setInput('requireGpgSignature', 'false');
 
 tr.registerMock('os', {
   type: () => 'Windows_NT',
@@ -16,42 +23,26 @@ tr.registerMock('os', {
   tmpdir: () => '/tmp'
 });
 
-// dns: the mirror host is a fake test domain; mock it to a public (non-private/
-// link-local) address so the #799 initial-host check passes without a real
-// network lookup, reaching the checksum-fetch failure this test exercises.
-tr.registerMock('dns', {
-  promises: {
-    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
-  }
-});
-
-// A NON-404 mirror SHA256SUMS fetch failure (e.g. a 5xx after the retries baked into
-// http-client) must be FATAL, not classified as "checksum absent". fetchTextAllow404
-// returns null ONLY for a genuine 404; here it throws, so the install must fail closed
-// even though requireChecksum / requireGpgSignature are left at their (true) defaults.
 tr.registerMock('./http-client', {
   fetchJson: async (url: string) => {
     throw new Error('fetchJson should not be called for mirror download. Called with: ' + url);
   },
-  fetchTextAllow404: async () => {
-    throw new Error('HTTP 503 fetching SHA256SUMS (server error, exhausted retries)');
-  },
-  // Mirror downloads now go through downloadToFile (#799); simulate a benign
-  // successful download so the checksum-fetch failure under test is reached.
+  fetchTextAllow404: async () => null, // no SHA256SUMS; requireChecksum=false -> warn + proceed
   downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Genuinely exercises the isHostAllowed callback terraform-installer.ts
+    // builds (real isRegistryHostAllowed logic against mirrorAllowedHosts),
+    // proving the pinned private-IP host is accepted rather than refused by
+    // the default baseline private/link-local check.
     isHostAllowed(new URL(url).hostname);
   },
   DOWNLOAD_TIMEOUT_MS: 30000
 });
 
-tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 tr.registerMock('undici', { ProxyAgent: class { } });
-tr.registerMock('./gpg-verifier', {
-  verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
-});
-tr.registerMock('./cosign-verifier', {
-  verifyCosignSignature: async () => { }
-});
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+tr.registerMock('./cosign-verifier', { verifyCosignSignature: async () => { } });
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
   findLocalTool: (_toolName: string, _version: string) => null,

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorAllowedHostAcceptL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorAllowedHostAcceptL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+  try {
+    await downloadTerraform('1.9.8');
+    tl.setResult(tl.TaskResult.Succeeded, 'MirrorAllowedHostAcceptL0 should have succeeded.');
+  } catch (error) {
+    tl.setResult(tl.TaskResult.Failed, 'MirrorAllowedHostAcceptL0 failed: ' + error.message);
+  }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccess.ts
@@ -16,9 +16,17 @@ tr.setInput('requireGpgSignature', 'false');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
 });
-
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup, reaching the downloadToFile call this test exercises.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
+});
 // http-client: mirror download — fetchText for SHA256SUMS will fail (unavailable), which is caught and warned
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => {
@@ -28,7 +36,19 @@ tr.registerMock('./http-client', {
         // Mirror SHA256SUMS is genuinely absent (404) — fetchTextAllow404 returns
         // null; with requireChecksum=false the installer warns and proceeds.
         return null;
-    }
+    },
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        // Mirror downloads now go through downloadToFile (#799), not
+        // tools.downloadTool, so every redirect hop is re-validated --
+        // isHostAllowed() is called here exactly as the real implementation
+        // calls it for the initial host. Also verify the mirror URL structure.
+        const expectedUrl = 'https://artifacts.example.com/hashicorp/terraform/1.9.8/terraform_1.9.8_windows_amd64.zip';
+        if (url !== expectedUrl) {
+            throw new Error('Unexpected download URL: ' + url + '. Expected: ' + expectedUrl);
+        }
+        isHostAllowed(new URL(url).hostname);
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
@@ -45,13 +65,8 @@ tr.registerMock('./cosign-verifier', {
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => null,
-    downloadTool: async (url: string, _fileName: string) => {
-        // Verify the mirror URL has the correct structure
-        const expectedUrl = 'https://artifacts.example.com/hashicorp/terraform/1.9.8/terraform_1.9.8_windows_amd64.zip';
-        if (url !== expectedUrl) {
-            throw new Error('Unexpected download URL: ' + url + '. Expected: ' + expectedUrl);
-        }
-        return '/tmp/terraform.zip';
+    downloadTool: async (_url: string, _fileName: string) => {
+        throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
     },
     extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
     cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostIsPrivateReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostIsPrivateReject.ts
@@ -1,0 +1,62 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #799 (follow-up to #729): mirrorBaseUrl's host is a literal private/link-local
+// address (the cloud metadata service). Unlike the registry path's download_url
+// (dynamically returned by a remote API), mirrorBaseUrl is operator-configured --
+// but the task must still refuse it outright before ever attempting a download.
+const tp = path.join(__dirname, 'MirrorHostIsPrivateRejectL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://169.254.169.254/hashicorp/terraform');
+
+tr.registerMock('os', {
+  type: () => 'Windows_NT',
+  arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    throw new Error('fetchJson should not be called for mirror download. Called with: ' + url);
+  },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, _isHostAllowed: (hostname: string) => void) => {
+    throw new Error('downloadToFile should not be reached for a mirror host that is a literal private/link-local address');
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+tr.registerMock('./cosign-verifier', { verifyCosignSignature: async () => { } });
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid-1234',
+  createHash: (_algorithm: string) => ({
+    update: (_data: any) => ({
+      digest: (_encoding: string) => 'should-not-be-reached'
+    })
+  })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: (_toolName: string, _version: string) => null,
+  downloadTool: async (_url: string, _fileName: string) => {
+    throw new Error('downloadTool should not be reached for a mirror host that is a private/link-local address');
+  },
+  extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+  cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+  cleanVersion: (version: string) => version,
+  prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  'find': {
+    '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostIsPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostIsPrivateRejectL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+  try {
+    await downloadTerraform('1.9.8');
+    tl.setResult(tl.TaskResult.Succeeded, 'MirrorHostIsPrivateRejectL0 should have succeeded.');
+  } catch (error) {
+    tl.setResult(tl.TaskResult.Failed, 'MirrorHostIsPrivateRejectL0 failed: ' + error.message);
+  }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostResolvesPrivateReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostResolvesPrivateReject.ts
@@ -1,0 +1,73 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #799: the mirror host is an ordinary-looking DNS name -- not a literal private
+// IP, so isPrivateOrLinkLocalHost alone would miss it -- but it resolves (via the
+// mocked dns module below) to the cloud metadata address 169.254.169.254. The
+// task must still reject before downloading, proving the mirror path's initial-
+// host check uses resolvesToPrivateOrLinkLocalAddress (the DNS-resolution
+// variant), not just a literal-IP check (mirrors the registry path's #769 test).
+const tp = path.join(__dirname, 'MirrorHostResolvesPrivateRejectL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://mirror.example.com/hashicorp/terraform');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
+});
+
+// dns: mirror.example.com is not a literal private IP but resolves to the cloud
+// metadata address -- the resolvesToPrivateOrLinkLocalAddress check must catch it.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '169.254.169.254', family: 4 }]
+    }
+});
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        throw new Error('fetchJson should not be called for mirror download. Called with: ' + url);
+    },
+    downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, _isHostAllowed: (hostname: string) => void) => {
+        throw new Error('downloadToFile should not be reached for a mirror host that resolves to a private address');
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+tr.registerMock('./cosign-verifier', { verifyCosignSignature: async () => { } });
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid-1234',
+    createHash: (_algorithm: string) => ({
+        update: (_data: any) => ({
+            digest: (_encoding: string) => 'should-not-be-reached'
+        })
+    })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => null,
+    downloadTool: async (_url: string, _fileName: string) => {
+        throw new Error('downloadTool should not be reached for a mirror host that resolves to a private address');
+    },
+    extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostResolvesPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostResolvesPrivateRejectL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+  try {
+    await downloadTerraform('1.9.8');
+    tl.setResult(tl.TaskResult.Succeeded, 'MirrorHostResolvesPrivateRejectL0 should have succeeded.');
+  } catch (error) {
+    tl.setResult(tl.TaskResult.Failed, 'MirrorHostResolvesPrivateRejectL0 failed: ' + error.message);
+  }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectToPrivateReject.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectToPrivateReject.ts
@@ -1,0 +1,76 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #799 (follow-up to #729): mirrorBaseUrl's own host is benign, but the (simulated)
+// download follows a redirect to the cloud metadata address 169.254.169.254 --
+// proving the mirror path re-validates every redirect hop via downloadToFile, not
+// just the initial host (mirrors the registry path's #729 follow-up fix).
+const tp = path.join(__dirname, 'MirrorRedirectToPrivateRejectL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'mirror');
+tr.setInput('mirrorBaseUrl', 'https://artifacts.example.com/hashicorp/terraform');
+
+tr.registerMock('os', {
+  type: () => 'Windows_NT',
+  arch: () => 'x64',
+  tmpdir: () => '/tmp'
+});
+// dns: the mirror host itself is benign (this test is about the REDIRECT hop,
+// not the initial host); mock it to a public address so the initial-host check
+// passes without a real network lookup, reaching the downloadToFile call.
+tr.registerMock('dns', {
+  promises: {
+    lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+  }
+});
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    throw new Error('fetchJson should not be called for mirror download. Called with: ' + url);
+  },
+  downloadToFile: async (_url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+    // Simulate a redirect hop landing on the cloud metadata service.
+    isHostAllowed('169.254.169.254');
+  },
+  DOWNLOAD_TIMEOUT_MS: 30000
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+tr.registerMock('./cosign-verifier', { verifyCosignSignature: async () => { } });
+
+tr.registerMock('fs', {
+  chmodSync: (_path: string, _mode: string) => { },
+  readFileSync: (_path: string) => Buffer.from('fake-zip-content')
+});
+
+tr.registerMock('crypto', {
+  randomUUID: () => 'test-uuid-1234',
+  createHash: (_algorithm: string) => ({
+    update: (_data: any) => ({
+      digest: (_encoding: string) => 'should-not-be-reached'
+    })
+  })
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: (_toolName: string, _version: string) => null,
+  downloadTool: async (_url: string, _fileName: string) => {
+    throw new Error('downloadTool should not be reached -- downloadToFile must be used so every redirect hop is re-validated');
+  },
+  extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
+  cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',
+  cleanVersion: (version: string) => version,
+  prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  'find': {
+    '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectToPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectToPrivateRejectL0.ts
@@ -1,0 +1,16 @@
+import tl = require('azure-pipelines-task-lib/task');
+import path = require('path');
+import { downloadTerraform } from '../src/terraform-installer';
+
+tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
+
+async function run() {
+  try {
+    await downloadTerraform('1.9.8');
+    tl.setResult(tl.TaskResult.Succeeded, 'MirrorRedirectToPrivateRejectL0 should have succeeded.');
+  } catch (error) {
+    tl.setResult(tl.TaskResult.Failed, 'MirrorRedirectToPrivateRejectL0 failed: ' + error.message);
+  }
+}
+
+run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorUserInfoRedacted.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorUserInfoRedacted.ts
@@ -18,14 +18,32 @@ tr.setInput('requireGpgSignature', 'false');
 
 tr.registerMock('os', {
     type: () => 'Windows_NT',
-    arch: () => 'x64'
+    arch: () => 'x64',
+    tmpdir: () => '/tmp'
+});
+
+// dns: the mirror host is a fake test domain; mock it to a public (non-private/
+// link-local) address so the #799 initial-host check passes without a real
+// network lookup, reaching the downloadToFile call this test exercises.
+tr.registerMock('dns', {
+    promises: {
+        lookup: async (_host: string, _opts: any) => [{ address: '203.0.113.10', family: 4 }]
+    }
 });
 
 tr.registerMock('./http-client', {
     fetchJson: async (url: string) => {
         throw new Error('fetchJson should not be called for mirror download. Called with: ' + url);
     },
-    fetchTextAllow404: async () => null // no SHA256SUMS; requireChecksum=false -> warn + proceed
+    fetchTextAllow404: async () => null, // no SHA256SUMS; requireChecksum=false -> warn + proceed
+    downloadToFile: async (url: string, _destPath: string, _timeoutMs: number, isHostAllowed: (hostname: string) => void) => {
+        // The actual download must retain the credential to reach the mirror.
+        if (!url.includes('user:s3cr3t@artifacts.example.com')) {
+            throw new Error('mirror download URL must retain the basic-auth userinfo; got: ' + url);
+        }
+        isHostAllowed(new URL(url).hostname);
+    },
+    DOWNLOAD_TIMEOUT_MS: 30000
 });
 
 tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
@@ -35,12 +53,8 @@ tr.registerMock('./cosign-verifier', { verifyCosignSignature: async () => { } })
 
 tr.registerMock('azure-pipelines-tool-lib/tool', {
     findLocalTool: (_toolName: string, _version: string) => null,
-    downloadTool: async (url: string, _fileName: string) => {
-        // The actual download must retain the credential to reach the mirror.
-        if (!url.includes('user:s3cr3t@artifacts.example.com')) {
-            throw new Error('mirror download URL must retain the basic-auth userinfo; got: ' + url);
-        }
-        return '/tmp/terraform.zip';
+    downloadTool: async (_url: string, _fileName: string) => {
+        throw new Error('downloadTool should not be called for a mirror download -- downloadToFile must be used (#799)');
     },
     extractZip: async (_zipPath: string) => '/tmp/terraform-extracted',
     cacheDir: async (_srcPath: string, _tool: string, _version: string) => '/tmp/terraform-cached',

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -333,10 +333,41 @@ async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Pr
     // Mirror must serve files at the same path structure as releases.hashicorp.com/terraform
     const downloadUrl = `${mirrorBaseUrl}/${version}/terraform_${version}_${osPlatform}_${arch}.zip`;
 
+    // Baseline SSRF protection (#799, follow-up to #729): mirrorBaseUrl is an
+    // operator-configured input (unlike the registry path's dynamically-returned
+    // download_url), but a compromised/misconfigured mirror SERVICE could still
+    // redirect the actual download at a private/link-local address (notably the
+    // cloud metadata service). Check the initial host up front, then re-validate
+    // every redirect hop via downloadToFile() below -- tools.downloadTool() (the
+    // prior implementation) follows redirects with no way to re-validate them,
+    // the same underlying gap #729 closed for the registry path. An operator
+    // running a legitimate mirror on a private/internal address (a real,
+    // pre-existing use case -- the registry path's own registryAllowedHosts
+    // exists for exactly this reason) can opt in via mirrorAllowedHosts,
+    // mirroring the registry path's allowlist shape exactly.
+    const mirrorAllowedHosts = parseAllowedHosts(tasks.getInput("mirrorAllowedHosts", false));
+    const initialHost = new URL(downloadUrl).hostname;
+    if (mirrorAllowedHosts.length > 0) {
+        if (!isRegistryHostAllowed(initialHost, mirrorAllowedHosts)) {
+            throw new Error(tasks.loc("MirrorDownloadHostNotAllowed", initialHost, mirrorAllowedHosts.join(', ')));
+        }
+    } else if (isPrivateOrLinkLocalHost(initialHost) || await resolvesToPrivateOrLinkLocalAddress(initialHost)) {
+        throw new Error(tasks.loc("MirrorDownloadHostIsPrivate", initialHost));
+    }
+
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
-    let zipPath: string;
+    const destDir = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
+    const zipPath = path.join(destDir, fileName);
     try {
-        zipPath = await tools.downloadTool(downloadUrl, fileName);
+        await downloadToFile(downloadUrl, zipPath, DOWNLOAD_TIMEOUT_MS, (hostname) => {
+            if (mirrorAllowedHosts.length > 0) {
+                if (!isRegistryHostAllowed(hostname, mirrorAllowedHosts)) {
+                    throw new Error(tasks.loc("MirrorDownloadHostNotAllowed", hostname, mirrorAllowedHosts.join(', ')));
+                }
+            } else if (isPrivateOrLinkLocalHost(hostname)) {
+                throw new Error(tasks.loc("MirrorDownloadHostIsPrivate", hostname));
+            }
+        });
     } catch (exception) {
         // downloadUrl embeds mirrorBaseUrl (possibly with userinfo); strip it from the
         // interpolated message (the userinfo is also setSecret-masked above) (#586).

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -91,6 +91,15 @@
             "helpMarkDown": "Base URL of your binary mirror. Must use HTTPS. Must serve files at the same path structure as releases.hashicorp.com/terraform. Example: https://artifacts.example.com/hashicorp/terraform"
         },
         {
+            "name": "mirrorAllowedHosts",
+            "type": "string",
+            "label": "Allowed mirror download hosts",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "binary = terraform && downloadSource = mirror",
+            "helpMarkDown": "Optional comma- or newline-separated allowlist of hostnames the mirror download is permitted to use (e.g. mirror.example.com, or *.internal.example.com to allow any subdomain). When empty (default), a mirror host that is a private/link-local address (e.g. the cloud metadata service) is refused. Set this to explicitly allow a legitimate private/internal mirror -- including one on a private IP -- for an air-gapped or otherwise network-isolated environment."
+        },
+        {
             "name": "requireGpgSignature",
             "type": "boolean",
             "label": "Require GPG signature verification",
@@ -173,6 +182,8 @@
         "ResolvedVersionFromRegistry": "Resolved latest version from registry: %s",
         "RegistryDownloadHostNotAllowed": "Registry download_url host '%s' is not in registryAllowedHosts: %s",
         "RegistryDownloadHostIsPrivate": "Registry download_url host '%s' is a private/link-local address, which is refused by default (a common SSRF target, e.g. the cloud metadata service). Set registryAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
+        "MirrorDownloadHostIsPrivate": "Mirror download host '%s' is a private/link-local address, which is refused (a common SSRF target, e.g. the cloud metadata service). Set mirrorAllowedHosts to explicitly allow this host if it is a legitimate internal mirror.",
+        "MirrorDownloadHostNotAllowed": "Mirror download host '%s' is not in mirrorAllowedHosts: %s",
         "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
         "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
         "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",


### PR DESCRIPTION
## Summary

Batch E of the 2026-07-22 accepted-risk remediation pass. Fixes **#799** (high severity) — "Mirror download path lacks the SSRF/redirect-to-private-address protection just added for the registry path", a follow-up to the #729/#550 registry-path fix.

Run through the `issue-remediation.copilot.md` 3-agent adversarial review process. **Round 1: 1/3 approve** (both rejecters independently flagged a real air-gapped regression). **Round 2 after adding the escape hatch: 2/3 approve** — consensus met, one final blocking item fixed.

## #799 — mirror-path SSRF hardening

Each installer task's mirror-download function (`downloadZipFromMirror`/`downloadFromMirror` in `TerraformInstallerV1`/`PolicyAgentInstallerV1`/`TerraformDocsInstallerV1`) built a URL from the operator-configured `mirrorBaseUrl`, checked only `startsWith('https://')`, then called `tools.downloadTool()` directly — with **no initial-host check** against private/link-local addresses and **no redirect-hop re-validation** (the same underlying gap #729 closed for the registry path, notably exposing the cloud metadata service at `169.254.169.254`).

Fix, applied to all 3 tasks (mirroring the registry path's existing pattern):
1. **Initial-host check** via `isPrivateOrLinkLocalHost` + `resolvesToPrivateOrLinkLocalAddress` before downloading (throws `MirrorDownloadHostIsPrivate`).
2. **Redirect-hop re-validation** by routing the download through the shared `downloadToFile()` helper (already used by the registry path) with a validator re-checking every hop — unlike `tools.downloadTool()`, which follows redirects unvalidated.
3. **Optional `mirrorAllowedHosts` opt-in** (added in review round 2, mirroring `registryAllowedHosts` exactly): empty (default) = enforce the private/link-local baseline; non-empty = trust the operator's explicit host pin (including a private IP) and re-validate every redirect hop against that allowlist. This preserves the documented **air-gapped/private-mirror** use case that an escape-hatch-less baseline check would have broken.

`TerraformInstallerV1` inlines the check in `downloadZipFromMirror`; `PolicyAgentInstaller`/`TerraformDocs` use a new `downloadFromMirrorUrl()` helper so the official/GitHub path's `downloadTo()` helper stays untouched.

## Review history

- **Round 1 (1/3)**: `correctness` approved. `regression-conventions` and `test-adequacy-siblings` both **rejected**, independently: the fix rejected ALL private/link-local mirror hosts with no escape hatch — unlike the registry path's `registryAllowedHosts` — **breaking the documented air-gapped private-mirror use case** (referenced in `overview.md`/`README.md`/`SECURITY.md`). Validated as real and fixed by adding `mirrorAllowedHosts` plus a positive escape-hatch test and the missing DNS-resolves-to-private test.
- **Round 2 (2/3, consensus met)**: `correctness` and `test-adequacy-siblings` approved (both confirmed the escape hatch resolves the regression, and that the PackerInstaller cross-repo sibling is a legitimate follow-up, not a must-fix-now gap). `regression-conventions` rejected on one valid blocking item: `mirrorAllowedHosts`'s `visibleRule` was `downloadSource = mirror` but should be `binary = terraform && downloadSource = mirror` (matching the sibling `registryAllowedHosts`) — because `downloadTerraform()` returns early to `downloadTofu()` for `binary=tofu`, and `downloadTofu()` ignores `downloadSource` (OpenTofu only downloads from its GitHub releases), so the mirror path is terraform-only. **Fixed** (visibleRule-only metadata change; no runtime change, since the runtime check already only runs for terraform).

## Sibling-scouting

- All 3 installer-family tasks share the defect and are all fixed (the complete sibling set #799 names).
- `TerraformProviderMirrorV1` checked and ruled out (different architecture — no configurable-mirror-URL binary download).
- **`PackerInstallerV1`** (in the SEPARATE `azure-pipelines-packer` repo) has the identical gap (`downloadZipFromMirror` via `downloadToolWithTimeout`, no host check) — **verified real, but out of scope** for a terraform-repo batch. Recommended as a follow-up issue against the packer repo (not filed yet — awaiting user approval per the net-new-issue gate).

## Test-fixture work (transparency)

Switching the mirror path from `tools.downloadTool()` to `downloadToFile()` broke **11 pre-existing** mirror fixtures across the 3 tasks (they mocked `downloadTool`, not `downloadToFile`) — all updated to mock `downloadToFile` with the same assertions, with the old `downloadTool` mocks changed to throw-if-reached tripwires. Also added `dns` mocks (the new initial-host check does a real DNS lookup for hostname mirrors) and `os.tmpdir` mocks where needed, matching the registry path's own fixture conventions.

## Verification

- `npm test`: `TerraformInstallerV1` **175 passing / 0 failing**; `PolicyAgentInstallerV1` **117 passing / 0 failing**; `TerraformDocsInstallerV1` **105 passing / 0 failing**
- `npm run test:coverage`: `check-per-file-coverage` passes for all 3 tasks
- `node scripts/check-shared-modules.js`: all parity checks pass (the shared `http-client.ts`/`registry-allowlist.ts` this fix depends on are unmodified)
- `node scripts/check-minor-bumps.js`: all 3 changed installer tasks already carry their required Minor bump relative to `v1.11.1` (from the merged Batch A)

Closes #799
