### PR TITLE
fix: audit-2026-07-22 remediation - installer resolve/verify hardening (#790, #778)

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitHashUnavailableStrict.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitHashUnavailableStrict.ts
@@ -1,0 +1,54 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #778 companion to CacheHitHashUnavailable: same scenario (cache hit, no
+// integrity marker, source unreachable during re-verification) but with the
+// opt-in requireOnlineReverification=true. The task must FAIL CLOSED
+// (CachedToolReverificationSourceUnreachable) instead of degrading to a warning
+// and trusting the unverified cache entry.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'official');
+tr.setInput('requireOnlineReverification', 'true');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('fetchJson should not be called for a specific version: ' + url); },
+  fetchTextAllow404: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while fetching ${url}`); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+tr.registerMock('fs', {
+  existsSync: (_p: string) => false,
+  readFileSync: (_p: string, _enc?: string) => {
+    throw new Error('readFileSync should not be called when the re-verification download failed');
+  },
+  writeFileSync: () => { throw new Error('writeFileSync should not be called when re-verification failed closed'); },
+  chmodSync: () => { },
+  mkdirSync: () => undefined,
+  copyFileSync: () => { }
+});
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid' });
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => '/tmp/opa-cached',
+  downloadTool: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while downloading ${url}`); },
+  extractZip: async () => { throw new Error('extractZip should not be called when the re-verification download failed'); },
+  cacheDir: async () => { throw new Error('cacheDir should not be called on a cache hit'); },
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -135,6 +135,23 @@ describe('PolicyAgentInstaller Test Suite', function () {
         }, tr);
     });
 
+    it('cache hit, no marker, source unreachable, requireOnlineReverification=true: fails closed instead of degrading (#778)', async () => {
+        const tp = path.join(__dirname, 'CacheHitHashUnavailableStrict.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed closed');
+            assert(
+                tr.errorIssues.some((e) => e.includes('CachedToolReverificationSourceUnreachable')),
+                'should fail via the strict-mode source-unreachable error. errors: ' + tr.errorIssues
+            );
+            assert(
+                tr.warningIssues.every((w) => !w.includes('CachedToolReverificationUnavailable')),
+                'must NOT also emit the degrade-with-warning message when failing closed. warnings: ' + tr.warningIssues
+            );
+        }, tr);
+    });
+
     it('cache hit, no marker (OPA): re-downloads, matches, writes the integrity marker', async () => {
         const tp = path.join(__dirname, 'CacheHitReverifyPass.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryVersionResolverL0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/RegistryVersionResolverL0.ts
@@ -69,6 +69,19 @@ describe('registry-version-resolver: maskOperatorUrlCredentials + resolveVersion
       );
     });
 
+    it('throws a clear diagnostic on a syntactically-valid but non-object 2xx body instead of a raw TypeError (#790)', async () => {
+      // fetchJson parses any valid JSON value (a bare null/number/string) and
+      // casts it straight to T; without the shape guard, dereferencing
+      // data.version on a null body would throw "Cannot read properties of
+      // null" rather than this actionable message.
+      globalThis.fetch = (async () => new Response('null', { status: 200 })) as unknown as typeof globalThis.fetch;
+
+      await assert.rejects(
+        resolveVersionFromRegistry('https://registry.example.com', 'terraform'),
+        /non-object/,
+      );
+    });
+
     it('propagates a fetch failure (network error / non-2xx) rather than silently resolving', async () => {
       globalThis.fetch = (async () => new Response('server error', { status: 500 })) as unknown as typeof globalThis.fetch;
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -637,6 +637,14 @@ async function reverifyUnmarkedCacheEntry(agent: string, downloadSource: string,
         if (isVerificationFailure(err)) {
             throw err;
         }
+        // #778: on a shared persistent agent an operator can opt into failing
+        // closed rather than degrading to an unverified cache entry when a
+        // required re-verification cannot reach the source. Default (false)
+        // preserves the availability-first degrade-with-warning behavior that
+        // keeps offline/air-gapped cache reuse working.
+        if (tasks.getBoolInput("requireOnlineReverification", false)) {
+            throw new Error(tasks.loc("CachedToolReverificationSourceUnreachable", toolLabel, err instanceof Error ? err.message : String(err)));
+        }
         tasks.warning(tasks.loc("CachedToolReverificationUnavailable", toolLabel, err instanceof Error ? err.message : String(err)));
         return;
     } finally {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-version-resolver.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/registry-version-resolver.ts
@@ -38,6 +38,14 @@ export async function resolveVersionFromRegistry(registryUrl: string, mirrorName
   console.log(tasks.loc("ResolvingLatestFromRegistry", redactUrlUserInfo(registryUrl)));
   const latestUrl = `${registryUrl}/terraform/binaries/${mirrorName}/versions/latest`;
   const data = await fetchJson<{ version: string }>(latestUrl);
+  // fetchJson() guards against a non-JSON body, but casts a successfully-parsed
+  // value straight to T with no shape check -- a syntactically valid but
+  // unexpected 2xx body (a bare null, number, or string) would otherwise make
+  // the data.version dereference below throw a raw, undiagnosed TypeError
+  // instead of this clear, actionable message (#790).
+  if (typeof data !== 'object' || data === null) {
+    throw new Error(`Registry API returned an unexpected (non-object) response from ${latestUrl}`);
+  }
   if (!data.version) {
     throw new Error(`Registry API returned invalid response: missing version field from ${latestUrl}`);
   }

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -114,6 +114,14 @@
             "defaultValue": "true",
             "required": false,
             "helpMarkDown": "When enabled (default), fail if a SHA256 checksum is not available for the requested version/platform. Note: OPA (and any mirror source) publishes no GPG/cosign signature here, so this checksum is a same-origin transport-integrity check, not independent-authenticity verification (see SECURITY.md). Also controls tool-cache re-verification on persistent/self-hosted agents: when enabled, a cached tool that carries no local integrity marker (cached by an older installer version, or by a job that ran with verification disabled) is re-downloaded and re-verified before use, degrading to a warning only when the source is unreachable (offline/air-gapped agents keep working). Avoid mixing requireChecksum values across jobs that share an agent's tool cache."
+        },
+        {
+            "name": "requireOnlineReverification",
+            "type": "boolean",
+            "label": "Fail closed if an unmarked cache entry cannot be re-verified online",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "When enabled, a tool-cache hit that has no local integrity marker and requires online re-verification (requireChecksum=true) FAILS the task if the configured source cannot be reached to re-verify, instead of degrading to a warning and using the unverified cached binary. Default (false) preserves the availability-first behavior that keeps offline/air-gapped cache reuse working. Enable on shared persistent self-hosted agents where you prefer an availability loss over trusting a cache entry an earlier job may have populated without verification. Has no effect when requireChecksum is false (re-verification is skipped) or on a cache entry that already carries an integrity marker (verified locally, offline)."
         }
     ],
     "restrictions": {
@@ -167,6 +175,7 @@
         "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
         "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
         "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",
+        "CachedToolReverificationSourceUnreachable": "Could not re-verify cached %s: %s. requireOnlineReverification is enabled, so the task fails closed rather than trusting an unverified cache entry. Ensure the configured source is reachable, or disable requireOnlineReverification to fall back to using the cached executable with a warning.",
         "CachedToolReverificationMismatch": "Cached %s does not match the freshly downloaded, verified release (verified: %s, cached: %s). The cached copy was either never verified or has been altered since caching; clear the agent's tool cache for this version and re-run.",
         "CachedToolReverified": "Cached %s re-verified against the freshly downloaded, verified release; integrity marker written for future cache hits."
     }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitHashUnavailableStrict.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitHashUnavailableStrict.ts
@@ -1,0 +1,49 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #778 companion to CacheHitHashUnavailable: same scenario (cache hit, no
+// integrity marker, source unreachable during re-verification) but with the
+// opt-in requireOnlineReverification=true. The task must FAIL CLOSED
+// (CachedToolReverificationSourceUnreachable) instead of degrading to a warning
+// and trusting the unverified cache entry.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('version', '0.24.0');
+tr.setInput('downloadSource', 'official');
+tr.setInput('requireOnlineReverification', 'true');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('fetchJson should not be called for a specific version: ' + url); },
+  fetchTextAllow404: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while fetching ${url}`); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('fs', {
+  existsSync: () => false,
+  readFileSync: () => { throw new Error('readFileSync should not be called when the re-verification download failed'); },
+  writeFileSync: () => { throw new Error('writeFileSync should not be called when re-verification failed closed'); },
+  chmodSync: () => { }
+});
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid' });
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => '/tmp/terraform-docs-cached',
+  downloadTool: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while downloading ${url}`); },
+  extractTar: async () => { throw new Error('extractTar should not be called when the re-verification download failed'); },
+  extractZip: async () => { throw new Error('extractZip should not be called when the re-verification download failed'); },
+  cacheDir: async () => { throw new Error('cacheDir should not be called on a cache hit'); },
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/terraform-docs-cached': ['/tmp/terraform-docs-cached/terraform-docs'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
@@ -130,6 +130,23 @@ describe('TerraformDocsInstaller Test Suite', function () {
     }, tr);
   });
 
+  it('cache hit, no marker, source unreachable, requireOnlineReverification=true: fails closed instead of degrading (#778)', async () => {
+    const tp = path.join(__dirname, 'CacheHitHashUnavailableStrict.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    await tr.runAsync();
+    runValidations(() => {
+      assert(tr.failed, 'task should have failed closed');
+      assert(
+        tr.errorIssues.some((e) => e.includes('CachedToolReverificationSourceUnreachable')),
+        'should fail via the strict-mode source-unreachable error. errors: ' + tr.errorIssues
+      );
+      assert(
+        tr.warningIssues.every((w) => !w.includes('CachedToolReverificationUnavailable')),
+        'must NOT also emit the degrade-with-warning message when failing closed. warnings: ' + tr.warningIssues
+      );
+    }, tr);
+  });
+
   it('cache hit, no marker: re-downloads, matches, writes the integrity marker', async () => {
     const tp = path.join(__dirname, 'CacheHitReverifyPass.js');
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryVersionResolverL0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/RegistryVersionResolverL0.ts
@@ -69,6 +69,19 @@ describe('registry-version-resolver: maskOperatorUrlCredentials + resolveVersion
       );
     });
 
+    it('throws a clear diagnostic on a syntactically-valid but non-object 2xx body instead of a raw TypeError (#790)', async () => {
+      // fetchJson parses any valid JSON value (a bare null/number/string) and
+      // casts it straight to T; without the shape guard, dereferencing
+      // data.version on a null body would throw "Cannot read properties of
+      // null" rather than this actionable message.
+      globalThis.fetch = (async () => new Response('null', { status: 200 })) as unknown as typeof globalThis.fetch;
+
+      await assert.rejects(
+        resolveVersionFromRegistry('https://registry.example.com', 'terraform'),
+        /non-object/,
+      );
+    });
+
     it('propagates a fetch failure (network error / non-2xx) rather than silently resolving', async () => {
       globalThis.fetch = (async () => new Response('server error', { status: 500 })) as unknown as typeof globalThis.fetch;
 

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-version-resolver.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/registry-version-resolver.ts
@@ -38,6 +38,14 @@ export async function resolveVersionFromRegistry(registryUrl: string, mirrorName
   console.log(tasks.loc("ResolvingLatestFromRegistry", redactUrlUserInfo(registryUrl)));
   const latestUrl = `${registryUrl}/terraform/binaries/${mirrorName}/versions/latest`;
   const data = await fetchJson<{ version: string }>(latestUrl);
+  // fetchJson() guards against a non-JSON body, but casts a successfully-parsed
+  // value straight to T with no shape check -- a syntactically valid but
+  // unexpected 2xx body (a bare null, number, or string) would otherwise make
+  // the data.version dereference below throw a raw, undiagnosed TypeError
+  // instead of this clear, actionable message (#790).
+  if (typeof data !== 'object' || data === null) {
+    throw new Error(`Registry API returned an unexpected (non-object) response from ${latestUrl}`);
+  }
   if (!data.version) {
     throw new Error(`Registry API returned invalid response: missing version field from ${latestUrl}`);
   }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -521,6 +521,14 @@ async function reverifyUnmarkedCacheEntry(downloadSource: string, version: strin
         if (isVerificationFailure(err)) {
             throw err;
         }
+        // #778: on a shared persistent agent an operator can opt into failing
+        // closed rather than degrading to an unverified cache entry when a
+        // required re-verification cannot reach the source. Default (false)
+        // preserves the availability-first degrade-with-warning behavior that
+        // keeps offline/air-gapped cache reuse working.
+        if (tasks.getBoolInput("requireOnlineReverification", false)) {
+            throw new Error(tasks.loc("CachedToolReverificationSourceUnreachable", toolLabel, err instanceof Error ? err.message : String(err)));
+        }
         tasks.warning(tasks.loc("CachedToolReverificationUnavailable", toolLabel, err instanceof Error ? err.message : String(err)));
         return;
     } finally {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -93,6 +93,14 @@
       "defaultValue": "true",
       "required": false,
       "helpMarkDown": "When enabled (default), fail if a SHA256 checksum is not available for the requested version/platform. Note: terraform-docs publishes no GPG/cosign signature, so this checksum is a same-origin transport-integrity check, not independent-authenticity verification (see SECURITY.md). Disable only for mirrors or registries that do not publish checksums. Also controls tool-cache re-verification on persistent/self-hosted agents: when enabled, a cached tool that carries no local integrity marker (cached by an older installer version, or by a job that ran with verification disabled) is re-downloaded and re-verified before use, degrading to a warning only when the source is unreachable (offline/air-gapped agents keep working). Avoid mixing requireChecksum values across jobs that share an agent's tool cache."
+    },
+    {
+      "name": "requireOnlineReverification",
+      "type": "boolean",
+      "label": "Fail closed if an unmarked cache entry cannot be re-verified online",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "When enabled, a tool-cache hit that has no local integrity marker and requires online re-verification (requireChecksum=true) FAILS the task if the configured source cannot be reached to re-verify, instead of degrading to a warning and using the unverified cached binary. Default (false) preserves the availability-first behavior that keeps offline/air-gapped cache reuse working. Enable on shared persistent self-hosted agents where you prefer an availability loss over trusting a cache entry an earlier job may have populated without verification. Has no effect when requireChecksum is false (re-verification is skipped) or on a cache entry that already carries an integrity marker (verified locally, offline)."
     }
   ],
   "restrictions": {
@@ -146,6 +154,7 @@
     "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
     "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
     "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",
+    "CachedToolReverificationSourceUnreachable": "Could not re-verify cached %s: %s. requireOnlineReverification is enabled, so the task fails closed rather than trusting an unverified cache entry. Ensure the configured source is reachable, or disable requireOnlineReverification to fall back to using the cached executable with a warning.",
     "CachedToolReverificationMismatch": "Cached %s does not match the freshly downloaded, verified release (verified: %s, cached: %s). The cached copy was either never verified or has been altered since caching; clear the agent's tool cache for this version and re-run.",
     "CachedToolReverified": "Cached %s re-verified against the freshly downloaded, verified release; integrity marker written for future cache hits."
   }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitHashUnavailableStrict.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitHashUnavailableStrict.ts
@@ -1,0 +1,76 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #778 companion to CacheHitHashUnavailable: same scenario (cache hit, no
+// integrity marker, source unreachable during re-verification) but with the
+// opt-in requireOnlineReverification=true. The task must FAIL CLOSED
+// (CachedToolReverificationSourceUnreachable) instead of degrading to a warning
+// and trusting the unverified cache entry.
+const tp = path.join(__dirname, 'CacheHitHashUnavailableL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'hashicorp');
+tr.setInput('requireOnlineReverification', 'true');
+
+tr.registerMock('os', {
+  type: () => 'Windows_NT',
+  arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => {
+    throw new Error('fetchJson should not be called for a specific version. Called with: ' + url);
+  },
+  fetchText: async (url: string) => {
+    throw new Error(`getaddrinfo ENOTFOUND while fetching ${url}`);
+  }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+  verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+  verifyCosignSignature: async () => { }
+});
+
+tr.registerMock('fs', {
+  existsSync: (_p: string) => false,
+  readFileSync: (_p: string, _enc?: string) => {
+    throw new Error('readFileSync should not be called when the re-verification download failed');
+  },
+  writeFileSync: () => {
+    throw new Error('writeFileSync should not be called when re-verification failed closed');
+  },
+  chmodSync: (_path: string, _mode: string) => { }
+});
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: (_toolName: string, _version: string) => '/tmp/terraform-cached',
+  downloadTool: async (url: string, _fileName: string) => {
+    throw new Error(`getaddrinfo ENOTFOUND while downloading ${url}`);
+  },
+  extractZip: async (_zipPath: string) => {
+    throw new Error('extractZip should not be called when the re-verification download failed');
+  },
+  cacheDir: async (_srcPath: string, _tool: string, _version: string) => {
+    throw new Error('cacheDir should not be called on a cache hit');
+  },
+  cleanVersion: (version: string) => version,
+  prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  'find': {
+    '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+  }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -183,6 +183,24 @@ describe('TerraformInstaller Test Suite', function () {
         }, tr);
     });
 
+    it('cache hit, no marker, source unreachable, requireOnlineReverification=true: fails closed instead of degrading (#778)', async () => {
+        const tp = path.join(__dirname, 'CacheHitHashUnavailableStrict.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed closed');
+            assert(
+                tr.errorIssues.some((e) => e.includes('CachedToolReverificationSourceUnreachable')),
+                'should fail via the strict-mode source-unreachable error. errors: ' + tr.errorIssues
+            );
+            assert(
+                tr.warningIssues.every((w) => !w.includes('CachedToolReverificationUnavailable')),
+                'must NOT also emit the degrade-with-warning message when failing closed. warnings: ' + tr.warningIssues
+            );
+        }, tr);
+    });
+
     it('cache hit, no marker: re-downloads, matches, writes the integrity marker', async () => {
         const tp = path.join(__dirname, 'CacheHitReverifyPass.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryVersionResolverL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryVersionResolverL0.ts
@@ -69,6 +69,19 @@ describe('registry-version-resolver: maskOperatorUrlCredentials + resolveVersion
       );
     });
 
+    it('throws a clear diagnostic on a syntactically-valid but non-object 2xx body instead of a raw TypeError (#790)', async () => {
+      // fetchJson parses any valid JSON value (a bare null/number/string) and
+      // casts it straight to T; without the shape guard, dereferencing
+      // data.version on a null body would throw "Cannot read properties of
+      // null" rather than this actionable message.
+      globalThis.fetch = (async () => new Response('null', { status: 200 })) as unknown as typeof globalThis.fetch;
+
+      await assert.rejects(
+        resolveVersionFromRegistry('https://registry.example.com', 'terraform'),
+        /non-object/,
+      );
+    });
+
     it('propagates a fetch failure (network error / non-2xx) rather than silently resolving', async () => {
       globalThis.fetch = (async () => new Response('server error', { status: 500 })) as unknown as typeof globalThis.fetch;
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-version-resolver.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/registry-version-resolver.ts
@@ -38,6 +38,14 @@ export async function resolveVersionFromRegistry(registryUrl: string, mirrorName
   console.log(tasks.loc("ResolvingLatestFromRegistry", redactUrlUserInfo(registryUrl)));
   const latestUrl = `${registryUrl}/terraform/binaries/${mirrorName}/versions/latest`;
   const data = await fetchJson<{ version: string }>(latestUrl);
+  // fetchJson() guards against a non-JSON body, but casts a successfully-parsed
+  // value straight to T with no shape check -- a syntactically valid but
+  // unexpected 2xx body (a bare null, number, or string) would otherwise make
+  // the data.version dereference below throw a raw, undiagnosed TypeError
+  // instead of this clear, actionable message (#790).
+  if (typeof data !== 'object' || data === null) {
+    throw new Error(`Registry API returned an unexpected (non-object) response from ${latestUrl}`);
+  }
   if (!data.version) {
     throw new Error(`Registry API returned invalid response: missing version field from ${latestUrl}`);
   }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -554,6 +554,14 @@ async function reverifyUnmarkedCacheEntry(
         if (isVerificationFailure(err)) {
             throw err;
         }
+        // #778: on a shared persistent agent an operator can opt into failing
+        // closed rather than degrading to an unverified cache entry when a
+        // required re-verification cannot reach the source. Default (false)
+        // preserves the availability-first degrade-with-warning behavior that
+        // keeps offline/air-gapped cache reuse working.
+        if (tasks.getBoolInput("requireOnlineReverification", false)) {
+            throw new Error(tasks.loc("CachedToolReverificationSourceUnreachable", toolLabel, err instanceof Error ? err.message : String(err)));
+        }
         tasks.warning(tasks.loc("CachedToolReverificationUnavailable", toolLabel, err instanceof Error ? err.message : String(err)));
         return;
     }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -133,6 +133,14 @@
             "defaultValue": "true",
             "required": false,
             "helpMarkDown": "When enabled (default), fail if the mirror or registry does not serve a SHA256SUMS file for the requested version, matching the PolicyAgentInstaller and TerraformDocsInstaller defaults (HashiCorp and OpenTofu releases always publish checksums, so fresh installs from those sources are unaffected). Also controls tool-cache re-verification on persistent/self-hosted agents: when enabled, a cached tool that carries no local integrity marker (cached by an older installer version, or by a job that ran with verification disabled) is re-downloaded and re-verified before use, degrading to a warning only when the source is unreachable (offline/air-gapped agents keep working). Avoid mixing requireChecksum values across jobs that share an agent's tool cache. Set to false to skip both checks."
+        },
+        {
+            "name": "requireOnlineReverification",
+            "type": "boolean",
+            "label": "Fail closed if an unmarked cache entry cannot be re-verified online",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "When enabled, a tool-cache hit that has no local integrity marker and requires online re-verification (requireChecksum=true) FAILS the task if the configured source cannot be reached to re-verify, instead of degrading to a warning and using the unverified cached binary. Default (false) preserves the availability-first behavior that keeps offline/air-gapped cache reuse working. Enable on shared persistent self-hosted agents where you prefer an availability loss over trusting a cache entry an earlier job may have populated without verification. Has no effect when requireChecksum is false (re-verification is skipped) or on a cache entry that already carries an integrity marker (verified locally, offline)."
         }
     ],
     "restrictions": {
@@ -187,6 +195,7 @@
         "CachedToolVerificationFailed": "Cached %s failed integrity re-verification (stored: %s, actual: %s). The cached copy may have been tampered with or corrupted since it was last verified; clear the tool cache for this version and re-run to force a fresh, verified download.",
         "ReverifyingCachedTool": "Cache hit for %s has no stored integrity marker (cached before re-verification existed, or with checksum verification disabled). Re-downloading the release to re-verify the cached executable; set requireChecksum to false to skip this.",
         "CachedToolReverificationUnavailable": "Could not re-verify cached %s: %s. Proceeding with the cached executable — expected for offline/air-gapped agents; set requireChecksum to false to skip the attempt and silence this warning.",
+        "CachedToolReverificationSourceUnreachable": "Could not re-verify cached %s: %s. requireOnlineReverification is enabled, so the task fails closed rather than trusting an unverified cache entry. Ensure the configured source is reachable, or disable requireOnlineReverification to fall back to using the cached executable with a warning.",
         "CachedToolReverificationMismatch": "Cached %s does not match the freshly downloaded, verified release (verified: %s, cached: %s). The cached copy was either never verified or has been altered since caching; clear the agent's tool cache for this version and re-run.",
         "CachedToolReverified": "Cached %s re-verified against the freshly downloaded, verified release; integrity marker written for future cache hits."
     }


### PR DESCRIPTION
## Summary

Batch F of the 2026-07-22 accepted-risk remediation pass. Two small low/info installer-family resolve/verify hardening issues across all three installer tasks (`TerraformInstallerV1`, `PolicyAgentInstallerV1`, `TerraformDocsInstallerV1`):

- **#790** (info) — shape-guard the registry latest-version response before dereferencing `.version`.
- **#778** (low) — opt-in `requireOnlineReverification` to fail closed (rather than degrade to a warning) when a required tool-cache re-verification cannot reach the source.

Run through the `issue-remediation.copilot.md` 3-agent adversarial review process: **3/3 approve, no blocking findings**.

> **#681 deliberately deferred**: the third issue originally grouped here (extract the still-duplicated `getPlatformString`/`getArchString`/`parseSha256`/`verifySha256`/`computeSha256Streaming` platform+checksum helpers into a shared module) is a substantial cross-task refactor — the three copies are **not** all byte-identical (`parseSha256` differs in TerraformInstaller; `getArchString` legitimately omits `ia32→386` in TerraformDocs). It is deferred to its own dedicated batch rather than ballooning this small hardening PR. All three reviewers independently confirmed the deferral is legitimate.

## #790 — registry latest-version response shape guard (info)

`resolveVersionFromRegistry()` in the shared `registry-version-resolver.ts` fetched the `versions/latest` endpoint and dereferenced `data.version` directly. `fetchJson()` guards a non-JSON body but casts the parsed value straight to `T` with no runtime shape check — so a syntactically-valid but unexpected 2xx body (a bare `null`) made the `data.version` dereference throw a raw, undiagnosed `TypeError` instead of an actionable message. Added a shape guard before the existing missing-`version` check:

```ts
if (typeof data !== 'object' || data === null) {
    throw new Error(`Registry API returned an unexpected (non-object) response from ${latestUrl}`);
}
```

The explicit `=== null` half is required precisely because `typeof null === 'object'`. Applied identically to all 3 byte-identical copies (shared-module parity gate re-run green).

## #778 — opt-in fail-closed on unreachable cache re-verification (low)

On a persistent/self-hosted agent, a tool-cache hit with no local integrity marker triggers a remote re-download+re-verify; if the source is unreachable the existing behavior degrades to a warning (`CachedToolReverificationUnavailable`) and trusts the cached binary, so offline/air-gapped reuse keeps working. Some shared-agent operators prefer to lose availability rather than trust a cache entry an earlier job may have populated unverified.

Added an opt-in `requireOnlineReverification` boolean (default `false`) that, in `reverifyUnmarkedCacheEntry`'s catch block — **AFTER** the unconditional `isVerificationFailure` re-throw (so genuine integrity failures still fail closed regardless), **before** the warning-degrade fallthrough — fails the task closed with a new `CachedToolReverificationSourceUnreachable` message when set:

```ts
if (tasks.getBoolInput("requireOnlineReverification", false)) {
    throw new Error(tasks.loc("CachedToolReverificationSourceUnreachable", toolLabel, err instanceof Error ? err.message : String(err)));
}
```

Default `false` preserves the prior degrade-with-warning behavior byte-for-byte. Applied to all 3 installer src files plus a `requireOnlineReverification` input and `CachedToolReverificationSourceUnreachable` message in each `task.json` (no `visibleRule` — applies to any download source; matches the `requireChecksum` input's conventions).

## Sibling-scouting

- **#790** — `resolveVersionFromRegistry` lives only in the shared `registry-version-resolver.ts` across exactly these 3 tasks; all fixed. Complete sibling set.
- **#778** — `reverifyUnmarkedCacheEntry` + the degrade path exist only in these 3 tasks; all fixed identically. Complete sibling set.
- `TerraformProviderMirrorV1` (name-adjacent) has neither construct.

## Review outcome — 3/3 approve

| Lens | Verdict | Notes |
|---|---|---|
| correctness | approve | #790 guard correctly ordered and handles `null`; #778 branch sits correctly after the `isVerificationFailure` re-throw. One low nit: an array body isn't caught by the guard — but still fails cleanly on the existing `!data.version` check (clear message, not a TypeError), so no change needed. |
| regression-conventions | approve | Default-off behavior byte-for-byte unchanged; task.json input/message match the `requireChecksum`/`CachedToolReverification*` sibling conventions; 3 resolver copies still byte-identical (parity green). |
| test-adequacy-siblings | approve | New tests exercise the new branches (the strict fixture asserts fail-closed AND absence of the degrade warning, catching a false pass via the old path); #681 deferral confirmed legitimate. |

## Testing

| Task | Tests | Coverage (stmts / branch) | Per-file floor |
|---|---|---|---|
| TerraformInstallerV1 | 177 passing (+2) | 94.39% / 85.1% | met |
| PolicyAgentInstallerV1 | 119 passing (+2) | 91.35% / 80.29% | met |
| TerraformDocsInstallerV1 | 107 passing (+2) | 92.35% / 81.37% | met |

`node scripts/check-shared-modules.js` green (`registry-version-resolver.ts` byte-identical across all 3 after the #790 edit). Version-bump gate green (all 3 installers already carry their one-per-cycle Minor bump).

Closes #790
Closes #778
