### PR TITLE
fix: audit-2026-07-22 remediation - policy-repo clone redirect scoping + subprocess wall-clock timeout (#779, #782)

### DIFF
--- a/Tasks/TerraformDocs/TerraformDocsV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Strings/resources.resjson/en-US/resources.resjson
@@ -26,5 +26,6 @@
   "loc.messages.TerraformDocsFailed": "terraform-docs failed with exit code %s.",
   "loc.messages.TerraformDocsFailedDetail": "terraform-docs failed with exit code %s: %s",
   "loc.messages.TerraformDocsOutdated": "Generated documentation is out of date (outputCheck is enabled) for '%s'. Run terraform-docs locally with the same formatter/config and commit the update.",
+  "loc.messages.TerraformDocsTimedOut": "terraform-docs exceeded its %s ms wall-clock timeout and was terminated. This usually indicates a hung invocation (e.g. on a very large or cyclic module graph).",
   "loc.messages.GeneratedFile": "terraform-docs documentation written to: %s"
 }

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ExecTimeoutL0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ExecTimeoutL0.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
+import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from '../src/exec-timeout';
+
+/**
+ * Direct unit tests for execWithTimeout (#782) — the wall-clock deadline wrapper
+ * that bounds the local policy-engine / terraform-docs subprocesses. On timeout
+ * it kills the child and rejects with the supplied message; otherwise it returns
+ * the tool's exit code unchanged (a non-zero code is a real outcome, not a hang).
+ */
+
+/** Fake ToolRunner whose execAsync resolution is controlled per-test. */
+class FakeTool {
+    public killed = false;
+    constructor(private readonly behavior: () => Promise<number>) { }
+    killChildProcess(): void { this.killed = true; }
+    execAsync(_options?: IExecOptions): Promise<number> { return this.behavior(); }
+}
+
+function asTool(fake: FakeTool): ToolRunner {
+    return fake as unknown as ToolRunner;
+}
+
+describe('execWithTimeout — bounded subprocess execution (#782)', function () {
+    it('returns the tool exit code and never kills the child when it completes before the deadline', async () => {
+        const fake = new FakeTool(async () => 0);
+        const code = await execWithTimeout(asTool(fake), <IExecOptions>{}, 'should-not-fire', 10_000);
+        assert.strictEqual(code, 0, 'should resolve with the tool exit code');
+        assert.strictEqual(fake.killed, false, 'must not kill a child that finished in time');
+    });
+
+    it('propagates a non-zero exit code unchanged (does not conflate a policy-fail exit with a timeout)', async () => {
+        const fake = new FakeTool(async () => 1);
+        const code = await execWithTimeout(asTool(fake), <IExecOptions>{}, 'should-not-fire', 10_000);
+        assert.strictEqual(code, 1);
+        assert.strictEqual(fake.killed, false);
+    });
+
+    it('kills the child and rejects with the supplied message when the deadline is exceeded', async () => {
+        // A child that never resolves; a tiny ceiling forces the deadline branch.
+        const fake = new FakeTool(() => new Promise<number>(() => { /* never resolves */ }));
+        await assert.rejects(
+            execWithTimeout(asTool(fake), <IExecOptions>{}, 'engine-timed-out', 20),
+            /engine-timed-out/,
+        );
+        assert.strictEqual(fake.killed, true, 'must kill the hung child on timeout');
+    });
+
+    it('propagates the underlying execAsync rejection (e.g. tool-not-found) without masking it as a timeout', async () => {
+        const fake = new FakeTool(() => Promise.reject(new Error('spawn ENOENT')));
+        await assert.rejects(
+            execWithTimeout(asTool(fake), <IExecOptions>{}, 'should-not-be-the-reported-error', 10_000),
+            /ENOENT/,
+        );
+        assert.strictEqual(fake.killed, false, 'a tool that failed on its own was never timed out');
+    });
+
+    it('exposes a positive default ceiling', function () {
+        assert.ok(TOOL_EXEC_TIMEOUT_MS > 0, 'default ceiling should be a positive duration');
+    });
+});

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/L0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/L0.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 
 // Direct unit tests for the argument builder.
 import './ArgsBuilderL0';
+// Direct unit tests for the bounded subprocess execution wrapper (#782).
+import './ExecTimeoutL0';
 
 describe('TerraformDocs Test Suite', function () {
 

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/exec-timeout.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/exec-timeout.ts
@@ -1,0 +1,49 @@
+import { IExecOptions, ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
+
+// Wall-clock ceiling for a local subprocess (policy engine / terraform-docs).
+// azure-pipelines-task-lib's execAsync only bounds output byte-size (the #632
+// capture caps), not wall-clock time, so a pathological policy bundle, a
+// misbehaving engine binary, or a doc-generation invocation that hangs (e.g. on
+// a huge/cyclic module graph) would otherwise block until the ADO job-level
+// timeout with no task-level diagnostic distinguishing a hang from ordinary
+// slowness. A few minutes is generous for these normally-fast tools while still
+// failing fast and distinctly. Mirrors policy-source.ts's git-clone GIT_TIMEOUT_MS
+// (#782).
+export const TOOL_EXEC_TIMEOUT_MS = 300_000;
+
+/**
+ * Runs a ToolRunner's execAsync under a hard wall-clock deadline. On timeout the
+ * child process is killed and the returned promise rejects with `timeoutMessage`;
+ * otherwise it resolves with the tool's exit code exactly as execAsync would.
+ *
+ * The same Promise.race-with-deadline-and-killChildProcess pattern already used
+ * for the git clone in policy-source.ts (execGit), generalized so the local
+ * policy-engine and terraform-docs subprocesses share one bounded-execution seam.
+ */
+export async function execWithTimeout(
+  tool: ToolRunner,
+  options: IExecOptions,
+  timeoutMessage: string,
+  timeoutMs: number = TOOL_EXEC_TIMEOUT_MS,
+): Promise<number> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      tool.killChildProcess();
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+  });
+  // If the deadline wins the race, killChildProcess() makes this promise reject
+  // later; attach a no-op catch so that late rejection is swallowed intentionally
+  // rather than surfacing as an unhandled promise rejection (these tasks have no
+  // process-level unhandledRejection handler).
+  const exec = tool.execAsync(options);
+  exec.catch(() => { /* swallowed: the timeout is reported via the deadline branch */ });
+  try {
+    return await Promise.race([exec, deadline]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
@@ -3,6 +3,7 @@ import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
 import fs = require('fs');
 import path = require('path');
 import { buildTerraformDocsArgs, buildModulePathArgs, sanitizeConfigFile, TerraformDocsConfig } from './args-builder';
+import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from './exec-timeout';
 
 // Upper bound on terraform-docs stdout+stderr buffered to classify an --output-check
 // failure and fold crash detail into the error message (mirrors the #632 / CWE-400
@@ -77,7 +78,11 @@ async function run() {
         toolRunner.on('stdout', capture);
         toolRunner.on('stderr', capture);
 
-        const exitCode = await toolRunner.execAsync(<IExecOptions>{ ignoreReturnCode: true });
+        const exitCode = await execWithTimeout(
+            toolRunner,
+            <IExecOptions>{ ignoreReturnCode: true },
+            tasks.loc('TerraformDocsTimedOut', TOOL_EXEC_TIMEOUT_MS),
+        );
         if (exitCode !== 0) {
             if (config.outputCheck && /is out of date/i.test(captured)) {
                 throw new Error(tasks.loc('TerraformDocsOutdated', config.outputFile || config.modulePath));

--- a/Tasks/TerraformDocs/TerraformDocsV1/task.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/task.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "7",
+    "Minor": "8",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",
@@ -154,6 +154,7 @@
     "TerraformDocsFailed": "terraform-docs failed with exit code %s.",
     "TerraformDocsFailedDetail": "terraform-docs failed with exit code %s: %s",
     "TerraformDocsOutdated": "Generated documentation is out of date (outputCheck is enabled) for '%s'. Run terraform-docs locally with the same formatter/config and commit the update.",
+    "TerraformDocsTimedOut": "terraform-docs exceeded its %s ms wall-clock timeout and was terminated. This usually indicates a hung invocation (e.g. on a very large or cyclic module graph).",
     "GeneratedFile": "terraform-docs documentation written to: %s"
   }
 }

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Strings/resources.resjson/en-US/resources.resjson
@@ -6,5 +6,6 @@
   "loc.messages.InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed.",
   "loc.messages.InvalidPolicyRepoRef": "Invalid policy repo ref rejected: %s. Refs must not start with '-' and may contain only letters, digits, '.', '_', '/', and '-'.",
   "loc.messages.PolicySubdirOutsideRepo": "Policy subdirectory escapes the cloned repository: %s",
-  "loc.messages.PolicyRepoCloneTimedOut": "Cloning the policy repository timed out after %s ms."
+  "loc.messages.PolicyRepoCloneTimedOut": "Cloning the policy repository timed out after %s ms.",
+  "loc.messages.PolicyEngineTimedOut": "The %s process exceeded its %s ms wall-clock timeout and was terminated. This usually indicates a hung or pathological policy evaluation (e.g. a malformed bundle or a runaway policy); inspect the policy set and input."
 }

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/ExecTimeoutL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/ExecTimeoutL0.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
+import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from '../src/exec-timeout';
+
+/**
+ * Direct unit tests for execWithTimeout (#782) — the wall-clock deadline wrapper
+ * that bounds the local policy-engine / terraform-docs subprocesses. On timeout
+ * it kills the child and rejects with the supplied message; otherwise it returns
+ * the tool's exit code unchanged (a non-zero code is a real outcome, not a hang).
+ */
+
+/** Fake ToolRunner whose execAsync resolution is controlled per-test. */
+class FakeTool {
+    public killed = false;
+    constructor(private readonly behavior: () => Promise<number>) { }
+    killChildProcess(): void { this.killed = true; }
+    execAsync(_options?: IExecOptions): Promise<number> { return this.behavior(); }
+}
+
+function asTool(fake: FakeTool): ToolRunner {
+    return fake as unknown as ToolRunner;
+}
+
+describe('execWithTimeout — bounded subprocess execution (#782)', function () {
+    it('returns the tool exit code and never kills the child when it completes before the deadline', async () => {
+        const fake = new FakeTool(async () => 0);
+        const code = await execWithTimeout(asTool(fake), <IExecOptions>{}, 'should-not-fire', 10_000);
+        assert.strictEqual(code, 0, 'should resolve with the tool exit code');
+        assert.strictEqual(fake.killed, false, 'must not kill a child that finished in time');
+    });
+
+    it('propagates a non-zero exit code unchanged (does not conflate a policy-fail exit with a timeout)', async () => {
+        const fake = new FakeTool(async () => 1);
+        const code = await execWithTimeout(asTool(fake), <IExecOptions>{}, 'should-not-fire', 10_000);
+        assert.strictEqual(code, 1);
+        assert.strictEqual(fake.killed, false);
+    });
+
+    it('kills the child and rejects with the supplied message when the deadline is exceeded', async () => {
+        // A child that never resolves; a tiny ceiling forces the deadline branch.
+        const fake = new FakeTool(() => new Promise<number>(() => { /* never resolves */ }));
+        await assert.rejects(
+            execWithTimeout(asTool(fake), <IExecOptions>{}, 'engine-timed-out', 20),
+            /engine-timed-out/,
+        );
+        assert.strictEqual(fake.killed, true, 'must kill the hung child on timeout');
+    });
+
+    it('propagates the underlying execAsync rejection (e.g. tool-not-found) without masking it as a timeout', async () => {
+        const fake = new FakeTool(() => Promise.reject(new Error('spawn ENOENT')));
+        await assert.rejects(
+            execWithTimeout(asTool(fake), <IExecOptions>{}, 'should-not-be-the-reported-error', 10_000),
+            /ENOENT/,
+        );
+        assert.strictEqual(fake.killed, false, 'a tool that failed on its own was never timed out');
+    });
+
+    it('exposes a positive default ceiling', function () {
+        assert.ok(TOOL_EXEC_TIMEOUT_MS > 0, 'default ceiling should be a positive duration');
+    });
+});

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitAuthEnvL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/GitAuthEnvL0.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import { buildGitAuthEnv } from '../src/policy-source';
+
+/**
+ * Direct unit tests for buildGitAuthEnv (#779) — the per-invocation git config
+ * ENV that carries the private-policy-repo clone credential. The credential must
+ * ride in GIT_CONFIG_* env (never on argv) AND redirect-following must be
+ * disabled so the non-host-scoped Authorization header cannot be forwarded to a
+ * cross-host redirect target.
+ */
+describe('buildGitAuthEnv — credential delivery + redirect scoping (#779)', function () {
+    const basic = Buffer.from(':secrettoken').toString('base64');
+    const env = buildGitAuthEnv(basic);
+
+    it('delivers the Authorization header via GIT_CONFIG env, not on the command line', function () {
+        assert.strictEqual(env.GIT_CONFIG_KEY_0, 'http.extraheader');
+        assert.strictEqual(env.GIT_CONFIG_VALUE_0, `Authorization: Basic ${basic}`);
+    });
+
+    it('disables http.followRedirects so the credential cannot be forwarded on a cross-host redirect', function () {
+        assert.strictEqual(env.GIT_CONFIG_KEY_1, 'http.followRedirects');
+        assert.strictEqual(env.GIT_CONFIG_VALUE_1, 'false');
+    });
+
+    it('declares exactly the two config pairs it sets', function () {
+        assert.strictEqual(env.GIT_CONFIG_COUNT, '2', 'GIT_CONFIG_COUNT must match the number of KEY/VALUE pairs set');
+    });
+});

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -17,6 +17,10 @@ import './SentinelConfigDirRegistrationL0';
 import './SecureTempL0';
 // Direct unit tests for the bounded engine-output capture guard (#632).
 import './OutputCapL0';
+// Direct unit tests for the git-clone credential env + redirect scoping (#779).
+import './GitAuthEnvL0';
+// Direct unit tests for the bounded subprocess execution wrapper (#782).
+import './ExecTimeoutL0';
 
 describe('TerraformPolicyCheck Test Suite', function () {
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/exec-timeout.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/exec-timeout.ts
@@ -1,0 +1,49 @@
+import { IExecOptions, ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
+
+// Wall-clock ceiling for a local subprocess (policy engine / terraform-docs).
+// azure-pipelines-task-lib's execAsync only bounds output byte-size (the #632
+// capture caps), not wall-clock time, so a pathological policy bundle, a
+// misbehaving engine binary, or a doc-generation invocation that hangs (e.g. on
+// a huge/cyclic module graph) would otherwise block until the ADO job-level
+// timeout with no task-level diagnostic distinguishing a hang from ordinary
+// slowness. A few minutes is generous for these normally-fast tools while still
+// failing fast and distinctly. Mirrors policy-source.ts's git-clone GIT_TIMEOUT_MS
+// (#782).
+export const TOOL_EXEC_TIMEOUT_MS = 300_000;
+
+/**
+ * Runs a ToolRunner's execAsync under a hard wall-clock deadline. On timeout the
+ * child process is killed and the returned promise rejects with `timeoutMessage`;
+ * otherwise it resolves with the tool's exit code exactly as execAsync would.
+ *
+ * The same Promise.race-with-deadline-and-killChildProcess pattern already used
+ * for the git clone in policy-source.ts (execGit), generalized so the local
+ * policy-engine and terraform-docs subprocesses share one bounded-execution seam.
+ */
+export async function execWithTimeout(
+  tool: ToolRunner,
+  options: IExecOptions,
+  timeoutMessage: string,
+  timeoutMs: number = TOOL_EXEC_TIMEOUT_MS,
+): Promise<number> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      tool.killChildProcess();
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+  });
+  // If the deadline wins the race, killChildProcess() makes this promise reject
+  // later; attach a no-op catch so that late rejection is swallowed intentionally
+  // rather than surfacing as an unhandled promise rejection (these tasks have no
+  // process-level unhandledRejection handler).
+  const exec = tool.execAsync(options);
+  exec.catch(() => { /* swallowed: the timeout is reported via the deadline branch */ });
+  try {
+    return await Promise.race([exec, deadline]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/opa-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/opa-engine.ts
@@ -2,6 +2,7 @@ import tasks = require('azure-pipelines-task-lib/task');
 import { IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
 import { PolicyResult, PolicyCase } from './types';
 import { attachBoundedCapture } from './output-cap';
+import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from './exec-timeout';
 
 /**
  * Evaluates OPA policies against Terraform plan/state JSON using `opa exec`.
@@ -32,8 +33,14 @@ export async function runOpa(opaPath: string, policyDir: string, inputFile: stri
     });
 
     // opa exec returns 0 even when the decision contains violations; we gate on the
-    // parsed result, not the exit code.
-    const code = await tool.execAsync(<IExecOptions>{ ignoreReturnCode: true });
+    // parsed result, not the exit code. Bounded by a wall-clock deadline (#782): the
+    // byte-cap above stops an OOM but not a hang, so a misbehaving opa or a
+    // pathological bundle is killed rather than blocking until the ADO job timeout.
+    const code = await execWithTimeout(
+        tool,
+        <IExecOptions>{ ignoreReturnCode: true },
+        tasks.loc('PolicyEngineTimedOut', 'opa exec', TOOL_EXEC_TIMEOUT_MS),
+    );
     capture.assertWithinCap();
 
     // A non-zero exit is a real failure (bad bundle, malformed input, opa crash),

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
@@ -74,6 +74,34 @@ export async function resolvePolicyDir(tempDirs: string[]): Promise<string> {
     return policyDir;
 }
 
+/**
+ * Builds the per-invocation git config ENV VARS (git >= 2.31) that carry the
+ * clone credential for a private policy repo.
+ *
+ * - The Authorization header is delivered via `GIT_CONFIG_*` env rather than a
+ *   `-c http.extraheader=...` argv item, so the token never appears in the child
+ *   process's command line (readable via ps / /proc/<pid>/cmdline by other
+ *   processes on a shared agent).
+ * - `http.followRedirects` is disabled (#779): git applies `http.extraheader` to
+ *   EVERY HTTP request and, with the default `followRedirects=initial`, re-sends
+ *   that header when the initial smart-HTTP request is redirected to a DIFFERENT
+ *   host. Because the header is not host-scoped, a `policyRepoUrl` pointed at a
+ *   host that issues a cross-host redirect would otherwise forward the
+ *   `Authorization: Basic <PAT>` to the redirect target. Disabling redirect
+ *   following for the authenticated clone keeps the credential pinned to the
+ *   originally-configured host. (Unauthenticated clones never call this and keep
+ *   git's default redirect behavior — there is no credential to protect.)
+ */
+export function buildGitAuthEnv(basic: string): Record<string, string> {
+    return {
+        GIT_CONFIG_COUNT: '2',
+        GIT_CONFIG_KEY_0: 'http.extraheader',
+        GIT_CONFIG_VALUE_0: `Authorization: Basic ${basic}`,
+        GIT_CONFIG_KEY_1: 'http.followRedirects',
+        GIT_CONFIG_VALUE_1: 'false',
+    };
+}
+
 async function cloneRepo(url: string, ref: string, token: string | undefined, cloneDir: string): Promise<void> {
     const gitPath = tasks.which('git', true);
     const isSha = /^[0-9a-fA-F]{40}$/.test(ref);
@@ -83,13 +111,7 @@ async function cloneRepo(url: string, ref: string, token: string | undefined, cl
         tasks.setSecret(token);
         const basic = Buffer.from(`:${token}`).toString('base64');
         tasks.setSecret(basic);
-        // Pass the credential to git via per-invocation config ENV VARS (git >= 2.31)
-        // instead of `-c http.extraheader=...` on argv, so the token never appears in
-        // the child process's command line (readable via ps / /proc/<pid>/cmdline by
-        // other processes on a shared agent).
-        authEnv['GIT_CONFIG_COUNT'] = '1';
-        authEnv['GIT_CONFIG_KEY_0'] = 'http.extraheader';
-        authEnv['GIT_CONFIG_VALUE_0'] = `Authorization: Basic ${basic}`;
+        Object.assign(authEnv, buildGitAuthEnv(basic));
     }
 
     if (isSha) {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/sentinel-engine.ts
@@ -6,6 +6,7 @@ import fs = require('fs');
 import { randomUUID as uuidV4 } from 'crypto';
 import { PolicyResult, PolicyCase } from './types';
 import { attachBoundedCapture } from './output-cap';
+import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from './exec-timeout';
 
 /**
  * Evaluates Sentinel policies against Terraform plan JSON.
@@ -51,7 +52,14 @@ export async function runSentinel(
     let stdout = '';
     const capture = attachBoundedCapture(tool, (_stream, text) => { stdout += text; });
 
-    const code = await tool.execAsync(<IExecOptions>{ cwd: workingDir, ignoreReturnCode: true });
+    // Bounded by a wall-clock deadline (#782): the byte-cap above stops an OOM but
+    // not a hang, so a misbehaving sentinel or a pathological policy set is killed
+    // rather than blocking until the ADO job timeout.
+    const code = await execWithTimeout(
+        tool,
+        <IExecOptions>{ cwd: workingDir, ignoreReturnCode: true },
+        tasks.loc('PolicyEngineTimedOut', 'sentinel apply', TOOL_EXEC_TIMEOUT_MS),
+    );
     capture.assertWithinCap();
 
     if (code === 3 || code === 9) {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "15",
+        "Minor": "16",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",
@@ -277,6 +277,7 @@
         "InsecureUrlRejected": "Insecure URL rejected: %s. Only HTTPS URLs are allowed.",
         "InvalidPolicyRepoRef": "Invalid policy repo ref rejected: %s. Refs must not start with '-' and may contain only letters, digits, '.', '_', '/', and '-'.",
         "PolicySubdirOutsideRepo": "Policy subdirectory escapes the cloned repository: %s",
-        "PolicyRepoCloneTimedOut": "Cloning the policy repository timed out after %s ms."
+        "PolicyRepoCloneTimedOut": "Cloning the policy repository timed out after %s ms.",
+        "PolicyEngineTimedOut": "The %s process exceeded its %s ms wall-clock timeout and was terminated. This usually indicates a hung or pathological policy evaluation (e.g. a malformed bundle or a runaway policy); inspect the policy set and input."
     }
 }

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -232,6 +232,22 @@ const FAMILIES = [
         // change at all (it reuses PlanDigest via the optional `planMode`
         // field). No new family was needed for Phase 5.
     },
+    {
+        // Wall-clock deadline wrapper for a local subprocess (execWithTimeout +
+        // the shared TOOL_EXEC_TIMEOUT_MS ceiling): a Promise.race deadline that
+        // kills the child on timeout, generalizing policy-source.ts's git-clone
+        // pattern for the policy-engine (opa/sentinel) and terraform-docs
+        // invocations that previously had only an output-byte cap and no
+        // wall-clock bound (#782). A drift here could silently drop the timeout in
+        // one task while the other keeps failing fast, so keep byte-identical.
+        dirs: [
+            'Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src',
+            'Tasks/TerraformDocs/TerraformDocsV1/src',
+        ],
+        modules: [
+            'exec-timeout.ts',
+        ],
+    },
 ];
 
 // These two families are deliberately NOT merged into one shared client, even


### PR DESCRIPTION
## Summary

Batch G of the 2026-07-22 accepted-risk remediation pass. Two low-severity policy-check / doc-generation resilience issues:

- **#779** (low, CWE-522) — the policy-repo clone in `TerraformPolicyCheckV1` forwarded the Basic-auth PAT (`http.extraheader`) on cross-host HTTP redirects.
- **#782** (low, CWE-400) — `runOpa` / `runSentinel` / TerraformDocs `run()` had no wall-clock timeout on their local subprocesses.

Run through the `issue-remediation.copilot.md` 3-agent adversarial review process: **3/3 approve, no blocking findings**.

## #779 — disable redirect-following on the authenticated policy-repo clone

git applies `http.extraheader` to **every** HTTP request and, with the default `http.followRedirects=initial`, re-sends it when the initial smart-HTTP request is redirected to a **different** host — forwarding the `Authorization: Basic <PAT>` to a redirect target the operator did not configure (the header is not host-scoped).

Extracted a small exported, unit-testable `buildGitAuthEnv(basic)` helper that returns the credential env **and** disables `http.followRedirects` (`GIT_CONFIG_COUNT=2`) on the authenticated path, pinning the credential to the originally-configured host:

```ts
export function buildGitAuthEnv(basic: string): Record<string, string> {
    return {
        GIT_CONFIG_COUNT: '2',
        GIT_CONFIG_KEY_0: 'http.extraheader',
        GIT_CONFIG_VALUE_0: `Authorization: Basic ${basic}`,
        GIT_CONFIG_KEY_1: 'http.followRedirects',
        GIT_CONFIG_VALUE_1: 'false',
    };
}
```

Applied **only** when a token is present — an unauthenticated clone never calls it and keeps git's default redirect behavior (no credential to protect). Chose `followRedirects=false` (one of the two options in the issue's own Recommendation) over URL-scoping the header because it is zero-auth-risk: the header is still delivered exactly as before to the direct host, with no silent under-match failure a mis-normalized `http.<url>.extraheader` key could cause.

## #782 — wall-clock deadline on local subprocess execution

New **byte-identical shared** `exec-timeout.ts` (in `TerraformPolicyCheckV1/src` and `TerraformDocsV1/src`, registered as a new parity-gate family) exporting `TOOL_EXEC_TIMEOUT_MS = 300_000` and `execWithTimeout(tool, options, timeoutMessage, timeoutMs?)` — the generalized form of the `Promise.race`-with-deadline-and-`killChildProcess` pattern already in `policy-source.ts`'s `execGit`. It races `execAsync` against a deadline, kills the child + rejects with a localized message on timeout, otherwise returns the exit code unchanged.

Wired into all three sites (each keeps its existing `attachBoundedCapture` byte-cap; the timeout is an independent additional bound):
- `opa-engine.ts` `runOpa`, `sentinel-engine.ts` `runSentinel` (PolicyCheck) → `PolicyEngineTimedOut` (2 `%s`: engine label, ms)
- `TerraformDocs/index.ts` `run` → `TerraformDocsTimedOut` (1 `%s`: ms)

New messages added to both tasks' `task.json` **and** their `resources.resjson` mirrors. `execGit` itself was left un-refactored (git-specific fail-fast env, `void` return, already has its own timeout, out of #782's scope).

## Review outcome — 3/3 approve

| Lens | Verdict | Notes |
|---|---|---|
| correctness | approve | `followRedirects=false` fully closes the vector on the authenticated path only; `execWithTimeout` handles all paths (return code, timer-clear in finally, kill+reject on timeout, underlying-rejection passthrough, no unhandled rejection via the swallow-catch). Exit-code semantics unchanged at all three sites. |
| regression-conventions | approve | No-token path byte-for-byte unchanged; `%s` counts match call sites (2/2, 1/1); both task.json and resjson mirrors updated; new parity family correct; two `exec-timeout.ts` copies byte-identical; leaving `execGit` alone is a sound surgical choice. |
| test-adequacy-siblings | approve | `GitAuthEnvL0` would fail against the old COUNT=1 code; `ExecTimeoutL0` covers all branches incl. the timeout+kill and swallow-catch; direct-unit-test for #779 justified (mock-runner can't observe child env); no missed sibling exec/clone site. |

## Testing

| Task | Tests | New-file coverage | Per-file floor |
|---|---|---|---|
| TerraformPolicyCheckV1 | 73 passing | `exec-timeout.js` 100% lines; `policy-source.js` 95.89% (security tier) | met |
| TerraformDocsV1 | 42 passing | `exec-timeout.js` 100% lines | met |

`node scripts/check-shared-modules.js` green (incl. the new `exec-timeout.ts` family). Minor versions bumped for both touched tasks (Docs 7→8, PolicyCheck 15→16).

Closes #779
Closes #782
