### PR TITLE
fix: audit-2026-07-22 remediation - TerraformTaskV5 handler hardening (#781, #783, #802)

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -2194,6 +2194,56 @@ describe('Terraform Test Suite', function () {
         fs.rmSync(agentTempDirectory, { recursive: true, force: true });
     });
 
+    it('aws show -json to file auto-scrubs+deletes a sensitive plan file at normal step end (#802)', async () => {
+        let tp = path.join(__dirname, './ShowTests/AWSShowSensitiveAutoCleanup.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        const workingDirectory = path.join(os.tmpdir(), 'tf-show-sensitive-autocleanup-test');
+        const showFile = path.join(workingDirectory, 'plan.json');
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(!fs.existsSync(showFile), `expected the sensitive show file to be scrubbed+deleted at normal step end (#802), but it still exists: ${showFile}`);
+        }, tr);
+        fs.rmSync(workingDirectory, { recursive: true, force: true });
+    });
+
+    it('aws show -json to file with cleanupShowFileIfSensitive=false retains the sensitive plan file at normal step end (#802 opt-out)', async () => {
+        let tp = path.join(__dirname, './ShowTests/AWSShowSensitiveAutoCleanupOptOut.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        const workingDirectory = path.join(os.tmpdir(), 'tf-show-sensitive-autocleanup-optout-test');
+        const showFile = path.join(workingDirectory, 'plan.json');
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(fs.existsSync(showFile), `expected the sensitive show file to be retained when opted out (#802), but it was deleted: ${showFile}`);
+        }, tr);
+        fs.rmSync(workingDirectory, { recursive: true, force: true });
+    });
+
+    it('aws output with malformed -json warns (not debug) for both sensitive-detection and TF_OUT_* export (#783)', async () => {
+        let tp = path.join(__dirname, './OutputTests/AWSOutputMalformedJsonWarns.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded (a parse failure is a warning, not an error)');
+            assert(
+                tr.warningIssues.some((w) => w.includes('no TF_OUT_* variables were set')),
+                'setOutputVariables parse failure should surface a warning (not debug-only). warnings: ' + tr.warningIssues,
+            );
+            assert(
+                tr.warningIssues.some((w) => w.includes('sensitive-value safety warning did not run')),
+                'warnIfSensitiveOutputFile parse failure should surface a warning (not debug-only). warnings: ' + tr.warningIssues,
+            );
+        }, tr);
+        fs.rmSync(path.join(os.tmpdir(), 'tf-output-malformed-json-warns-agenttemp'), { recursive: true, force: true });
+    });
+
     /* terraform custom tests */
 
     it('azure custom command to console should succeed', async () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputMalformedJsonWarns.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputMalformedJsonWarns.ts
@@ -1,0 +1,45 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// #783: when `terraform output -json` returns something that is not parseable
+// JSON, both the sensitive-output detection (warnIfSensitiveOutputFile) and the
+// TF_OUT_* pipeline-variable export (setOutputVariables) fail to parse it. Those
+// two catch blocks previously logged only at debug (invisible unless
+// System.Debug is on) while silently exporting ZERO output variables; they now
+// warn (visible by default), matching the sibling detectDestroyChanges /
+// warnIfSensitiveOutputs handlers.
+const agentTempDirectory = path.join(os.tmpdir(), 'tf-output-malformed-json-warns-agenttemp');
+fs.rmSync(agentTempDirectory, { recursive: true, force: true });
+fs.mkdirSync(agentTempDirectory, { recursive: true });
+process.env['AGENT_TEMPDIRECTORY'] = agentTempDirectory;
+
+const tp = path.join(__dirname, './AWSOutputMalformedJsonWarnsL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'output');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'which': { 'terraform': 'terraform' },
+    'checkPath': { 'terraform': true },
+    'exec': {
+        'terraform output -json': {
+            'code': 0,
+            'stdout': 'Error: this is not valid JSON output {'
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputMalformedJsonWarnsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/AWSOutputMalformedJsonWarnsL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAWS } from './../../src/aws-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAWS(), 'output', 'AWSOutputMalformedJsonWarnsL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanup.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanup.ts
@@ -1,0 +1,63 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// #802: a `show -json` file written to the operator-chosen filename (by default
+// inside the working directory, unlike output()'s Agent.TempDirectory temp file)
+// that contains sensitive plan values is now auto-registered for
+// NORMAL-completion scrub+delete by default (cleanupShowFileIfSensitive defaults
+// to true), mirroring output()'s #650 handling -- so its cleartext values are not
+// left in a working directory a "publish the working directory" artifact step
+// could sweep up. Uses ParentCommandHandler (via runViaParentHandler) since
+// cleanupTempFiles() only runs from execute()'s finally block.
+//
+// cleanupShowFileIfSensitive is set explicitly to 'true' here even though that's
+// its task.json default: mock-task's getBoolInput() only reads the INPUT_* env
+// var tr.setInput() sets and never consults task.json defaults (that resolution
+// is the real ADO agent's job, done before the task process starts).
+const workingDirectory = path.join(os.tmpdir(), 'tf-show-sensitive-autocleanup-test');
+fs.rmSync(workingDirectory, { recursive: true, force: true });
+fs.mkdirSync(workingDirectory, { recursive: true });
+
+const tp = path.join(__dirname, './AWSShowSensitiveAutoCleanupL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'show');
+tr.setInput('outputTo', 'file');
+tr.setInput('outputFormat', 'json');
+tr.setInput('filename', 'plan.json');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('cleanupShowFileIfSensitive', 'true');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+const planJson = JSON.stringify({
+    planned_values: {
+        outputs: {
+            db_password: { sensitive: true, value: 'hunter2' },
+            safe_output: { sensitive: false, value: 'hello' }
+        }
+    }
+});
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'which': { 'terraform': 'terraform' },
+    'checkPath': { 'terraform': true },
+    'exec': {
+        'terraform show -json': {
+            'code': 0,
+            'stdout': planJson
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanupL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanupL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../test-l0-helpers';
+
+runViaParentHandler('AWSShowSensitiveAutoCleanupL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanupOptOut.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanupOptOut.ts
@@ -1,0 +1,56 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// #802 opt-out: with cleanupShowFileIfSensitive=false the sensitive `show -json`
+// file is RETAINED at normal step end (a downstream step in the SAME job still
+// needs to read it via showFilePath) -- the mirror of the #650
+// cleanupOutputFileIfSensitive=false opt-out. (On a cancellation it would still
+// be scrubbed+deleted via the emergency-only path, where no downstream reader
+// remains -- not exercised here, which is the normal-completion case.)
+const workingDirectory = path.join(os.tmpdir(), 'tf-show-sensitive-autocleanup-optout-test');
+fs.rmSync(workingDirectory, { recursive: true, force: true });
+fs.mkdirSync(workingDirectory, { recursive: true });
+
+const tp = path.join(__dirname, './AWSShowSensitiveAutoCleanupOptOutL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'aws');
+tr.setInput('command', 'show');
+tr.setInput('outputTo', 'file');
+tr.setInput('outputFormat', 'json');
+tr.setInput('filename', 'plan.json');
+tr.setInput('commandOptions', '');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('cleanupShowFileIfSensitive', 'false');
+tr.setInput('environmentServiceNameAWS', 'AWS');
+
+process.env['ENDPOINT_AUTH_SCHEME_AWS'] = 'Basic';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_USERNAME'] = 'test-access-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_PASSWORD'] = 'test-secret-key';
+process.env['ENDPOINT_AUTH_PARAMETER_AWS_REGION'] = 'us-east-1';
+
+const planJson = JSON.stringify({
+    planned_values: {
+        outputs: {
+            db_password: { sensitive: true, value: 'hunter2' },
+            safe_output: { sensitive: false, value: 'hello' }
+        }
+    }
+});
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'which': { 'terraform': 'terraform' },
+    'checkPath': { 'terraform': true },
+    'exec': {
+        'terraform show -json': {
+            'code': 0,
+            'stdout': planJson
+        }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanupOptOutL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/AWSShowSensitiveAutoCleanupOptOutL0.ts
@@ -1,0 +1,3 @@
+import { runViaParentHandler } from '../test-l0-helpers';
+
+runViaParentHandler('AWSShowSensitiveAutoCleanupOptOutL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/results/ApplyDigestL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/results/ApplyDigestL0.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { buildApplyDigest } from '../../src/results/apply-digest';
+import { buildApplyDigest, parseNdjsonLines } from '../../src/results/apply-digest';
 import { DigestBuildMeta } from '../../src/results/plan-digest';
 import { MAX_DIAGNOSTICS, MAX_OUTPUTS, MAX_RESOURCES } from '../../src/results/caps';
 
@@ -13,6 +13,47 @@ const META: DigestBuildMeta = {
 function line(o: unknown): string {
   return JSON.stringify(o);
 }
+
+// #781: the single tolerant NDJSON parser now shared by apply-digest's own
+// builder and base-terraform-command-handler.ts's error-extraction / console-echo
+// passes. Directly unit-tested here so the three former inline copies' agreed
+// behavior (skip blanks, strip CR, drop malformed/non-object lines, count them)
+// is pinned in one place.
+describe('parseNdjsonLines (#781)', () => {
+  it('returns only object events and skips blank lines', () => {
+    const ndjson = ['', line({ a: 1 }), '   ', line({ b: 2 }), ''].join('\n');
+    const { events, malformed } = parseNdjsonLines(ndjson);
+    assert.deepStrictEqual(events, [{ a: 1 }, { b: 2 }]);
+    assert.strictEqual(malformed, 0);
+  });
+
+  it('strips a trailing CR before parsing (CRLF streams)', () => {
+    const ndjson = `${line({ a: 1 })}\r\n${line({ b: 2 })}\r`;
+    const { events, malformed } = parseNdjsonLines(ndjson);
+    assert.deepStrictEqual(events, [{ a: 1 }, { b: 2 }]);
+    assert.strictEqual(malformed, 0);
+  });
+
+  it('counts and drops a line that fails to JSON.parse', () => {
+    const ndjson = [line({ a: 1 }), '{ not valid json', line({ b: 2 })].join('\n');
+    const { events, malformed } = parseNdjsonLines(ndjson);
+    assert.deepStrictEqual(events, [{ a: 1 }, { b: 2 }]);
+    assert.strictEqual(malformed, 1);
+  });
+
+  it('counts and drops a syntactically-valid but non-object line (bare number/string/null)', () => {
+    const ndjson = ['5', '"hi"', 'null', line({ a: 1 })].join('\n');
+    const { events, malformed } = parseNdjsonLines(ndjson);
+    assert.deepStrictEqual(events, [{ a: 1 }]);
+    assert.strictEqual(malformed, 3);
+  });
+
+  it('returns empty for a non-string input', () => {
+    const { events, malformed } = parseNdjsonLines(undefined as unknown as string);
+    assert.deepStrictEqual(events, []);
+    assert.strictEqual(malformed, 0);
+  });
+});
 
 describe('buildApplyDigest', () => {
   it('parses a successful stream: resources, durations, outcome, summary, outputs', () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -4,7 +4,7 @@ import { TerraformBaseCommandInitializer, TerraformAuthorizationCommandInitializ
 import { getSecureVarFileArgs, SecureFileLoader } from './secure-file-loader';
 import { replaceSecretFile, scrubFile, writeSecretFile } from './secure-temp';
 import { buildPlanDigest, DigestBuildMeta } from './results/plan-digest';
-import { buildApplyDigest, ApplyDigestOptions } from './results/apply-digest';
+import { buildApplyDigest, ApplyDigestOptions, parseNdjsonLines } from './results/apply-digest';
 import { buildStateDigest } from './results/state-digest';
 import { Digest } from './results/digest-schema';
 import { serializeDigest, maskHasSensitiveLeaf } from './results/redact';
@@ -792,7 +792,24 @@ export abstract class BaseTerraformCommandHandler {
             // Detect destroy changes in JSON plan output
             if (outputFormat === "json") {
                 this.detectDestroyChanges(commandOutput.stdout);
-                this.warnIfSensitiveOutputs(commandOutput.stdout, showFilePath);
+                const hasSensitive = this.warnIfSensitiveOutputs(commandOutput.stdout, showFilePath);
+                // #802: a `show -json` file lands at the operator-chosen `filename`
+                // (by default inside the working directory, unlike output()'s
+                // Agent.TempDirectory temp file), so a "publish the working directory"
+                // artifact step could sweep up its cleartext sensitive values. Mirror
+                // output()'s #650 handling: when the file contains sensitive content,
+                // auto-register it for NORMAL-completion scrub+delete
+                // (cleanupShowFileIfSensitive, default true) unless the operator opts
+                // out because a downstream step in the SAME job still needs to read
+                // it -- in which case it still gets the emergency-only scrub+delete on
+                // a cancellation, where no legitimate downstream reader remains.
+                if (hasSensitive) {
+                    if (tasks.getBoolInput('cleanupShowFileIfSensitive', false)) {
+                        this.tempFiles.push(showFilePath);
+                    } else {
+                        this.emergencyOnlyTempFiles.push(showFilePath);
+                    }
+                }
             }
 
             result = commandOutput.code;
@@ -1314,16 +1331,9 @@ export abstract class BaseTerraformCommandHandler {
     private extractApplyErrorDiagnostics(ndjson: string): string[] {
         const knownSecrets = EnvironmentVariableHelper.getTrackedSecretValues();
         const summaries: string[] = [];
-        for (const rawLine of ndjson.split('\n')) {
-            const line = rawLine.replace(/\r$/, '').trim();
-            if (!line) continue;
-            let event: unknown;
-            try {
-                event = JSON.parse(line);
-            } catch {
-                continue;
-            }
-            if (!event || typeof event !== 'object') continue;
+        // Shared tolerant NDJSON parse (#781): yields only object events, dropping
+        // malformed/non-object lines exactly as this pass did inline before.
+        for (const event of parseNdjsonLines(ndjson).events) {
             const diagnostic = (event as Record<string, unknown>).diagnostic;
             if (!diagnostic || typeof diagnostic !== 'object') continue;
             const d = diagnostic as Record<string, unknown>;
@@ -1352,16 +1362,12 @@ export abstract class BaseTerraformCommandHandler {
      * separately (see #678) and neutralized via echoSafeConsoleLine().
      */
     private echoApplyMessages(ndjson: string): void {
-        for (const rawLine of ndjson.split('\n')) {
-            const line = rawLine.replace(/\r$/, '').trim();
-            if (!line) continue;
-            try {
-                const event = JSON.parse(line);
-                if (event && typeof event === 'object' && typeof event['@message'] === 'string') {
-                    this.echoSafeConsoleLine(event['@message']);
-                }
-            } catch {
-                // ignore -- see doc comment above.
+        // Shared tolerant NDJSON parse (#781): yields only object events, silently
+        // dropping malformed lines exactly as this pass did inline before.
+        for (const event of parseNdjsonLines(ndjson).events) {
+            const message = (event as Record<string, unknown>)['@message'];
+            if (typeof message === 'string') {
+                this.echoSafeConsoleLine(message);
             }
         }
     }
@@ -1801,7 +1807,12 @@ export abstract class BaseTerraformCommandHandler {
                 tasks.debug(`Set pipeline variable TF_OUT_${key}${isSecret ? ' (secret)' : ''}`);
             }
         } catch (err) {
-            tasks.debug(`Could not parse terraform output as JSON for pipeline variables: ${err}`);
+            // #783: a parse failure here silently populates ZERO TF_OUT_* variables,
+            // which a downstream step reads as empty/undefined with no explanation.
+            // Surface it at warning (visible by default), matching the sibling
+            // detectDestroyChanges / warnIfSensitiveOutputs handlers rather than the
+            // System.Debug-only visibility this previously had.
+            tasks.warning(`Could not parse terraform output as JSON for pipeline variables; no TF_OUT_* variables were set: ${err}`);
         }
     }
 
@@ -1839,14 +1850,19 @@ export abstract class BaseTerraformCommandHandler {
      * captured stdout, so a strict failure throws before anything reaches the
      * console at all rather than merely warning after the fact.
      */
-    private warnIfSensitiveOutputs(jsonOutput: string, filePath: string | undefined): void {
+    private warnIfSensitiveOutputs(jsonOutput: string, filePath: string | undefined): boolean {
         let plan: { planned_values?: { outputs?: unknown }, resource_changes?: unknown };
         try {
             plan = JSON.parse(jsonOutput);
         } catch (error) {
             tasks.warning(`Could not parse terraform plan for sensitive-output detection; the sensitive-value safety warning did not run: ${String(error)}`);
-            return;
+            return false;
         }
+
+        // #802: track whether the plan carries ANY sensitive content (outputs or
+        // resource attributes) so the show() outputTo=file path can auto-register
+        // the just-written file for scrub+delete, mirroring output()'s #650 handling.
+        let sensitive = false;
 
         // Check for sensitive values in planned_values outputs. maskHasSensitiveLeaf
         // shares its "mask === true at any depth" predicate with the WP-1 redaction
@@ -1858,6 +1874,7 @@ export abstract class BaseTerraformCommandHandler {
                 .filter(([, v]) => maskHasSensitiveLeaf((v as { sensitive?: unknown }).sensitive))
                 .map(([k]) => k);
             if (sensitiveKeys.length > 0) {
+                sensitive = true;
                 if (tasks.getBoolInput('failOnSensitiveOutputs', false)) {
                     if (filePath) {
                         this.tempFiles.push(filePath);
@@ -1883,6 +1900,7 @@ export abstract class BaseTerraformCommandHandler {
                 maskHasSensitiveLeaf(rc.change?.after_sensitive)
             );
             if (sensitiveResources.length > 0) {
+                sensitive = true;
                 if (filePath) {
                     tasks.warning(`Terraform plan contains ${sensitiveResources.length} resource(s) with sensitive attributes. The output file may contain unredacted secrets.`);
                 } else {
@@ -1890,6 +1908,8 @@ export abstract class BaseTerraformCommandHandler {
                 }
             }
         }
+
+        return sensitive;
     }
 
     /**
@@ -1918,7 +1938,11 @@ export abstract class BaseTerraformCommandHandler {
         try {
             outputs = JSON.parse(jsonOutput);
         } catch (error) {
-            tasks.debug(`Could not parse terraform output as JSON for sensitive-output detection: ${error}`);
+            // #783: escalate from debug to warning so a failed sensitivity check is
+            // visible by default, matching the sibling warnIfSensitiveOutputs /
+            // detectDestroyChanges handlers -- an unparseable output means this
+            // safety check silently did not run over a file that may hold secrets.
+            tasks.warning(`Could not parse terraform output as JSON for sensitive-output detection; the sensitive-value safety warning did not run: ${error}`);
             return false;
         }
         if (!outputs || typeof outputs !== 'object') return false;

--- a/Tasks/TerraformTask/TerraformTaskV5/src/results/apply-digest.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/results/apply-digest.ts
@@ -220,24 +220,37 @@ export function buildApplyDigest(ndjson: string, meta: DigestBuildMeta, options?
 
 // ---- parsing / accumulation helpers ----
 
-function parseNdjson(ndjson: string, ctx: RedactContext): unknown[] {
-  const out: unknown[] = [];
-  if (typeof ndjson !== 'string') return out;
-  const lines = ndjson.split('\n');
+/**
+ * Tolerantly parses an NDJSON stream into its object events: splits on newlines,
+ * strips a trailing CR, skips blank lines, JSON.parses each, and silently drops
+ * any line that fails to parse or is not a JSON object (counting them). This is
+ * the single shared implementation of the "split NDJSON, skip malformed lines"
+ * loop that apply's digest builder here and base-terraform-command-handler.ts's
+ * lighter-weight error-extraction / console-echo passes all need to agree on
+ * (#781); callers that don't care about the malformed count simply ignore it.
+ */
+export function parseNdjsonLines(ndjson: string): { events: unknown[]; malformed: number } {
+  const events: unknown[] = [];
   let malformed = 0;
-  for (const rawLine of lines) {
+  if (typeof ndjson !== 'string') return { events, malformed };
+  for (const rawLine of ndjson.split('\n')) {
     const line = rawLine.replace(/\r$/, '').trim();
     if (line === '') continue;
     try {
       const parsed = JSON.parse(line);
-      if (parsed && typeof parsed === 'object') out.push(parsed);
+      if (parsed && typeof parsed === 'object') events.push(parsed);
       else malformed++;
     } catch {
       malformed++;
     }
   }
+  return { events, malformed };
+}
+
+function parseNdjson(ndjson: string, ctx: RedactContext): unknown[] {
+  const { events, malformed } = parseNdjsonLines(ndjson);
   if (malformed > 0) ctx.notes.push(`skipped ${malformed} malformed apply event line(s)`);
-  return out;
+  return events;
 }
 
 function ensureAcc(map: Map<string, ResAcc>, address: string, action: ApplyResource['action'], order: number): ResAcc {

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -461,6 +461,15 @@
             "helpMarkDown": "When the output command's JSON file is detected to contain one or more Terraform outputs declared `sensitive = true` (see the sensitive-output warning), delete it automatically at the end of this step -- even though 'Delete the output JSON file at task end' (cleanupOutputFile) is off -- rather than leaving cleartext sensitive values on disk for the rest of the job relying solely on the agent's end-of-job temp directory purge. Has no effect when cleanupOutputFile is already enabled (the file is always deleted then) or when the output contains no sensitive values (the general retain-by-default behavior described above is unchanged). Disable this only if a downstream step in the SAME job still needs to read this specific file's sensitive value from disk via jsonOutputVariablesPath."
         },
         {
+            "name": "cleanupShowFileIfSensitive",
+            "type": "boolean",
+            "label": "Delete the show output file at task end if it contains sensitive values",
+            "defaultValue": "true",
+            "required": false,
+            "visibleRule": "command = show",
+            "helpMarkDown": "When `show` with JSON output to a file (Output to = file) writes a plan whose `planned_values` outputs or resource changes are detected to contain values declared `sensitive = true`, delete that file automatically at the end of this step rather than leaving cleartext sensitive values on disk. Unlike the `output` command's file (written under `Agent.TempDirectory`), the `show` file lands at the path you choose in 'Output filename' -- by default inside the working directory -- so a step that publishes the working directory as an artifact would otherwise sweep up its cleartext values. Has no effect when the shown plan contains no sensitive values. Disable this only if a downstream step in the SAME job still needs to read this specific file from disk via showFilePath; even then, the file is still scrubbed and deleted on a build cancellation, where no downstream reader remains."
+        },
+        {
             "name": "failOnSensitiveOutputs",
             "type": "boolean",
             "label": "Fail when sensitive outputs would be retained",


### PR DESCRIPTION
## Summary

Batch H of the 2026-07-22 accepted-risk remediation pass. Three low-severity **TerraformTaskV5** handler-hardening issues (all in `base-terraform-command-handler.ts` / `results/apply-digest.ts`):

- **#781** (low, CWE-1041) — the "split NDJSON, skip malformed lines" loop was implemented three times in one task.
- **#783** (low, CWE-390) — two JSON-parse-failure catches logged only at `tasks.debug` (invisible by default).
- **#802** (low) — `show()`'s `outputTo=file` path had the #650 gap the `output` command already closed.

Run through the `issue-remediation.copilot.md` 3-agent adversarial review process: **3/3 approve, no blocking findings**.

> **#775 split out**: the fourth issue originally grouped here (SIGTERM/SIGINT cleanup handlers in `TerraformDriftReportV1` + `TerraformPolicyCheckV1` — a *different pair* of tasks) is shipped as its own follow-up batch, to keep this PR to a single task/test-suite and isolate the riskier process-level signal-handler change. All three reviewers confirmed the split is legitimate.

## #781 — single shared tolerant NDJSON parser

Added and exported `parseNdjsonLines(ndjson): { events, malformed }` from `results/apply-digest.ts` (split on `\n`, strip trailing `\r`, skip blanks, `JSON.parse`, keep only objects, count the rest). apply-digest's private `parseNdjson` now calls it (still pushing the malformed count into `ctx.notes`); `extractApplyErrorDiagnostics` and `echoApplyMessages` iterate its `.events` instead of re-implementing the loop. **No observable behavior change.**

## #783 — escalate two silent debug-only parse failures to warnings

`setOutputVariables`' catch (which silently exported **zero** `TF_OUT_*` variables) and the analogous catch in `warnIfSensitiveOutputFile` now `tasks.warning` with the concrete consequence stated, matching the sibling `detectDestroyChanges` / `warnIfSensitiveOutputs` handlers.

## #802 — auto-cleanup a sensitive `show -json` file (mirror of #650)

`warnIfSensitiveOutputs` now returns whether the plan carried any sensitive content (outputs **or** resource attributes). `show()`'s file branch uses that to register the file for normal scrub+delete (new `cleanupShowFileIfSensitive` input, default `true`) or, when opted out, emergency-only scrub+delete on a cancellation — mirroring `output()`'s #650 handling. Unlike `output()`'s `Agent.TempDirectory` temp file, the `show` file lands at the operator-chosen `filename` (by default in the working directory), where a "publish the working directory" artifact step could otherwise sweep up its cleartext values. The new `cleanupShowFileIfSensitive` task.json input mirrors the #650 `cleanupOutputFileIfSensitive` field-for-field (incl. its task.json-only placement — that sibling is likewise absent from the `resources.resjson` mirror).

> Self-caught during testing: `tasks.getBoolInput(name, ...)`'s second arg is `required`, **not** a default — an initial `true` made it throw `Input required` and broke two existing sensitive-show tests; fixed to `false` (default-true comes from the task.json `defaultValue`, exactly like the #650 sibling).

## Review outcome — 3/3 approve

| Lens | Verdict | Notes |
|---|---|---|
| correctness | approve | `parseNdjsonLines` preserves all three loops' semantics; `warnIfSensitiveOutputs` boolean is outputs-OR-resources and doesn't change strict-throw/warn; no double-registration (strict throw preempts show()'s registration); `getBoolInput(..., false)` + task.json default-true correct. |
| regression-conventions | approve | New input mirrors `cleanupOutputFileIfSensitive` field-for-field; task.json-only placement verified consistent with the sibling (resjson omits it too); #781 pure extraction; #783 two independent (non-duplicate) warnings; surgical. |
| test-adequacy-siblings | approve | New tests exercise every branch and fail against pre-fix code; #802 tests run via `runViaParentHandler` so cleanup actually fires; #775 split legitimate; no missed sibling. |

## Testing

TerraformTaskV5 **590 passing**; `base-terraform-command-handler.js` 90.4% / `apply-digest.js` 92.38% line coverage, per-file floors met; shared-module parity green (no shared-family files touched). New tests: `parseNdjsonLines` unit block (#781), `AWSOutputMalformedJsonWarns` (#783, asserts both warnings fire and the task still succeeds), `AWSShowSensitiveAutoCleanup` + `OptOut` (#802). TaskV5 already carries its one-per-cycle Minor bump (286→287).

Closes #781
Closes #783
Closes #802
