### PR TITLE
fix: audit-2026-07-22 remediation - SIGTERM/SIGINT emergency cleanup for drift-report + policy-check (#775)

### DIFF
--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -21,6 +21,8 @@ import './FailOnCallbackErrorDefaultL0';
 import './SecureTempL0';
 // Direct unit tests for the shared retry.ts module (retryAsync + parseRetryAfterMs).
 import './RetryL0';
+// End-to-end coverage for index.ts's SIGTERM/SIGINT emergency summary-file scrub (#775).
+import './SignalHandlerL0';
 
 describe('TerraformDriftReport callback transport', function () {
     it('refuses to POST the callback token over a non-HTTPS URL', async () => {

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/SignalHandlerL0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/SignalHandlerL0.ts
@@ -1,0 +1,169 @@
+import * as assert from 'assert';
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * End-to-end coverage for src/index.ts's SIGTERM/SIGINT/uncaughtException/
+ * unhandledRejection registration (#775): a pipeline cancellation mid-run must
+ * scrub+delete the writeSecretFile'd summary file (which can hold sensitive plan
+ * values) and then re-raise the signal. Unlike the normal-completion path (which
+ * keeps the opt-in cleanupSummaryFile gate), the emergency path deletes the file
+ * unconditionally -- on a cancellation there is no downstream step left to read
+ * summaryFilePath.
+ *
+ * Follows TerraformTaskV5's SignalHandlerL0.ts approach: rather than a
+ * cross-process spawn + child.kill (non-deterministic on Windows), drive the
+ * REAL, unmodified index.ts in-process (reloaded fresh via the require cache each
+ * test). run() is synchronous through writeSecretFile() and suspends at the first
+ * await -- the callback POST -- so summarize() is stubbed (a fixed result) and
+ * postJsonWithRetry is stubbed to never resolve (standing in for a TSM callback
+ * still in flight when the signal arrives). process.kill / process.exit are
+ * captured (not executed) so the mocha process itself survives.
+ */
+describe('index.ts SIGTERM/SIGINT registration -- emergency summary-file scrub then re-raise (#775)', function () {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch shared modules for the duration of each test
+    const t = tasks as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = process as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const callback = require('../src/callback') as any;
+    const origGetInput = tasks.getInput;
+    const origGetBoolInput = tasks.getBoolInput;
+    const origGetVariable = tasks.getVariable;
+    const origKill = process.kill.bind(process);
+    const origExit = process.exit.bind(process);
+    const origPost = callback.postJsonWithRetry;
+    const indexModulePath = require.resolve('../src/index');
+    const trackedEvents = ['SIGTERM', 'SIGINT', 'uncaughtException', 'unhandledRejection'] as const;
+
+    let scratchDir: string;
+    let planFile: string;
+    let killCalls: Array<{ pid: number; signal: string }>;
+    let exitCalls: number[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let listenerSnapshots: Map<string, any[]>;
+
+    function summaryFiles(): string[] {
+        return (fs.existsSync(scratchDir) ? fs.readdirSync(scratchDir) : []).filter((f) => f.startsWith('tsm-drift-report-'));
+    }
+
+    beforeEach(() => {
+        scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdr-signal-e2e-'));
+        planFile = path.join(scratchDir, 'plan.json');
+        fs.writeFileSync(planFile, '{}');
+        killCalls = [];
+        exitCalls = [];
+
+        listenerSnapshots = new Map();
+        for (const event of trackedEvents) {
+            listenerSnapshots.set(event, [...p.listeners(event)]);
+        }
+
+        t.getInput = (name: string) => {
+            if (name === 'planJsonFile') return planFile;
+            if (name === 'callbackUrl') return 'https://tsm.example.com/callback';
+            if (name === 'callbackToken') return 'test-token';
+            return undefined;
+        };
+        t.getBoolInput = () => false;
+        t.getVariable = (name: string) => (name === 'Agent.TempDirectory' ? scratchDir : undefined);
+
+        p.kill = (pid: number, signal?: string | number) => {
+            killCalls.push({ pid, signal: String(signal ?? 'SIGTERM') });
+            return true;
+        };
+        p.exit = (code?: number) => { exitCalls.push(code ?? 0); };
+
+        // The real summarize() handles an empty plan gracefully (all zeros), so no
+        // stub is needed; the callback POST then hangs, standing in for a TSM
+        // callback still in flight when a termination signal arrives. (summarize is
+        // a read-only ESM getter on the terraform-drift-contract package and cannot
+        // be reassigned anyway -- postJsonWithRetry is same-task src and is writable.)
+        callback.postJsonWithRetry = () => new Promise(() => { /* never resolves */ });
+
+        delete require.cache[indexModulePath];
+    });
+
+    afterEach(() => {
+        t.getInput = origGetInput;
+        t.getBoolInput = origGetBoolInput;
+        t.getVariable = origGetVariable;
+        p.kill = origKill;
+        p.exit = origExit;
+        callback.postJsonWithRetry = origPost;
+        delete require.cache[indexModulePath];
+
+        for (const event of trackedEvents) {
+            p.removeAllListeners(event);
+            for (const listener of listenerSnapshots.get(event)!) {
+                p.on(event, listener);
+            }
+        }
+        fs.rmSync(scratchDir, { recursive: true, force: true });
+    });
+
+    async function loadIndexAndConfirmSummaryWritten(): Promise<void> {
+        require('../src/index');
+        // run() is synchronous through writeSecretFile() and only suspends at the
+        // first await (the callback POST), so the summary file is on disk by the
+        // time require() returns; a microtask yield advances run() into the hanging
+        // postJsonWithRetry (the realistic "signal arrives mid-run" state).
+        await Promise.resolve();
+        assert.strictEqual(summaryFiles().length, 1, `the writeSecretFile'd summary must exist once run() has started; found: ${summaryFiles().join(', ')}`);
+    }
+
+    function invokeFreshListener(event: typeof trackedEvents[number], ...args: unknown[]): void {
+        const before = listenerSnapshots.get(event)!;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- listener signatures vary by event
+        const fresh = p.listeners(event).find((listener: any) => !before.includes(listener));
+        assert.ok(fresh, `index.ts must register a new ${event} listener on load`);
+        fresh(...args);
+    }
+
+    it('SIGTERM: emergency cleanup scrubs+deletes the summary file, then the signal is re-raised', async () => {
+        await loadIndexAndConfirmSummaryWritten();
+
+        const listenersBefore = process.listenerCount('SIGTERM');
+        process.emit('SIGTERM', 'SIGTERM');
+
+        assert.strictEqual(summaryFiles().length, 0, 'emergencyCleanup() must delete the summary file when SIGTERM arrives mid-run');
+        assert.strictEqual(process.listenerCount('SIGTERM'), listenersBefore - 1, 'the handler must remove itself before re-raising');
+        assert.strictEqual(killCalls.length, 1, 'the signal must be re-raised via process.kill after cleanup');
+        assert.strictEqual(killCalls[0].pid, process.pid);
+        assert.strictEqual(killCalls[0].signal, 'SIGTERM');
+    });
+
+    it('SIGINT: emergency cleanup scrubs+deletes the summary file, then the signal is re-raised', async () => {
+        await loadIndexAndConfirmSummaryWritten();
+
+        const listenersBefore = process.listenerCount('SIGINT');
+        process.emit('SIGINT', 'SIGINT');
+
+        assert.strictEqual(summaryFiles().length, 0, 'emergencyCleanup() must delete the summary file when SIGINT arrives mid-run');
+        assert.strictEqual(process.listenerCount('SIGINT'), listenersBefore - 1, 'the handler must remove itself before re-raising');
+        assert.strictEqual(killCalls.length, 1, 'the signal must be re-raised via process.kill after cleanup');
+        assert.strictEqual(killCalls[0].signal, 'SIGINT');
+    });
+
+    it('uncaughtException: emergency cleanup scrubs+deletes the summary file, then the process exits 1', async () => {
+        await loadIndexAndConfirmSummaryWritten();
+
+        invokeFreshListener('uncaughtException', new Error('boom'));
+
+        assert.strictEqual(summaryFiles().length, 0, 'emergencyCleanup() must delete the summary file on an uncaught exception mid-run');
+        assert.strictEqual(exitCalls.length, 1, 'the process must exit after cleanup');
+        assert.strictEqual(exitCalls[0], 1);
+    });
+
+    it('unhandledRejection: emergency cleanup scrubs+deletes the summary file, then the process exits 1', async () => {
+        await loadIndexAndConfirmSummaryWritten();
+
+        invokeFreshListener('unhandledRejection', new Error('boom'));
+
+        assert.strictEqual(summaryFiles().length, 0, 'emergencyCleanup() must delete the summary file on an unhandled rejection mid-run');
+        assert.strictEqual(exitCalls.length, 1, 'the process must exit after cleanup');
+        assert.strictEqual(exitCalls[0], 1);
+    });
+});

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -52,6 +52,46 @@ async function run(): Promise<void> {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
     // Hoisted so the finally can optionally clean it up (see cleanupSummaryFile).
     let summaryFile: string | undefined;
+
+    // #775: Node terminates immediately on an unhandled SIGTERM/SIGINT without
+    // running the try/finally below, so a pipeline cancellation mid-run would
+    // otherwise leave the writeSecretFile'd summary (which can hold sensitive plan
+    // values) on disk -- scrubbed only by the agent's end-of-job temp purge, a
+    // plain delete rather than a secure overwrite, and not at all when
+    // Agent.TempDirectory is unset and os.tmpdir() is used. On a cancellation there
+    // is no downstream step left to read summaryFilePath, so scrub+delete it
+    // unconditionally here (the normal-completion path below keeps the opt-in
+    // cleanupSummaryFile gate). Registering a signal listener suppresses Node's
+    // default terminate-on-signal behavior, so each handler must also re-raise the
+    // signal with its default disposition. Mirrors TerraformTaskV5's index.ts.
+    const emergencyCleanup = () => {
+        if (summaryFile && fs.existsSync(summaryFile)) {
+            try {
+                scrubFile(summaryFile);
+            } catch { /* best-effort scrub before the unlink below */ }
+            try {
+                fs.unlinkSync(summaryFile);
+            } catch { /* best-effort: the agent temp purge is the backstop */ }
+        }
+    };
+    const handleTerminationSignal = (signal: NodeJS.Signals) => {
+        emergencyCleanup();
+        process.removeListener(signal, handleTerminationSignal);
+        process.kill(process.pid, signal);
+    };
+    process.on('SIGTERM', handleTerminationSignal);
+    process.on('SIGINT', handleTerminationSignal);
+    process.on('uncaughtException', (err) => {
+        emergencyCleanup();
+        tasks.setResult(tasks.TaskResult.Failed, `Uncaught exception: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+    });
+    process.on('unhandledRejection', (reason) => {
+        emergencyCleanup();
+        tasks.setResult(tasks.TaskResult.Failed, `Unhandled rejection: ${reason instanceof Error ? reason.message : String(reason)}`);
+        process.exit(1);
+    });
+
     try {
         const planFile = path.resolve(tasks.getInput('planJsonFile', true)!);
         const planStat = fs.existsSync(planFile) ? fs.statSync(planFile) : undefined;
@@ -195,6 +235,8 @@ async function run(): Promise<void> {
                 tasks.warning(`Failed to clean up summary file ${summaryFile}: ${err}`);
             }
         }
+        process.removeListener('SIGTERM', handleTerminationSignal);
+        process.removeListener('SIGINT', handleTerminationSignal);
     }
 }
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -9,7 +9,7 @@
   "author": "sethbacon",
   "version": {
     "Major": "1",
-    "Minor": "15",
+    "Minor": "16",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -21,6 +21,8 @@ import './OutputCapL0';
 import './GitAuthEnvL0';
 // Direct unit tests for the bounded subprocess execution wrapper (#782).
 import './ExecTimeoutL0';
+// End-to-end coverage for index.ts's SIGTERM/SIGINT emergency cleanup (#775).
+import './SignalHandlerL0';
 
 describe('TerraformPolicyCheck Test Suite', function () {
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SignalHandlerL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/SignalHandlerL0.ts
@@ -1,0 +1,172 @@
+import * as assert from 'assert';
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * End-to-end coverage for src/index.ts's SIGTERM/SIGINT/uncaughtException/
+ * unhandledRejection registration (#775): a pipeline cancellation mid-run must
+ * run cleanup(tempDirs) -- deleting the cloned (possibly private) policy repo
+ * and any generated Sentinel config dir -- and then re-raise the signal so the
+ * process still dies promptly.
+ *
+ * Follows TerraformTaskV5's SignalHandlerL0.ts approach: rather than a
+ * cross-process spawn + child.kill (non-deterministic on Windows, which
+ * hard-terminates the target without ever invoking its listener), drive the
+ * REAL, unmodified index.ts in-process (reloaded fresh via the require cache each
+ * test). Two module seams are stubbed: resolvePolicyDir (to create+track a REAL
+ * temp dir synchronously, standing in for a completed clone) and runOpa (to never
+ * resolve, standing in for a policy engine still running when the signal arrives).
+ * process.kill / process.exit are captured (not executed) so the mocha process
+ * itself survives.
+ */
+describe('index.ts SIGTERM/SIGINT registration -- emergency cleanup then re-raise (#775)', function () {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch shared modules for the duration of each test
+    const t = tasks as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = process as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const policySource = require('../src/policy-source') as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opaEngine = require('../src/opa-engine') as any;
+    const origGetInput = tasks.getInput;
+    const origWhich = tasks.which;
+    const origKill = process.kill.bind(process);
+    const origExit = process.exit.bind(process);
+    const origResolve = policySource.resolvePolicyDir;
+    const origRunOpa = opaEngine.runOpa;
+    const indexModulePath = require.resolve('../src/index');
+    const trackedEvents = ['SIGTERM', 'SIGINT', 'uncaughtException', 'unhandledRejection'] as const;
+
+    let scratchDir: string;
+    let inputFile: string;
+    let clonedDir: string;
+    let killCalls: Array<{ pid: number; signal: string }>;
+    let exitCalls: number[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let listenerSnapshots: Map<string, any[]>;
+
+    beforeEach(() => {
+        scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tpc-signal-e2e-'));
+        inputFile = path.join(scratchDir, 'plan.json');
+        fs.writeFileSync(inputFile, '{}');
+        clonedDir = '';
+        killCalls = [];
+        exitCalls = [];
+
+        listenerSnapshots = new Map();
+        for (const event of trackedEvents) {
+            listenerSnapshots.set(event, [...p.listeners(event)]);
+        }
+
+        t.getInput = (name: string) => {
+            if (name === 'engine') return 'opa';
+            if (name === 'inputFile') return inputFile;
+            return undefined;
+        };
+        t.which = () => '/usr/bin/opa';
+
+        p.kill = (pid: number, signal?: string | number) => {
+            killCalls.push({ pid, signal: String(signal ?? 'SIGTERM') });
+            return true;
+        };
+        p.exit = (code?: number) => { exitCalls.push(code ?? 0); };
+
+        // Create+track a REAL temp dir synchronously (so it exists once require()
+        // returns), then resolve. runOpa hangs -- standing in for a policy engine
+        // still running when the termination signal arrives.
+        policySource.resolvePolicyDir = async (tempDirs: string[]) => {
+            clonedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tpc-policy-repo-'));
+            tempDirs.push(clonedDir);
+            return clonedDir;
+        };
+        opaEngine.runOpa = () => new Promise(() => { /* never resolves */ });
+
+        delete require.cache[indexModulePath];
+    });
+
+    afterEach(() => {
+        t.getInput = origGetInput;
+        t.which = origWhich;
+        p.kill = origKill;
+        p.exit = origExit;
+        policySource.resolvePolicyDir = origResolve;
+        opaEngine.runOpa = origRunOpa;
+        delete require.cache[indexModulePath];
+
+        for (const event of trackedEvents) {
+            p.removeAllListeners(event);
+            for (const listener of listenerSnapshots.get(event)!) {
+                p.on(event, listener);
+            }
+        }
+        fs.rmSync(scratchDir, { recursive: true, force: true });
+        if (clonedDir) fs.rmSync(clonedDir, { recursive: true, force: true });
+    });
+
+    async function loadIndexAndConfirmCloneTracked(): Promise<void> {
+        require('../src/index');
+        // run() is synchronous up to `await resolvePolicyDir(tempDirs)`; the stub
+        // creates the dir synchronously before returning its promise, so the dir
+        // exists by the time require() returns. A microtask yield lets the awaited
+        // resolvePolicyDir settle and run() advance into the hanging runOpa (the
+        // realistic "signal arrives mid-run" state); the handlers are live either way.
+        await Promise.resolve();
+        assert.notStrictEqual(clonedDir, '', 'resolvePolicyDir stub must have created the tracked policy-repo dir');
+        assert.strictEqual(fs.existsSync(clonedDir), true, 'the tracked policy-repo dir must exist once resolvePolicyDir has run');
+    }
+
+    function invokeFreshListener(event: typeof trackedEvents[number], ...args: unknown[]): void {
+        const before = listenerSnapshots.get(event)!;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- listener signatures vary by event
+        const fresh = p.listeners(event).find((listener: any) => !before.includes(listener));
+        assert.ok(fresh, `index.ts must register a new ${event} listener on load`);
+        fresh(...args);
+    }
+
+    it('SIGTERM: cleanup deletes the tracked policy-repo dir, then the signal is re-raised', async () => {
+        await loadIndexAndConfirmCloneTracked();
+
+        const listenersBefore = process.listenerCount('SIGTERM');
+        process.emit('SIGTERM', 'SIGTERM');
+
+        assert.strictEqual(fs.existsSync(clonedDir), false, 'cleanup() must delete the tracked policy-repo dir when SIGTERM arrives mid-run');
+        assert.strictEqual(process.listenerCount('SIGTERM'), listenersBefore - 1, 'the handler must remove itself before re-raising');
+        assert.strictEqual(killCalls.length, 1, 'the signal must be re-raised via process.kill after cleanup');
+        assert.strictEqual(killCalls[0].pid, process.pid);
+        assert.strictEqual(killCalls[0].signal, 'SIGTERM');
+    });
+
+    it('SIGINT: cleanup deletes the tracked policy-repo dir, then the signal is re-raised', async () => {
+        await loadIndexAndConfirmCloneTracked();
+
+        const listenersBefore = process.listenerCount('SIGINT');
+        process.emit('SIGINT', 'SIGINT');
+
+        assert.strictEqual(fs.existsSync(clonedDir), false, 'cleanup() must delete the tracked policy-repo dir when SIGINT arrives mid-run');
+        assert.strictEqual(process.listenerCount('SIGINT'), listenersBefore - 1, 'the handler must remove itself before re-raising');
+        assert.strictEqual(killCalls.length, 1, 'the signal must be re-raised via process.kill after cleanup');
+        assert.strictEqual(killCalls[0].signal, 'SIGINT');
+    });
+
+    it('uncaughtException: cleanup deletes the tracked policy-repo dir, then the process exits 1', async () => {
+        await loadIndexAndConfirmCloneTracked();
+
+        invokeFreshListener('uncaughtException', new Error('boom'));
+
+        assert.strictEqual(fs.existsSync(clonedDir), false, 'cleanup() must delete the tracked policy-repo dir on an uncaught exception mid-run');
+        assert.strictEqual(exitCalls.length, 1, 'the process must exit after cleanup');
+        assert.strictEqual(exitCalls[0], 1);
+    });
+
+    it('unhandledRejection: cleanup deletes the tracked policy-repo dir, then the process exits 1', async () => {
+        await loadIndexAndConfirmCloneTracked();
+
+        invokeFreshListener('unhandledRejection', new Error('boom'));
+
+        assert.strictEqual(fs.existsSync(clonedDir), false, 'cleanup() must delete the tracked policy-repo dir on an unhandled rejection mid-run');
+        assert.strictEqual(exitCalls.length, 1, 'the process must exit after cleanup');
+        assert.strictEqual(exitCalls[0], 1);
+    });
+});

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/index.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/index.ts
@@ -26,6 +26,32 @@ async function run() {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
     const tempDirs: string[] = [];
 
+    // #775: Node terminates immediately on an unhandled SIGTERM/SIGINT without
+    // running the try/finally below, so a pipeline cancellation mid-run would
+    // otherwise leave the cloned (possibly private) policy repo and any generated
+    // Sentinel config dir on disk, relying solely on the agent's end-of-job temp
+    // purge. Registering a signal listener suppresses Node's default
+    // terminate-on-signal behavior, so each handler must clean up AND re-raise the
+    // signal with its default disposition so the process still dies promptly.
+    // Mirrors TerraformTaskV5's index.ts.
+    const handleTerminationSignal = (signal: NodeJS.Signals) => {
+        cleanup(tempDirs);
+        process.removeListener(signal, handleTerminationSignal);
+        process.kill(process.pid, signal);
+    };
+    process.on('SIGTERM', handleTerminationSignal);
+    process.on('SIGINT', handleTerminationSignal);
+    process.on('uncaughtException', (err) => {
+        cleanup(tempDirs);
+        tasks.setResult(tasks.TaskResult.Failed, `Uncaught exception: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+    });
+    process.on('unhandledRejection', (reason) => {
+        cleanup(tempDirs);
+        tasks.setResult(tasks.TaskResult.Failed, `Unhandled rejection: ${reason instanceof Error ? reason.message : String(reason)}`);
+        process.exit(1);
+    });
+
     try {
         const engine = tasks.getInput('engine') || 'opa';
 
@@ -71,6 +97,8 @@ async function run() {
         tasks.setResult(tasks.TaskResult.Failed, error instanceof Error ? error.message : String(error));
     } finally {
         cleanup(tempDirs);
+        process.removeListener('SIGTERM', handleTerminationSignal);
+        process.removeListener('SIGINT', handleTerminationSignal);
     }
 }
 


### PR DESCRIPTION
## Summary

Batch H2 of the 2026-07-22 accepted-risk remediation pass — **#775** (medium, CWE-459), split out of Batch H to isolate this process-level signal-handler change to its own task pair.

Run through the `issue-remediation.copilot.md` 3-agent adversarial review process: **3/3 approve, no blocking findings**.

## #775 — cancellation cleanup implemented in only 1 of ~11 tasks

Only `TerraformTaskV5`'s `index.ts` registered process-level SIGTERM/SIGINT/uncaughtException/unhandledRejection handlers. Node does **not** run a JS `finally` block on an unhandled SIGTERM/SIGINT (its default disposition terminates the process immediately), so a pipeline cancellation mid-run in the two other tasks that write a sensitive artifact to disk skipped their scrub/cleanup discipline, relying solely on the agent's `Agent.TempDirectory` purge — a plain delete, and not guaranteed at all when `Agent.TempDirectory` is unset and `os.tmpdir()` is used:

- **TerraformDriftReportV1** — a `writeSecretFile`'d plan-derived summary (can hold sensitive values).
- **TerraformPolicyCheckV1** — a cloned (possibly private) policy repo + generated Sentinel config dir.

The fix mirrors `TerraformTaskV5`'s `index.ts` exactly: register the four handlers, run the task's cleanup, then re-raise the signal (`process.kill(pid, signal)` after `removeListener`) / `process.exit(1)` for the exception handlers.

- **PolicyCheck**: wire the handlers to the **existing** `cleanup(tempDirs)` (an `fs.rmSync` of each tracked dir); the `finally` now also `removeListener`s the signals. Cleanup logic unchanged.
- **DriftReport**: add a new `emergencyCleanup()` that scrubs (`scrubFile`) + deletes the `summaryFile` **unconditionally** — on a cancellation there is no downstream step left to read `summaryFilePath`, so the availability-vs-exposure tradeoff flips to always-scrub. The `finally`'s opt-in `cleanupSummaryFile` gate is unchanged (normal completion still retains the file by default). This mirrors TaskV5's `emergencyOnlyTempFiles` concept.

## Review outcome — 3/3 approve

| Lens | Verdict | Notes |
|---|---|---|
| correctness | approve | Both mirror TaskV5's pattern with correct closure semantics; DriftReport's unconditional emergency scrub is correct; `emergencyCleanup` guards `summaryFile && existsSync` and wraps scrub/unlink so it can't throw out of the handler; no double-unlink (finally re-checks `existsSync`); no listener leak. |
| regression-conventions | approve | Normal-completion behavior byte-for-byte unchanged (PolicyCheck `cleanup` untouched; DriftReport opt-in gate untouched); handler shapes/re-raise/exit codes match TaskV5; surgical (two `index.ts` + two test files, no task.json/message/resjson changes). |
| test-adequacy-siblings | approve | Tests prove artifact-deleted + signal-re-raised for all 4 events and fail against the pre-fix (no-handler) code; the in-process require-fresh approach is deterministic (a cross-process `child.kill` is flaky on Windows); `afterEach` restores kill/exit/stubs/listeners so no test pollution; no missed sibling task. |

## Testing

New `Tests/SignalHandlerL0.ts` in each task, modeled on TaskV5's: a real in-process, require-cache-fresh load of the unmodified `index.ts` (**not** a cross-process spawn + `child.kill`, which is non-deterministic on Windows — it hard-terminates without invoking the listener), with `process.kill`/`process.exit` captured (not executed). Each asserts, for all four events, that the sensitive artifact is deleted and the signal is re-raised / process exits 1.

> Test-writing note: `terraform-drift-contract`'s `summarize` export is a read-only ESM getter and can't be reassigned, so the DriftReport test doesn't stub it (the real function handles an empty plan) and only stubs the same-task-src `postJsonWithRetry` to suspend `run()` after `writeSecretFile`.

TerraformPolicyCheckV1 **77 passing** (+4), TerraformDriftReportV1 **71 passing** (+4); per-file coverage floors met on both; shared-module parity green (no shared-family files touched). Minor versions bumped (both 15→16).

Closes #775
