### PR TITLE
test: forbid pending tests suite-wide; add Sentinel GPG + module-publish https-client contract tests (#784, #785, #786)

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/package.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/package.json
@@ -7,8 +7,8 @@
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
-    "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
-    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
+    "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
     "posttest:coverage": "node ../../../scripts/check-per-file-coverage.js",
     "lint": "npx eslint src/ Tests/"
   },

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -73,6 +73,44 @@ describe('PolicyAgentInstaller Test Suite', function () {
     // accepted (the air-gapped escape hatch), not refused by the default baseline.
     expectSuccess('MirrorAllowedHostAccept');
 
+    // #786: end-to-end Sentinel GPG-signature scenarios mirroring TerraformInstallerV1's
+    // terraform GPG scenario set (the underlying gpg-verifier.ts is byte-identical, but
+    // only the terraform path previously had task-flow-level bad/missing-signature proof).
+    it('SentinelGpgSignatureUnavailable — a missing .sig with requireGpgSignature=false succeeds with a warning', async () => {
+        const tp = path.join(__dirname, 'SentinelGpgSignatureUnavailable.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+        }, tr);
+    });
+
+    it('SentinelGpgVerificationFail — an invalid SHA256SUMS signature fails the task closed', async () => {
+        const tp = path.join(__dirname, 'SentinelGpgVerificationFail.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some((e) => /GPG signature/i.test(e)),
+                'should fail via the GPG signature check. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
+    it('SentinelGpgSignatureRequiredButMissing — a missing .sig fails when requireGpgSignature is in effect', async () => {
+        const tp = path.join(__dirname, 'SentinelGpgSignatureRequiredButMissing.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should have failed');
+            assert(
+                tr.errorIssues.some((e) => /GPG signature file unavailable/i.test(e)),
+                'should fail via the required-but-missing GPG signature check. errors: ' + tr.errorIssues,
+            );
+        }, tr);
+    });
+
     it('OpaOfficialChecksumSkip warns when the .sha256 is unavailable', async () => {
         const tp = path.join(__dirname, 'OpaOfficialChecksumSkip.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelGpgSignatureRequiredButMissing.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelGpgSignatureRequiredButMissing.ts
@@ -1,0 +1,69 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #786: end-to-end proof that a MISSING Sentinel SHA256SUMS.sig fails the whole
+// task closed when requireGpgSignature is in effect (default true via
+// getBoolInputDefaultTrue) -- mirrors TerraformInstallerV1's
+// GpgSignatureRequiredButMissing for the terraform path.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'sentinel');
+tr.setInput('version', '0.40.0');
+tr.setInput('downloadSource', 'official');
+
+tr.registerMock('os', { type: () => 'Windows_NT', arch: () => 'x64' });
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => { throw new Error('Specific version should not call fetchJson: ' + url); },
+    fetchText: async (url: string) => {
+        if (url.includes('SHA256SUMS')) {
+            return `${EXPECTED_SHA256}  sentinel_0.40.0_windows_amd64.zip\n`;
+        }
+        throw new Error('Unexpected fetchText URL: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+// gpg-verifier: the .sig is unavailable AND verification is required -- the real
+// implementation throws a VerificationFailure. Mock throws when required=true.
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async (_sha256SumsContent: string, signatureUrl: string, required: boolean) => {
+        if (required) {
+            throw new Error(`GPG signature file unavailable (${signatureUrl}) and signature verification is required. Set 'requireGpgSignature' to false to skip.`);
+        }
+    }
+});
+
+tr.registerMock('fs', {
+    chmodSync: () => { },
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-zip'))
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid',
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: () => null,
+    downloadTool: async () => '/tmp/sentinel.zip',
+    extractZip: async () => '/tmp/sentinel-extracted',
+    cacheDir: async () => '/tmp/sentinel-cached',
+    cleanVersion: (v: string) => v,
+    prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    find: { '/tmp/sentinel-cached': ['/tmp/sentinel-cached/sentinel.exe'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelGpgSignatureUnavailable.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelGpgSignatureUnavailable.ts
@@ -1,0 +1,67 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #786: end-to-end proof that a MISSING Sentinel SHA256SUMS.sig degrades
+// gracefully (warn, do not fail) when requireGpgSignature is explicitly false --
+// mirrors TerraformInstallerV1's GpgSignatureUnavailable for the terraform path.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'sentinel');
+tr.setInput('version', '0.40.0');
+tr.setInput('downloadSource', 'official');
+tr.setInput('requireGpgSignature', 'false');
+
+tr.registerMock('os', { type: () => 'Windows_NT', arch: () => 'x64' });
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => { throw new Error('Specific version should not call fetchJson: ' + url); },
+    fetchText: async (url: string) => {
+        if (url.includes('SHA256SUMS')) {
+            return `${EXPECTED_SHA256}  sentinel_0.40.0_windows_amd64.zip\n`;
+        }
+        throw new Error('Unexpected fetchText URL: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+// gpg-verifier: mock the .sig as unavailable but NOT required -- the real
+// implementation warns via tasks.warning and returns without throwing.
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string, _required: boolean) => {
+        // graceful degradation: no throw
+    }
+});
+
+tr.registerMock('fs', {
+    chmodSync: () => { },
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-zip'))
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid',
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: () => null,
+    downloadTool: async () => '/tmp/sentinel.zip',
+    extractZip: async () => '/tmp/sentinel-extracted',
+    cacheDir: async () => '/tmp/sentinel-cached',
+    cleanVersion: (v: string) => v,
+    prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    find: { '/tmp/sentinel-cached': ['/tmp/sentinel-cached/sentinel.exe'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelGpgVerificationFail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/SentinelGpgVerificationFail.ts
@@ -1,0 +1,66 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #786: end-to-end proof that an INVALID Sentinel SHA256SUMS GPG signature fails
+// the whole task closed (mirrors TerraformInstallerV1's GpgVerificationFail for
+// the terraform path). requireGpgSignature defaults to true (getBoolInputDefaultTrue),
+// so no input is needed to enforce it.
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'sentinel');
+tr.setInput('version', '0.40.0');
+tr.setInput('downloadSource', 'official');
+
+tr.registerMock('os', { type: () => 'Windows_NT', arch: () => 'x64' });
+
+const EXPECTED_SHA256 = 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => { throw new Error('Specific version should not call fetchJson: ' + url); },
+    fetchText: async (url: string) => {
+        if (url.includes('SHA256SUMS')) {
+            return `${EXPECTED_SHA256}  sentinel_0.40.0_windows_amd64.zip\n`;
+        }
+        throw new Error('Unexpected fetchText URL: ' + url);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+// gpg-verifier: mock GPG verification as FAILING (invalid signature).
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => {
+        throw new Error('GPG signature verification failed for SHA256SUMS: Signature is not valid');
+    }
+});
+
+tr.registerMock('fs', {
+    chmodSync: () => { },
+    createReadStream: () => require('stream').Readable.from(Buffer.from('fake-zip'))
+});
+
+tr.registerMock('crypto', {
+    randomUUID: () => 'test-uuid',
+    createHash: () => {
+        const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
+        hash.digest = () => EXPECTED_SHA256;
+        return hash;
+    }
+});
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: () => null,
+    downloadTool: async () => '/tmp/sentinel.zip',
+    extractZip: async () => '/tmp/sentinel-extracted',
+    cacheDir: async () => '/tmp/sentinel-cached',
+    cleanVersion: (v: string) => v,
+    prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    find: { '/tmp/sentinel-cached': ['/tmp/sentinel-cached/sentinel.exe'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
@@ -7,8 +7,8 @@
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
-    "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
-    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
+    "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
     "posttest:coverage": "node ../../../scripts/check-per-file-coverage.js",
     "lint": "npx eslint src/ Tests/"
   },

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/package.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/package.json
@@ -7,8 +7,8 @@
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
-    "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts Tests/ProxyL0.ts",
-    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts Tests/ProxyL0.ts",
+    "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts Tests/ProxyL0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts Tests/ProxyL0.ts",
     "posttest:coverage": "node ../../../scripts/check-per-file-coverage.js",
     "lint": "npx eslint src/ Tests/"
   },

--- a/Tasks/TerraformDocs/TerraformDocsV1/package.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/package.json
@@ -7,8 +7,8 @@
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
-    "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
-    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
+    "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
     "posttest:coverage": "node ../../../scripts/check-per-file-coverage.js",
     "lint": "npx eslint src/ Tests/"
   },

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
@@ -7,8 +7,8 @@
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
-    "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
-    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
+    "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
     "posttest:coverage": "node ../../../scripts/check-per-file-coverage.js",
     "lint": "npx eslint src/ Tests/"
   },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CosignVerifierL0.ts
@@ -332,42 +332,47 @@ describe('cosign-verifier: verifyCosignSignature behavior', () => {
 // end-to-end verify against genuine OpenTofu keyless material (which needs Sigstore
 // network + a real release) is covered by weekly-security.yml's opentofu-cosign-canary,
 // which installs cosign and drives this same verifyCosignSignature code.
-describe('cosign-verifier: real cosign invocation (graceful skip when unavailable) (#656)', function () {
+describe('cosign-verifier: real cosign invocation (defined only when cosign is available) (#656)', function () {
     this.timeout(30000);
 
     /* eslint-disable @typescript-eslint/no-explicit-any */
     const hc = httpClient as any;
     const origFetchBufferAllow404 = hc.fetchBufferAllow404;
     const VERSION = '1.11.6';
-    let cosignAvailable = false;
 
-    before(() => {
-        try {
-            tasks.which('cosign', true);
-            cosignAvailable = true;
-        } catch {
-            cosignAvailable = false;
-            console.log('cosign not found on PATH — skipping the real cosign invocation test (#656).');
-        }
-    });
+    // Detect cosign synchronously at test-tree-build time so the real-binary test is
+    // DEFINED only when cosign is present, rather than defined-then-this.skip()'d at
+    // run time. A runtime this.skip() marks the test PENDING, which the suite's
+    // --forbid-pending flag (#784) treats as a failure; conditionally defining it
+    // instead degrades gracefully in the per-PR Installer V1 CI job (which installs
+    // no cosign) with no pending test.
+    let cosignAvailable = false;
+    try {
+        tasks.which('cosign', true);
+        cosignAvailable = true;
+    } catch {
+        console.log('cosign not found on PATH — the real cosign invocation test is not defined (#656).');
+    }
+
     afterEach(() => { hc.fetchBufferAllow404 = origFetchBufferAllow404; });
 
-    it('spawns the real cosign binary with the built argv and maps its failure to a VerificationFailure', async function () {
-        if (!cosignAvailable) { this.skip(); }
-        // A well-formed PEM wrapper around non-certificate bytes: cosign parses the
-        // --certificate flag we pass, fails to load it as a real X.509 cert, and exits
-        // non-zero — offline, deterministically, without contacting Rekor.
-        hc.fetchBufferAllow404 = async (url: string) =>
-            url.endsWith('.pem')
-                ? new TextEncoder().encode('-----BEGIN CERTIFICATE-----\nbm90LWEtcmVhbC1jZXJ0\n-----END CERTIFICATE-----\n')
-                : new Uint8Array([0x00, 0x01, 0x02, 0x03]);
-        await assert.rejects(
-            verifyCosignSignature('sums-content', 'https://x.example/SHA256SUMS.sig', 'https://x.example/SHA256SUMS.pem', VERSION, true),
-            (err: unknown) => {
-                assert.ok(isVerificationFailure(err), 'a real cosign non-zero exit must map to a typed VerificationFailure');
-                return true;
-            },
-        );
-    });
+    if (cosignAvailable) {
+        it('spawns the real cosign binary with the built argv and maps its failure to a VerificationFailure', async function () {
+            // A well-formed PEM wrapper around non-certificate bytes: cosign parses the
+            // --certificate flag we pass, fails to load it as a real X.509 cert, and exits
+            // non-zero — offline, deterministically, without contacting Rekor.
+            hc.fetchBufferAllow404 = async (url: string) =>
+                url.endsWith('.pem')
+                    ? new TextEncoder().encode('-----BEGIN CERTIFICATE-----\nbm90LWEtcmVhbC1jZXJ0\n-----END CERTIFICATE-----\n')
+                    : new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+            await assert.rejects(
+                verifyCosignSignature('sums-content', 'https://x.example/SHA256SUMS.sig', 'https://x.example/SHA256SUMS.pem', VERSION, true),
+                (err: unknown) => {
+                    assert.ok(isVerificationFailure(err), 'a real cosign non-zero exit must map to a typed VerificationFailure');
+                    return true;
+                },
+            );
+        });
+    }
     /* eslint-enable @typescript-eslint/no-explicit-any */
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -7,8 +7,8 @@
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
-    "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
-    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register --require ./Tests/coverage-warmup.cjs Tests/L0.ts",
+    "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register --require ./Tests/coverage-warmup.cjs Tests/L0.ts",
     "posttest:coverage": "node ../../../scripts/check-per-file-coverage.js",
     "lint": "npx eslint src/ Tests/"
   },

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/HttpsClientHostHandlingByDesignL0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/HttpsClientHostHandlingByDesignL0.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import { createHttpsClient } from '../src/http';
+
+// Confirms createHttpsClient's ONLY validation gate on the destination is the
+// https:// scheme check -- there is no destination-host allowlist/denylist on
+// this sink. https-client.ts is byte-identical across TerraformModulePublishV1
+// (this registry-publish Bearer/API-key sink) and TerraformDriftReportV1 (the
+// TSM-callback token sink), gated by scripts/check-shared-modules.js -- but that
+// gate only diffs src/, never Tests/, so TerraformDriftReportV1's
+// HttpsClientHostHandlingByDesignL0.ts had no counterpart here until #785. This
+// pins the *design* (accept any https host) so a future change that silently
+// narrows or widens it shows up in a diff in BOTH tasks that share the sink, not
+// only one.
+describe('module-publish https-client: destination-host handling (by design, no restriction)', () => {
+  it('rejects a non-https URL before any network attempt, regardless of host', async () => {
+    const client = createHttpsClient(true, 2000);
+    await assert.rejects(
+      () => client('POST', 'http://registry.example.com/v1/modules', { Authorization: 'Bearer k' }, '{}'),
+      /non-HTTPS/,
+    );
+  });
+
+  it('does not reject an unusual/unexpected https host at a scheme-check layer (no host allowlist exists)', async () => {
+    // A .invalid TLD (RFC 6761) is guaranteed to never resolve, so the request
+    // fails at the network/DNS layer, never at a host-validation layer --
+    // proving no such layer exists for this sink.
+    const client = createHttpsClient(true, 2000);
+    await assert.rejects(
+      () => client('POST', 'https://internal-registry.invalid/v1/modules', { Authorization: 'Bearer k' }, '{}'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(
+          !/non-HTTPS/.test(err.message),
+          'an https:// URL to any host must not be rejected as a scheme violation',
+        );
+        return true;
+      },
+    );
+  });
+});

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/Tests/L0.ts
@@ -12,6 +12,8 @@ import { TLS_CERT, TLS_KEY } from './loopback-tls';
 import { startConnectProxy, startRefusingConnectProxy, startHangingConnectProxy } from './proxy-connect-server';
 // Direct unit tests for the shared retry.ts module (retryAsync + parseRetryAfterMs).
 import './RetryL0';
+// Contract test pinning the shared https-client's no-destination-host-restriction design (#785).
+import './HttpsClientHostHandlingByDesignL0';
 
 const noop = (): void => {
     /* suppress log output during tests */

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
@@ -7,8 +7,8 @@
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",
-    "test": "npm run compile:all && mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
-    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --require ts-node/register Tests/L0.ts",
+    "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
+    "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
     "posttest:coverage": "node ../../../scripts/check-per-file-coverage.js",
     "lint": "npx eslint src/ Tests/"
   },


### PR DESCRIPTION
## Batch I — test hardening (#784, #785, #786)

Test-only + package.json-only changes. **No `src/` or `task.json` changes, so no task Minor bump is required** (per `scripts/check-minor-bumps.js`, which diffs only `<task>/src` and `<task>/task.json`).

### #784 — forbid pending tests suite-wide
Added `--forbid-pending` to the `test` and `test:coverage` mocha invocations in the 7 tasks that lacked it (`Markdown2HtmlV1`, `PolicyAgentInstallerV1`, `PublishKbArticleV1`, `TerraformDocsV1`, `TerraformDocsInstallerV1`, `TerraformInstallerV1`, `TerraformModulePublishV1`). The other 4 tasks already had it, so **all 11 tasks now reject a silently-pending test that could mask a regression.**

Refactored `TerraformInstallerV1/Tests/CosignVerifierL0.ts`: the `#656` real-cosign test previously did `before(){ detect }` + `it(){ if(!cosignAvailable) this.skip() }`. A runtime `this.skip()` produces a *pending* test, which `--forbid-pending` now rejects. It now detects cosign **synchronously at test-tree-build time** and **conditionally defines** the `it` only when cosign is on PATH. Behaviour in the per-PR CI job (no cosign installed) is unchanged — the test simply isn't defined instead of being defined-then-skipped.

### #785 — module-publish https-client host-handling contract test
Ported `TerraformDriftReportV1`'s `HttpsClientHostHandlingByDesignL0` to `TerraformModulePublishV1`, which shares the byte-identical https-client sink. The shared-module parity gate only diffs `src/`, never `Tests/`, so the two tasks' coverage of that sink's "https-scheme-only, no host allowlist" design had drifted. This pins the design (accept any https host, reject non-https) in **both** tasks so a future narrowing/widening shows up in a diff in both.

### #786 — Sentinel GPG task-flow fixtures
Added three `PolicyAgentInstallerV1` fixtures mirroring `TerraformInstallerV1`'s terraform GPG scenario set:
- `SentinelGpgVerificationFail` — an invalid `SHA256SUMS` signature fails the task closed.
- `SentinelGpgSignatureUnavailable` — a missing `.sig` with `requireGpgSignature=false` succeeds with a warning.
- `SentinelGpgSignatureRequiredButMissing` — a missing `.sig` fails when `requireGpgSignature` is in effect (default true).

The OPA download path uses SHA256-only verification (no GPG) and already has equivalent checksum fixtures.

### Verification
- `--forbid-pending` green across all 7 newly-flagged tasks (no hidden pending): Markdown2Html 118, PublishKbArticle 221, TerraformDocs 42, TerraformDocsInstaller 107, TerraformInstaller 177, PolicyAgent 122, ModulePublish 76.
- `npm run test:coverage` per-file floors met for TerraformInstaller, PolicyAgent, ModulePublish.
- `scripts/check-shared-modules.js` parity green (no shared `src/` touched).
- `scripts/check-minor-bumps.js` green (no `src/`/`task.json` changes).

Closes #784
Closes #785
Closes #786
