### PR TITLE
ci: verify marketplace deployment branch policy; re-run auto-bump on reopened (#780, #788)

### DIFF
--- a/.github/workflows/release-pr-minor-bumps.yml
+++ b/.github/workflows/release-pr-minor-bumps.yml
@@ -10,7 +10,7 @@ name: Auto-bump Release PR Minor Versions
 # Minor bumps" guard is the final defense.
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
     branches: [main]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,29 @@ jobs:
               return;
             }
 
-            core.info(`OK: '${ENVIRONMENT}' environment has ${requiredReviewersRule.reviewers.length} required reviewer(s) configured.`);
+            // #780: a required-reviewers rule alone still lets the publish deploy
+            // from ANY ref -- an unreviewed feature branch or a fork branch -- once
+            // a reviewer approves that one run. Also require a deployment branch/ref
+            // policy so only an approved branch/tag (e.g. main / v*) can ever reach
+            // the marketplace publish. The environments API returns
+            // deployment_branch_policy as null when unrestricted, or
+            // { protected_branches, custom_branch_policies } booleans when a policy
+            // is set (one of the two is true).
+            const branchPolicy = env.deployment_branch_policy;
+            const hasDeploymentBranchPolicy = Boolean(
+              branchPolicy && (branchPolicy.protected_branches === true || branchPolicy.custom_branch_policies === true)
+            );
+
+            if (!hasDeploymentBranchPolicy) {
+              core.setFailed(
+                `The '${ENVIRONMENT}' GitHub Environment has no deployment branch/ref policy configured, ` +
+                `so a marketplace publish could run from an unapproved ref even with reviewer approval. ` +
+                `Configure it under Settings -> Environments -> ${ENVIRONMENT} -> Deployment branches and tags.`
+              );
+              return;
+            }
+
+            core.info(`OK: '${ENVIRONMENT}' environment has ${requiredReviewersRule.reviewers.length} required reviewer(s) and a deployment branch/ref policy configured.`);
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -196,7 +196,29 @@ jobs:
               return;
             }
 
-            core.info(`OK: '${ENVIRONMENT}' environment has ${requiredReviewersRule.reviewers.length} required reviewer(s) configured.`);
+            // #780: a required-reviewers rule alone still lets the publish deploy
+            // from ANY ref -- an unreviewed feature branch or a fork branch -- once
+            // a reviewer approves that one run. Also require a deployment branch/ref
+            // policy so only an approved branch/tag (e.g. main / v*) can ever reach
+            // the marketplace publish. The environments API returns
+            // deployment_branch_policy as null when unrestricted, or
+            // { protected_branches, custom_branch_policies } booleans when a policy
+            // is set (one of the two is true).
+            const branchPolicy = env.deployment_branch_policy;
+            const hasDeploymentBranchPolicy = Boolean(
+              branchPolicy && (branchPolicy.protected_branches === true || branchPolicy.custom_branch_policies === true)
+            );
+
+            if (!hasDeploymentBranchPolicy) {
+              core.setFailed(
+                `The '${ENVIRONMENT}' GitHub Environment has no deployment branch/ref policy configured, ` +
+                `so a marketplace publish could run from an unapproved ref even with reviewer approval. ` +
+                `Configure it under Settings -> Environments -> ${ENVIRONMENT} -> Deployment branches and tags.`
+              );
+              return;
+            }
+
+            core.info(`OK: '${ENVIRONMENT}' environment has ${requiredReviewersRule.reviewers.length} required reviewer(s) and a deployment branch/ref policy configured.`);
 
   # ── OpenTofu cosign trust-root canary ──────────────────
   # Exercises the installer's REAL verifyCosignSignature() (cosign-verifier.ts) --

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,12 +13,12 @@ rules:
       # The release pipeline's 4 setup-node steps do not enable dependency
       # caching (no `cache:` input), so there is no cached artifact to poison.
       # zizmor flags setup-node defensively in any artifact-publishing workflow.
-      - release.yml:134:9
-      - release.yml:157:9
-      - release.yml:189:9
-      - release.yml:416:9
+      - release.yml:156:9
+      - release.yml:179:9
+      - release.yml:211:9
+      - release.yml:438:9
   superfluous-actions:
     ignore:
       # softprops/action-gh-release is used deliberately for its multi-file
       # glob upload + release-notes generation; `gh release` is not equivalent.
-      - release.yml:393:15
+      - release.yml:415:15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Closes #12
 
 **[CONTRIBUTING.md → Release process](CONTRIBUTING.md#release-process) is the single authoritative reference.** release-please opens a **Release PR** that bumps the extension version and changelog. Per-task `task.json` `Minor` bumps are applied automatically and triple-enforced (auto-bump workflow, PR merge gate, tag-time guard) — never hand-edit them, and never bump an already-bumped task again (no double-increment). Merging the Release PR pushes the `vX.Y.Z` tag, and `release.yml` then runs full CI, builds and signs the `.vsix`, and publishes it to the VS Marketplace via GitHub OIDC federated to Microsoft Entra.
 
-The `marketplace` environment (Settings → Environments) must have at least one required reviewer so every VS Marketplace publish gets human approval. This is verified automatically by the `verify-marketplace-environment-protection` job in `weekly-security.yml`, which fails the scheduled run (filing an issue) if the required-reviewer rule is missing, removed, or the environment itself no longer exists.
+The `marketplace` environment (Settings → Environments) must have (1) at least one required reviewer so every VS Marketplace publish gets human approval, and (2) a deployment branch/ref policy so a publish can only run from an approved branch or tag (e.g. `main` / `v*`) even after a reviewer approves. Both are verified automatically by the `verify-marketplace-environment-protection` job in `weekly-security.yml` — which fails the scheduled run (filing an issue) if either rule, or the environment itself, is missing or removed — and, fail-closed at publish time, by the matching guard step in `release.yml`.
 
 ## Publisher Registration
 


### PR DESCRIPTION
## Batch J — CI/workflow hardening (#780, #788)

`.github/`-only plus a CLAUDE.md doc update. **No `src/`/`task.json` change, so no task Minor bump.**

### #780 — verify a deployment branch/ref policy on the `marketplace` environment
The marketplace-environment protection verification checked only for a **required-reviewers** rule. A required reviewer alone still lets a publish deploy from **any** ref (an unreviewed feature branch, a fork branch) once that one run is approved.

Both verification steps — `release.yml`'s fail-closed tag-time guard and `weekly-security.yml`'s weekly canary — now **also require a deployment branch/ref policy**:

```js
const branchPolicy = env.deployment_branch_policy;
const hasDeploymentBranchPolicy = Boolean(
  branchPolicy && (branchPolicy.protected_branches === true || branchPolicy.custom_branch_policies === true)
);
if (!hasDeploymentBranchPolicy) { core.setFailed(/* ...configure Deployment branches and tags... */); return; }
```

The GitHub REST API returns `deployment_branch_policy` as `null` (allow **all** branches — the gap) or an object with the mutually-exclusive booleans `protected_branches` / `custom_branch_policies`. The check fails closed on `null`, using the **same `core.setFailed`** mechanism each file already uses for a missing required-reviewers rule. `CLAUDE.md`'s Release Process section documents the added requirement.

**zizmor reconciliation:** the insertion shifted `release.yml`'s `setup-node`/`action-gh-release` steps down ~22 lines, so `.github/zizmor.yml`'s line:column-scoped ignores (kept precise per #686) are re-pinned: cache-poisoning `156/179/211/438`, superfluous-actions `415`. Verified locally: `actionlint` RC=0, `zizmor --offline .github/workflows/` → *"No findings to report (5 ignored, 15 suppressed)"* RC=0.

### #788 — re-run the auto-bump workflow on `reopened`
`release-pr-minor-bumps.yml` only triggered on `[opened, synchronize]`, so a closed-then-reopened Release PR (with no new push) never got its per-task Minor bumps auto-applied, relying entirely on the always-on merge-gate backstop in `pr-checks.yml`. Added `reopened` to the trigger types so the auto-bump runs immediately; the backstop remains complementary.

### Note on #596 (not included)
#596 (align the CI/release `npm audit` level down to `moderate` to match PR-time) is intentionally **deferred**: the only moderate advisory in the tree is `uuid <11.1.1` (GHSA-w5hq-g745-h8pq) pulled transitively by `azure-pipelines-tool-lib@2.0.12` (declares `uuid ^3.3.2`), marked **"No fix available"** — the fix is a major-version jump (v3→v11) that would break tool-lib. Tightening the gate would fail CI on an unactionable, negligible-real-impact advisory. Left open pending an upstream fix.

Closes #780
Closes #788
