### PR TITLE
security(coverage): tier secret-scrub; lead quick-starts with a pinned version (#797)

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -44,14 +44,7 @@ Runs on **Windows**, **Linux**, and **macOS** agents.
 
 ### Install Terraform
 
-```yaml
-- task: PipelineTerraformInstaller@1
-  displayName: 'Install Terraform'
-  inputs:
-    terraformVersion: 'latest'
-```
-
-To pin a specific version:
+Pin an explicit version for reproducible, supply-chain-hardened builds (recommended):
 
 ```yaml
 - task: PipelineTerraformInstaller@1
@@ -60,13 +53,22 @@ To pin a specific version:
     terraformVersion: '1.11.3'
 ```
 
-### Init, Plan, and Apply with AzureRM (Workload Identity Federation)
+Or use `latest` to resolve the newest release at run time (convenient, but the resolved version *number* is only as trustworthy as the release oracle it comes from):
 
 ```yaml
 - task: PipelineTerraformInstaller@1
   displayName: 'Install Terraform'
   inputs:
     terraformVersion: 'latest'
+```
+
+### Init, Plan, and Apply with AzureRM (Workload Identity Federation)
+
+```yaml
+- task: PipelineTerraformInstaller@1
+  displayName: 'Install Terraform 1.11.3'
+  inputs:
+    terraformVersion: '1.11.3'
 
 - task: PipelineTerraformTask@5
   displayName: 'Terraform Init'

--- a/scripts/check-per-file-coverage.js
+++ b/scripts/check-per-file-coverage.js
@@ -75,6 +75,13 @@ const SECURITY_TIER = new Set([
     // fail-closed redaction core standing between raw plan/state values and a
     // build-attachment-visible (not secret-masked) pipeline artifact.
     'Tasks/TerraformTask/TerraformTaskV5/src/results/redact.js',
+    // Freeform-text safety for apply/state diagnostics: known-secret literal
+    // removal + PEM/high-entropy heuristic (scrubSecrets), plus CRLF/logging-
+    // command injection stripping for the attachment name (sanitizeAttachmentName).
+    // The single-copy producer-side sibling of redact.js -- the last redaction
+    // layer before diagnostic text becomes a build-visible (not secret-masked)
+    // attachment; belongs in the same tier as redact.js it sits beside.
+    'Tasks/TerraformTask/TerraformTaskV5/src/results/secret-scrub.js',
     // Owner-only 0600 + O_EXCL (Unix) / restrictive icacls DACL (Windows)
     // secure-temp-file primitive guarding WIF/OCI credential material.
     // Byte-identical parity family across all four listed tasks (Batch E


### PR DESCRIPTION
## Batch M — tier `secret-scrub` coverage; lead quick-starts with a pinned version (#797)

Docs + coverage-gate only. **No task `src/`/`task.json` change, so no task Minor bump.**

### Coverage hardening — tier `secret-scrub.ts`
`Tasks/TerraformTask/TerraformTaskV5/src/results/secret-scrub.ts` is the freeform-diagnostic redaction sibling of the already-tiered `redact.ts` / `uri-scheme-guard.ts`:
- `scrubSecrets()` — known-secret literal removal + PEM/high-entropy heuristic before diagnostic text becomes a build-visible attachment.
- `sanitizeAttachmentName()` — strips CR/LF and `]`/`;`/`%` logging-command injection vectors from the publish name.

It was not in the coverage `SECURITY_TIER`. Added it — it already clears the tier at **96.87% lines / 100% branches / 75% functions** (verified: `check-per-file-coverage` reports *"secret-scrub.js: 96.87% (security tier) … all files meet the per-file floor"*). Self-test and `check-shared-modules` parity remain green.

### #797 — quick-starts lead with a pinned version
`overview.md`'s Quick Start led with `terraformVersion: 'latest'`. It now:
- Leads the **Install Terraform** snippet with a pinned version (the supply-chain-hardened, recommended default), showing `latest` as the explicit secondary convenience option.
- Pins the installer step in the **Init/Plan/Apply with AzureRM** end-to-end example to match.

README's installer sections already document the pinning guidance in the `terraformVersion` input table (reference tables, not reorderable snippets), so no README change was needed.

### Verification
- `check-per-file-coverage` self-test — RC=0 (secret-scrub tier entry is well-formed).
- `check-shared-modules.js` parity — RC=0.
- TaskV5 coverage table confirms secret-scrub.js at 96.87/100/75; the gate passes it as a security-tier file.

Closes #797
