### PR TITLE
docs: clarify the release is published as a public Marketplace extension (#795)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ Closes #12
 
 **[CONTRIBUTING.md → Release process](CONTRIBUTING.md#release-process) is the single authoritative reference.** release-please opens a **Release PR** that bumps the extension version and changelog. Per-task `task.json` `Minor` bumps are applied automatically and triple-enforced (auto-bump workflow, PR merge gate, tag-time guard) — never hand-edit them, and never bump an already-bumped task again (no double-increment). Merging the Release PR pushes the `vX.Y.Z` tag, and `release.yml` then runs full CI, builds and signs the `.vsix`, and publishes it to the VS Marketplace via GitHub OIDC federated to Microsoft Entra.
 
+The release is a **public, publicly-listed** Marketplace extension: `npm run package:release` overrides the base manifest with `configs/release.json` (`"public": true`, `galleryFlags: ["Public"]`). The `"public": false` in `azure-devops-extension.json` (and in `configs/dev.json` / `configs/test.json`) is only the dev-safe default so a dev/test package can never accidentally ship a public listing — it is not the distribution model.
+
 The `marketplace` environment (Settings → Environments) must have (1) at least one required reviewer so every VS Marketplace publish gets human approval, and (2) a deployment branch/ref policy so a publish can only run from an approved branch or tag (e.g. `main` / `v*`) even after a reviewer approves. Both are verified automatically by the `verify-marketplace-environment-protection` job in `weekly-security.yml` — which fails the scheduled run (filing an issue) if either rule, or the environment itself, is missing or removed — and, fail-closed at publish time, by the matching guard step in `release.yml`.
 
 ## Publisher Registration


### PR DESCRIPTION
## Summary

Corrects the documentation gap behind audit issue #795, which claimed the extension is "distributed as an unlisted/private Marketplace listing."

**That premise is incorrect.** The published release is a public, publicly-listed Marketplace extension:

- `npm run package:release` packages with `--overrides-file ./configs/release.json`.
- `configs/release.json` sets `"public": true` and `galleryFlags: ["Public"]`.

The `"public": false` at `azure-devops-extension.json:16` that the audit cited (along with the dev/test configs) is only the **dev-safe default** — it is overridden at release time so a dev/test package can never accidentally ship a public listing. It was never the distribution model.

## Change

`CLAUDE.md` → Release Process: add one paragraph stating the release is a public, publicly-listed Marketplace extension and explaining the `configs/release.json` override, so the base manifest's `"public": false` is no longer misread as the product's distribution model (which is what led to #795).

Docs-only; no task `src`/`task.json` touched, so no version bump.

Closes #795
