### PR TITLE
chore(tests): clean up unused-var lint warnings

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -54,15 +54,6 @@ function writeTmpDir(files: Record<string, string>): string {
     return dir;
 }
 
-// Normalise whitespace for comparison: collapse runs, strip trailing spaces
-function normalise(s: string): string {
-    return s
-        .replace(/\r\n/g, '\n')
-        .replace(/[ \t]+\n/g, '\n')
-        .replace(/\n{3,}/g, '\n\n')
-        .trim();
-}
-
 // ---------------------------------------------------------------------------
 // parseFrontMatter
 // ---------------------------------------------------------------------------

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/InsecureUrlReject.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/InsecureUrlReject.ts
@@ -1,4 +1,3 @@
-import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/InvalidVersionFail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/InvalidVersionFail.ts
@@ -1,4 +1,3 @@
-import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/Sha256Fail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/Sha256Fail.ts
@@ -1,4 +1,3 @@
-import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts
@@ -31,7 +31,6 @@ tr.registerMock('./http-client', {
 tr.registerMock('undici', { ProxyAgent: class { } });
 
 // gpg-verifier: mock .sig file unavailable — should warn but not fail
-let gpgWarningIssued = false;
 tr.registerMock('./gpg-verifier', {
     verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => {
         // Simulate graceful degradation: no error thrown, just returns

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccessL0.ts
@@ -6,7 +6,7 @@ tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
 
 async function run() {
     try {
-        const result = await downloadTerraform('latest');
+        await downloadTerraform('latest');
         tl.setResult(tl.TaskResult.Succeeded, 'HashiCorpLatestSuccessL0 should have succeeded.');
     } catch (error) {
         tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestSuccessL0 failed: ' + error.message);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccessL0.ts
@@ -6,7 +6,7 @@ tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
 
 async function run() {
     try {
-        const result = await downloadTerraform('1.11.6');
+        await downloadTerraform('1.11.6');
         tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuCachedSuccessL0 should have succeeded.');
     } catch (error) {
         tl.setResult(tl.TaskResult.Failed, 'OpenTofuCachedSuccessL0 failed: ' + error.message);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccessL0.ts
@@ -6,7 +6,7 @@ tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
 
 async function run() {
     try {
-        const result = await downloadTerraform('latest');
+        await downloadTerraform('latest');
         tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuLatestSuccessL0 should have succeeded.');
     } catch (error) {
         tl.setResult(tl.TaskResult.Failed, 'OpenTofuLatestSuccessL0 failed: ' + error.message);

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccessL0.ts
@@ -6,7 +6,7 @@ tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
 
 async function run() {
     try {
-        const result = await downloadTerraform('1.11.6');
+        await downloadTerraform('1.11.6');
         tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuSpecificVersionSuccessL0 should have succeeded.');
     } catch (error) {
         tl.setResult(tl.TaskResult.Failed, 'OpenTofuSpecificVersionSuccessL0 failed: ' + error.message);


### PR DESCRIPTION
## Summary

Cleans up 9 pre-existing ESLint `no-unused-vars` warnings surfaced as CI annotations (severity: warning, not blocking any job) across 3 tasks' test suites. Unrelated to any in-flight work this session -- pure dead-code removal in tests.

| File | Fix |
|---|---|
| `TerraformInstallerV1/Tests/OpenTofu{SpecificVersion,Latest,Cached}SuccessL0.ts`, `HashiCorpLatestSuccessL0.ts` | Dropped an unused `const result =` capture of an awaited call whose return value was never read |
| `TerraformInstallerV1/Tests/GpgSignatureUnavailable.ts` | Removed `gpgWarningIssued`, a tracking variable that was declared, never set (the mock body was simplified to a no-op at some point) and never read |
| `Markdown2HtmlV1/Tests/L0.ts` | Removed `normalise()`, a whitespace-comparison helper with zero call sites in the file |
| `PolicyAgentInstallerV1/Tests/{Sha256Fail,InvalidVersionFail,InsecureUrlReject}.ts` | Removed an unused `import ma = require('azure-pipelines-task-lib/mock-answer')` -- verified empirically (not just by inspection) that `ma` has no other reference in each file before removing |

## Verification

- `npm run lint` on all 3 tasks: 0 warnings (was 5 + 1 + 3 = 9)
- `npm run compile` on all 3 tasks: clean
- `npm test` on all 3 tasks: 185 / 118 / 140 passing, 0 failing -- specifically confirmed the exact scenarios in the edited files still pass (`Sha256Fail`, `InvalidVersionFail`, `InsecureUrlReject`, the OpenTofu/HashiCorp success paths, `GPG signature unavailable: should succeed with warning when .sig file is missing`)
- `node scripts/check-shared-modules.js`: parity gate passes

No `src/*.ts` or `task.json` touched -- Tests-only, no version bump needed.
