### PR TITLE
ci: pin release test-gate to guard SHA + job timeouts + tooling canary + coverage artifacts (#485, #823, #824, #828)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ jobs:
   analyze:
     name: Analyze TypeScript
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,7 @@ jobs:
   conventional-title:
     name: Conventional PR Title
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check PR title follows Conventional Commits
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
@@ -45,6 +46,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -72,6 +74,7 @@ jobs:
   release-pr-minor-bumps:
     name: Release PR Minor Bumps
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Skip for non-release PRs
         if: ${{ ! startsWith(github.event.pull_request.head.ref, 'release-please--') }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,7 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Get GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release-pr-minor-bumps.yml
+++ b/.github/workflows/release-pr-minor-bumps.yml
@@ -28,6 +28,7 @@ jobs:
   auto-bump:
     name: Auto-bump task Minor versions
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Only the release-please Release PR, and only when it lives in this repo
     # (never a fork — a fork PR has no access to the App key, and we must not
     # push back to a fork's branch). release-please names its branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
   guard:
     name: Verify tag is on main
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       sha: ${{ steps.resolve-sha.outputs.sha }}
     steps:
@@ -143,11 +144,14 @@ jobs:
     name: CI (build + test)
     needs: guard
     uses: ./.github/workflows/unit-test.yml
+    with:
+      ref: ${{ needs.guard.outputs.sha }}
 
   build:
     name: Build release bundle
     needs: [guard, ci]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -171,6 +175,7 @@ jobs:
     name: Package extension (.vsix)
     needs: [guard, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -203,6 +208,7 @@ jobs:
       id-token: write
       attestations: write # required by attest-build-provenance / attest
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -378,6 +384,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       release_id: ${{ steps.create_release.outputs.id }}
     steps:
@@ -426,6 +433,7 @@ jobs:
     name: Publish to VS Marketplace
     needs: [guard, draft-release]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: marketplace
     permissions:
       id-token: write # GitHub OIDC -> Microsoft Entra federated credential
@@ -511,6 +519,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Undraft the release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,7 +7,16 @@ on:
   push:
     branches: [main]
   workflow_dispatch: {}
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: >-
+          Commit SHA or ref to check out (defaults to github.sha when
+          omitted). Lets a caller (e.g. release.yml's guard-validated
+          release pipeline) pin every job in this reusable workflow to an
+          exact commit instead of a mutable tag/branch name (#485).
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -16,9 +25,11 @@ jobs:
   check-versions:
     name: Check Version Consistency
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - name: Validate version fields
         run: node scripts/check-versions.js
@@ -51,9 +62,11 @@ jobs:
   check-shared-modules:
     name: Check Shared Module Parity
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - name: Validate shared installer modules are identical
         run: node scripts/check-shared-modules.js
@@ -65,6 +78,7 @@ jobs:
   build-and-test-v5:
     name: Build and Test V5 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -97,6 +112,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-task-v5-${{ matrix.os }}
+          path: Tasks/TerraformTask/TerraformTaskV5/coverage/
+          retention-days: 7
       # Every task.json in this repo declares a Node20_1 execution handler
       # alongside Node24 (see CLAUDE.md's task.json Schema Key Points) so older
       # on-prem/air-gapped agents without the Node 24 runner can still invoke
@@ -153,6 +175,7 @@ jobs:
   build-and-test-v5-smoke:
     name: Build and Test V5 Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -163,6 +186,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -185,6 +209,7 @@ jobs:
     needs: build-and-test-v5-smoke
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Verify all V5 smoke matrix legs passed
         if: needs.build-and-test-v5-smoke.result != 'success'
@@ -193,6 +218,7 @@ jobs:
   build-and-test-installer-v1:
     name: Build and Test Installer V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -203,6 +229,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -221,6 +248,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-installer-v1-${{ matrix.os }}
+          path: Tasks/TerraformInstaller/TerraformInstallerV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -233,6 +267,7 @@ jobs:
   build-and-test-mirror-v1:
     name: Build and Test Provider Mirror V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -243,6 +278,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -261,6 +297,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-provider-mirror-v1-${{ matrix.os }}
+          path: Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -273,6 +316,7 @@ jobs:
   build-and-test-publish-v1:
     name: Build and Test Module Publish V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -283,6 +327,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -301,6 +346,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-module-publish-v1-${{ matrix.os }}
+          path: Tasks/TerraformModulePublish/TerraformModulePublishV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -313,6 +365,7 @@ jobs:
   build-and-test-policy-installer-v1:
     name: Build and Test Policy Agent Installer V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -323,6 +376,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -341,6 +395,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-policy-agent-installer-v1-${{ matrix.os }}
+          path: Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -353,6 +414,7 @@ jobs:
   build-and-test-policy-check-v1:
     name: Build and Test Policy Check V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -363,6 +425,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -381,6 +444,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-policy-check-v1-${{ matrix.os }}
+          path: Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -393,6 +463,7 @@ jobs:
   build-and-test-driftreport-v1:
     name: Build and Test Drift Report V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -403,6 +474,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -421,6 +493,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-drift-report-v1-${{ matrix.os }}
+          path: Tasks/TerraformDriftReport/TerraformDriftReportV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -433,6 +512,7 @@ jobs:
   build-and-test-docs-installer-v1:
     name: Build and Test terraform-docs Installer V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -443,6 +523,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -461,6 +542,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-docs-installer-v1-${{ matrix.os }}
+          path: Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -473,6 +561,7 @@ jobs:
   build-and-test-docs-v1:
     name: Build and Test terraform-docs V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -483,6 +572,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -501,6 +591,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-terraform-docs-v1-${{ matrix.os }}
+          path: Tasks/TerraformDocs/TerraformDocsV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -513,6 +610,7 @@ jobs:
   build-and-test-markdown2html-v1:
     name: Build and Test Markdown2Html V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -523,6 +621,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -541,6 +640,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-markdown2html-v1-${{ matrix.os }}
+          path: Tasks/Markdown2Html/Markdown2HtmlV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -553,6 +659,7 @@ jobs:
   build-and-test-publishkbarticle-v1:
     name: Build and Test Publish KB Article V1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -563,6 +670,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -581,6 +689,13 @@ jobs:
         run: npm run compile
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-publish-kb-article-v1-${{ matrix.os }}
+          path: Tasks/PublishKbArticle/PublishKbArticleV1/coverage/
+          retention-days: 7
       # See build-and-test-v5's identical step above for the full rationale
       # (issue #654): this task.json also declares a Node20_1 handler.
       - name: Set up Node 20 for Node20_1 handler smoke test
@@ -593,6 +708,7 @@ jobs:
   build-and-test-tab:
     name: Build and Test Tab (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -600,6 +716,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -617,6 +734,13 @@ jobs:
         run: npx --no-install tsc -p src/tab/tsconfig.json --noEmit
       - name: Run tab unit tests
         run: npm run test:tab
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-tab-${{ matrix.os }}
+          path: coverage/
+          retention-days: 7
 
   # Stable required-status-check context for the Tab tests. Branch protection
   # on main pins the bare "Build and Test Tab" context, but the matrix job
@@ -632,6 +756,7 @@ jobs:
     needs: build-and-test-tab
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Verify all Tab matrix legs passed
         if: needs.build-and-test-tab.result != 'success'
@@ -640,9 +765,11 @@ jobs:
   actionlint:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - name: Install actionlint
         shell: bash
@@ -667,11 +794,13 @@ jobs:
   zizmor:
     name: Scan Workflows (zizmor)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - name: Download and verify zizmor
         shell: bash

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -18,6 +18,7 @@ jobs:
   osv-scan:
     name: OSV Vulnerability Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write
@@ -107,6 +108,7 @@ jobs:
   stale-dependabot:
     name: Flag stale Dependabot PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       pull-requests: write
     steps:
@@ -152,6 +154,7 @@ jobs:
   verify-marketplace-environment-protection:
     name: Verify marketplace environment protection
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -238,6 +241,7 @@ jobs:
   opentofu-cosign-canary:
     name: OpenTofu cosign trust-root canary
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     defaults:
@@ -305,6 +309,7 @@ jobs:
   hashicorp-gpg-canary:
     name: HashiCorp GPG trust-root canary
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     defaults:
@@ -394,11 +399,70 @@ jobs:
             })().catch(function (err) { console.error("Key-expiry check FAILED: " + (err && err.message ? err.message : err)); process.exit(1); });
           '
 
+  # ── Tooling version drift canary ───────────────────────
+  # actionlint and zizmor are both hand-pinned inline (curl + sha256) in
+  # unit-test.yml's actionlint/zizmor jobs rather than tracked by any package
+  # manager Dependabot understands (#824) -- dependabot.yml has no ecosystem
+  # entry for either, so a new release only gets adopted if a human remembers
+  # to bump the version string by hand. Mirrors the HashiCorp GPG / OpenTofu
+  # cosign trust-root canaries above: compares the pinned version against the
+  # tool's latest published release and fails (opening an issue via
+  # notify-on-failure below) when they diverge, rather than drifting forever.
+  tooling-version-drift-canary:
+    name: Tooling version drift canary (actionlint, zizmor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Check actionlint version drift
+        run: |
+          set -euo pipefail
+          pinned=$(grep -E 'curl .*actionlint/releases/download/v[0-9]' .github/workflows/unit-test.yml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$pinned" ]; then
+            echo "::error::Could not resolve the actionlint version pinned in unit-test.yml."
+            exit 1
+          fi
+          latest=$(curl -fsSL https://api.github.com/repos/rhysd/actionlint/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          if [ -z "$latest" ] || [ "$latest" = "null" ]; then
+            echo "::error::Could not resolve the latest actionlint release version."
+            exit 1
+          fi
+          echo "Pinned actionlint version: $pinned; latest release: $latest"
+          if [ "$pinned" != "$latest" ]; then
+            echo "::error::actionlint is pinned to $pinned in unit-test.yml but the latest release is $latest. Bump the pinned version, tarball URL, and sha256 checksum (issue #824)."
+            exit 1
+          fi
+          echo "OK: actionlint pin ($pinned) matches the latest release."
+      - name: Check zizmor version drift
+        run: |
+          set -euo pipefail
+          pinned=$(grep -oE 'zizmor-[0-9]+\.[0-9]+\.[0-9]+-py3-none-manylinux' .github/workflows/unit-test.yml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$pinned" ]; then
+            echo "::error::Could not resolve the zizmor version pinned in unit-test.yml."
+            exit 1
+          fi
+          latest=$(curl -fsSL https://pypi.org/pypi/zizmor/json | jq -r '.info.version')
+          if [ -z "$latest" ] || [ "$latest" = "null" ]; then
+            echo "::error::Could not resolve the latest zizmor release version from PyPI."
+            exit 1
+          fi
+          echo "Pinned zizmor version: $pinned; latest release: $latest"
+          if [ "$pinned" != "$latest" ]; then
+            echo "::error::zizmor is pinned to $pinned in unit-test.yml but the latest release is $latest. Bump the pinned version, wheel URL, and sha256 checksum (issue #824)."
+            exit 1
+          fi
+          echo "OK: zizmor pin ($pinned) matches the latest release."
+
   # ── Notify on failure ─────────────────────────────────
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
-    needs: [ci, osv-scan, stale-dependabot, verify-marketplace-environment-protection, opentofu-cosign-canary, hashicorp-gpg-canary]
+    timeout-minutes: 30
+    needs: [ci, osv-scan, stale-dependabot, verify-marketplace-environment-protection, opentofu-cosign-canary, hashicorp-gpg-canary, tooling-version-drift-canary]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,12 +13,12 @@ rules:
       # The release pipeline's 4 setup-node steps do not enable dependency
       # caching (no `cache:` input), so there is no cached artifact to poison.
       # zizmor flags setup-node defensively in any artifact-publishing workflow.
-      - release.yml:156:9
-      - release.yml:179:9
-      - release.yml:211:9
-      - release.yml:438:9
+      - release.yml:160:9
+      - release.yml:184:9
+      - release.yml:217:9
+      - release.yml:446:9
   superfluous-actions:
     ignore:
       # softprops/action-gh-release is used deliberately for its multi-file
       # glob upload + release-notes generation; `gh release` is not equivalent.
-      - release.yml:415:15
+      - release.yml:422:15


### PR DESCRIPTION
## Batch B — CI/CD & release-pipeline hardening

Remediates 4 findings from the 2026-07-25 blind audit. **Workflow-only change** (no task `src/`/`task.json` touched → no Minor bump).

### #485 — release test-gate now runs the guard-validated commit (medium, CWE-367)
The `build`/`package`/`sbom-and-sign`/`draft-release`/`publish-marketplace` jobs already checkout `needs.guard.outputs.sha`, but the `ci` test-gate job called the reusable `unit-test.yml` with **no ref**, so a `workflow_dispatch` re-run of an old tag tested `github.sha` (branch tip), not the guard commit.
- `unit-test.yml` gains an optional `workflow_call` input `ref`; every checkout uses `${{ inputs.ref || github.sha }}` → **push/PR behaviour is unchanged**.
- `release.yml`'s `ci` job now `needs: guard` and passes `ref: ${{ needs.guard.outputs.sha }}`.

### #823 — job timeouts (low)
Every real job across all 7 workflows now sets `timeout-minutes`: **15–20** for credential-minting jobs (id-token/attestations/contents:write, App token), **30** default, **45** for the external Marketplace publish (real runs reach ~16 min and it must not be killed mid-publish — cancel-in-progress is false by design — but 45 still bounds a hung job + its short-lived Entra token far below the 6 h default). Reusable-workflow (`uses:`) jobs correctly get none (schema-invalid there).

### #824 — tooling version-drift canary (low)
New `tooling-version-drift-canary` job in `weekly-security.yml` compares the inline-pinned actionlint/zizmor versions against upstream (GitHub Releases / PyPI) and opens an issue on divergence — mirroring the existing HashiCorp-GPG / OpenTofu-cosign canaries. The working curl+sha256 install is unchanged; the version grep is anchored to the `curl` line.

### #828 — coverage artifacts (low)
Every coverage-producing job (11 task jobs **+ the Jest Tab job**) uploads its `coverage/` directory as a workflow artifact (`if: always()`).

### Validation
`.github/zizmor.yml` line-pinned ignores recomputed after line shifts. **actionlint** and **zizmor** (with token, ref-version audit included) both pass locally with **zero findings**. Reviewed by a 3-agent adversarial panel — 3/3 approve; the panel's 3 in-scope refinements (publish-marketplace timeout 20→45, Tab coverage upload, canary grep anchoring) are folded in.

Closes #485
Closes #823
Closes #824
Closes #828
