### PR TITLE
fix: cancellation cleanup, SIGKILL timeouts, and OPA failMode allowlist

### DIFF
--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ExecTimeoutL0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ExecTimeoutL0.ts
@@ -12,8 +12,9 @@ import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from '../src/exec-timeout';
 /** Fake ToolRunner whose execAsync resolution is controlled per-test. */
 class FakeTool {
     public killed = false;
+    public killSignal: number | NodeJS.Signals | undefined;
     constructor(private readonly behavior: () => Promise<number>) { }
-    killChildProcess(): void { this.killed = true; }
+    killChildProcess(signal?: number | NodeJS.Signals): void { this.killed = true; this.killSignal = signal; }
     execAsync(_options?: IExecOptions): Promise<number> { return this.behavior(); }
 }
 
@@ -44,6 +45,7 @@ describe('execWithTimeout — bounded subprocess execution (#782)', function () 
             /engine-timed-out/,
         );
         assert.strictEqual(fake.killed, true, 'must kill the hung child on timeout');
+        assert.strictEqual(fake.killSignal, 'SIGKILL', 'must kill with SIGKILL, not the default SIGTERM, so a hung child cannot ignore/catch it');
     });
 
     it('propagates the underlying execAsync rejection (e.g. tool-not-found) without masking it as a timeout', async () => {

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/L0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/L0.ts
@@ -6,6 +6,8 @@ import * as path from 'path';
 import './ArgsBuilderL0';
 // Direct unit tests for the bounded subprocess execution wrapper (#782).
 import './ExecTimeoutL0';
+// End-to-end coverage for index.ts's SIGTERM/SIGINT cancellation handling (#775).
+import './SignalHandlerL0';
 
 describe('TerraformDocs Test Suite', function () {
 

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/SignalHandlerL0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/SignalHandlerL0.ts
@@ -1,0 +1,163 @@
+import * as assert from 'assert';
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * End-to-end coverage for src/index.ts's SIGTERM/SIGINT/uncaughtException/
+ * unhandledRejection registration (#775). Unlike TerraformDriftReportV1/
+ * TerraformPolicyCheckV1 (whose handlers scrub a sensitive temp dir), this task
+ * writes no sensitive temp file, so cleanup() is a deliberate no-op -- but the
+ * handler is still registered so a cancelled run dies promptly (re-raising the
+ * signal with its default disposition) instead of lingering, and so a future
+ * addition of temp-file handling inherits the same cancellation discipline.
+ *
+ * Follows TerraformPolicyCheckV1's SignalHandlerL0.ts approach: drive the REAL,
+ * unmodified index.ts in-process (reloaded fresh via the require cache each test)
+ * with the long-running seam stubbed. execWithTimeout is stubbed to never resolve
+ * (standing in for terraform-docs still running when the signal arrives), and the
+ * registered listener is invoked directly (rather than process.emit) so the mocha
+ * runner's own signal handling is never disturbed. process.kill / process.exit are
+ * captured (not executed) so the mocha process survives.
+ */
+describe('index.ts SIGTERM/SIGINT registration -- re-raise after (no-op) cleanup (#775)', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch shared modules for the duration of each test
+  const t = tasks as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const p = process as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const execTimeout = require('../src/exec-timeout') as any;
+  const origGetInput = tasks.getInput;
+  const origGetPathInput = tasks.getPathInput;
+  const origGetBoolInput = tasks.getBoolInput;
+  const origWhich = tasks.which;
+  const origTool = tasks.tool;
+  const origKill = process.kill.bind(process);
+  const origExit = process.exit.bind(process);
+  const origExecWithTimeout = execTimeout.execWithTimeout;
+  const indexModulePath = require.resolve('../src/index');
+  const trackedEvents = ['SIGTERM', 'SIGINT', 'uncaughtException', 'unhandledRejection'] as const;
+
+  let killCalls: Array<{ pid: number; signal: string }>;
+  let exitCalls: number[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let listenerSnapshots: Map<string, any[]>;
+
+  beforeEach(() => {
+    killCalls = [];
+    exitCalls = [];
+
+    listenerSnapshots = new Map();
+    for (const event of trackedEvents) {
+      listenerSnapshots.set(event, [...p.listeners(event)]);
+    }
+
+    t.getInput = (name: string) => {
+      if (name === 'formatter') return 'markdown-table';
+      return undefined;
+    };
+    t.getPathInput = (name: string) => {
+      if (name === 'modulePath') return '.';
+      return undefined;
+    };
+    t.getBoolInput = () => false;
+    t.which = () => '/usr/bin/terraform-docs';
+    // Minimal ToolRunner stand-in: index.ts only chains .arg()/.line()/.on()
+    // before awaiting execWithTimeout (which we hang below).
+    t.tool = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fake: any = {
+        arg: () => fake,
+        line: () => fake,
+        on: () => fake,
+      };
+      return fake;
+    };
+
+    p.kill = (pid: number, signal?: string | number) => {
+      killCalls.push({ pid, signal: String(signal ?? 'SIGTERM') });
+      return true;
+    };
+    p.exit = (code?: number) => { exitCalls.push(code ?? 0); };
+
+    // terraform-docs "still running" when the termination signal arrives.
+    execTimeout.execWithTimeout = () => new Promise(() => { /* never resolves */ });
+
+    delete require.cache[indexModulePath];
+  });
+
+  afterEach(() => {
+    t.getInput = origGetInput;
+    t.getPathInput = origGetPathInput;
+    t.getBoolInput = origGetBoolInput;
+    t.which = origWhich;
+    t.tool = origTool;
+    p.kill = origKill;
+    p.exit = origExit;
+    execTimeout.execWithTimeout = origExecWithTimeout;
+    delete require.cache[indexModulePath];
+
+    for (const event of trackedEvents) {
+      p.removeAllListeners(event);
+      for (const listener of listenerSnapshots.get(event)!) {
+        p.on(event, listener);
+      }
+    }
+  });
+
+  async function loadIndex(): Promise<void> {
+    require('../src/index');
+    // run() registers the handlers synchronously before its first await, then
+    // parks at the hanging execWithTimeout. A microtask yield lets it advance
+    // into that awaited state (the realistic "signal arrives mid-run" state);
+    // the handlers are live either way.
+    await Promise.resolve();
+  }
+
+  function invokeFreshListener(event: typeof trackedEvents[number], ...args: unknown[]): void {
+    const before = listenerSnapshots.get(event)!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- listener signatures vary by event
+    const fresh = p.listeners(event).find((listener: any) => !before.includes(listener));
+    assert.ok(fresh, `index.ts must register a new ${event} listener on load`);
+    fresh(...args);
+  }
+
+  it('SIGTERM: the handler removes itself and re-raises the signal', async () => {
+    await loadIndex();
+
+    const listenersBefore = process.listenerCount('SIGTERM');
+    invokeFreshListener('SIGTERM', 'SIGTERM');
+
+    assert.strictEqual(process.listenerCount('SIGTERM'), listenersBefore - 1, 'the handler must remove itself before re-raising');
+    assert.strictEqual(killCalls.length, 1, 'the signal must be re-raised via process.kill after cleanup');
+    assert.strictEqual(killCalls[0].pid, process.pid);
+    assert.strictEqual(killCalls[0].signal, 'SIGTERM');
+  });
+
+  it('SIGINT: the handler removes itself and re-raises the signal', async () => {
+    await loadIndex();
+
+    const listenersBefore = process.listenerCount('SIGINT');
+    invokeFreshListener('SIGINT', 'SIGINT');
+
+    assert.strictEqual(process.listenerCount('SIGINT'), listenersBefore - 1, 'the handler must remove itself before re-raising');
+    assert.strictEqual(killCalls.length, 1, 'the signal must be re-raised via process.kill after cleanup');
+    assert.strictEqual(killCalls[0].signal, 'SIGINT');
+  });
+
+  it('uncaughtException: the process exits 1 after cleanup', async () => {
+    await loadIndex();
+
+    invokeFreshListener('uncaughtException', new Error('boom'));
+
+    assert.strictEqual(exitCalls.length, 1, 'the process must exit after cleanup');
+    assert.strictEqual(exitCalls[0], 1);
+  });
+
+  it('unhandledRejection: the process exits 1 after cleanup', async () => {
+    await loadIndex();
+
+    invokeFreshListener('unhandledRejection', new Error('boom'));
+
+    assert.strictEqual(exitCalls.length, 1, 'the process must exit after cleanup');
+    assert.strictEqual(exitCalls[0], 1);
+  });
+});

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/exec-timeout.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/exec-timeout.ts
@@ -29,7 +29,7 @@ export async function execWithTimeout(
   let timer: NodeJS.Timeout | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      tool.killChildProcess();
+      tool.killChildProcess('SIGKILL');
       reject(new Error(timeoutMessage));
     }, timeoutMs);
   });

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/index.ts
@@ -14,6 +14,34 @@ const MAX_CAPTURED_TOOL_BYTES = 64 * 1024; // 64 KiB
 async function run() {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
 
+    // #775: unlike TerraformDriftReportV1/TerraformPolicyCheckV1/TerraformTaskV5
+    // (whose SIGTERM/SIGINT pattern this mirrors), this task writes no sensitive
+    // temp file, so cleanup() is a deliberate no-op -- the handler is still
+    // registered so a cancelled run dies promptly instead of lingering
+    // (registering a signal listener suppresses Node's default terminate-on-
+    // signal behavior, so the signal must be re-raised with its default
+    // disposition after cleanup) and so a future addition of temp-file handling
+    // here inherits the same cancellation discipline instead of silently
+    // missing it.
+    const cleanup = (): void => { /* No sensitive temp file/state to clean up today. */ };
+    const handleTerminationSignal = (signal: NodeJS.Signals) => {
+        cleanup();
+        process.removeListener(signal, handleTerminationSignal);
+        process.kill(process.pid, signal);
+    };
+    process.on('SIGTERM', handleTerminationSignal);
+    process.on('SIGINT', handleTerminationSignal);
+    process.on('uncaughtException', (err) => {
+        cleanup();
+        tasks.setResult(tasks.TaskResult.Failed, `Uncaught exception: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+    });
+    process.on('unhandledRejection', (reason) => {
+        cleanup();
+        tasks.setResult(tasks.TaskResult.Failed, `Unhandled rejection: ${reason instanceof Error ? reason.message : String(reason)}`);
+        process.exit(1);
+    });
+
     try {
         const config: TerraformDocsConfig = {
             formatter: tasks.getInput('formatter', true)!,
@@ -104,6 +132,9 @@ async function run() {
         tasks.setResult(tasks.TaskResult.Succeeded, '');
     } catch (error) {
         tasks.setResult(tasks.TaskResult.Failed, error instanceof Error ? error.message : String(error));
+    } finally {
+        process.removeListener('SIGTERM', handleTerminationSignal);
+        process.removeListener('SIGINT', handleTerminationSignal);
     }
 }
 

--- a/Tasks/TerraformDocs/TerraformDocsV1/task.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/task.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "8",
+    "Minor": "9",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/ExecTimeoutL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/ExecTimeoutL0.ts
@@ -12,8 +12,9 @@ import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from '../src/exec-timeout';
 /** Fake ToolRunner whose execAsync resolution is controlled per-test. */
 class FakeTool {
     public killed = false;
+    public killSignal: number | NodeJS.Signals | undefined;
     constructor(private readonly behavior: () => Promise<number>) { }
-    killChildProcess(): void { this.killed = true; }
+    killChildProcess(signal?: number | NodeJS.Signals): void { this.killed = true; this.killSignal = signal; }
     execAsync(_options?: IExecOptions): Promise<number> { return this.behavior(); }
 }
 
@@ -44,6 +45,7 @@ describe('execWithTimeout — bounded subprocess execution (#782)', function () 
             /engine-timed-out/,
         );
         assert.strictEqual(fake.killed, true, 'must kill the hung child on timeout');
+        assert.strictEqual(fake.killSignal, 'SIGKILL', 'must kill with SIGKILL, not the default SIGTERM, so a hung child cannot ignore/catch it');
     });
 
     it('propagates the underlying execAsync rejection (e.g. tool-not-found) without masking it as a timeout', async () => {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/L0.ts
@@ -21,6 +21,8 @@ import './OutputCapL0';
 import './GitAuthEnvL0';
 // Direct unit tests for the bounded subprocess execution wrapper (#782).
 import './ExecTimeoutL0';
+// Direct unit tests for OPA failMode allowlist validation (#827).
+import './OpaFailModeValidationL0';
 // End-to-end coverage for index.ts's SIGTERM/SIGINT emergency cleanup (#775).
 import './SignalHandlerL0';
 

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/OpaFailModeValidationL0.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/Tests/OpaFailModeValidationL0.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import { validateFailMode } from '../src/opa-engine';
+
+// Direct unit tests for failMode validation (#827). failMode selects which shape
+// extractViolations expects from the OPA decision (a collection of violations vs.
+// a defined/truthy scalar). ADO does not enforce picklist values at runtime, and
+// an unrecognized value previously fell through silently to the 'nonEmpty' branch
+// -- so a typo'd failMode could pass a scalar-decision policy that was never
+// actually evaluated as intended, opening the gate rather than failing loudly.
+// Mirrors sentinel-engine.ts's validateEnforcementLevel reject-path test.
+describe('OPA failMode validation', () => {
+  it('accepts the two recognized failMode values unchanged', () => {
+    assert.strictEqual(validateFailMode('nonEmpty'), 'nonEmpty');
+    assert.strictEqual(validateFailMode('defined'), 'defined');
+  });
+
+  it('rejects any value outside the recognized set', () => {
+    const rejected = [
+      'Defined',     // wrong case
+      'nonempty',    // wrong case
+      'NonEmpty',    // wrong case
+      'bogus',       // unknown value
+      '',            // empty
+      'nonEmpty ',   // trailing whitespace
+    ];
+    for (const bad of rejected) {
+      assert.throws(
+        () => validateFailMode(bad),
+        /Invalid failMode/,
+        `expected rejection for: ${JSON.stringify(bad)}`,
+      );
+    }
+  });
+});

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/exec-timeout.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/exec-timeout.ts
@@ -29,7 +29,7 @@ export async function execWithTimeout(
   let timer: NodeJS.Timeout | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      tool.killChildProcess();
+      tool.killChildProcess('SIGKILL');
       reject(new Error(timeoutMessage));
     }, timeoutMs);
   });

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/opa-engine.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/opa-engine.ts
@@ -15,7 +15,7 @@ import { execWithTimeout, TOOL_EXEC_TIMEOUT_MS } from './exec-timeout';
  */
 export async function runOpa(opaPath: string, policyDir: string, inputFile: string): Promise<PolicyResult> {
     const decisionPath = tasks.getInput('decisionPath') || 'terraform/deny';
-    const failMode = tasks.getInput('failMode') || 'nonEmpty';
+    const failMode = validateFailMode(tasks.getInput('failMode') || 'nonEmpty');
 
     const tool = tasks.tool(opaPath);
     tool.arg('exec');
@@ -75,6 +75,26 @@ export async function runOpa(opaPath: string, policyDir: string, inputFile: stri
     }
 
     return { passed, violations, cases, rawOutput: stdout };
+}
+
+const FAIL_MODES = new Set(['nonEmpty', 'defined']);
+
+/**
+ * failMode selects which shape extractViolations expects from the OPA decision
+ * below (a collection of violations vs. a defined/truthy scalar). ADO does not
+ * enforce picklist values at runtime, and an unrecognized value previously fell
+ * through silently to the 'nonEmpty' branch -- so a typo'd failMode could pass a
+ * scalar-decision policy that was never actually evaluated as intended, opening
+ * the gate rather than failing loudly. Constrain it to the exact set this engine
+ * understands, mirroring sentinel-engine.ts's validateEnforcementLevel.
+ */
+export function validateFailMode(mode: string): string {
+    if (!FAIL_MODES.has(mode)) {
+        throw new Error(
+            `Invalid failMode '${mode}': must be one of nonEmpty, defined.`
+        );
+    }
+    return mode;
 }
 
 function extractViolations(decision: unknown, failMode: string, decisionPath: string): string[] {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/policy-source.ts
@@ -151,7 +151,7 @@ async function execGit(tool: ToolRunner, extraEnv: Record<string, string> = {}):
     let timer: NodeJS.Timeout | undefined;
     const deadline = new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
-            tool.killChildProcess();
+            tool.killChildProcess('SIGKILL');
             reject(new Error(tasks.loc('PolicyRepoCloneTimedOut', GIT_TIMEOUT_MS)));
         }, GIT_TIMEOUT_MS);
     });

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "16",
+        "Minor": "17",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",


### PR DESCRIPTION
## Batch D — cancellation safety, SIGKILL timeouts, OPA failMode allowlist

Remediates three `[audit]` findings in the TerraformDocs and TerraformPolicyCheck tasks.

### #775 — cancellation cleanup for TerraformDocsV1
Registers `SIGTERM`/`SIGINT`/`uncaughtException`/`unhandledRejection` handlers in
`TerraformDocsV1/src/index.ts`, mirroring the pattern already shipped for
DriftReport/PolicyCheck/TaskV5 (cleanup → remove listener → re-raise the signal
with its default disposition). This task writes no sensitive temp file, so
`cleanup()` is a documented no-op, but the handler ensures a cancelled run dies
promptly and future temp-file handling inherits the same discipline. New
`Tests/SignalHandlerL0.ts` drives the real `index.ts` in-process (with the
`execWithTimeout` seam hung) and asserts the re-raise + listener-removal + exit(1)
contract for all four events.

### #825 — SIGKILL on subprocess deadline
A bounded-subprocess deadline previously called `killChildProcess()` with the
default **catchable** `SIGTERM`, which a hung/uncooperative child can ignore.
Now passes `'SIGKILL'` explicitly in:
- both byte-identical `exec-timeout.ts` copies (TerraformDocs, PolicyCheck), and
- PolicyCheck's `policy-source.ts` `execGit` deadline.

`Tests/ExecTimeoutL0.ts` (both copies) now asserts the child is killed with
`SIGKILL`.

### #827 — OPA failMode allowlist
`failMode` selects which decision shape `extractViolations` expects. ADO does not
enforce picklist values at runtime, and an unrecognized value silently fell
through to the `nonEmpty` branch — so a typo could pass a scalar-decision policy
that was never evaluated as intended (fail-open). Now validated against an explicit
`{nonEmpty, defined}` allowlist (mirroring `sentinel-engine.ts`'s
`validateEnforcementLevel`); an invalid value throws a clear error. New
`Tests/OpaFailModeValidationL0.ts` covers the accept and reject paths.

### Scoped out (documented): TerraformProviderMirrorV1
Considered as a #775 sibling and deliberately **not** changed. Its `run()` has no
long-running subprocess to interrupt, and its credential-bearing `.terraformrc` is
**intentionally persisted** for the rest of the job (`TF_CLI_CONFIG_FILE` points at
it) and is never delete-tracked — so there is no cleanup/delete step a cancellation
could skip. The #775 defect signature (a scrub-then-delete a cancel could bypass)
does not apply.

### Review & validation
- 3-agent adversarial panel (correctness / completeness-siblings / regression).
  Iteration 1 rejected on two test-adequacy gaps (no `validateFailMode` reject test,
  no TerraformDocs `SignalHandlerL0`) and a contested ProviderMirror sibling; this
  revision adds both tests and documents the ProviderMirror scope-out.
- `TerraformDocs`: **46 passing**; `TerraformPolicyCheck`: **79 passing**.
- Per-file coverage gate: **all files meet the floor** for both tasks.
- `scripts/check-shared-modules.js`: **exec-timeout.ts parity holds** (exit 0).

Closes #775
Closes #825
Closes #827
