### PR TITLE
fix: recommend WIF in AWS/GCP auth help text; document task.json convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,16 @@ azure-pipelines-terraform/
 | `proxy-config.ts`                      | Builds `fetch()` options routing the OIDC/OCI outbound HTTPS calls through the agent's configured proxy (`Agent.ProxyUrl`/`Agent.ProxyUsername`/`Agent.ProxyPassword`) |
 | `temp-dir.ts`                          | Resolves the directory for ephemeral WIF credential/token files (prefers agent-purged `Agent.TempDirectory` over `os.tmpdir()`); shared by the AWS/GCP/OCI handlers |
 
+### Manifest (`task.json`) size & organization convention
+
+`TerraformTaskV5/task.json` is by far the largest task manifest (~1,200 lines vs. <330 for every other task), because it declares several cloud provider/backend combinations plus the dynamic AzureRM/AWS/OCI pickers in one task. That size is expected, but the manifest gets no compiler/lint support the way `.ts` does, so keep it reviewable as it grows:
+
+- Group every input under a `groupName` (e.g. `providerAzureRm`, `backendAWS`, `backendGCP`) and keep a provider's inputs contiguous with its group.
+- Put dynamic pickList lookups in the `dataSourceBindings` block, keyed by the target input — do not inline lookup logic elsewhere.
+- Prefer a `visibleRule` on an existing input over adding a new input when an input can simply be shown conditionally.
+
+New inputs should extend an existing group rather than adding a parallel section, so the manifest grows proportionally to real capability rather than becoming an unreviewable flat list (#836).
+
 ### Structured plan/apply results (`src/results/`)
 
 Builds the redacted JSON digests published to the **Terraform** tab (see `docs/design/plan-apply-digest-spec.md` for the frozen schema/redaction contract):

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -561,7 +561,7 @@
             "defaultValue": "ServiceConnection",
             "required": false,
             "visibleRule": "provider = aws && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
-            "helpMarkDown": "Select how to authenticate with AWS. 'Service connection' uses static credentials from the service connection. 'Workload Identity Federation' uses OIDC to assume an IAM role without static credentials.",
+            "helpMarkDown": "Select how to authenticate with AWS. 'Service connection' uses static credentials from the service connection. 'Workload Identity Federation' uses OIDC to assume an IAM role without static credentials. Workload Identity Federation is recommended: it issues short-lived OIDC tokens with no long-lived access key to leak or rotate; the 'Service connection' default is retained only for backward compatibility.",
             "options": {
                 "ServiceConnection": "Service connection (static credentials)",
                 "WorkloadIdentityFederation": "Workload Identity Federation (OIDC)"
@@ -649,7 +649,7 @@
             "defaultValue": "ServiceConnection",
             "required": false,
             "visibleRule": "provider = gcp && command != init && command != validate && command != workspace && command != state && command != fmt && command != get && command != forceunlock && command != test",
-            "helpMarkDown": "Select how to authenticate with GCP. 'Service connection' uses a service account key. 'Workload Identity Federation' uses OIDC without static credentials.",
+            "helpMarkDown": "Select how to authenticate with GCP. 'Service connection' uses a service account key. 'Workload Identity Federation' uses OIDC without static credentials. Workload Identity Federation is recommended: it issues short-lived OIDC tokens with no long-lived service-account key to leak or rotate; the 'Service connection' default is retained only for backward compatibility.",
             "options": {
                 "ServiceConnection": "Service connection (service account key)",
                 "WorkloadIdentityFederation": "Workload Identity Federation (OIDC)"
@@ -885,7 +885,7 @@
             "label": "Backend authentication scheme",
             "defaultValue": "ServiceConnection",
             "required": false,
-            "helpMarkDown": "Select how to authenticate with the S3 backend. 'Service connection' uses static credentials. 'Workload Identity Federation' uses OIDC to assume an IAM role without static credentials.",
+            "helpMarkDown": "Select how to authenticate with the S3 backend. 'Service connection' uses static credentials. 'Workload Identity Federation' uses OIDC to assume an IAM role without static credentials. Workload Identity Federation is recommended: it issues short-lived OIDC tokens with no long-lived access key to leak or rotate; the 'Service connection' default is retained only for backward compatibility.",
             "groupName": "backendAWS",
             "options": {
                 "ServiceConnection": "Service connection (static credentials)",
@@ -995,7 +995,7 @@
             "label": "Backend authentication scheme",
             "defaultValue": "ServiceConnection",
             "required": false,
-            "helpMarkDown": "Select how to authenticate with the GCS backend. 'Service connection' uses a service account key. 'Workload Identity Federation' uses OIDC without static credentials.",
+            "helpMarkDown": "Select how to authenticate with the GCS backend. 'Service connection' uses a service account key. 'Workload Identity Federation' uses OIDC without static credentials. Workload Identity Federation is recommended: it issues short-lived OIDC tokens with no long-lived service-account key to leak or rotate; the 'Service connection' default is retained only for backward compatibility.",
             "groupName": "backendGCP",
             "options": {
                 "ServiceConnection": "Service connection (service account key)",


### PR DESCRIPTION
## Batch G — AWS/GCP auth-scheme WIF guidance + task.json convention

The final remediation batch (2 low/info findings on TerraformTaskV5).

### #833 (low) — static-credential default lacks a WIF recommendation at config time
The AWS/GCP provider and backend auth-scheme picklists —
`environmentAuthSchemeAWS`/`environmentAuthSchemeGCP` and
`backendAuthSchemeAWS`/`backendAuthSchemeGCP` — default to `ServiceConnection`
(long-lived static access key / service-account key) rather than
`WorkloadIdentityFederation`, so an operator who doesn't read past the default
lands on the legacy path for two of four clouds even though this project treats WIF
as the recommended posture.

Changing the default would be a behavior change requiring a major-version note.
Instead, this adds a WIF-recommended callout to each input's **`helpMarkDown`** (the
text operators see in the ADO UI at configuration time, not just the README): WIF
issues short-lived OIDC tokens with no long-lived key to leak or rotate, and the
`ServiceConnection` default is retained only for backward compatibility. All four
auth-scheme inputs updated.

### #836 (info) — large task.json manifest has no documented size/organization convention
`TerraformTaskV5/task.json` (~1,200 lines) is ~3.7x the next-largest task manifest
and gets no compiler/lint support. Per the finding's recommendation, documented an
explicit convention in CLAUDE.md: group inputs by `groupName`, keep dynamic pickList
lookups in `dataSourceBindings`, prefer `visibleRule` over new inputs, and extend an
existing group rather than adding a parallel section — so the manifest grows
proportionally to real capability rather than becoming an unreviewable flat list.

### Notes
- `task.json` changed → TerraformTaskV5 receives a Minor bump (via
  `scripts/bump-minor-versions.js`). The CLAUDE.md note is documentation only.
- `helpMarkDown`-only string additions; no input names, defaults, `visibleRule`s, or
  `dataSourceBindings` changed — no behavior change, task.json remains valid JSON.

Closes #833
Closes #836
