### PR TITLE
security: bump postcss to 8.5.23 in Markdown2Html

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/package-lock.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/package-lock.json
@@ -3915,9 +3915,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3934,7 +3934,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/package.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/package.json
@@ -32,7 +32,8 @@
     "js-yaml": "^4.2.0",
     "adm-zip": "^0.6.0",
     "linkify-it": "^5.0.2",
-    "brace-expansion": "5.0.9"
+    "brace-expansion": "5.0.9",
+    "postcss": "8.5.23"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## Summary

Follow-up to #860, which explicitly flagged this exact finding as pre-existing and out of scope: *"`postcss` in Markdown2HtmlV1 — pre-existing (not touched by this diff), moderate, `npm audit fix` available but out of scope for this PR; flagging for a follow-up."* This PR is that follow-up.

`npm audit --omit=dev --audit-level=high` in `Tasks/Markdown2Html/Markdown2HtmlV1` reports one moderate finding #860 didn't touch (it only bumped `brace-expansion`/`undici`):

## What's fixed

| Package | Bump | Manifest | GHSA |
|---|---|---|---|
| `postcss` (override, transitive via `sanitize-html`) | `8.5.19` → `8.5.23` | Markdown2HtmlV1 | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) (moderate — incomplete fix of GHSA-6g55-p6wh-862q; attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset) |

`sanitize-html@2.17.6`'s own `"postcss": "^8.3.11"` dependency range already permits a patched postcss, so this was a stale lockfile resolution (`8.5.19`), not a version-range conflict. Adds `"postcss": "8.5.23"` to Markdown2HtmlV1's own `overrides` block — the same value already in the root `package.json`'s `overrides` block, and the same pattern as this task's existing `diff`/`serialize-javascript`/`js-yaml`/`adm-zip`/`linkify-it`/`brace-expansion` overrides — then regenerates the lockfile. `PublishKbArticleV1` already resolves postcss to `8.5.23` without an explicit override, so this brings Markdown2HtmlV1 in line with it.

## Verification

- `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities** (was 1 moderate)
- `npm run compile` → zero errors
- `npm test` → **122 passing** (same count as before this change)
- Diff scope: `package.json` (+1 override line) and `package-lock.json` (postcss version/resolved/integrity, plus its own declared nanoid range bump — no separate nanoid re-resolution needed) only. No `task.json`, source, or shared-module files touched, so `Check Version Consistency` / `Check Shared Module Parity` are unaffected by construction.

No dependabot alert was open when this work started (proactive, same rationale as #860); GitHub's re-scan landed [alert #130](https://github.com/sethbacon/azure-pipelines-terraform/security/dependabot/130) for this exact finding while this PR was in flight. It will auto-dismiss once this merges to `main` and Dependabot re-scans.
