### PR TITLE
chore(ci): bump zizmor pin 1.28.0 -> 1.29.0

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -812,16 +812,16 @@ jobs:
         # no runtime Python dependencies (requires_dist is empty per the PyPI
         # JSON API), so verifying the single wheel it resolves to is
         # sufficient. Checksum from
-        # https://pypi.org/pypi/zizmor/1.28.0/json (manylinux_2_28_x86_64
+        # https://pypi.org/pypi/zizmor/1.29.0/json (manylinux_2_28_x86_64
         # wheel, matching this job's ubuntu-latest x86_64 runner).
         run: |
           set -euo pipefail
-          curl -sSfLO https://files.pythonhosted.org/packages/5b/b4/f823bd2a1ba6dc432fdcbd249d4c442ce79bd137d34d986fce5c181f2800/zizmor-1.28.0-py3-none-manylinux_2_28_x86_64.whl
-          echo "ae2cab67ce713e760e0d1b61ad749d374693ea2b310337aab11cd446748267f3  zizmor-1.28.0-py3-none-manylinux_2_28_x86_64.whl" | sha256sum -c -
+          curl -sSfLO https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl
+          echo "587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20  zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl" | sha256sum -c -
       # Online audits (ref-version-mismatch, impostor-commit, known-vulnerable
       # actions) use GITHUB_TOKEN; the rest (unpinned-uses, template-injection,
       # excessive-permissions) run regardless. Pinned for a deterministic gate.
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pipx run --spec ./zizmor-1.28.0-py3-none-manylinux_2_28_x86_64.whl zizmor .github/workflows/
+        run: pipx run --spec ./zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl zizmor .github/workflows/


### PR DESCRIPTION
Fixes the root cause of #853 (`Scheduled build failed — 2026-08-03`): the `Tooling version drift canary` job added for #824 correctly detected the zizmor pin in `unit-test.yml` had drifted (1.28.0 vs PyPI latest 1.29.0) and fails the weekly scan on purpose until it's bumped.

- Wheel URL + sha256 updated to `zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl` (both occurrences: the verify step and the `pipx run --spec` invocation).
- Checksum independently verified locally (downloaded the wheel, `sha256sum`'d it, matches PyPI's published digest).
- Confirmed the drift-canary's own regex still extracts `1.29.0` correctly from the new pin.
- This repo's `Scan Workflows (zizmor)` CI job runs zizmor against `.github/workflows/` on every PR — including this one — so it doubles as validation that 1.29.0's ruleset doesn't surface anything new.

Closes #853 once merged and a scheduled/dispatched `weekly-security.yml` run confirms the drift canary passes.