### PR TITLE
security: register credentials with setSecret before they can be logged

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
@@ -130,6 +130,18 @@ function buildFetchOptions(): RequestInit {
         }
         url.username = proxy.proxyUsername;
         url.password = proxy.proxyPassword ?? "";
+        // url.password is now the WHATWG URL setter's PERCENT-ENCODED form (e.g.
+        // 'p@ss' -> 'p%40ss') — a byte-different string from the raw
+        // proxyPassword already setSecret()'d above. ADO's log masker matches
+        // literal registered strings, not derivations, so this encoded form
+        // (which is what url.toString() below actually embeds in proxyUrl, and
+        // therefore what an undici/ProxyAgent connection-failure message would
+        // surface) needs its own registration too. Matches the derived-form
+        // masking proxy-config.ts and the https-client.ts/servicenow-http.ts
+        // families already do (#684).
+        if (url.password) {
+            tasks.setSecret(url.password);
+        }
         proxyUrl = url.toString();
     }
 

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -235,10 +235,22 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
     if (!data.download_url) {
         throw new Error(`Registry API returned invalid response: missing download_url from ${infoUrl}`);
     }
+    // The pre-signed download_url carries a live, read-scoped storage credential in
+    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
+    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
+    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
+    // normal registry run. Register each token component as a secret FIRST -- before
+    // ANY emission that can carry this URL, including the https-pin rejection below,
+    // which used to interpolate the raw pre-signed URL into its message while this
+    // registration still sat further down the function (#66/#98).
+    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
+    for (const secret of urlTokenSecrets) {
+        tasks.setSecret(secret);
+    }
     // The download URL is registry-controlled and fetched outside fetchJson's HTTPS
     // guard, so pin it to HTTPS before downloading — as the mirror path already does.
     if (!data.download_url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", data.download_url));
+        throw new Error(tasks.loc("InsecureUrlRejected", redactUrl(data.download_url)));
     }
 
     // Optional opt-in host pin: a compromised registry could still point download_url
@@ -278,16 +290,6 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
 
     const ext = agent === "sentinel" ? ".zip" : (isWindows ? ".exe" : "");
     const fileName = `${agent}-${version}-${uuidV4()}${ext}`;
-    // The pre-signed download_url carries a live, read-scoped storage credential in
-    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
-    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
-    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
-    // normal registry run. Register each token component as a secret FIRST so the
-    // agent masks it in tool-lib's log line (and in any failure message).
-    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
-    for (const secret of urlTokenSecrets) {
-        tasks.setSecret(secret);
-    }
     let filePath: string;
     try {
         if (allowedHosts.length > 0) {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
@@ -130,6 +130,18 @@ function buildFetchOptions(): RequestInit {
         }
         url.username = proxy.proxyUsername;
         url.password = proxy.proxyPassword ?? "";
+        // url.password is now the WHATWG URL setter's PERCENT-ENCODED form (e.g.
+        // 'p@ss' -> 'p%40ss') — a byte-different string from the raw
+        // proxyPassword already setSecret()'d above. ADO's log masker matches
+        // literal registered strings, not derivations, so this encoded form
+        // (which is what url.toString() below actually embeds in proxyUrl, and
+        // therefore what an undici/ProxyAgent connection-failure message would
+        // surface) needs its own registration too. Matches the derived-form
+        // masking proxy-config.ts and the https-client.ts/servicenow-http.ts
+        // families already do (#684).
+        if (url.password) {
+            tasks.setSecret(url.password);
+        }
         proxyUrl = url.toString();
     }
 

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -172,10 +172,22 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
     if (!data.download_url) {
         throw new Error(`Registry API returned invalid response: missing download_url from ${infoUrl}`);
     }
+    // The pre-signed download_url carries a live, read-scoped storage credential in
+    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
+    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
+    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
+    // normal registry run. Register each token component as a secret FIRST -- before
+    // ANY emission that can carry this URL, including the https-pin rejection below,
+    // which used to interpolate the raw pre-signed URL into its message while this
+    // registration still sat further down the function (#66/#98).
+    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
+    for (const secret of urlTokenSecrets) {
+        tasks.setSecret(secret);
+    }
     // The download URL is registry-controlled and fetched outside fetchJson's HTTPS
     // guard, so pin it to HTTPS before downloading — as the mirror path already does.
     if (!data.download_url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", data.download_url));
+        throw new Error(tasks.loc("InsecureUrlRejected", redactUrl(data.download_url)));
     }
 
     // Optional opt-in host pin: a compromised registry could still point download_url
@@ -214,16 +226,6 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
     }
 
     const fileName = `terraform-docs-${version}-${uuidV4()}.${getArchiveExtension()}`;
-    // The pre-signed download_url carries a live, read-scoped storage credential in
-    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
-    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
-    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
-    // normal registry run. Register each token component as a secret FIRST so the
-    // agent masks it in tool-lib's log line (and in any failure message).
-    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
-    for (const secret of urlTokenSecrets) {
-        tasks.setSecret(secret);
-    }
     let filePath: string;
     try {
         if (allowedHosts.length > 0) {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
@@ -130,6 +130,18 @@ function buildFetchOptions(): RequestInit {
         }
         url.username = proxy.proxyUsername;
         url.password = proxy.proxyPassword ?? "";
+        // url.password is now the WHATWG URL setter's PERCENT-ENCODED form (e.g.
+        // 'p@ss' -> 'p%40ss') — a byte-different string from the raw
+        // proxyPassword already setSecret()'d above. ADO's log masker matches
+        // literal registered strings, not derivations, so this encoded form
+        // (which is what url.toString() below actually embeds in proxyUrl, and
+        // therefore what an undici/ProxyAgent connection-failure message would
+        // surface) needs its own registration too. Matches the derived-form
+        // masking proxy-config.ts and the https-client.ts/servicenow-http.ts
+        // families already do (#684).
+        if (url.password) {
+            tasks.setSecret(url.password);
+        }
         proxyUrl = url.toString();
     }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -201,10 +201,22 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     }
     // data.download_url = pre-signed storage URL (15-minute TTL)
     // data.sha256       = hex SHA256 of the zip (may be empty if registry verified server-side)
+    // The pre-signed download_url carries a live, read-scoped storage credential in
+    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
+    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
+    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
+    // normal registry run. Register each token component as a secret FIRST -- before
+    // ANY emission that can carry this URL, including the https-pin rejection below,
+    // which used to interpolate the raw pre-signed URL into its message while this
+    // registration still sat further down the function (#66/#98).
+    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
+    for (const secret of urlTokenSecrets) {
+        tasks.setSecret(secret);
+    }
     // The download URL is registry-controlled and fetched outside fetchJson's HTTPS
     // guard, so pin it to HTTPS before downloading — as the mirror path already does.
     if (!data.download_url.startsWith('https://')) {
-        throw new Error(tasks.loc("InsecureUrlRejected", data.download_url));
+        throw new Error(tasks.loc("InsecureUrlRejected", redactUrl(data.download_url)));
     }
 
     // Optional opt-in host pin: a compromised registry could still point
@@ -243,16 +255,6 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     }
 
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
-    // The pre-signed download_url carries a live, read-scoped storage credential in
-    // its query string. tools.downloadTool logs the URL at INFO and only auto-redacts
-    // Azure `sig=`, so AWS X-Amz-Signature/X-Amz-Credential/X-Amz-Security-Token and
-    // GCS X-Goog-Signature/X-Goog-Credential would otherwise print unredacted on every
-    // normal registry run. Register each token component as a secret FIRST so the
-    // agent masks it in tool-lib's log line (and in any failure message).
-    const urlTokenSecrets = extractUrlTokenSecrets(data.download_url);
-    for (const secret of urlTokenSecrets) {
-        tasks.setSecret(secret);
-    }
     let zipPath: string;
     try {
         if (allowedHosts.length > 0) {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -41,6 +41,9 @@ import './OciWifHandleProviderL0';
 // Direct unit tests for handleProvider's classic (non-WIF, API-key) private
 // key masking guarantees (#723).
 import './OciApiKeyPrivateKeyMaskingL0';
+// Table-driven CLASS test: credential emitted before it was registered as a secret
+// (the packer-extension audit's #185/#195/#186/#193/#66 class, re-enumerated here).
+import './PreMaskingClassL0';
 // Direct unit tests for cross-cloud state backend detection.
 import './BackendDetectionTests/BackendDetectionL0';
 // Direct unit tests for ParentCommandHandler's cross-cloud injection decisions.

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciApiKeyPrivateKeyMaskingL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciApiKeyPrivateKeyMaskingL0.ts
@@ -45,15 +45,26 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
     const setSecretCalls: string[] = [];
     let endpointData: Record<string, string> = {};
 
+    // The private key is no longer read through tasks.getEndpointDataParameter --
+    // that helper debug-logs the value it returns, so it can never carry a secret
+    // (#185). readSecretEndpointDataParameter reads the ENDPOINT_DATA_* variable
+    // the agent actually sets, so the test has to deliver it the same way the
+    // agent does rather than by stubbing the accessor.
+    const PRIVATE_KEY_ENV = 'ENDPOINT_DATA_OCI_PRIVATEKEY';
+    function deliverPrivateKey(value: string | undefined): void {
+        if (value === undefined) delete process.env[PRIVATE_KEY_ENV];
+        else process.env[PRIVATE_KEY_ENV] = value;
+    }
+
     beforeEach(() => {
         setSecretCalls.length = 0;
         endpointData = {
-            privateKey: TEST_OCI_PRIVATE_KEY_SPACES,
             tenancy: 'ocid1.tenancy.oc1..dummy',
             user: 'ocid1.user.oc1..dummy',
             region: 'us-ashburn-1',
             fingerprint: 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
         };
+        deliverPrivateKey(TEST_OCI_PRIVATE_KEY_SPACES);
         t.getEndpointDataParameter = (_service: string, key: string) => endpointData[key];
         // No environmentAuthSchemeOCI input configured -> resolveAuthScheme defaults
         // to "ServiceConnection", taking the classic (non-WIF) branch under test.
@@ -64,6 +75,7 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
     });
 
     afterEach(() => {
+        deliverPrivateKey(undefined);
         t.getEndpointDataParameter = orig.getEndpointDataParameter;
         t.getInput = orig.getInput;
         t.getBoolInput = orig.getBoolInput;
@@ -106,11 +118,17 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
             assert.ok(setSecretCalls.includes(line), `normalized PEM body line must be masked: ${line.slice(0, 12)}...`);
         }
 
+        // The raw key must not be left in process.env: ENDPOINT_DATA_* is not
+        // vaulted by task-lib, so anything still there is inherited by the
+        // terraform child process and every provider plugin it forks (#185).
+        assert.strictEqual(process.env[PRIVATE_KEY_ENV], undefined,
+            'the ENDPOINT_DATA_* private key must be deleted from the environment once read');
+
         handler.cleanupTempFiles();
     });
 
     it('masks every non-boundary line of an already-multiline (LF) PEM the same way', async () => {
-        endpointData.privateKey = TEST_OCI_PRIVATE_KEY_PEM;
+        deliverPrivateKey(TEST_OCI_PRIVATE_KEY_PEM);
 
         const handler = new TerraformCommandHandlerOCI();
         await handler.handleProvider(makeCommand());
@@ -124,7 +142,7 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
     });
 
     it('masks every non-boundary line of a CRLF-delivered PEM the same way', async () => {
-        endpointData.privateKey = TEST_OCI_PRIVATE_KEY_CRLF;
+        deliverPrivateKey(TEST_OCI_PRIVATE_KEY_CRLF);
 
         const handler = new TerraformCommandHandlerOCI();
         await handler.handleProvider(makeCommand());
@@ -153,7 +171,8 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
     });
 
     it('throws before writing any file when the service connection has no privateKey data parameter', async () => {
-        endpointData = {}; // privateKey (and everything else) missing
+        endpointData = {};
+        deliverPrivateKey(undefined); // privateKey (and everything else) missing
 
         const handler = new TerraformCommandHandlerOCI();
         await assert.rejects(

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
@@ -1,0 +1,329 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import tasks = require('azure-pipelines-task-lib/task');
+import { TerraformCommandHandlerOCI } from '../src/oci-terraform-command-handler';
+import { TerraformAuthorizationCommandInitializer } from '../src/terraform-commands';
+import { EnvironmentVariableHelper } from '../src/environment-variables';
+import { getSecureVarFileArgs, ISecureFileLoader } from '../src/secure-file-loader';
+import { TEST_OCI_PRIVATE_KEY_PEM } from './test-oci-fixtures';
+
+/**
+ * CLASS TEST — "credential-bearing material reaches the build log in a form that
+ * was never registered with tasks.setSecret() BEFORE the emission".
+ *
+ * Cross-repo twin of azure-pipelines-packer's
+ * Tasks/PackerTask/PackerTaskV1/Tests/PreMaskingClassL0.ts. The class was
+ * reported against the packer extension (#185, #195, #186, #193, #66) but the
+ * two extensions are built to the same idioms and copy modules between each
+ * other, so every mechanism was re-enumerated here and fixed at the same time.
+ *
+ *   M1  read-then-mask   — the value is logged by the read API itself
+ *                          (tasks.getEndpointDataParameter debug-logs its result)
+ *   M2  registration throws — setSecret() rejects CR/LF, so a whole-PEM
+ *                          registration throws and registers NOTHING
+ *   M3  wrong form registered — the emitted serialization (URL percent-encoding,
+ *                          PEM normalization) differs byte-wise from the
+ *                          registered one
+ *   M4  never registered — secure var-file CONTENTS were never masked at all
+ *   M5  credential-bearing URL — a pre-signed/userinfo URL is emitted before (or
+ *                          without) its credential being registered/redacted
+ *
+ * Rows in THIS npm package are exercised behaviourally. Rows in the sibling
+ * installer packages (separate npm packages that cannot be imported from here)
+ * are asserted at source level against the same predicate the re-runnable class
+ * signature uses: the guard construct must be present, and the pre-fix defect
+ * shape must be absent. Inverting either guard turns its own row RED.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const TF_INSTALLER = path.join(REPO_ROOT, 'Tasks', 'TerraformInstaller', 'TerraformInstallerV1', 'src');
+const POLICY_INSTALLER = path.join(REPO_ROOT, 'Tasks', 'PolicyAgentInstaller', 'PolicyAgentInstallerV1', 'src');
+const DOCS_INSTALLER = path.join(REPO_ROOT, 'Tasks', 'TerraformDocsInstaller', 'TerraformDocsInstallerV1', 'src');
+
+function readSource(file: string): string {
+    return fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+}
+
+interface SourceSite {
+    mechanism: 'M1' | 'M2' | 'M3' | 'M4' | 'M5';
+    site: string;
+    file: string;
+    guard: RegExp;
+    defect: RegExp;
+}
+
+/**
+ * M3: the WHATWG URL setter percent-encodes the password, so the string
+ * url.toString() embeds is byte-different from the raw proxyPassword that was
+ * registered. All three http-client.ts copies are byte-identical (gated by
+ * scripts/check-shared-modules.js), so all three carry the same row.
+ */
+const PROXY_ENCODED_GUARD = /url\.password = proxy\.proxyPassword \?\? "";[\s\S]{0,1200}?if \(url\.password\) \{\s*\n\s*tasks\.setSecret\(url\.password\);\s*\n\s*\}\s*\n\s*proxyUrl = url\.toString\(\);/;
+const PROXY_ENCODED_DEFECT = /url\.password = proxy\.proxyPassword \?\? "";\s*\n\s*proxyUrl = url\.toString\(\);/;
+
+/**
+ * M5: the registry-supplied pre-signed download_url carries a live signing token
+ * in its query string. The token registration must happen BEFORE the https-pin
+ * rejection that interpolates that same URL into its message.
+ */
+const PRESIGNED_GUARD = /const urlTokenSecrets = extractUrlTokenSecrets\(data\.download_url\);[\s\S]{0,400}?tasks\.setSecret\(secret\);[\s\S]{0,400}?if \(!data\.download_url\.startsWith\('https:\/\/'\)\) \{\s*\n\s*throw new Error\(tasks\.loc\("InsecureUrlRejected", redactUrl\(data\.download_url\)\)\);/;
+const PRESIGNED_DEFECT = /tasks\.loc\("InsecureUrlRejected", data\.download_url\)/;
+
+const SOURCE_SITES: SourceSite[] = [
+    {
+        mechanism: 'M3',
+        site: 'TerraformInstallerV1/src/http-client.ts:buildFetchOptions',
+        file: path.join(TF_INSTALLER, 'http-client.ts'),
+        guard: PROXY_ENCODED_GUARD,
+        defect: PROXY_ENCODED_DEFECT,
+    },
+    {
+        mechanism: 'M3',
+        site: 'PolicyAgentInstallerV1/src/http-client.ts:buildFetchOptions',
+        file: path.join(POLICY_INSTALLER, 'http-client.ts'),
+        guard: PROXY_ENCODED_GUARD,
+        defect: PROXY_ENCODED_DEFECT,
+    },
+    {
+        mechanism: 'M3',
+        site: 'TerraformDocsInstallerV1/src/http-client.ts:buildFetchOptions',
+        file: path.join(DOCS_INSTALLER, 'http-client.ts'),
+        guard: PROXY_ENCODED_GUARD,
+        defect: PROXY_ENCODED_DEFECT,
+    },
+    {
+        mechanism: 'M5',
+        site: 'TerraformInstallerV1/src/terraform-installer.ts:downloadZipFromRegistry (pre-signed download_url)',
+        file: path.join(TF_INSTALLER, 'terraform-installer.ts'),
+        guard: PRESIGNED_GUARD,
+        defect: PRESIGNED_DEFECT,
+    },
+    {
+        mechanism: 'M5',
+        site: 'PolicyAgentInstallerV1/src/policy-agent-installer.ts:downloadFromRegistry (pre-signed download_url)',
+        file: path.join(POLICY_INSTALLER, 'policy-agent-installer.ts'),
+        guard: PRESIGNED_GUARD,
+        defect: PRESIGNED_DEFECT,
+    },
+    {
+        mechanism: 'M5',
+        site: 'TerraformDocsInstallerV1/src/terraform-docs-installer.ts:downloadFromRegistry (pre-signed download_url)',
+        file: path.join(DOCS_INSTALLER, 'terraform-docs-installer.ts'),
+        guard: PRESIGNED_GUARD,
+        defect: PRESIGNED_DEFECT,
+    },
+    {
+        mechanism: 'M5',
+        site: 'TerraformInstallerV1/src/terraform-installer.ts:downloadZipFromRegistry/FromMirror (operator userinfo) — PRE-EXISTING GUARD',
+        file: path.join(TF_INSTALLER, 'terraform-installer.ts'),
+        // Already closed before this batch (#586); pinned here so the class test
+        // fails if a later change drops it, rather than only covering what this
+        // batch happened to touch.
+        guard: /maskOperatorUrlCredentials\(registryUrl\);[\s\S]*maskOperatorUrlCredentials\(mirrorBaseUrl\);[\s\S]*tasks\.loc\("InsecureUrlRejected", redactUrlUserInfo\(mirrorBaseUrl\)\)/,
+        defect: /tasks\.loc\("InsecureUrlRejected", mirrorBaseUrl\)|terraformDownloadedFrom', `(registry:\$\{registryUrl\}|mirror:\$\{mirrorBaseUrl\})`/,
+    },
+    {
+        mechanism: 'M5',
+        site: 'TerraformInstallerV1/src/terraform-installer.ts:downloadZipFromHashiCorp/downloadTofu (RECORDED EXEMPTION)',
+        file: path.join(TF_INSTALLER, 'terraform-installer.ts'),
+        // Exempt, and the exemption is asserted rather than asserted-away: these
+        // two download URLs are built from hardcoded release-host literals plus a
+        // validated version/platform/arch, so no operator input reaches them and
+        // they can carry neither userinfo nor a signing token. If either constant
+        // is ever replaced by an input-derived value this row goes RED and the
+        // sites stop being exempt.
+        guard: /return `https:\/\/releases\.hashicorp\.com\/terraform\/[\s\S]*const downloadUrl = `https:\/\/github\.com\/opentofu\/opentofu\/releases\/download\//,
+        defect: /function getHashiCorpDownloadUrl\([\s\S]{0,400}?(registryUrl|mirrorBaseUrl|tasks\.getInput)|opentofu\/releases\/download\/v\$\{version\}[\s\S]{0,80}?(registryUrl|mirrorBaseUrl|tasks\.getInput)/,
+    },
+];
+
+describe('Pre-mask defect class — credential emitted before it was registered as a secret', function () {
+    this.timeout(15000);
+
+    describe('source-level rows (sibling installer npm packages)', () => {
+        for (const row of SOURCE_SITES) {
+            it(`${row.mechanism} — ${row.site}`, () => {
+                const source = readSource(row.file);
+                assert.ok(
+                    row.guard.test(source),
+                    `guard missing or inverted at ${row.site}: ${row.guard}`,
+                );
+                assert.ok(
+                    !row.defect.test(source),
+                    `pre-fix defect shape is back at ${row.site}: ${row.defect}`,
+                );
+            });
+        }
+    });
+
+    describe('behavioural rows (this npm package)', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch the shared task-lib module
+        const t = tasks as any;
+        const orig = {
+            setSecret: t.setSecret,
+            debug: t.debug,
+            warning: t.warning,
+            getInput: t.getInput,
+            getBoolInput: t.getBoolInput,
+            getEndpointDataParameter: t.getEndpointDataParameter,
+        };
+
+        let setSecretCalls: string[] = [];
+        let debugLines: string[] = [];
+        let warnings: string[] = [];
+
+        const PRIVATE_KEY_ENV = 'ENDPOINT_DATA_OCI_PRIVATEKEY';
+        const endpointData: Record<string, string> = {
+            tenancy: 'ocid1.tenancy.oc1..dummy',
+            user: 'ocid1.user.oc1..dummy',
+            region: 'us-ashburn-1',
+            fingerprint: 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+        };
+
+        beforeEach(() => {
+            setSecretCalls = [];
+            debugLines = [];
+            warnings = [];
+            // Reproduce task-lib's real setSecret contract exactly: it THROWS on a
+            // CR/LF-bearing value (LIB_MultilineSecret) rather than registering it.
+            // That is what makes the M2 row mutation-provable.
+            t.setSecret = (value: string) => {
+                if (value && /\r|\n/.test(value)) {
+                    throw new Error('LIB_MultilineSecret');
+                }
+                setSecretCalls.push(value);
+            };
+            t.debug = (message: string) => { debugLines.push(String(message)); };
+            t.warning = (message: string) => { warnings.push(String(message)); };
+            t.getInput = () => undefined;
+            t.getBoolInput = () => false;
+            // Non-secret OCI data parameters keep the ordinary accessor; only the
+            // private key must bypass it. A stub that RECORDS the key would hide
+            // the defect, so this one emits the same debug line task-lib does.
+            t.getEndpointDataParameter = (id: string, key: string) => {
+                const value = key === 'privateKey' ? process.env[PRIVATE_KEY_ENV] : endpointData[key];
+                debugLines.push(`${id} data ${key} = ${value}`);
+                return value;
+            };
+        });
+
+        afterEach(() => {
+            t.setSecret = orig.setSecret;
+            t.debug = orig.debug;
+            t.warning = orig.warning;
+            t.getInput = orig.getInput;
+            t.getBoolInput = orig.getBoolInput;
+            t.getEndpointDataParameter = orig.getEndpointDataParameter;
+            delete process.env[PRIVATE_KEY_ENV];
+            EnvironmentVariableHelper.clearTrackedVariables();
+        });
+
+        it('M1 — TerraformTaskV5/src/oci-terraform-command-handler.ts:handleProvider (OCI privateKey endpoint DATA param)', async () => {
+            process.env[PRIVATE_KEY_ENV] = TEST_OCI_PRIVATE_KEY_PEM;
+
+            const handler = new TerraformCommandHandlerOCI();
+            await handler.handleProvider(new TerraformAuthorizationCommandInitializer('plan', 'DummyWorkingDirectory', 'OCI'));
+
+            // (a) The key must never have been emitted on a debug line. This is the
+            //     whole of M1: tasks.getEndpointDataParameter() ends with
+            //     debug(id + ' data ' + key + ' = ' + val), which fires at READ
+            //     time — strictly before any setSecret the handler could make.
+            const bodyLines = TEST_OCI_PRIVATE_KEY_PEM.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('-----'));
+            assert.ok(bodyLines.length > 0, 'sanity: the fixture PEM has body lines');
+            for (const line of bodyLines) {
+                assert.ok(
+                    !debugLines.some((d) => d.includes(line)),
+                    'no ##vso[task.debug] line may contain the OCI private key body',
+                );
+            }
+
+            // (b) The raw value must not survive in process.env: ENDPOINT_DATA_* is
+            //     not vaulted by task-lib, so anything left there is inherited by
+            //     the terraform child process and every provider plugin it forks.
+            assert.strictEqual(process.env[PRIVATE_KEY_ENV], undefined,
+                'the ENDPOINT_DATA_* private key must be deleted from the environment once read');
+
+            handler.cleanupTempFiles();
+        });
+
+        it('M2 — TerraformTaskV5/src/oci-terraform-command-handler.ts:getPrivateKeyFilePath (genuine multi-line PEM)', async () => {
+            // A service connection created via the REST API / az devops CLI (rather
+            // than the UI passwordbox, which flattens newlines) delivers a real
+            // multi-line PEM. A whole-value setSecret() throws on it — registering
+            // NOTHING — so the handler must register line-wise.
+            process.env[PRIVATE_KEY_ENV] = TEST_OCI_PRIVATE_KEY_PEM;
+
+            const handler = new TerraformCommandHandlerOCI();
+            await handler.handleProvider(new TerraformAuthorizationCommandInitializer('plan', 'DummyWorkingDirectory', 'OCI'));
+
+            const rawLines = TEST_OCI_PRIVATE_KEY_PEM.split('\n').map((l) => l.trim()).filter((l) => l);
+            for (const line of rawLines) {
+                assert.ok(setSecretCalls.includes(line),
+                    `raw PEM line must be registered: ${line.slice(0, 12)}...`);
+            }
+
+            // M3 in its PEM guise: normalizePem rewrites the key to a byte-different
+            // on-disk form, which needs its own registration.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const tempFiles: string[] = (handler as any).tempFiles;
+            assert.strictEqual(tempFiles.length, 1, 'exactly one tracked temp file: the OCI key');
+            const onDisk = fs.readFileSync(tempFiles[0], 'utf8');
+            const onDiskBody = onDisk.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('-----'));
+            assert.ok(onDiskBody.length > 0, 'sanity: the normalized PEM has body lines');
+            for (const line of onDiskBody) {
+                assert.ok(setSecretCalls.includes(line),
+                    `normalized on-disk PEM body line must be registered: ${line.slice(0, 12)}...`);
+            }
+
+            handler.cleanupTempFiles();
+        });
+
+        it('M4 — TerraformTaskV5/src/secure-file-loader.ts:getSecureVarFileArgs (secure var-file contents)', async () => {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'premask-class-'));
+            const varFile = path.join(dir, 'secrets.tfvars');
+            const hclSecret = 'sup3r-s3cret-value-from-hcl';
+            const jsonSecret = 'sup3r-s3cret-value-from-json';
+            fs.writeFileSync(varFile, [
+                '# a comment mentioning "not-a-secret-comment-token"',
+                `api_token = "${hclSecret}"`,
+                'replica_count = 3',
+                'flags = ["alpha-flag", "beta-flag"]',
+            ].join('\n'));
+
+            const jsonFile = path.join(dir, 'secrets.tfvars.json');
+            fs.writeFileSync(jsonFile, JSON.stringify({ nested: { api_token: jsonSecret }, count: 3 }));
+
+            t.getInput = (name: string) => (name === 'secureVarsFile' ? 'secure-file-id' : undefined);
+
+            const loaderFor = (filePath: string): ISecureFileLoader => ({
+                downloadSecureFile: async () => filePath,
+                deleteSecureFile: () => { /* cleanup is elsewhere */ },
+            });
+
+            const hclResult = await getSecureVarFileArgs(loaderFor(varFile));
+            assert.strictEqual(hclResult?.varFileArg, `-var-file=${varFile}`);
+            assert.ok(setSecretCalls.includes(hclSecret),
+                'an HCL secure var-file value must be registered with the masker');
+            assert.ok(setSecretCalls.includes('alpha-flag'),
+                'list elements of a secure var-file value must be registered too');
+            assert.ok(!setSecretCalls.includes('not-a-secret-comment-token'),
+                'a quoted word inside a comment must not be registered (over-masking guard)');
+
+            setSecretCalls = [];
+            const jsonResult = await getSecureVarFileArgs(loaderFor(jsonFile));
+            assert.strictEqual(jsonResult?.varFileArg, `-var-file=${jsonFile}`);
+            assert.ok(setSecretCalls.includes(jsonSecret),
+                'a nested JSON secure var-file value must be registered with the masker');
+
+            // Best-effort contract: an unreadable file warns, it does not throw.
+            setSecretCalls = [];
+            await getSecureVarFileArgs(loaderFor(path.join(dir, 'does-not-exist.tfvars')));
+            assert.ok(warnings.some((w) => w.includes('mask')),
+                'an unreadable secure var file must warn rather than fail the task');
+
+            fs.rmSync(dir, { recursive: true, force: true });
+        });
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/src/endpoint-data-secret.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/endpoint-data-secret.ts
@@ -1,0 +1,67 @@
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * Registers every non-empty line of a (possibly multi-line) credential with the
+ * agent's log masker.
+ *
+ * `tasks.setSecret()` throws `LIB_MultilineSecret` when its argument contains a
+ * CR or LF, so a whole PEM must never be handed to it in one piece: that call
+ * throws and NOTHING ends up registered — the masking that was supposed to
+ * cover the credential is what fails. ADO's masker also matches within a single
+ * log line, so per-line registration is the only form that actually masks a
+ * multi-line value. Boundary lines are kept (the UI passwordbox flattens a PEM
+ * onto one line that itself starts with `-----BEGIN`, so that single "line" IS
+ * the credential).
+ */
+export function maskSecretLines(value: string): void {
+    for (const line of value.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed) {
+            tasks.setSecret(trimmed);
+        }
+    }
+}
+
+/**
+ * Reads an ADO service-connection *data* parameter that carries credential
+ * material, without letting the value reach the build log first.
+ *
+ * `tasks.getEndpointDataParameter()` cannot be used for a secret. task-lib's
+ * implementation ends with
+ *
+ *     debug(id + ' data ' + key + ' = ' + dataParamVal);
+ *
+ * (azure-pipelines-task-lib/task.js, getEndpointDataParameter), so the raw value
+ * is emitted as a `##vso[task.debug]` line at READ time — strictly before the
+ * caller has any opportunity to `tasks.setSecret()` it. And unlike `INPUT_*`,
+ * `ENDPOINT_AUTH_*`, `SECUREFILE_TICKET_*` and `SECRET_*`, `ENDPOINT_DATA_*` is
+ * NOT in task-lib's `_loadData` vaulting list, so the value is neither
+ * encrypted in-process, nor deleted from `process.env`, nor seeded into the
+ * agent's masker at job start.
+ *
+ * This helper therefore:
+ *   1. reads the same environment variable task-lib would read, bypassing that
+ *      `debug()` call entirely;
+ *   2. registers the value with the masker line-wise BEFORE returning it, so
+ *      the first possible emission is already covered;
+ *   3. deletes the variable so the raw credential is not inherited by the tool
+ *      child process (packer/terraform) or by any plugin binary that process
+ *      forks — which `EnvironmentVariableHelper.clearTrackedVariables()` cannot
+ *      do, since it only clears variables this task set itself.
+ *
+ * Returns `undefined` when the parameter is absent or empty; the caller owns the
+ * "missing credential" error message.
+ */
+export function readSecretEndpointDataParameter(serviceName: string, key: string): string | undefined {
+    // Must match task-lib's own key derivation EXACTLY:
+    // 'ENDPOINT_DATA_' + id + '_' + key.toUpperCase() — the id is used verbatim,
+    // it is NOT upper-cased.
+    const envName = `ENDPOINT_DATA_${serviceName}_${key.toUpperCase()}`;
+    const value = process.env[envName];
+    if (!value) {
+        return undefined;
+    }
+    maskSecretLines(value);
+    delete process.env[envName];
+    return value;
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -7,6 +7,7 @@ import { generateIdToken } from './id-token-generator';
 import { exchangeOidcForUpst } from './oci-token-exchange';
 import { writeSecretFile, tightenFilePermissions } from './secure-temp';
 import { normalizePem } from './pem-normalizer';
+import { readSecretEndpointDataParameter } from './endpoint-data-secret';
 import { resolveWifTempDir } from './temp-dir';
 import path = require('path');
 import crypto = require('crypto');
@@ -305,7 +306,13 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
             await this.handleProviderWIF(command);
         } else {
             if (command.serviceProviderName) {
-                const rawPrivateKey = tasks.getEndpointDataParameter(command.serviceProviderName, "privateKey", false);
+                // NOT tasks.getEndpointDataParameter(): that helper debug-logs the
+                // value it returns, so the raw OCI API signing key would already be
+                // in the build log before getPrivateKeyFilePath's first setSecret.
+                // readSecretEndpointDataParameter reads the same ENDPOINT_DATA_*
+                // variable directly, masks it line-wise, and deletes it so the
+                // terraform child process does not inherit it (endpoint-data-secret.ts).
+                const rawPrivateKey = readSecretEndpointDataParameter(command.serviceProviderName, "privateKey");
                 if (!rawPrivateKey) {
                     throw new Error("OCI private key not found in service connection. Ensure the 'privateKey' field is configured.");
                 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/secure-file-loader.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/secure-file-loader.ts
@@ -1,5 +1,6 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { scrubFile, tightenFilePermissions } from './secure-temp';
+import { maskSecureVarFileValues } from './secure-var-file-masking';
 
 export interface ISecureFileLoader {
     downloadSecureFile(secureFileId: string): Promise<string>;
@@ -100,5 +101,11 @@ export async function getSecureVarFileArgs(loader?: ISecureFileLoader): Promise<
 
     const secureFileLoader = loader || new SecureFileLoader();
     const filePath = await secureFileLoader.downloadSecureFile(secureFileId);
+    // task.json steers secrets into this file, but nothing ever registered its
+    // CONTENTS with the masker -- only the file's permissions were tightened and
+    // its bytes scrubbed at cleanup. Register every scalar string value BEFORE
+    // the path reaches terraform, so a value terraform echoes (a diagnostic that
+    // quotes the offending value, TF_LOG output) is masked.
+    maskSecureVarFileValues(filePath);
     return { varFileArg: `-var-file=${filePath}`, secureFileId, filePath };
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/secure-var-file-masking.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/secure-var-file-masking.ts
@@ -1,0 +1,124 @@
+import tasks = require('azure-pipelines-task-lib/task');
+import fs = require('fs');
+
+/**
+ * The task manifest documents `secureVarsFile` as THE place to put sensitive
+ * variables, but the file's contents were never registered with the agent's
+ * secret masker — only the file's on-disk permissions were tightened. The tool
+ * echoes variable values in several ordinary situations (HCL validation
+ * diagnostics that quote the offending value, `console` evaluation output,
+ * TF_LOG/PACKER_LOG debug output — all reachable through this task's own
+ * inputs), and any such value printed verbatim would appear unmasked in the
+ * build log because nothing ever registered it.
+ *
+ * This module closes that gap: after the secure file is downloaded, every scalar
+ * string value it declares is registered with `tasks.setSecret()` BEFORE the
+ * file path is handed to the tool. Parsing is best-effort by design — an
+ * unreadable or unparseable file warns and leaves the existing behaviour
+ * untouched rather than failing the task.
+ */
+
+/**
+ * Values shorter than this are not registered. `setSecret` masks every
+ * occurrence of a literal substring anywhere in the log, so registering a short
+ * token (`"dev"`, `"true"`, `"1.0"`) would blank out unrelated, non-secret log
+ * text across the whole run. Real credentials are comfortably longer.
+ */
+export const MIN_MASKABLE_VALUE_LENGTH = 4;
+
+/** Strips `#` and `//` line comments so a quoted word inside a comment is not mistaken for a value. */
+function stripLineComments(content: string): string {
+    return content
+        .split('\n')
+        .map((line) => line.replace(/(^|\s)(#|\/\/).*$/, ''))
+        .join('\n');
+}
+
+function collectJsonStrings(node: unknown, out: string[]): void {
+    if (typeof node === 'string') {
+        out.push(node);
+        return;
+    }
+    if (Array.isArray(node)) {
+        for (const item of node) collectJsonStrings(item, out);
+        return;
+    }
+    if (node && typeof node === 'object') {
+        // Only VALUES are collected — a variable NAME is not a secret, and
+        // masking it would blank out ordinary log text.
+        for (const value of Object.values(node as Record<string, unknown>)) collectJsonStrings(value, out);
+    }
+}
+
+/**
+ * Extracts the scalar string values declared by a var file. Handles both
+ * supported shapes:
+ *   - `*.pkrvars.json` / `*.tfvars.json` — parsed as JSON, every string value at
+ *     any nesting depth (including inside lists and maps) is returned;
+ *   - `*.pkrvars.hcl` / `*.tfvars` — every double-quoted string literal is
+ *     returned (in HCL var files, variable NAMES are unquoted, so a quoted
+ *     literal is always a value, an element of a list value, or a map value).
+ * Returns an empty array when nothing can be extracted; never throws.
+ */
+export function extractVarFileScalarStrings(content: string): string[] {
+    const out: string[] = [];
+    const trimmed = content.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+        try {
+            collectJsonStrings(JSON.parse(trimmed), out);
+            return out;
+        } catch {
+            // Not valid JSON after all — fall through to the HCL scan rather
+            // than failing: a `.hcl` file may legitimately start with a block.
+        }
+    }
+    const withoutComments = stripLineComments(content);
+    const quoted = /"((?:[^"\\]|\\.)*)"/g;
+    let match: RegExpExecArray | null;
+    while ((match = quoted.exec(withoutComments)) !== null) {
+        // Unescape the HCL/JSON escapes that matter for byte-exact masking.
+        out.push(match[1]
+            .replace(/\\n/g, '\n')
+            .replace(/\\r/g, '\r')
+            .replace(/\\t/g, '\t')
+            .replace(/\\"/g, '"')
+            .replace(/\\\\/g, '\\'));
+    }
+    return out;
+}
+
+/**
+ * Registers every scalar string value declared in the downloaded secure var file
+ * with the agent's secret masker.
+ *
+ * Registration is LINE-WISE: `tasks.setSecret()` throws `LIB_MultilineSecret` on
+ * a CR/LF-bearing argument (which would leave the value unregistered entirely),
+ * and ADO's masker matches within a single log line anyway, so a heredoc/
+ * multi-line value has to be registered a line at a time to actually be masked.
+ *
+ * Best-effort: an unreadable or unparseable file warns and returns, preserving
+ * the previous behaviour of simply passing the file through to the tool.
+ */
+export function maskSecureVarFileValues(filePath: string): void {
+    let content: string;
+    try {
+        content = fs.readFileSync(filePath, 'utf8');
+    } catch (error) {
+        tasks.warning(`Could not read the secure variable file to mask its values; values it contains will NOT be masked in the build log: ${error instanceof Error ? error.message : error}`);
+        return;
+    }
+    const values = extractVarFileScalarStrings(content);
+    if (values.length === 0) {
+        tasks.debug('No scalar string values were extracted from the secure variable file; nothing to mask.');
+        return;
+    }
+    for (const value of values) {
+        for (const line of value.split(/\r?\n/)) {
+            const trimmed = line.trim();
+            if (trimmed.length >= MIN_MASKABLE_VALUE_LENGTH) {
+                tasks.setSecret(trimmed);
+            }
+        }
+    }
+    tasks.debug(`Registered ${values.length} secure variable file value(s) with the secret masker.`);
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -221,7 +221,7 @@
             "label": "Secure variables file (.tfvars)",
             "required": false,
             "visibleRule": "command = plan || command = apply || command = destroy || command = import || command = refresh",
-            "helpMarkDown": "Select a .tfvars file from the ADO Secure Files library. The file will be downloaded to a temporary location and passed as -var-file to the terraform command. The file is automatically deleted after execution. Useful for secrets that should not be stored in source control."
+            "helpMarkDown": "Select a .tfvars file from the ADO Secure Files library. The file will be downloaded to a temporary location and passed as -var-file to the terraform command. The file is automatically deleted after execution. Useful for secrets that should not be stored in source control. Every scalar string value in the file (JSON `.tfvars.json` or quoted HCL literals) is registered with the build-log secret masker before terraform runs, so a value terraform echoes is redacted. Values shorter than 4 characters, and numeric/boolean values, are NOT masked."
         },
         {
             "name": "terraformVariables",


### PR DESCRIPTION
Cross-repo half of a defect class remediated in the sibling packer extension (sethbacon/azure-pipelines-packer#225). **None of the instances fixed here are named in any issue in this repo** — they were found by enumerating the class across both extensions instead of scoping it to the repo whose audit reported it.

## The class

> Credential-bearing material reaches the build log in a form that was never registered with `tasks.setSecret()` **before** the emission.

## What was live here

| mechanism | site | note |
| --- | --- | --- |
| **M1** | `TerraformTaskV5/src/oci-terraform-command-handler.ts` | **This is the packer audit's only high**, present identically here and unreported. `getEndpointDataParameter` ends with `debug(id + ' data ' + key + ' = ' + val)` and `ENDPOINT_DATA_*` is not vaulted, so the OCI signing key was emitted *at read time* — before `getPrivateKeyFilePath`'s masking runs — and left in `process.env` for the child process. |
| **M3** | all three `http-client.ts` copies | The WHATWG URL setter percent-encodes the password that `url.toString()` embeds, so a password outside the userinfo-safe set was unmasked in the string actually used. |
| **M4** | `TerraformTaskV5/src/secure-file-loader.ts` | `secureVarsFile` is documented as the secret-safe channel; its contents were never registered. |
| **M5** | all three installers' `downloadFromRegistry` | The pre-signed `download_url` carries a signing token, and the https-pin rejection emitted it **one line before** the token was registered. |

Worth noting in the other direction: this repo was already **ahead** of packer on M2 — `getPrivateKeyFilePath` masks line-wise precisely to avoid `LIB_MultilineSecret`. That approach was ported *to* packer. Each repo was ahead of the other on a different half of the same class, which is invisible from either side alone.

## Gates

- **Class gate** — signature re-run by the orchestrator here as well as in packer. Residual is **4 sites, all recorded exemptions**: two constant-host release URLs (`releases.hashicorp.com`, the OpenTofu GitHub asset), one where `maskOperatorUrlCredentials` runs in the *caller* so an intra-procedural signature cannot see it, and `TerraformModulePublishV1` where `https-client.ts` builds requests from `hostname`/`port`/`pathname+search` only, so URL userinfo is dropped and never sent as authentication. Each validated by reading code.
- **Mutation check** — inverting a guard turns that guard's own class-test row red and no other.
- **Tests** — TerraformTaskV5 624, TerraformInstallerV1 187, PolicyAgentInstallerV1 146, TerraformDocsInstallerV1 127, all 0 failing. `check-shared-modules.js` green; the three-copy `http-client.ts` family stayed byte-identical.

## Notes

`endpoint-data-secret.ts` and `secure-var-file-masking.ts` are new here and byte-identical to the packer copies, so the primitives cannot drift apart the way `http-client.ts` previously did.

`OciApiKeyPrivateKeyMaskingL0.ts` was **strengthened, not relaxed**: the key is now delivered through the real `ENDPOINT_DATA_OCI_PRIVATEKEY` env var rather than a stubbed accessor, with a new assertion that the variable is deleted after the read.

Task `Minor` bumps are deliberately not hand-edited — CONTRIBUTING assigns those to the auto-bump workflow.

Refs sethbacon/azure-pipelines-packer#185
Refs sethbacon/azure-pipelines-packer#193
Refs sethbacon/azure-pipelines-packer#186
Refs sethbacon/azure-pipelines-packer#66