### PR TITLE
security: fail closed on absent or malformed provider credentials

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailEmptyWorkingDirectory.ts
@@ -12,10 +12,10 @@ tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameOCI', 'OCI');
 tr.setInput('commandOptions', '');
 
-process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
-process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplyFailInvalidWorkingDirectory.ts
@@ -12,10 +12,10 @@ tr.setInput('workingDirectory', '/invalid/path/that/does/not/exist');
 tr.setInput('environmentServiceNameOCI', 'OCI');
 tr.setInput('commandOptions', '');
 
-process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
-process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApprove.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessAdditionalArgsWithAutoApprove.ts
@@ -12,10 +12,10 @@ tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameOCI', 'OCI');
 tr.setInput('commandOptions', '-auto-approve -var abc=123');
 
-process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
-process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ApplyTests/OCI/OCIApplySuccessNoAdditionalArgs.ts
@@ -15,7 +15,7 @@ tr.setInput('commandOptions', '');
 process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CredentialFailClosedMatrixL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CredentialFailClosedMatrixL0.ts
@@ -1,0 +1,544 @@
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import tasks = require('azure-pipelines-task-lib/task');
+import idTokenGeneratorModule = require('../src/id-token-generator');
+import ociTokenExchangeModule = require('../src/oci-token-exchange');
+import { TerraformCommandHandlerAzureRM } from '../src/azure-terraform-command-handler';
+import { TerraformCommandHandlerAWS } from '../src/aws-terraform-command-handler';
+import { TerraformCommandHandlerGCP } from '../src/gcp-terraform-command-handler';
+import { TerraformCommandHandlerOCI } from '../src/oci-terraform-command-handler';
+import { TerraformCommandHandlerHCP } from '../src/hcp-terraform-command-handler';
+import { TerraformCommandHandlerGeneric } from '../src/generic-terraform-command-handler';
+import { BaseTerraformCommandHandler } from '../src/base-terraform-command-handler';
+import { TerraformAuthorizationCommandInitializer } from '../src/terraform-commands';
+import { EnvironmentVariableHelper } from '../src/environment-variables';
+
+/**
+ * THE CLASS TEST for the provider-auth fail-open defect class
+ * (#97 and its terraform-side siblings of packer #187/#194/#199/#197).
+ *
+ * Its rows ARE the cells of the (handler x auth-branch x required-field) matrix
+ * that `scripts/auth-parity-matrix.cjs` enumerates -- not the individual call
+ * sites named in the issues. #97 reopened in the sibling packer extension
+ * because its first fix hardened one branch of one file and its test asserted
+ * that one branch; the WIF branch of the same file stayed fail-open and stayed
+ * green. When that class was re-enumerated here, THIS repo turned out to still
+ * carry the original defect verbatim: `mapAuthorizationScheme` defaulted an
+ * absent authorization scheme to Workload Identity Federation with a warning,
+ * and both Azure credential getters read `serviceprincipalid`/
+ * `serviceprincipalkey` as optional behind a `!`.
+ *
+ * Each row is mutation-provable: invert the predicate of the guard the row names
+ * and the row turns RED, because the row asserts the REJECTION, not the happy
+ * path. The `complete` control row per branch proves the guards do not simply
+ * reject everything.
+ */
+describe('credential fail-closed matrix (handler x auth-branch x required-field)', function () {
+    this.timeout(20000);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch the shared task-lib module
+    const t = tasks as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const itg = idTokenGeneratorModule as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ote = ociTokenExchangeModule as any;
+
+    const orig = {
+        debug: t.debug,
+        warning: t.warning,
+        setSecret: t.setSecret,
+        getInput: t.getInput,
+        getBoolInput: t.getBoolInput,
+        getVariable: t.getVariable,
+        getEndpointAuthorizationParameter: t.getEndpointAuthorizationParameter,
+        getEndpointAuthorizationScheme: t.getEndpointAuthorizationScheme,
+        getEndpointDataParameter: t.getEndpointDataParameter,
+        getEndpointUrl: t.getEndpointUrl,
+        generateIdToken: itg.generateIdToken,
+        exchangeOidcForUpst: ote.exchangeOidcForUpst,
+    };
+
+    /** A real RSA key: the OCI/GCP handlers run normalizePem for real. */
+    const { privateKey: REAL_PEM } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    interface Fixture {
+        inputs?: Record<string, string>;
+        bools?: Record<string, boolean>;
+        vars?: Record<string, string>;
+        auth?: Record<string, string>;
+        data?: Record<string, string>;
+        scheme?: string;
+        /** Pre-existing agent environment for the neutralization rows. */
+        env?: Record<string, string>;
+        serviceConnection?: string;
+    }
+
+    const touchedEnv = new Set<string>();
+
+    function install(fixture: Fixture): void {
+        t.debug = () => { /* silence */ };
+        t.warning = () => { /* silence */ };
+        t.setSecret = () => { /* no-op: masking has its own tests */ };
+        t.getInput = (name: string, required?: boolean) => {
+            const v = fixture.inputs?.[name];
+            if (required && !v) throw new Error(`Input required: ${name}`);
+            return v;
+        };
+        t.getBoolInput = (name: string) => fixture.bools?.[name] ?? false;
+        t.getVariable = (name: string) => fixture.vars?.[name];
+        t.getEndpointAuthorizationParameter = (id: string, key: string, optional: boolean) => {
+            // The WIF token-refresh path reads the pipeline's own access token
+            // from SystemVssConnection, not from the provider connection.
+            const v = id === 'SystemVssConnection' && key === 'AccessToken'
+                ? 'system-vss-access-token'
+                : fixture.auth?.[key];
+            if (!optional && !v) throw new Error(`LIB_EndpointAuthNotExist: ${key}`);
+            return v;
+        };
+        t.getEndpointAuthorizationScheme = (_id: string, optional: boolean) => {
+            const v = fixture.scheme;
+            if (!optional && !v) throw new Error('LIB_EndpointAuthNotExist: scheme');
+            return v;
+        };
+        t.getEndpointDataParameter = (_id: string, key: string, optional: boolean) => {
+            const v = fixture.data?.[key];
+            if (!optional && !v) throw new Error(`LIB_EndpointDataNotExist: ${key}`);
+            return v;
+        };
+        t.getEndpointUrl = (_id: string, optional: boolean) => {
+            if (!optional) throw new Error('LIB_EndpointNotExist');
+            return undefined;
+        };
+        itg.generateIdToken = async () => 'mock-oidc-jwt-for-matrix';
+        ote.exchangeOidcForUpst = async () => 'mock-upst-for-matrix';
+        installEndpointDataEnvironment(fixture);
+        for (const [k, v] of Object.entries(fixture.env ?? {})) {
+            process.env[k] = v;
+            touchedEnv.add(k);
+        }
+    }
+
+    /**
+     * Provisions the REAL `ENDPOINT_DATA_<id>_<KEY>` channel the agent sets, in
+     * addition to the `getEndpointDataParameter` stub above.
+     *
+     * A data-family SECRET is deliberately not read through
+     * `tasks.getEndpointDataParameter` -- that accessor debug-logs the value at
+     * read time and leaves `ENDPOINT_DATA_*` in `process.env` for the terraform
+     * child, so `requireSecretField(..., { source: 'data' })` routes through
+     * `readSecretEndpointDataParameter`, which reads this variable directly
+     * (src/endpoint-data-secret.ts). Stubbing only the accessor would make the
+     * `complete` control row for such a branch fail for the wrong reason and
+     * would let its reject row pass without ever exercising the guard, so the
+     * fixture has to deliver the value the way the agent does.
+     *
+     * Mirrored under every endpoint id the fixture names -- the real agent sets
+     * these for every service connection referenced by the job -- so the next
+     * handler that gains a data-family secret inherits the channel.
+     */
+    function installEndpointDataEnvironment(fixture: Fixture): void {
+        const ids = new Set<string>();
+        if (fixture.serviceConnection) ids.add(fixture.serviceConnection);
+        for (const [name, value] of Object.entries(fixture.inputs ?? {})) {
+            if (/^(environmentServiceName|backendService)/.test(name) && value) ids.add(value);
+        }
+        for (const id of ids) {
+            for (const [key, value] of Object.entries(fixture.data ?? {})) {
+                // task-lib's own derivation: the id verbatim, the key upper-cased.
+                const name = `ENDPOINT_DATA_${id}_${key.toUpperCase()}`;
+                process.env[name] = value;
+                touchedEnv.add(name);
+            }
+        }
+    }
+
+    afterEach(() => {
+        Object.assign(t, {
+            debug: orig.debug,
+            warning: orig.warning,
+            setSecret: orig.setSecret,
+            getInput: orig.getInput,
+            getBoolInput: orig.getBoolInput,
+            getVariable: orig.getVariable,
+            getEndpointAuthorizationParameter: orig.getEndpointAuthorizationParameter,
+            getEndpointAuthorizationScheme: orig.getEndpointAuthorizationScheme,
+            getEndpointDataParameter: orig.getEndpointDataParameter,
+            getEndpointUrl: orig.getEndpointUrl,
+        });
+        itg.generateIdToken = orig.generateIdToken;
+        ote.exchangeOidcForUpst = orig.exchangeOidcForUpst;
+        EnvironmentVariableHelper.clearTrackedVariables();
+        for (const k of touchedEnv) delete process.env[k];
+        touchedEnv.clear();
+    });
+
+    // --- complete, valid fixtures: one per (handler, auth-branch) -------------
+
+    const AZURE_COMMON = {
+        auth: {
+            serviceprincipalid: 'e7a1b2c3-0000-4444-8888-99990000aaaa',
+            serviceprincipalkey: 'sp-secret-value',
+            tenantid: '11112222-3333-4444-5555-666677778888',
+        },
+        data: { subscriptionid: 'aaaabbbb-cccc-dddd-eeee-ffff00001111' },
+    };
+
+    const COMPLETE: Record<string, Fixture> = {
+        'azurerm.WorkloadIdentityFederation': {
+            inputs: { environmentServiceNameAzureRM: 'AzureRM' },
+            scheme: 'WorkloadIdentityFederation',
+            ...AZURE_COMMON,
+        },
+        'azurerm.ServicePrincipal': {
+            inputs: { environmentServiceNameAzureRM: 'AzureRM' },
+            scheme: 'ServicePrincipal',
+            ...AZURE_COMMON,
+        },
+        'azurerm.ManagedServiceIdentity': {
+            inputs: { environmentServiceNameAzureRM: 'AzureRM' },
+            scheme: 'ManagedServiceIdentity',
+            auth: { tenantid: '11112222-3333-4444-5555-666677778888' },
+            data: { subscriptionid: 'aaaabbbb-cccc-dddd-eeee-ffff00001111' },
+        },
+        'aws.static': {
+            serviceConnection: 'AWS',
+            inputs: {},
+            auth: { username: 'AKIAEXAMPLEKEYID', password: 'example-secret-access-key' },
+        },
+        'aws.WorkloadIdentityFederation': {
+            serviceConnection: 'AWS',
+            inputs: {
+                environmentAuthSchemeAWS: 'WorkloadIdentityFederation',
+                awsRoleArn: 'arn:aws:iam::123456789012:role/terraform',
+                awsRegion: 'us-east-1',
+            },
+            vars: { 'System.TeamProject': 'Contoso Infra', 'Build.BuildId': '4242' },
+        },
+        'aws.backendStatic': {
+            serviceConnection: 'AWS',
+            inputs: { backendServiceAWS: 'AWS' },
+            auth: { username: 'AKIAEXAMPLEKEYID', password: 'example-secret-access-key', region: 'us-east-1' },
+        },
+        'aws.backendWIF': {
+            serviceConnection: 'AWS',
+            inputs: {
+                backendServiceAWS: 'AWS',
+                backendAuthSchemeAWS: 'WorkloadIdentityFederation',
+                backendAWSRoleArn: 'arn:aws:iam::123456789012:role/terraform-backend',
+                backendAWSRegion: 'us-east-1',
+            },
+            vars: { 'System.TeamProject': 'Contoso Infra', 'Build.BuildId': '4242' },
+        },
+        'gcp.static': {
+            serviceConnection: 'GCP',
+            inputs: {},
+            auth: {
+                Issuer: 'terraform@example.iam.gserviceaccount.com',
+                Audience: 'https://oauth2.googleapis.com/token',
+                PrivateKey: REAL_PEM as string,
+            },
+            data: { project: 'example-project' },
+        },
+        'gcp.WorkloadIdentityFederation': {
+            serviceConnection: 'GCP',
+            inputs: {
+                environmentAuthSchemeGCP: 'WorkloadIdentityFederation',
+                gcpProjectNumber: '123456789012',
+                gcpWorkloadIdentityPoolId: 'ado-pool',
+                gcpWorkloadIdentityProviderId: 'ado-provider',
+                gcpServiceAccountEmail: 'terraform@example.iam.gserviceaccount.com',
+            },
+        },
+        'oci.static': {
+            serviceConnection: 'OCI',
+            inputs: {},
+            data: {
+                privateKey: (REAL_PEM as string).replace(/\n/g, ' ').trim(),
+                tenancy: 'ocid1.tenancy.oc1..aaaaaaaaexampletenancyocid',
+                user: 'ocid1.user.oc1..aaaaaaaaexampleuserocid',
+                region: 'us-ashburn-1',
+                fingerprint: 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+            },
+        },
+        'oci.WorkloadIdentityFederation': {
+            serviceConnection: 'OCI',
+            inputs: {
+                environmentAuthSchemeOCI: 'WorkloadIdentityFederation',
+                ociWifIdentityDomainUrl: 'https://idcs-dummy.identity.oraclecloud.com',
+                ociWifClientId: 'dummy-client-id',
+                ociWifTenancyOcid: 'ocid1.tenancy.oc1..aaaaaaaaexampletenancyocid',
+                ociWifRegion: 'us-ashburn-1',
+            },
+        },
+        'hcp.backend': { inputs: { backendHCPToken: 'hcp-token-value' } },
+        'generic.provider': { inputs: {} },
+    };
+
+    function clone(base: string | Fixture): Fixture {
+        const source = typeof base === 'string' ? COMPLETE[base] : base;
+        return JSON.parse(JSON.stringify(source)) as Fixture;
+    }
+
+    function makeHandler(handler: string): BaseTerraformCommandHandler {
+        switch (handler) {
+            case 'azurerm': return new TerraformCommandHandlerAzureRM();
+            case 'aws': return new TerraformCommandHandlerAWS();
+            case 'gcp': return new TerraformCommandHandlerGCP();
+            case 'oci': return new TerraformCommandHandlerOCI();
+            case 'hcp': return new TerraformCommandHandlerHCP();
+            case 'generic': return new TerraformCommandHandlerGeneric();
+            default: throw new Error(`unknown handler ${handler}`);
+        }
+    }
+
+    /** `provider` exercises handleProvider; `backend` exercises configureBackendCredentials. */
+    type Entry = 'provider' | 'backend';
+
+    async function run(handler: string, fixture: Fixture, entry: Entry = 'provider'): Promise<BaseTerraformCommandHandler> {
+        const impl = makeHandler(handler);
+        install(fixture);
+        try {
+            if (entry === 'backend') {
+                await impl.configureBackendCredentials();
+            } else {
+                await impl.handleProvider(
+                    new TerraformAuthorizationCommandInitializer('plan', '', fixture.serviceConnection ?? ''));
+            }
+        } finally {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tempFiles is protected
+            (impl as any).tempFiles = [];
+        }
+        return impl;
+    }
+
+    /** Removes one field from a complete fixture -- the "absent credential" mutation. */
+    function without(base: string, bucket: 'inputs' | 'auth' | 'data' | 'scheme' | 'serviceConnection', key?: string): Fixture {
+        const f = clone(base);
+        if (bucket === 'scheme' || bucket === 'serviceConnection') delete f[bucket];
+        else delete (f[bucket] as Record<string, string>)?.[key!];
+        return f;
+    }
+
+    /** Replaces one field with an HCL/INI-injecting value -- the "malformed" mutation. */
+    function malformed(base: string, bucket: 'inputs' | 'auth' | 'data', key: string): Fixture {
+        const f = clone(base);
+        (f[bucket] as Record<string, string>)[key] = '${file("/etc/passwd")}';
+        return f;
+    }
+
+    // --- ROWS: every required field of every branch must fail closed ----------
+
+    interface Row { site: string; handler: string; entry?: Entry; fixture: () => Fixture }
+
+    const REJECT_ROWS: Row[] = [
+        // #97, still present verbatim in THIS repo before this change.
+        { site: 'azurerm.schemeResolution.authorizationScheme', handler: 'azurerm', fixture: () => without('azurerm.WorkloadIdentityFederation', 'scheme') },
+        { site: 'azurerm.WorkloadIdentityFederation.serviceprincipalid', handler: 'azurerm', fixture: () => without('azurerm.WorkloadIdentityFederation', 'auth', 'serviceprincipalid') },
+        { site: 'azurerm.WorkloadIdentityFederation.tenantid', handler: 'azurerm', fixture: () => without('azurerm.WorkloadIdentityFederation', 'auth', 'tenantid') },
+        { site: 'azurerm.ServicePrincipal.serviceprincipalid', handler: 'azurerm', fixture: () => without('azurerm.ServicePrincipal', 'auth', 'serviceprincipalid') },
+        { site: 'azurerm.ServicePrincipal.serviceprincipalkey', handler: 'azurerm', fixture: () => without('azurerm.ServicePrincipal', 'auth', 'serviceprincipalkey') },
+        { site: 'azurerm.ManagedServiceIdentity.tenantid', handler: 'azurerm', fixture: () => without('azurerm.ManagedServiceIdentity', 'auth', 'tenantid') },
+        // The same guards must hold on the BACKEND entry point, not just the provider one.
+        { site: 'azurerm.backend.schemeResolution.authorizationScheme', handler: 'azurerm', entry: 'backend', fixture: () => ({ ...without('azurerm.WorkloadIdentityFederation', 'scheme'), inputs: { backendServiceArm: 'AzureRM' } }) },
+        { site: 'azurerm.backend.WorkloadIdentityFederation.serviceprincipalid', handler: 'azurerm', entry: 'backend', fixture: () => ({ ...without('azurerm.WorkloadIdentityFederation', 'auth', 'serviceprincipalid'), inputs: { backendServiceArm: 'AzureRM' } }) },
+        // #199 -- value validation, not just presence.
+        { site: 'azurerm.WorkloadIdentityFederation.serviceprincipalid[malformed]', handler: 'azurerm', fixture: () => malformed('azurerm.WorkloadIdentityFederation', 'auth', 'serviceprincipalid') },
+        { site: 'azurerm.WorkloadIdentityFederation.tenantid[malformed]', handler: 'azurerm', fixture: () => malformed('azurerm.WorkloadIdentityFederation', 'auth', 'tenantid') },
+        { site: 'azurerm.handleProvider.subscriptionid[malformed]', handler: 'azurerm', fixture: () => malformed('azurerm.ServicePrincipal', 'data', 'subscriptionid') },
+
+        { site: 'aws.static.serviceConnection', handler: 'aws', fixture: () => without('aws.static', 'serviceConnection') },
+        { site: 'aws.static.username', handler: 'aws', fixture: () => without('aws.static', 'auth', 'username') },
+        { site: 'aws.static.password', handler: 'aws', fixture: () => without('aws.static', 'auth', 'password') },
+        { site: 'aws.static.username[malformed]', handler: 'aws', fixture: () => malformed('aws.static', 'auth', 'username') },
+        { site: 'aws.WorkloadIdentityFederation.serviceConnection', handler: 'aws', fixture: () => without('aws.WorkloadIdentityFederation', 'serviceConnection') },
+        { site: 'aws.WorkloadIdentityFederation.awsRoleArn', handler: 'aws', fixture: () => without('aws.WorkloadIdentityFederation', 'inputs', 'awsRoleArn') },
+        { site: 'aws.WorkloadIdentityFederation.awsRegion', handler: 'aws', fixture: () => without('aws.WorkloadIdentityFederation', 'inputs', 'awsRegion') },
+        { site: 'aws.WorkloadIdentityFederation.awsRoleArn[malformed]', handler: 'aws', fixture: () => malformed('aws.WorkloadIdentityFederation', 'inputs', 'awsRoleArn') },
+        { site: 'aws.backendStatic.username', handler: 'aws', entry: 'backend', fixture: () => without('aws.backendStatic', 'auth', 'username') },
+        { site: 'aws.backendStatic.password', handler: 'aws', entry: 'backend', fixture: () => without('aws.backendStatic', 'auth', 'password') },
+        // #197 -- an explicit session name outside AWS's grammar must fail here.
+        {
+            site: 'aws.WorkloadIdentityFederation.roleSessionName[malformed]', handler: 'aws', fixture: () => {
+                const f = clone('aws.WorkloadIdentityFederation');
+                f.inputs!.awsSessionName = 'not a valid session name!';
+                return f;
+            }
+        },
+        {
+            site: 'aws.backendWIF.roleSessionName[malformed]', handler: 'aws', entry: 'backend', fixture: () => {
+                const f = clone('aws.backendWIF');
+                f.inputs!.backendAWSSessionName = 'not a valid session name!';
+                return f;
+            }
+        },
+
+        { site: 'gcp.static.serviceConnection', handler: 'gcp', fixture: () => without('gcp.static', 'serviceConnection') },
+        { site: 'gcp.static.Issuer', handler: 'gcp', fixture: () => without('gcp.static', 'auth', 'Issuer') },
+        { site: 'gcp.static.Audience', handler: 'gcp', fixture: () => without('gcp.static', 'auth', 'Audience') },
+        { site: 'gcp.static.PrivateKey', handler: 'gcp', fixture: () => without('gcp.static', 'auth', 'PrivateKey') },
+        { site: 'gcp.static.project', handler: 'gcp', fixture: () => without('gcp.static', 'data', 'project') },
+        { site: 'gcp.static.project[malformed]', handler: 'gcp', fixture: () => malformed('gcp.static', 'data', 'project') },
+        {
+            site: 'gcp.static.Audience[foreign-origin]', handler: 'gcp', fixture: () => {
+                const f = clone('gcp.static');
+                f.auth!.Audience = 'https://attacker.example.com/token';
+                return f;
+            }
+        },
+        { site: 'gcp.WorkloadIdentityFederation.serviceConnection', handler: 'gcp', fixture: () => without('gcp.WorkloadIdentityFederation', 'serviceConnection') },
+        { site: 'gcp.WorkloadIdentityFederation.gcpProjectNumber', handler: 'gcp', fixture: () => without('gcp.WorkloadIdentityFederation', 'inputs', 'gcpProjectNumber') },
+        { site: 'gcp.WorkloadIdentityFederation.gcpServiceAccountEmail[malformed]', handler: 'gcp', fixture: () => malformed('gcp.WorkloadIdentityFederation', 'inputs', 'gcpServiceAccountEmail') },
+
+        { site: 'oci.static.serviceConnection', handler: 'oci', fixture: () => without('oci.static', 'serviceConnection') },
+        { site: 'oci.static.privateKey', handler: 'oci', fixture: () => without('oci.static', 'data', 'privateKey') },
+        { site: 'oci.static.tenancy', handler: 'oci', fixture: () => without('oci.static', 'data', 'tenancy') },
+        { site: 'oci.static.user', handler: 'oci', fixture: () => without('oci.static', 'data', 'user') },
+        { site: 'oci.static.region', handler: 'oci', fixture: () => without('oci.static', 'data', 'region') },
+        { site: 'oci.static.fingerprint', handler: 'oci', fixture: () => without('oci.static', 'data', 'fingerprint') },
+        { site: 'oci.static.tenancy[malformed]', handler: 'oci', fixture: () => malformed('oci.static', 'data', 'tenancy') },
+        { site: 'oci.WorkloadIdentityFederation.serviceConnection', handler: 'oci', fixture: () => without('oci.WorkloadIdentityFederation', 'serviceConnection') },
+    ];
+
+    for (const row of REJECT_ROWS) {
+        it(`fails closed: ${row.site}`, async () => {
+            await assert.rejects(
+                () => run(row.handler, row.fixture(), row.entry),
+                `${row.site}: an absent or malformed credential field must fail the task, not degrade to ambient credentials`);
+        });
+    }
+
+    // --- CONTROL ROWS: the guards must accept a complete configuration --------
+
+    const ACCEPT_ROWS: Row[] = [
+        { site: 'azurerm.WorkloadIdentityFederation.complete', handler: 'azurerm', fixture: () => clone('azurerm.WorkloadIdentityFederation') },
+        { site: 'azurerm.ServicePrincipal.complete', handler: 'azurerm', fixture: () => clone('azurerm.ServicePrincipal') },
+        { site: 'azurerm.ManagedServiceIdentity.complete', handler: 'azurerm', fixture: () => clone('azurerm.ManagedServiceIdentity') },
+        // The one designed-optional identity read in the matrix: an MSI-scheme
+        // connection with a BLANK service principal id means "system-assigned",
+        // which must keep working.
+        { site: 'azurerm.ManagedServiceIdentity.serviceprincipalid[exempt-optional]', handler: 'azurerm', fixture: () => without('azurerm.ManagedServiceIdentity', 'auth', 'serviceprincipalid') },
+        { site: 'aws.static.complete', handler: 'aws', fixture: () => clone('aws.static') },
+        { site: 'aws.WorkloadIdentityFederation.complete', handler: 'aws', fixture: () => clone('aws.WorkloadIdentityFederation') },
+        { site: 'aws.backendStatic.complete', handler: 'aws', entry: 'backend', fixture: () => clone('aws.backendStatic') },
+        { site: 'aws.backendWIF.complete', handler: 'aws', entry: 'backend', fixture: () => clone('aws.backendWIF') },
+        { site: 'gcp.static.complete', handler: 'gcp', fixture: () => clone('gcp.static') },
+        { site: 'gcp.WorkloadIdentityFederation.complete', handler: 'gcp', fixture: () => clone('gcp.WorkloadIdentityFederation') },
+        { site: 'oci.static.complete', handler: 'oci', fixture: () => clone('oci.static') },
+        // The code-verified exemptions: neither handler has a cloud identity.
+        { site: 'hcp.handleProvider.no-credentials[exempt]', handler: 'hcp', fixture: () => clone('hcp.backend') },
+        { site: 'generic.handleProvider.no-credentials[exempt]', handler: 'generic', fixture: () => clone('generic.provider') },
+    ];
+
+    for (const row of ACCEPT_ROWS) {
+        it(`accepts a complete configuration: ${row.site}`, async () => {
+            await run(row.handler, row.fixture(), row.entry);
+        });
+    }
+
+    // --- NEUTRALIZATION ROWS (#187) ------------------------------------------
+
+    const NEUTRALIZE_ROWS: Array<{ site: string; handler: string; base: string; entry?: Entry; competing: string[] }> = [
+        {
+            site: 'aws.WorkloadIdentityFederation.competing-credential-env', handler: 'aws', base: 'aws.WorkloadIdentityFederation',
+            competing: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN', 'AWS_PROFILE', 'AWS_SHARED_CREDENTIALS_FILE'],
+        },
+        {
+            site: 'aws.backendWIF.competing-credential-env', handler: 'aws', base: 'aws.backendWIF', entry: 'backend',
+            competing: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN'],
+        },
+        {
+            site: 'aws.static.competing-credential-env', handler: 'aws', base: 'aws.static',
+            competing: ['AWS_WEB_IDENTITY_TOKEN_FILE', 'AWS_ROLE_ARN', 'AWS_SESSION_TOKEN'],
+        },
+        {
+            // ARM_USE_MSI only reaches the agent identity while these are absent.
+            site: 'azurerm.ManagedServiceIdentity.competing-credential-env', handler: 'azurerm', base: 'azurerm.ManagedServiceIdentity',
+            competing: ['ARM_CLIENT_SECRET', 'ARM_OIDC_TOKEN', 'ARM_CLIENT_CERTIFICATE_PATH', 'ARM_USE_OIDC', 'ARM_USE_CLI'],
+        },
+        {
+            // The cell no per-branch list can close: MSI legitimately MAY set
+            // ARM_CLIENT_ID (user-assigned), so the wholesale clear at the top of
+            // setCommonVariables is what stops an inherited one substituting an
+            // identity nobody configured.
+            site: 'azurerm.ManagedServiceIdentity.competing-credential-env[ARM_CLIENT_ID]', handler: 'azurerm', base: 'azurerm.ManagedServiceIdentity',
+            competing: ['ARM_CLIENT_ID'],
+        },
+        {
+            site: 'azurerm.WorkloadIdentityFederation.competing-credential-env', handler: 'azurerm', base: 'azurerm.WorkloadIdentityFederation',
+            competing: ['ARM_CLIENT_SECRET', 'ARM_CLIENT_CERTIFICATE_PATH', 'ARM_USE_MSI', 'ARM_USE_CLI'],
+        },
+        {
+            site: 'azurerm.ServicePrincipal.competing-credential-env', handler: 'azurerm', base: 'azurerm.ServicePrincipal',
+            competing: ['ARM_OIDC_TOKEN', 'ARM_CLIENT_CERTIFICATE_PATH', 'ARM_USE_MSI', 'ARM_USE_OIDC', 'ARM_USE_CLI'],
+        },
+        {
+            site: 'gcp.static.competing-credential-env', handler: 'gcp', base: 'gcp.static',
+            competing: ['GOOGLE_APPLICATION_CREDENTIALS', 'GOOGLE_OAUTH_ACCESS_TOKEN', 'CLOUDSDK_AUTH_ACCESS_TOKEN'],
+        },
+        {
+            site: 'gcp.WorkloadIdentityFederation.competing-credential-env', handler: 'gcp', base: 'gcp.WorkloadIdentityFederation',
+            competing: ['GOOGLE_APPLICATION_CREDENTIALS', 'GOOGLE_OAUTH_ACCESS_TOKEN'],
+        },
+        {
+            site: 'oci.static.competing-credential-env', handler: 'oci', base: 'oci.static',
+            competing: ['OCI_CLI_CONFIG_FILE', 'OCI_CLI_PROFILE', 'OCI_CLI_TENANCY', 'OCI_CLI_KEY_FILE'],
+        },
+    ];
+
+    for (const row of NEUTRALIZE_ROWS) {
+        it(`clears competing identity env vars: ${row.site}`, async () => {
+            const fixture = clone(row.base);
+            fixture.env = Object.fromEntries(row.competing.map((name) => [name, 'inherited-from-agent']));
+            await run(row.handler, fixture, row.entry);
+            for (const name of row.competing) {
+                assert.strictEqual(process.env[name], undefined,
+                    `${row.site}: '${name}' was inherited from the agent and can out-rank the credentials this branch injects; it must be cleared`);
+            }
+        });
+    }
+
+    // --- SESSION-NAME ROWS (#197) --------------------------------------------
+
+    for (const [site, handler, entry, prefix] of [
+        ['aws.WorkloadIdentityFederation.roleSessionName', 'aws', 'provider', 'ado-tf'],
+        ['aws.backendWIF.roleSessionName', 'aws', 'backend', 'ado-tf-backend'],
+    ] as Array<[string, string, Entry, string]>) {
+        it(`derives a per-run role session name instead of a shared constant: ${site}`, async () => {
+            await run(handler, clone(entry === 'backend' ? 'aws.backendWIF' : 'aws.WorkloadIdentityFederation'), entry);
+            const sessionName = process.env['AWS_ROLE_SESSION_NAME'];
+            assert.ok(sessionName, 'AWS_ROLE_SESSION_NAME must be set on the WIF path');
+            assert.ok(!/^AzureDevOps-Terraform(-Backend)?$/.test(sessionName!),
+                'a fixed constant collapses CloudTrail attribution across every federated run of every pipeline');
+            assert.ok(sessionName!.startsWith(prefix), `expected the ${entry} prefix '${prefix}'; got '${sessionName}'`);
+            assert.ok(sessionName!.includes('4242'),
+                `the session name must identify the run (CloudTrail userIdentity.arn pivot); got '${sessionName}'`);
+            assert.ok(/^[\w+=,.@-]{2,64}$/.test(sessionName!),
+                `the session name must satisfy AWS's RoleSessionName grammar; got '${sessionName}'`);
+        });
+    }
+
+    // --- STRUCTURAL ROW: the matrix itself must have no unguarded cell --------
+    // This is what keeps the table above honest: a NEW handler, or a new branch
+    // in an existing one, appears as a new matrix cell and fails here until it
+    // is guarded or carries a code-verified @credential-exempt marker.
+
+    it('scripts/auth-parity-matrix.cjs reports zero UNGUARDED cells', () => {
+        const script = path.resolve(__dirname, '../../../../scripts/auth-parity-matrix.cjs');
+        const repoRoot = path.resolve(__dirname, '../../../..');
+        const out = execFileSync(process.execPath, [script, repoRoot, '--json'], { encoding: 'utf8' });
+        const report = JSON.parse(out) as {
+            cells: Array<{ site: string; verdict: string; detail: string }>;
+            unguarded: number;
+        };
+        assert.ok(report.cells.length > 0, 'the signature must enumerate at least one cell');
+        assert.strictEqual(report.unguarded, 0,
+            'unguarded credential cells: ' + report.cells.filter((c) => c.verdict === 'UNGUARDED')
+                .map((c) => `${c.site} (${c.detail})`).join('; '));
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/AwsConfigureBackendCredentialsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CrossCloudBackendCredentialTests/AwsConfigureBackendCredentialsL0.ts
@@ -64,7 +64,14 @@ describe('TerraformCommandHandlerAWS.configureBackendCredentials (cross-cloud)',
 
     assert.strictEqual(process.env['AWS_ROLE_ARN'], 'arn:aws:iam::922142189708:role/ADO-role');
     assert.strictEqual(process.env['AWS_REGION'], 'us-east-1');
-    assert.strictEqual(process.env['AWS_ROLE_SESSION_NAME'], 'AzureDevOps-Terraform-Backend');
+    // #197: the session name is derived from job context, not a constant shared by
+    // every federated run of every pipeline -- it is CloudTrail's
+    // userIdentity.arn pivot. The 'ado-tf-backend' prefix keeps the backend's
+    // assumed-role session distinguishable from the provider's.
+    const backendSessionName = process.env['AWS_ROLE_SESSION_NAME']!;
+    assert.notStrictEqual(backendSessionName, 'AzureDevOps-Terraform-Backend');
+    assert.ok(backendSessionName.startsWith('ado-tf-backend'), `unexpected session name: ${backendSessionName}`);
+    assert.ok(/^[\w+=,.@-]{2,64}$/.test(backendSessionName), `session name must satisfy AWS's grammar: ${backendSessionName}`);
 
     const tokenFilePath = process.env['AWS_WEB_IDENTITY_TOKEN_FILE']!;
     assert.ok(tokenFilePath, 'AWS_WEB_IDENTITY_TOKEN_FILE should be set');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroyFailEmptyWorkingDirectory.ts
@@ -12,10 +12,10 @@ tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameOCI', 'OCI');
 tr.setInput('commandOptions', '');
 
-process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
-process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroySuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/DestroyTests/OCI/OCIDestroySuccessNoAdditionalArgs.ts
@@ -15,7 +15,7 @@ tr.setInput('commandOptions', '');
 process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitMissingAuthenticationSchemeRejects.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitMissingAuthenticationSchemeRejects.ts
@@ -2,7 +2,16 @@ import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
-let tp = path.join(__dirname, './AzureInitSuccessMissingAuthenticationSchemeL0.js');
+/**
+ * #97: a service connection with NO authorization scheme used to default to
+ * Workload Identity Federation with only a warning. Because the resulting run
+ * set ARM_USE_OIDC without a verified client identity, the azurerm provider
+ * completed authentication from whatever ambient identity the agent carried
+ * (Azure CLI login or managed identity). It now fails closed, so this scenario
+ * asserts the REJECTION.
+ */
+
+let tp = path.join(__dirname, './AzureInitMissingAuthenticationSchemeRejectsL0.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
 
 tr.setInput('provider', 'azurerm');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitMissingAuthenticationSchemeRejectsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitMissingAuthenticationSchemeRejectsL0.ts
@@ -1,4 +1,4 @@
 import { TerraformCommandHandlerAzureRM } from './../../../src/azure-terraform-command-handler';
 import { runCommand } from '../../test-l0-helpers';
 
-runCommand(new TerraformCommandHandlerAzureRM(), 'init', 'AzureInitSuccessMissingAuthenticationSchemeL0');
+runCommand(new TerraformCommandHandlerAzureRM(), 'init', 'AzureInitMissingAuthenticationSchemeRejectsL0');

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -59,6 +59,9 @@ import './BinaryNameAllowlistL0';
 import './GcpTokenUriValidationL0';
 // Direct unit tests for the hoisted auth-scheme validator shared by AWS/GCP/OCI.
 import './AuthSchemeValidatorL0';
+
+// The credential fail-closed class test (#97 and its siblings).
+import './CredentialFailClosedMatrixL0';
 // Direct unit tests for the plan/apply digest REDACTION CORE (WP-1, the single
 // most security-critical unit): recursive redaction, digest builders, freeform
 // diagnostic scrub, and the golden-fixture regression + no-leak tripwire.
@@ -153,18 +156,24 @@ describe('Terraform Test Suite', function () {
 
     });
 
-    it('azure init should succeed with missing authentication scheme', async () => {
-        let tp = path.join(__dirname, './InitTests/Azure/AzureInitSuccessMissingAuthenticationScheme.js');
+    // #97: an absent authorization scheme used to default silently to Workload
+    // Identity Federation (warning only), which -- combined with the azurerm
+    // provider's own fallbacks -- could authenticate as the agent's ambient
+    // identity. It must now fail closed, like every other provider handler.
+    it('azure init should FAIL with missing authentication scheme (#97)', async () => {
+        let tp = path.join(__dirname, './InitTests/Azure/AzureInitMissingAuthenticationSchemeRejects.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         await tr.runAsync();
 
         runValidations(() => {
-            assert(tr.succeeded, 'task should have succeeded');
-            assert(tr.invokedToolCount === 1, 'tool should have been invoked one time. actual: ' + tr.invokedToolCount);
-            assert(tr.errorIssues.length === 0, 'should have no errors');
-            assert(tr.warningIssues.length === 1, 'should have 1 warning');
-            assert(tr.stdOutContained('AzureInitSuccessMissingAuthenticationSchemeL0 should have succeeded.'), 'Should have printed: AzureInitSuccessMissingAuthenticationSchemeL0 should have succeeded.');
+            assert(tr.failed, 'task should have failed');
+            assert(tr.invokedToolCount === 0, 'terraform must not be invoked without a resolved authorization scheme. actual: ' + tr.invokedToolCount);
+            assert(tr.errorIssues.length > 0, 'should have an error issue');
+            assert(
+                tr.errorIssues.some((e) => e.includes('has no authorization scheme')),
+                'should name the missing authorization scheme. errors: ' + tr.errorIssues
+            );
         }, tr);
     });
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciApiKeyPrivateKeyMaskingL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciApiKeyPrivateKeyMaskingL0.ts
@@ -177,7 +177,7 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
         const handler = new TerraformCommandHandlerOCI();
         await assert.rejects(
             handler.handleProvider(makeCommand()),
-            /OCI private key not found in service connection/,
+            /field 'privateKey' is missing or empty/,
         );
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciBackendConfigFileL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciBackendConfigFileL0.ts
@@ -5,6 +5,7 @@ import path = require('path');
 import tasks = require('azure-pipelines-task-lib/task');
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformCommandHandlerOCI } from '../src/oci-terraform-command-handler';
+import { TEST_OCI_PRIVATE_KEY_SPACES } from './test-oci-fixtures';
 
 /**
  * Direct unit tests for the generated OCI backend config file (#545). The
@@ -15,6 +16,25 @@ import { TerraformCommandHandlerOCI } from '../src/oci-terraform-command-handler
  * stay INSIDE the working directory (terraform init only loads *.tf from
  * there) and remain registered for cleanup.
  */
+/** A complete, well-formed OCI API-key connection: handleProvider now fails closed without one. */
+const OCI_ENDPOINT_DATA: Record<string, string> = {
+    tenancy: 'ocid1.tenancy.oc1..dummy',
+    user: 'ocid1.user.oc1..dummy',
+    region: 'us-ashburn-1',
+    fingerprint: 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+};
+
+/**
+ * The signing key is NOT in OCI_ENDPOINT_DATA above, because it is not read
+ * through `tasks.getEndpointDataParameter` -- that accessor debug-logs the value
+ * it returns and leaves `ENDPOINT_DATA_*` in `process.env` for the terraform
+ * child, so `requireSecretField(..., { source: 'data' })` routes through
+ * `readSecretEndpointDataParameter`, which reads this variable directly
+ * (src/endpoint-data-secret.ts). The fixture therefore has to deliver it the way
+ * the agent does, exactly as the OCI mock-runner test setups do.
+ */
+const OCI_PRIVATE_KEY_ENV = 'ENDPOINT_DATA_OCI_PRIVATEKEY';
+
 describe('OCI backend config file — secret-file write hardening (#545)', function () {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- monkeypatch the shared task-lib module
     const t = tasks as any;
@@ -22,7 +42,10 @@ describe('OCI backend config file — secret-file write hardening (#545)', funct
         getInput: t.getInput,
         setSecret: t.setSecret,
         debug: t.debug,
+        warning: t.warning,
+        getEndpointDataParameter: t.getEndpointDataParameter,
     };
+
     let scratchDir: string;
 
     const parUrl = 'https://objectstorage.us-ashburn-1.oraclecloud.com/p/TOKEN123/n/ns/b/tfstate/o/state';
@@ -38,12 +61,16 @@ describe('OCI backend config file — secret-file write hardening (#545)', funct
         };
         t.setSecret = () => { /* no-op */ };
         t.debug = () => { /* silence */ };
+        t.warning = () => { /* silence */ };
+        t.getEndpointDataParameter = (_id: string, key: string) => OCI_ENDPOINT_DATA[key];
     });
 
     afterEach(() => {
         t.getInput = taskOrig.getInput;
         t.setSecret = taskOrig.setSecret;
         t.debug = taskOrig.debug;
+        t.warning = taskOrig.warning;
+        t.getEndpointDataParameter = taskOrig.getEndpointDataParameter;
         fs.rmSync(scratchDir, { recursive: true, force: true });
     });
 
@@ -135,6 +162,8 @@ describe('OCI backend cache cleanup — opt-in scrub of .terraform/terraform.tfs
         getBoolInput: t.getBoolInput,
         setSecret: t.setSecret,
         debug: t.debug,
+        warning: t.warning,
+        getEndpointDataParameter: t.getEndpointDataParameter,
     };
     let scratchDir: string;
     let cachePath: string;
@@ -155,6 +184,12 @@ describe('OCI backend cache cleanup — opt-in scrub of .terraform/terraform.tfs
     }
 
     beforeEach(() => {
+        // handleProvider now fails closed without a complete API-key connection
+        // (the cache-registration behaviour under test is independent of that).
+        t.warning = () => { /* silence */ };
+        t.getEndpointDataParameter = (_id: string, key: string) => OCI_ENDPOINT_DATA[key];
+        // Re-set per test: readSecretEndpointDataParameter deletes it once read.
+        process.env[OCI_PRIVATE_KEY_ENV] = TEST_OCI_PRIVATE_KEY_SPACES;
         scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oci-backend-cache-test-'));
         fs.mkdirSync(path.join(scratchDir, '.terraform'));
         cachePath = path.join(scratchDir, '.terraform', 'terraform.tfstate');
@@ -168,6 +203,9 @@ describe('OCI backend cache cleanup — opt-in scrub of .terraform/terraform.tfs
         t.getBoolInput = taskOrig.getBoolInput;
         t.setSecret = taskOrig.setSecret;
         t.debug = taskOrig.debug;
+        t.warning = taskOrig.warning;
+        t.getEndpointDataParameter = taskOrig.getEndpointDataParameter;
+        delete process.env[OCI_PRIVATE_KEY_ENV];
         fs.rmSync(scratchDir, { recursive: true, force: true });
     });
 
@@ -197,7 +235,11 @@ describe('OCI backend cache cleanup — opt-in scrub of .terraform/terraform.tfs
     it('also registers the cache for cleanup from handleProvider (apply/destroy as the last step, no handleBackend call)', async () => {
         installInputs(true);
         const handler = new TerraformCommandHandlerOCI();
-        await handler.handleProvider({ serviceProviderName: undefined } as unknown as Parameters<TerraformCommandHandlerOCI['handleProvider']>[0]);
+        // A real run always carries a service connection here (createAuthCommand
+        // reads it as a required input); handleProvider now fails closed without
+        // one, so the cache-registration behaviour under test is exercised with a
+        // connection whose credential reads are stubbed below.
+        await handler.handleProvider({ serviceProviderName: 'OCI' } as unknown as Parameters<TerraformCommandHandlerOCI['handleProvider']>[0]);
         handler.cleanupTempFiles();
 
         assert.ok(!fs.existsSync(cachePath), 'handleProvider (used by plan/apply/destroy/...) must register the same opt-in cleanup, not only handleBackend (init)');
@@ -211,7 +253,11 @@ describe('OCI backend cache cleanup — opt-in scrub of .terraform/terraform.tfs
             return undefined;
         };
         const handler = new TerraformCommandHandlerOCI();
-        await handler.handleProvider({ serviceProviderName: undefined } as unknown as Parameters<TerraformCommandHandlerOCI['handleProvider']>[0]);
+        // A real run always carries a service connection here (createAuthCommand
+        // reads it as a required input); handleProvider now fails closed without
+        // one, so the cache-registration behaviour under test is exercised with a
+        // connection whose credential reads are stubbed below.
+        await handler.handleProvider({ serviceProviderName: 'OCI' } as unknown as Parameters<TerraformCommandHandlerOCI['handleProvider']>[0]);
         handler.cleanupTempFiles();
 
         // backendOCIConfigGenerate's own input group is only visible/defaulted

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/OCIOutputSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputTests/OCIOutputSuccess.ts
@@ -25,7 +25,7 @@ tr.setInput('environmentServiceNameOCI', 'OCI');
 process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 tr.registerMock('crypto', { randomUUID: () => '123' });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanFailEmptyWorkingDirectory.ts
@@ -12,10 +12,10 @@ tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('environmentServiceNameOCI', 'OCI');
 tr.setInput('commandOptions', '');
 
-process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'dummy-tenancy-ocid';
-process.env['ENDPOINT_DATA_OCI_USER'] = 'dummy-user-ocid';
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanInvalidAuthScheme.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanInvalidAuthScheme.ts
@@ -15,7 +15,7 @@ tr.setInput('commandOptions', '');
 process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = 'dummy-key';
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PlanTests/OCI/OCIPlanSuccessNoAdditionalArgs.ts
@@ -15,7 +15,7 @@ tr.setInput('commandOptions', '');
 process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/OCIShowConsoleSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ShowTests/OCIShowConsoleSuccess.ts
@@ -17,7 +17,7 @@ tr.setInput('environmentServiceNameOCI', 'OCI');
 process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccess.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TestCommandTests/OCITestSuccess.ts
@@ -12,10 +12,10 @@ tr.setInput('workingDirectory', 'DummyWorkingDirectory');
 tr.setInput('commandOptions', '');
 tr.setInput('environmentServiceNameOCI', 'OCI');
 
-process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'DummyTenancy';
-process.env['ENDPOINT_DATA_OCI_USER'] = 'DummyUser';
+process.env['ENDPOINT_DATA_OCI_TENANCY'] = 'ocid1.tenancy.oc1..dummy';
+process.env['ENDPOINT_DATA_OCI_USER'] = 'ocid1.user.oc1..dummy';
 process.env['ENDPOINT_DATA_OCI_REGION'] = 'us-ashburn-1';
-process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'DummyFingerprint';
+process.env['ENDPOINT_DATA_OCI_FINGERPRINT'] = 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99';
 process.env['ENDPOINT_DATA_OCI_PRIVATEKEY'] = TEST_OCI_PRIVATE_KEY_SPACES;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -6,6 +6,38 @@ import { EnvironmentVariableHelper } from './environment-variables';
 import { generateIdToken } from './id-token-generator';
 import { writeSecretFile } from './secure-temp';
 import { resolveWifTempDir } from './temp-dir';
+import {
+    assertIdentityValue,
+    neutralizeEnvironmentVariables,
+    requireIdentityField,
+    requireSecretField,
+    resolveRoleSessionName,
+} from './credential-guards';
+
+/**
+ * Environment variables the AWS SDK's default credential chain matches BEFORE
+ * the web-identity token file (`resolveCredentials()` in
+ * aws/session/credentials.go; same ordering in aws-sdk-go-v2's
+ * `resolveCredentialChain`). Any of these left set by a self-hosted agent or a
+ * pipeline variable wins outright over a freshly minted federated assertion, so
+ * the WIF path clears them before injecting (#187).
+ */
+const AWS_STATIC_CREDENTIAL_ENV = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_PROFILE',
+    'AWS_SHARED_CREDENTIALS_FILE',
+] as const;
+
+/** The mirror set: web-identity/role selectors the static-key path must clear. */
+const AWS_FEDERATED_CREDENTIAL_ENV = [
+    'AWS_WEB_IDENTITY_TOKEN_FILE',
+    'AWS_ROLE_ARN',
+    'AWS_SESSION_TOKEN',
+    'AWS_PROFILE',
+    'AWS_SHARED_CREDENTIALS_FILE',
+] as const;
 import path = require('path');
 import { randomUUID as uuidV4 } from 'crypto';
 
@@ -22,10 +54,16 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
      * `configureBackendCredentials` (cross-cloud injection on later commands).
      */
     private setEnvOnlyAwsCredentials(backendServiceName: string): void {
-        const accessKey = tasks.getEndpointAuthorizationParameter(backendServiceName, "username", true)!;
-        const secretKey = tasks.getEndpointAuthorizationParameter(backendServiceName, "password", true)!;
-        if (secretKey) { tasks.setSecret(secretKey); }
+        // Both fields were read with optional=true behind a `!`: an absent access
+        // key or secret produced `undefined`, which setEnvironmentVariable skips
+        // with a warning, so the s3 backend silently fell through to the agent's
+        // instance-profile/ambient credentials -- the same fail-open shape as #97
+        // and exactly what the provider path already refused to do.
+        const accessKey = requireIdentityField(backendServiceName, "username");
+        const secretKey = requireSecretField(backendServiceName, "password");
+        tasks.setSecret(secretKey);
 
+        neutralizeEnvironmentVariables(AWS_FEDERATED_CREDENTIAL_ENV, "AWS static backend");
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_ACCESS_KEY_ID", accessKey);
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_SECRET_ACCESS_KEY", secretKey, true);
     }
@@ -33,7 +71,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
     private setupBackend(backendServiceName: string) {
         this.backendConfig.set('bucket', tasks.getInput("backendAWSBucketName", true)!);
         this.backendConfig.set('key', tasks.getInput("backendAWSKey", true)!);
-        this.backendConfig.set('region', tasks.getEndpointAuthorizationParameter(backendServiceName, "region", true)!);
+        this.backendConfig.set('region', requireIdentityField(backendServiceName, "region"));
 
         this.setEnvOnlyAwsCredentials(backendServiceName);
     }
@@ -58,23 +96,38 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
         writeSecretFile(tokenFilePath, oidcToken);
         this.tempFiles.push(tokenFilePath);
 
+        // Clear the static keys FIRST: the SDK matches them before the
+        // web-identity token file, so an inherited pair would silently discard
+        // the assertion just written above (#187).
+        neutralizeEnvironmentVariables(AWS_STATIC_CREDENTIAL_ENV, "AWS Workload Identity Federation");
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_ARN", params.roleArn);
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFilePath);
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_REGION", params.region);
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_ROLE_SESSION_NAME", params.sessionName);
     }
 
+    /**
+     * The backend's Workload Identity Federation parameter block, shared by
+     * `setupBackendWIF` (init) and `configureBackendCredentials` (cross-cloud).
+     * These were two verbatim copies, and the #197 session-name fix landing in
+     * only one of them would have been this batch's own defect class in
+     * miniature: one branch guarded, its sibling not.
+     */
+    private async applyBackendWifEnvironment(backendServiceName: string): Promise<void> {
+        await this.applyWifEnvironment({
+            serviceConnection: backendServiceName,
+            roleArn: assertIdentityValue(tasks.getInput("backendAWSRoleArn", true), "Input 'backendAWSRoleArn'"),
+            region: assertIdentityValue(tasks.getInput("backendAWSRegion", true), "Input 'backendAWSRegion'"),
+            sessionName: resolveRoleSessionName("backendAWSSessionName", "ado-tf-backend"),
+            tokenFilePrefix: "aws-backend-oidc-token",
+        });
+    }
+
     private async setupBackendWIF(backendServiceName: string): Promise<void> {
         this.backendConfig.set('bucket', tasks.getInput("backendAWSBucketName", true)!);
         this.backendConfig.set('key', tasks.getInput("backendAWSKey", true)!);
 
-        await this.applyWifEnvironment({
-            serviceConnection: backendServiceName,
-            roleArn: tasks.getInput("backendAWSRoleArn", true)!,
-            region: tasks.getInput("backendAWSRegion", true)!,
-            sessionName: tasks.getInput("backendAWSSessionName", false) || "AzureDevOps-Terraform-Backend",
-            tokenFilePrefix: "aws-backend-oidc-token",
-        });
+        await this.applyBackendWifEnvironment(backendServiceName);
     }
 
     public async handleBackend(terraformToolRunner: ToolRunner): Promise<void> {
@@ -102,13 +155,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
 
         tasks.debug("Configuring cross-cloud s3 backend credentials (environment variables only).");
         if (authScheme === "WorkloadIdentityFederation") {
-            await this.applyWifEnvironment({
-                serviceConnection: backendServiceName,
-                roleArn: tasks.getInput("backendAWSRoleArn", true)!,
-                region: tasks.getInput("backendAWSRegion", true)!,
-                sessionName: tasks.getInput("backendAWSSessionName", false) || "AzureDevOps-Terraform-Backend",
-                tokenFilePrefix: "aws-backend-oidc-token",
-            });
+            await this.applyBackendWifEnvironment(backendServiceName);
         } else {
             this.setEnvOnlyAwsCredentials(backendServiceName);
         }
@@ -122,21 +169,36 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
             await this.handleProviderWIF(command);
         } else {
             if (command.serviceProviderName) {
-                const accessKeyId = tasks.getEndpointAuthorizationParameter(command.serviceProviderName, "username", false);
-                const secretAccessKey = tasks.getEndpointAuthorizationParameter(command.serviceProviderName, "password", false);
-                if (secretAccessKey) { tasks.setSecret(secretAccessKey); }
-                EnvironmentVariableHelper.setEnvironmentVariable("AWS_ACCESS_KEY_ID", accessKeyId ?? '');
-                EnvironmentVariableHelper.setEnvironmentVariable("AWS_SECRET_ACCESS_KEY", secretAccessKey ?? '', true);
+                // `?? ''` made an absent field a silently skipped environment
+                // variable, which the AWS SDK reads as "not set" and answers from
+                // the instance profile instead. Both now fail closed.
+                const accessKeyId = requireIdentityField(command.serviceProviderName, "username");
+                const secretAccessKey = requireSecretField(command.serviceProviderName, "password");
+                tasks.setSecret(secretAccessKey);
+                neutralizeEnvironmentVariables(AWS_FEDERATED_CREDENTIAL_ENV, "AWS static");
+                EnvironmentVariableHelper.setEnvironmentVariable("AWS_ACCESS_KEY_ID", accessKeyId);
+                EnvironmentVariableHelper.setEnvironmentVariable("AWS_SECRET_ACCESS_KEY", secretAccessKey, true);
+            } else {
+                // Silently injecting nothing leaves terraform to authenticate from
+                // whatever ambient credentials the agent carries -- the defect this
+                // whole matrix exists to remove.
+                throw new Error("An AWS service connection is required for this command. Set environmentServiceNameAWS.");
             }
         }
     }
 
     private async handleProviderWIF(command: TerraformAuthorizationCommandInitializer): Promise<void> {
+        if (!command.serviceProviderName) {
+            // Fail closed like the static path: an empty service connection would
+            // otherwise POST to the ADO OIDC endpoint with an empty id and surface
+            // a cryptic downstream error instead of a clear misconfiguration.
+            throw new Error("An AWS service connection is required for Workload Identity Federation. Set environmentServiceNameAWS.");
+        }
         await this.applyWifEnvironment({
             serviceConnection: command.serviceProviderName,
-            roleArn: tasks.getInput("awsRoleArn", true)!,
-            region: tasks.getInput("awsRegion", true)!,
-            sessionName: tasks.getInput("awsSessionName", false) || "AzureDevOps-Terraform",
+            roleArn: assertIdentityValue(tasks.getInput("awsRoleArn", true), "Input 'awsRoleArn'"),
+            region: assertIdentityValue(tasks.getInput("awsRegion", true), "Input 'awsRegion'"),
+            sessionName: resolveRoleSessionName("awsSessionName", "ado-tf"),
             tokenFilePrefix: "aws-oidc-token",
         });
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -4,6 +4,54 @@ import { TerraformAuthorizationCommandInitializer } from "./terraform-commands";
 import { BaseTerraformCommandHandler } from "./base-terraform-command-handler";
 import { EnvironmentVariableHelper } from "./environment-variables";
 import { generateIdToken } from './id-token-generator';
+import {
+    assertIdentityValue,
+    neutralizeEnvironmentVariables,
+    requireIdentityField,
+    requireSecretField,
+} from './credential-guards';
+
+/**
+ * The `ARM_*` variables that make the azurerm provider choose a particular
+ * credential. Each auth branch clears the ones belonging to the schemes it is
+ * NOT using, so a value inherited from a self-hosted agent or an earlier task
+ * cannot decide the run's identity (#187). `ARM_USE_MSI` in particular only
+ * reaches the agent identity while the secret/OIDC/certificate variables are
+ * absent.
+ */
+const ARM_IDENTITY_SELECTORS = {
+    secret: 'ARM_CLIENT_SECRET',
+    oidcToken: 'ARM_OIDC_TOKEN',
+    certPath: 'ARM_CLIENT_CERTIFICATE_PATH',
+    cert: 'ARM_CLIENT_CERTIFICATE',
+    useMsi: 'ARM_USE_MSI',
+    useOidc: 'ARM_USE_OIDC',
+} as const;
+
+/**
+ * Every ARM_* variable that can decide WHICH identity the azurerm provider
+ * authenticates as. Cleared wholesale at the top of `setCommonVariables`, before
+ * the scheme branch re-establishes exactly the ones it needs.
+ * ARM_SUBSCRIPTION_ID is not here: it names a target, not an identity, and is
+ * resolved and set by the caller before `setCommonVariables` runs.
+ */
+const ARM_CREDENTIAL_SELECTOR_ENV = [
+    'ARM_CLIENT_ID',
+    'ARM_CLIENT_SECRET',
+    'ARM_CLIENT_CERTIFICATE',
+    'ARM_CLIENT_CERTIFICATE_PATH',
+    'ARM_CLIENT_CERTIFICATE_PASSWORD',
+    'ARM_OIDC_TOKEN',
+    'ARM_OIDC_TOKEN_FILE_PATH',
+    'ARM_OIDC_REQUEST_TOKEN',
+    'ARM_OIDC_REQUEST_URL',
+    'ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID',
+    'ARM_OIDC_AZURE_SERVICE_CONNECTION_ID',
+    'ARM_USE_MSI',
+    'ARM_USE_OIDC',
+    'ARM_USE_CLI',
+    'ARM_TENANT_ID',
+] as const;
 
 /**
  * Wall-clock bound for `az login`/`az account set` (#822, CWE-1088) -- ALWAYS
@@ -26,6 +74,15 @@ export const AZ_LOGIN_TIMEOUT_MS = AZ_LOGIN_TIMEOUT_MINUTES * 60_000;
  * left blank), which preserves the existing system-assigned-only behavior.
  */
 export function getManagedIdentityClientId(serviceConnectionID: string): string | undefined {
+    // @credential-exempt: this read is optional BY DESIGN and is the one place in
+    // the matrix where absence is the correct, secure outcome. An MSI-scheme
+    // connection leaves "Service Principal Id" blank for a SYSTEM-assigned
+    // identity; returning undefined then means "use the agent's own identity",
+    // which is precisely the principal that scheme selects. Making it required
+    // would break every system-assigned connection. The caller's MSI branch
+    // clears ARM_CLIENT_ID when this returns undefined, so an inherited value
+    // cannot substitute a user-assigned identity nobody configured.
+    //
     // getEndpointAuthorizationParameter's 3rd param is named `optional` (true =
     // don't throw when absent) - the opposite convention from getInput's
     // `required`. true here is what makes this genuinely optional.
@@ -49,14 +106,20 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
      * per HashiCorp's guidance against caching backend credentials on disk).
      */
     private async applyBackendCredentialEnv(serviceConnectionID: string, useCliFlagsForBackend: boolean): Promise<AuthorizationScheme> {
-        const authorizationScheme = this.mapAuthorizationScheme(tasks.getEndpointAuthorizationScheme(serviceConnectionID, true)!);
+        const authorizationScheme = this.mapAuthorizationScheme(tasks.getEndpointAuthorizationScheme(serviceConnectionID, true), serviceConnectionID);
 
         let subscriptionId = tasks.getInput("backendAzureRmOverrideSubscriptionID", false);
         if (!subscriptionId) {
             subscriptionId = tasks.getEndpointDataParameter(serviceConnectionID, "subscriptionid", true);
         }
         if (subscriptionId) {
+            subscriptionId = assertIdentityValue(subscriptionId, `Azure subscription id for service connection '${serviceConnectionID}'`);
             EnvironmentVariableHelper.setEnvironmentVariable("ARM_SUBSCRIPTION_ID", subscriptionId);
+        } else {
+            // Nothing resolved from the input or the connection: an inherited
+            // ARM_SUBSCRIPTION_ID would otherwise silently target a subscription
+            // this service connection never named (#187).
+            neutralizeEnvironmentVariables(['ARM_SUBSCRIPTION_ID'], "Azure");
         }
 
         const fallbackToIdTokenGeneration = tasks.getBoolInput("backendAzureRmUseIdTokenGeneration", false);
@@ -84,7 +147,11 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             subscriptionId = tasks.getEndpointDataParameter(serviceConnectionID, "subscriptionid", true);
         }
         if (subscriptionId && resourceGroupName) {
-            this.backendConfig.set("subscription_id", subscriptionId);
+            // Cached into .terraform/terraform.tfstate as a -backend-config value,
+            // so it gets the same charset validation as every injected identity
+            // field (#199).
+            this.backendConfig.set("subscription_id",
+                assertIdentityValue(subscriptionId, `Azure subscription id for service connection '${serviceConnectionID}'`));
         }
 
         // Setup Entra ID authentication (set as backend config to ensure it is cached)
@@ -123,7 +190,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
     public async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> {
         const serviceConnectionID = tasks.getInput("environmentServiceNameAzureRM", true)!;
-        const authorizationScheme = this.mapAuthorizationScheme(tasks.getEndpointAuthorizationScheme(serviceConnectionID, true)!);
+        const authorizationScheme = this.mapAuthorizationScheme(tasks.getEndpointAuthorizationScheme(serviceConnectionID, true), serviceConnectionID);
 
         tasks.debug("Setting up provider for authorization scheme: " + authorizationScheme + ".");
 
@@ -133,7 +200,13 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             subscriptionId = tasks.getEndpointDataParameter(serviceConnectionID, "subscriptionid", true);
         }
         if (subscriptionId) {
+            subscriptionId = assertIdentityValue(subscriptionId, `Azure subscription id for service connection '${serviceConnectionID}'`);
             EnvironmentVariableHelper.setEnvironmentVariable("ARM_SUBSCRIPTION_ID", subscriptionId);
+        } else {
+            // Nothing resolved from the input or the connection: an inherited
+            // ARM_SUBSCRIPTION_ID would otherwise silently target a subscription
+            // this service connection never named (#187).
+            neutralizeEnvironmentVariables(['ARM_SUBSCRIPTION_ID'], "Azure");
         }
 
         const fallbackToIdTokenGeneration = tasks.getBoolInput("environmentAzureRmUseIdTokenGeneration", false);
@@ -170,11 +243,11 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             throw new Error("az CLI not found. Install the Azure CLI on the agent to use 'Run az login'. See https://docs.microsoft.com/cli/azure/install-azure-cli");
         }
 
-        const tenantId = tasks.getEndpointAuthorizationParameter(serviceConnectionID, "tenantid", true)!;
+        const tenantId = requireIdentityField(serviceConnectionID, "tenantid");
 
         switch (authorizationScheme) {
             case AuthorizationScheme.WorkloadIdentityFederation: {
-                const spnId = tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalid", true)!;
+                const spnId = requireIdentityField(serviceConnectionID, "serviceprincipalid");
                 const oidcToken = await generateIdToken(serviceConnectionID);
                 tasks.setSecret(oidcToken);
 
@@ -189,8 +262,8 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                 break;
             }
             case AuthorizationScheme.ServicePrincipal: {
-                const spnId = tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalid", true)!;
-                const spnKey = tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalkey", false)!;
+                const spnId = requireIdentityField(serviceConnectionID, "serviceprincipalid");
+                const spnKey = requireSecretField(serviceConnectionID, "serviceprincipalkey");
                 tasks.setSecret(spnKey);
 
                 const loginTool: ToolRunner = tasks.tool(azPath);
@@ -254,10 +327,32 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
 
     private async setCommonVariables(authorizationScheme: AuthorizationScheme, serviceConnectionID: string, fallbackToIdTokenGeneration: boolean, useCliFlagsForBackend: boolean): Promise<void> {
-        EnvironmentVariableHelper.setEnvironmentVariable("ARM_TENANT_ID", tasks.getEndpointAuthorizationParameter(serviceConnectionID, "tenantid", false) ?? '');
+        // Clear EVERY ARM_* credential selector before any branch injects its own
+        // (#187). Doing it once here rather than only per-branch closes the case
+        // no per-branch list can: an inherited ARM_CLIENT_ID on the MSI path,
+        // where the branch legitimately MAY set that variable (a user-assigned
+        // identity) and so cannot blanket-clear it. ARM_SUBSCRIPTION_ID is
+        // deliberately absent from this list -- the caller resolves and sets it
+        // before calling this method.
+        neutralizeEnvironmentVariables(ARM_CREDENTIAL_SELECTOR_ENV, "Azure");
+        // optional=false already threw for an absent tenant, so the `?? ''` tail
+        // was unreachable (#194); requireIdentityField keeps the same fail-closed
+        // contract while adding the charset validation the injected value never
+        // had (#199) and a message that names the field.
+        EnvironmentVariableHelper.setEnvironmentVariable("ARM_TENANT_ID", requireIdentityField(serviceConnectionID, "tenantid"));
 
         switch (authorizationScheme) {
             case AuthorizationScheme.ManagedServiceIdentity: {
+                // @credential-exempt: ManagedServiceIdentity deliberately requires no
+                // credential field -- the agent's own managed identity IS the intended
+                // principal, and the connection's optional client id only disambiguates
+                // a user-assigned identity (see getManagedIdentityClientId).
+                // The azurerm provider only reaches that identity while the
+                // secret/OIDC/certificate variables are absent, so an inherited one
+                // must be cleared or it silently selects a different principal (#187).
+                neutralizeEnvironmentVariables(
+                    [ARM_IDENTITY_SELECTORS.secret, ARM_IDENTITY_SELECTORS.oidcToken, ARM_IDENTITY_SELECTORS.certPath, ARM_IDENTITY_SELECTORS.cert, ARM_IDENTITY_SELECTORS.useOidc],
+                    "Azure Managed Identity");
                 EnvironmentVariableHelper.setEnvironmentVariable("ARM_USE_MSI", "true");
                 // ARM_USE_MSI alone authenticates as the agent's system-assigned identity.
                 // If the connection targets a user-assigned identity instead, the azurerm
@@ -274,6 +369,9 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             }
 
             case AuthorizationScheme.WorkloadIdentityFederation: {
+                neutralizeEnvironmentVariables(
+                    [ARM_IDENTITY_SELECTORS.secret, ARM_IDENTITY_SELECTORS.certPath, ARM_IDENTITY_SELECTORS.cert, ARM_IDENTITY_SELECTORS.useMsi],
+                    "Azure Workload Identity Federation");
                 const workloadIdentityFederationCredentials = await this.getWorkloadIdentityFederationCredentials(serviceConnectionID, fallbackToIdTokenGeneration);
                 if (useCliFlagsForBackend) {
                     // By persisting the client ID in the backend config, we can support multiple service connections for backend and provider auth.
@@ -327,7 +425,10 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                 tasks.warning("Client secret authentication is not secure and will be deprecated in the next major version of this task. Please use Workload identity federation authentication instead.");
 
                 const servicePrincipalCredentials = this.getServicePrincipalCredentials(serviceConnectionID);
-                if (servicePrincipalCredentials.servicePrincipalKey) { tasks.setSecret(servicePrincipalCredentials.servicePrincipalKey); }
+                tasks.setSecret(servicePrincipalCredentials.servicePrincipalKey);
+                neutralizeEnvironmentVariables(
+                    [ARM_IDENTITY_SELECTORS.oidcToken, ARM_IDENTITY_SELECTORS.certPath, ARM_IDENTITY_SELECTORS.cert, ARM_IDENTITY_SELECTORS.useMsi, ARM_IDENTITY_SELECTORS.useOidc],
+                    "Azure service principal");
                 EnvironmentVariableHelper.setEnvironmentVariable("ARM_CLIENT_ID", servicePrincipalCredentials.servicePrincipalId);
                 EnvironmentVariableHelper.setEnvironmentVariable("ARM_CLIENT_SECRET", servicePrincipalCredentials.servicePrincipalKey, true);
                 break;
@@ -335,17 +436,31 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
         }
     }
 
+    /**
+     * #97: both fields were read with optional=true behind a `!`, so a service
+     * connection missing either one produced `undefined`, which
+     * setEnvironmentVariable then skipped with a warning -- leaving ARM_CLIENT_ID
+     * and/or ARM_CLIENT_SECRET unset and the azurerm provider free to fall back
+     * to the agent's ambient identity. Both now fail closed, and the id is
+     * charset-validated like every other injected identity field (#199).
+     */
     private getServicePrincipalCredentials(serviceConnectionID: string): ServicePrincipalCredentials {
-        const servicePrincipalCredentials: ServicePrincipalCredentials = {
-            servicePrincipalId: tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalid", true)!,
-            servicePrincipalKey: tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalkey", true)!
-        }
-        return servicePrincipalCredentials;
+        return {
+            servicePrincipalId: requireIdentityField(serviceConnectionID, "serviceprincipalid"),
+            servicePrincipalKey: requireSecretField(serviceConnectionID, "serviceprincipalkey")
+        };
     }
 
+    /**
+     * The branch #97 REOPENED over in the sibling packer extension: the
+     * ServicePrincipal path above was hardened while this one kept reading
+     * `serviceprincipalid` as optional behind a `!`, so an empty client id
+     * yielded a silently skipped ARM_CLIENT_ID with ARM_USE_OIDC still set --
+     * the azurerm provider then resolved an identity from the agent instead.
+     */
     private async getWorkloadIdentityFederationCredentials(serviceConnectionID: string, getIdToken: boolean): Promise<WorkloadIdentityFederationCredentials> {
         const workloadIdentityFederationCredentials: WorkloadIdentityFederationCredentials = {
-            servicePrincipalId: tasks.getEndpointAuthorizationParameter(serviceConnectionID, "serviceprincipalid", true)!,
+            servicePrincipalId: requireIdentityField(serviceConnectionID, "serviceprincipalid"),
             oidcToken: ""
         }
         if (getIdToken) {
@@ -354,10 +469,21 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
         return workloadIdentityFederationCredentials;
     }
 
-    private mapAuthorizationScheme(authorizationScheme: string): AuthorizationScheme {
-        if (authorizationScheme === undefined) {
-            tasks.warning("The authorization scheme could not be found for your Service Connection, using Workload identity federation by default, but this could cause issues.");
-            return AuthorizationScheme.WorkloadIdentityFederation;
+    /**
+     * #97: an absent authorization scheme used to default to Workload Identity
+     * Federation with only a warning, and the parameter was typed `string` while
+     * the caller passed `getEndpointAuthorizationScheme(id, true)!` -- optional,
+     * so genuinely `string | undefined` at runtime. The `!` and the
+     * `=== undefined` check contradicted each other, and the silent default meant
+     * a service connection with no scheme still produced a credential-less WIF
+     * setup, which the azurerm provider then completed from whatever ambient
+     * identity the agent had (Azure CLI login or managed identity). The parameter
+     * is now typed honestly and an absent scheme fails closed, matching the
+     * AWS/GCP/OCI handlers and the sibling packer extension.
+     */
+    private mapAuthorizationScheme(authorizationScheme: string | undefined, serviceConnectionID: string): AuthorizationScheme {
+        if (!authorizationScheme) {
+            throw new Error(`Service connection '${serviceConnectionID}' has no authorization scheme. Expected one of: WorkloadIdentityFederation, ManagedServiceIdentity, ServicePrincipal.`);
         }
 
         if (authorizationScheme.toLowerCase() === AuthorizationScheme.ServicePrincipal) {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/credential-guards.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/credential-guards.ts
@@ -1,0 +1,208 @@
+import tasks = require('azure-pipelines-task-lib/task');
+import { readSecretEndpointDataParameter } from './endpoint-data-secret';
+
+/**
+ * Fail-closed credential primitives shared by EVERY provider handler.
+ *
+ * The defect class these exist to eliminate: a provider auth handler accepts an
+ * absent, empty or malformed credential input and proceeds -- degrading to the
+ * agent's ambient/instance credentials, to a different auth scheme, or to a
+ * silently skipped environment variable -- instead of failing closed.
+ * Equivalently: a validation applied in one handler, or in ONE BRANCH of one
+ * handler, is absent from its siblings.
+ *
+ * This module is the terraform-side half of a deliberate PARALLEL
+ * IMPLEMENTATION: the sibling `azure-pipelines-packer` extension carries the
+ * same contract in `PackerTaskV1/src/credential-guards.ts`. The two are NOT
+ * byte-identical and are intentionally not in `scripts/check-shared-modules.js`
+ * -- the accessor keys, the injected variable families (`ARM_*`/`TF_VAR_*` here
+ * vs `PKR_VAR_*` there) and the backend concept (which packer has no equivalent
+ * of) differ. What must stay in lockstep is the CONTRACT, and that is enforced
+ * executably rather than textually: `scripts/auth-parity-matrix.cjs` exists in
+ * both repos, enumerates (handler x auth-branch x required-field) in whichever
+ * repo it is run from, and fails on any cell that reads a credential field
+ * without one of these helpers.
+ *
+ * Why it matters here specifically: this repo's Azure handler still carried the
+ * ORIGINAL #97 defect verbatim. `mapAuthorizationScheme` treated an absent
+ * authorization scheme as Workload Identity Federation with only a warning, and
+ * both `getServicePrincipalCredentials` and
+ * `getWorkloadIdentityFederationCredentials` read `serviceprincipalid` /
+ * `serviceprincipalkey` through `getEndpointAuthorizationParameter(id, key, true)`
+ * (optional = true, so undefined at runtime) behind a `!` assertion. An empty
+ * value then reached `EnvironmentVariableHelper.setEnvironmentVariable`, which
+ * skips an empty value with a warning, so `ARM_CLIENT_ID`/`ARM_CLIENT_SECRET`
+ * were simply never set and the azurerm provider fell through to whatever
+ * ambient identity the agent had (Azure CLI login or managed identity).
+ */
+
+/**
+ * The charset permitted in a service-connection field that becomes an injected
+ * credential value (`ARM_*`, `AWS_*`, `GOOGLE_*`, `TF_VAR_*`, an OCI INI config
+ * key, or a `-backend-config` value).
+ *
+ * Terraform does not treat `TF_VAR_*` as opaque strings: for a variable declared
+ * with a non-string type the environment value is parsed as an HCL EXPRESSION,
+ * and the OCI path interpolates fields into an INI config file where a newline
+ * introduces a new key. This allowlist admits every real identifier shape these
+ * fields carry (GUIDs, OCIDs, regions, fingerprints, ARNs, UPNs, URLs) while
+ * rejecting what an HCL expression, an INI key or an injected log line needs:
+ * whitespace, CR/LF/NUL and the rest of C0, quotes, parentheses, braces, `$`,
+ * `%` and backticks.
+ */
+export const IDENTITY_FIELD_PATTERN = /^[A-Za-z0-9._:@\/=+-]+$/;
+
+/** Strict per-field grammars, applied on top of IDENTITY_FIELD_PATTERN. */
+export const OCID_PATTERN = /^ocid1\.[a-z0-9_]+\.[a-z0-9._-]*$/;
+export const REGION_PATTERN = /^[a-z0-9-]+$/;
+export const FINGERPRINT_PATTERN = /^([0-9a-fA-F]{2}:){15}[0-9a-fA-F]{2}$/;
+
+/** AWS's own `RoleSessionName` grammar for AssumeRoleWithWebIdentity (2-64 chars). */
+export const ROLE_SESSION_NAME_PATTERN = /^[\w+=,.@-]{2,64}$/;
+
+/** Which task-lib accessor family a service-connection field lives in. */
+export type EndpointSource = 'auth' | 'data';
+
+function readEndpointField(serviceName: string, key: string, source: EndpointSource): string | undefined {
+    // optional = true everywhere: absence is diagnosed HERE, naming the field and
+    // the service connection, rather than by task-lib's generic
+    // LIB_EndpointAuthNotExist which names only the connection and reads like an
+    // expired credential.
+    return source === 'data'
+        ? tasks.getEndpointDataParameter(serviceName, key, true)
+        : tasks.getEndpointAuthorizationParameter(serviceName, key, true);
+}
+
+export interface RequireFieldOptions {
+    /** Which accessor family the field lives in. Defaults to the auth parameters. */
+    source?: EndpointSource;
+    /** An additional strict grammar (OCID_PATTERN, REGION_PATTERN, ...). */
+    pattern?: RegExp;
+    /** Human-readable field description used in the error message. */
+    description?: string;
+}
+
+/**
+ * Reads a NON-SECRET identity field (client id, tenant, subscription, region,
+ * account, user, fingerprint, ...) and fails closed unless it is present AND
+ * well-formed. Returns the validated value, never an empty string.
+ */
+export function requireIdentityField(serviceName: string, key: string, options: RequireFieldOptions = {}): string {
+    const value = readEndpointField(serviceName, key, options.source ?? 'auth');
+    return assertIdentityValue(value, `service connection '${serviceName}' field '${key}'`, options.pattern, options.description);
+}
+
+/**
+ * Validates an identity value that did not come from a service connection (a
+ * task input, or a value already read elsewhere). Same contract as
+ * `requireIdentityField`: present and well-formed, or throw.
+ */
+export function assertIdentityValue(value: string | undefined, subject: string, pattern?: RegExp, description?: string): string {
+    if (!value) {
+        throw new Error(`${subject} is missing or empty. Refusing to continue: an unset credential field would be silently skipped and terraform would authenticate with the agent's ambient credentials instead.`);
+    }
+    if (!IDENTITY_FIELD_PATTERN.test(value)) {
+        throw new Error(`${subject} contains characters that are not allowed in a credential field (letters, digits and . _ : @ / = + - only). Reject reason: the value is injected as an environment variable or interpolated into a generated config file.`);
+    }
+    if (pattern && !pattern.test(value)) {
+        throw new Error(`${subject} is not a valid ${description ?? 'value'}.`);
+    }
+    return value;
+}
+
+/**
+ * Reads a SECRET endpoint field without letting the value reach the build log at
+ * read time.
+ *
+ * A `data` parameter must NOT be read through `tasks.getEndpointDataParameter()`
+ * (which `readEndpointField` above uses for non-secret identity fields): that
+ * accessor ends with `debug(id + ' data ' + key + ' = ' + val)`, so the raw value
+ * is emitted BEFORE any caller can `setSecret()` it, and `ENDPOINT_DATA_*` is not
+ * in task-lib's vaulting list, so it also stays in `process.env` for the
+ * terraform child to inherit. `readSecretEndpointDataParameter` reads the same
+ * variable directly, registers it line-wise with the masker, and deletes it
+ * (endpoint-data-secret.ts). `ENDPOINT_AUTH_*` IS vaulted and its accessor does
+ * not log the value, so the auth family is read as before.
+ *
+ * Routing this through the shared helper rather than the OCI call site keeps the
+ * two guards composed: the next data-parameter secret inherits the non-logging
+ * read instead of having to remember it.
+ */
+function readSecretEndpointField(serviceName: string, key: string, source: EndpointSource): string | undefined {
+    return source === 'data'
+        ? readSecretEndpointDataParameter(serviceName, key)
+        : tasks.getEndpointAuthorizationParameter(serviceName, key, true);
+}
+
+/**
+ * Reads a SECRET field (client secret, password, private key, access key). Only
+ * presence is checkable -- the value is opaque by definition, so no charset
+ * validation is applied. Fails closed when absent.
+ */
+export function requireSecretField(serviceName: string, key: string, options: RequireFieldOptions = {}): string {
+    const value = readSecretEndpointField(serviceName, key, options.source ?? 'auth');
+    if (!value) {
+        throw new Error(`service connection '${serviceName}' field '${key}' is missing or empty. Refusing to continue: an unset secret would be silently skipped and terraform would authenticate with the agent's ambient credentials instead.`);
+    }
+    return value;
+}
+
+/**
+ * Removes environment variables that select a DIFFERENT identity than the one
+ * this branch is about to inject (#187).
+ *
+ * Setting the right credentials is not sufficient when a competing variable
+ * out-ranks them in the provider SDK's own resolution order. The AWS SDK matches
+ * static env credentials STRICTLY BEFORE the web-identity token file
+ * (`resolveCredentials()` in aws/session/credentials.go; identical ordering in
+ * aws-sdk-go-v2's `resolveCredentialChain`), so an `AWS_ACCESS_KEY_ID` inherited
+ * from a self-hosted agent or from a pipeline variable silently wins over a
+ * correctly minted federated assertion. The azurerm provider is the mirror
+ * image: `ARM_USE_MSI` only reaches the agent identity while `ARM_CLIENT_SECRET`
+ * / `ARM_OIDC_TOKEN` / `ARM_CLIENT_CERTIFICATE_PATH` are absent.
+ *
+ * Each branch therefore clears the variables of the schemes it is NOT using
+ * before injecting its own.
+ */
+export function neutralizeEnvironmentVariables(names: readonly string[], context: string): void {
+    for (const name of names) {
+        if (process.env[name] === undefined) continue;
+        delete process.env[name];
+        tasks.warning(`Cleared the inherited environment variable '${name}' before applying ${context} credentials: it selects a different identity and would otherwise take precedence over the credentials resolved from the service connection.`);
+    }
+}
+
+/**
+ * Resolves a federated role session name (#197).
+ *
+ * For `AssumeRoleWithWebIdentity` the session name is the human-readable half of
+ * CloudTrail's `userIdentity.arn`
+ * (`arn:aws:sts::<acct>:assumed-role/<Role>/<SessionName>`) and the field
+ * incident responders pivot on. A fixed constant -- which is what the code
+ * fallbacks here used to be -- collapses that attribution across every federated
+ * run of every pipeline in every organization using this extension, and
+ * forecloses `sts:RoleSessionName` trust-policy conditions.
+ *
+ * An explicit input still wins, but is validated against AWS's own grammar so an
+ * invalid name fails here with a clear message rather than as an opaque STS
+ * rejection. Otherwise the name is derived from job context and sanitized into
+ * the 2-64 character `[\w+=,.@-]` charset. The `prefix` keeps the provider and
+ * backend sessions of one job distinguishable from each other.
+ */
+export function resolveRoleSessionName(inputName: string, prefix: string): string {
+    const explicit = tasks.getInput(inputName, false);
+    if (explicit && explicit.trim()) {
+        const value = explicit.trim();
+        if (!ROLE_SESSION_NAME_PATTERN.test(value)) {
+            throw new Error(`Input '${inputName}' value '${value}' is not a valid AWS role session name: 2-64 characters from [A-Za-z0-9_+=,.@-].`);
+        }
+        return value;
+    }
+    const parts = [prefix, tasks.getVariable('System.TeamProject'), tasks.getVariable('Build.BuildId')]
+        .filter((p): p is string => !!p && !!p.trim());
+    const derived = parts.join('-').replace(/[^\w+=,.@-]/g, '-').replace(/-{2,}/g, '-').replace(/^-+|-+$/g, '');
+    // Keep the tail (the build id) when truncating: it is the part that actually
+    // distinguishes one run from the next.
+    const bounded = derived.length > 64 ? derived.slice(derived.length - 64).replace(/^-+/, '') : derived;
+    return ROLE_SESSION_NAME_PATTERN.test(bounded) ? bounded : prefix;
+}

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -7,6 +7,27 @@ import { generateIdToken } from './id-token-generator';
 import { normalizePem } from './pem-normalizer';
 import { writeSecretFile } from './secure-temp';
 import { resolveWifTempDir } from './temp-dir';
+import {
+    assertIdentityValue,
+    neutralizeEnvironmentVariables,
+    requireIdentityField,
+    requireSecretField,
+} from './credential-guards';
+
+/**
+ * Google credential sources that resolve AHEAD of, or instead of, the
+ * credentials file this handler writes (an inherited GOOGLE_CREDENTIALS /
+ * GOOGLE_APPLICATION_CREDENTIALS / gcloud ADC override on a self-hosted agent).
+ * Cleared on both provider branches so the run cannot authenticate as an
+ * identity the service connection never named (#187).
+ */
+const GOOGLE_COMPETING_CREDENTIAL_ENV = [
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'GOOGLE_OAUTH_ACCESS_TOKEN',
+    'GOOGLE_GHA_CREDS_PATH',
+    'CLOUDSDK_AUTH_ACCESS_TOKEN',
+    'CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE',
+] as const;
 import path = require('path');
 import { randomUUID as uuidV4 } from 'crypto';
 
@@ -51,15 +72,9 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         // Get credentials for json file
         const jsonKeyFilePath = path.join(resolveWifTempDir(), `credentials-${uuidV4()}.json`);
 
-        const clientEmail = tasks.getEndpointAuthorizationParameter(serviceName, "Issuer", false);
-        const tokenUri = tasks.getEndpointAuthorizationParameter(serviceName, "Audience", false);
-        const privateKey = tasks.getEndpointAuthorizationParameter(serviceName, "PrivateKey", false);
-
-        if (!clientEmail || !tokenUri || !privateKey) {
-            const missing = ([!clientEmail && "Issuer", !tokenUri && "Audience", !privateKey && "PrivateKey"] as (string | false)[])
-                .filter(Boolean).join(", ");
-            throw new Error(`GCP service connection is missing required fields: ${missing}`);
-        }
+        const clientEmail = requireIdentityField(serviceName, "Issuer");
+        const tokenUri = requireIdentityField(serviceName, "Audience");
+        const privateKey = requireSecretField(serviceName, "PrivateKey");
         assertGoogleTokenUri(tokenUri);
         // Mask the raw value first: a service connection may deliver the key
         // flattened to a single line (which itself starts with "-----BEGIN"),
@@ -104,6 +119,12 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
      * See https://developer.hashicorp.com/terraform/language/backend#credentials-and-sensitive-data
      */
     private applyBackendCredentialFile(credentialsFilePath: string): void {
+        // @credential-exempt: GOOGLE_BACKEND_CREDENTIALS takes precedence over
+        // GOOGLE_CREDENTIALS / GOOGLE_APPLICATION_CREDENTIALS / ADC in the gcs
+        // backend's own resolution order, so an inherited value cannot out-rank
+        // it. Clearing the lower-precedence names here would be actively WRONG in
+        // a cross-cloud run: `handleProvider` sets GOOGLE_CREDENTIALS for the
+        // PROVIDER, and the backend path can run after it in the same process.
         EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_BACKEND_CREDENTIALS", credentialsFilePath);
     }
 
@@ -222,26 +243,44 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         } else {
             if (command.serviceProviderName) {
                 const jsonKeyFilePath = this.getJsonKeyFilePath(command.serviceProviderName);
+                // optional=false already throws for an absent project, so the
+                // `|| ''` tail was unreachable (#194); the project id is also
+                // charset-validated before it becomes GOOGLE_PROJECT (#199).
+                const project = requireIdentityField(command.serviceProviderName, "project", { source: 'data' });
 
+                neutralizeEnvironmentVariables(GOOGLE_COMPETING_CREDENTIAL_ENV, "GCP service account key");
                 EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_CREDENTIALS", jsonKeyFilePath);
-                EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_PROJECT", tasks.getEndpointDataParameter(command.serviceProviderName, "project", false) || '');
+                EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_PROJECT", project);
+            } else {
+                // Silently injecting nothing leaves terraform to authenticate from
+                // whatever ambient credentials the agent carries.
+                throw new Error("A GCP service connection is required for this command. Set environmentServiceNameGCP.");
             }
         }
     }
 
     private async handleProviderWIF(command: TerraformAuthorizationCommandInitializer): Promise<void> {
-        const projectNumber = tasks.getInput("gcpProjectNumber", true)!;
+        if (!command.serviceProviderName) {
+            // Fail closed rather than requesting an OIDC token for an empty
+            // service connection id.
+            throw new Error("A GCP service connection is required for Workload Identity Federation. Set environmentServiceNameGCP.");
+        }
+        // Every one of these is interpolated into the audience / impersonation
+        // URLs written to the credentials file, so each is charset-validated
+        // rather than trusted as free text (#199).
+        const projectNumber = assertIdentityValue(tasks.getInput("gcpProjectNumber", true), "Input 'gcpProjectNumber'");
 
         const credentialsFilePath = await this.writeWifCredentials({
             serviceConnection: command.serviceProviderName,
             projectNumber,
-            poolId: tasks.getInput("gcpWorkloadIdentityPoolId", true)!,
-            providerId: tasks.getInput("gcpWorkloadIdentityProviderId", true)!,
-            serviceAccountEmail: tasks.getInput("gcpServiceAccountEmail", true)!,
+            poolId: assertIdentityValue(tasks.getInput("gcpWorkloadIdentityPoolId", true), "Input 'gcpWorkloadIdentityPoolId'"),
+            providerId: assertIdentityValue(tasks.getInput("gcpWorkloadIdentityProviderId", true), "Input 'gcpWorkloadIdentityProviderId'"),
+            serviceAccountEmail: assertIdentityValue(tasks.getInput("gcpServiceAccountEmail", true), "Input 'gcpServiceAccountEmail'"),
             tokenFilePrefix: "gcp-oidc-token",
             credentialsFilePrefix: "gcp-wif-credentials",
         });
 
+        neutralizeEnvironmentVariables(GOOGLE_COMPETING_CREDENTIAL_ENV, "GCP Workload Identity Federation");
         EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_CREDENTIALS", credentialsFilePath);
         EnvironmentVariableHelper.setEnvironmentVariable("GOOGLE_PROJECT", projectNumber);
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/generic-terraform-command-handler.ts
@@ -22,7 +22,13 @@ export class TerraformCommandHandlerGeneric extends BaseTerraformCommandHandler 
     }
 
     public async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> {
-        // No provider credentials needed for generic/local backend type
+        // @credential-exempt: the generic/local backend type has no cloud provider
+        // identity. Generic backends (http, PostgreSQL, Consul, Kubernetes, ...)
+        // are authenticated, if at all, by the user's own environment
+        // (CONSUL_HTTP_TOKEN, TF_HTTP_*), which this task must not touch: there is
+        // no service connection to read a credential from and nothing to
+        // neutralize. Verified by inspection -- this method's body is empty and
+        // handleBackend only forwards non-secret -backend-config arguments.
     }
 
     /**

--- a/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
@@ -10,7 +10,17 @@ export class TerraformCommandHandlerHCP extends BaseTerraformCommandHandler {
         this.providerName = "hcp";
     }
 
-    /** Shared by `handleBackend` (init) and `configureBackendCredentials` (cross-cloud). */
+    /**
+     * Shared by `handleBackend` (init) and `configureBackendCredentials` (cross-cloud).
+     *
+     * @credential-exempt: TF_TOKEN_app_terraform_io is the ONLY credential this
+     * backend has, it is always overwritten here from a required input, and it
+     * out-ranks a `terraform login` credentials file in Terraform's own token
+     * resolution. The one variable that could redirect it, TF_CLI_CONFIG_FILE, is
+     * legitimately set by the TerraformProviderMirror task earlier in the same
+     * job, so clearing it here would break provider mirroring. There is no
+     * competing identity to neutralize.
+     */
     private applyBackendEnv(): void {
         const token = tasks.getInput("backendHCPToken", true)!;
         if (token) { tasks.setSecret(token); }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -7,8 +7,32 @@ import { generateIdToken } from './id-token-generator';
 import { exchangeOidcForUpst } from './oci-token-exchange';
 import { writeSecretFile, tightenFilePermissions } from './secure-temp';
 import { normalizePem } from './pem-normalizer';
-import { readSecretEndpointDataParameter } from './endpoint-data-secret';
 import { resolveWifTempDir } from './temp-dir';
+import {
+    FINGERPRINT_PATTERN,
+    neutralizeEnvironmentVariables,
+    OCID_PATTERN,
+    REGION_PATTERN,
+    requireIdentityField,
+    requireSecretField,
+} from './credential-guards';
+
+/**
+ * OCI SDK configuration the oci provider honours ahead of, or instead of, the
+ * TF_VAR_ and OCI_CLI_ values this handler injects. Cleared so an inherited
+ * config file or profile on a self-hosted agent cannot redirect the run to a
+ * different tenancy/user (#187).
+ */
+const OCI_COMPETING_CREDENTIAL_ENV = [
+    'OCI_CLI_CONFIG_FILE',
+    'OCI_CLI_PROFILE',
+    'OCI_CLI_AUTH',
+    'OCI_CLI_TENANCY',
+    'OCI_CLI_USER',
+    'OCI_CLI_FINGERPRINT',
+    'OCI_CLI_KEY_FILE',
+    'OCI_CLI_REGION',
+] as const;
 import path = require('path');
 import crypto = require('crypto');
 import { randomUUID as uuidV4 } from 'crypto';
@@ -306,27 +330,49 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
             await this.handleProviderWIF(command);
         } else {
             if (command.serviceProviderName) {
-                // NOT tasks.getEndpointDataParameter(): that helper debug-logs the
-                // value it returns, so the raw OCI API signing key would already be
-                // in the build log before getPrivateKeyFilePath's first setSecret.
-                // readSecretEndpointDataParameter reads the same ENDPOINT_DATA_*
-                // variable directly, masks it line-wise, and deletes it so the
-                // terraform child process does not inherit it (endpoint-data-secret.ts).
-                const rawPrivateKey = readSecretEndpointDataParameter(command.serviceProviderName, "privateKey");
-                if (!rawPrivateKey) {
-                    throw new Error("OCI private key not found in service connection. Ensure the 'privateKey' field is configured.");
-                }
+                // Fails closed on an absent/empty key, AND is read through
+                // readSecretEndpointDataParameter rather than
+                // tasks.getEndpointDataParameter: the latter debug-logs the value it
+                // returns, so the raw OCI API signing key would already be in the
+                // build log before getPrivateKeyFilePath's first setSecret, and it
+                // leaves ENDPOINT_DATA_* in process.env for the terraform child to
+                // inherit. Both guards compose inside requireSecretField(source:
+                // 'data') -- see credential-guards.ts readSecretEndpointField and
+                // endpoint-data-secret.ts.
+                const rawPrivateKey = requireSecretField(command.serviceProviderName, "privateKey", { source: 'data' });
                 const privateKeyFilePath = this.getPrivateKeyFilePath(rawPrivateKey);
-                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_tenancy_ocid", tasks.getEndpointDataParameter(command.serviceProviderName, "tenancy", false) || '');
-                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_user_ocid", tasks.getEndpointDataParameter(command.serviceProviderName, "user", false) || '');
-                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_region", tasks.getEndpointDataParameter(command.serviceProviderName, "region", false) || '');
-                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_fingerprint", tasks.getEndpointDataParameter(command.serviceProviderName, "fingerprint", false) || '');
+                // Each of these used an `optional=false` accessor inside an `|| ''`
+                // chain: the tail was unreachable (#194) and, more importantly, the
+                // values reached TF_VAR_* with none of the grammar checks the WIF
+                // path on this same handler already applied to the equivalent
+                // fields (#199). The sibling packer extension's OCI handler has
+                // validated exactly these four since it was written -- this branch
+                // was the unguarded sibling.
+                const tenancy = requireIdentityField(command.serviceProviderName, "tenancy", { source: 'data', pattern: OCID_PATTERN, description: 'OCID' });
+                const user = requireIdentityField(command.serviceProviderName, "user", { source: 'data', pattern: OCID_PATTERN, description: 'OCID' });
+                const region = requireIdentityField(command.serviceProviderName, "region", { source: 'data', pattern: REGION_PATTERN, description: 'region identifier' });
+                const fingerprint = requireIdentityField(command.serviceProviderName, "fingerprint", { source: 'data', pattern: FINGERPRINT_PATTERN, description: 'key fingerprint' });
+
+                neutralizeEnvironmentVariables(OCI_COMPETING_CREDENTIAL_ENV, "OCI API key");
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_tenancy_ocid", tenancy);
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_user_ocid", user);
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_region", region);
+                EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_fingerprint", fingerprint);
                 EnvironmentVariableHelper.setEnvironmentVariable("TF_VAR_private_key_path", privateKeyFilePath);
+            } else {
+                // Silently injecting nothing leaves terraform to authenticate from
+                // the agent's ambient OCI config or instance principal.
+                throw new Error("An OCI service connection is required for this command. Set environmentServiceNameOCI.");
             }
         }
     }
 
     private async handleProviderWIF(command: TerraformAuthorizationCommandInitializer): Promise<void> {
+        if (!command.serviceProviderName) {
+            // Fail closed rather than requesting an OIDC token for an empty
+            // service connection id.
+            throw new Error("An OCI service connection is required for Workload Identity Federation. Set environmentServiceNameOCI.");
+        }
         // 1. Get OIDC JWT from Azure DevOps
         const oidcToken = await generateIdToken(command.serviceProviderName);
         tasks.setSecret(oidcToken);
@@ -389,6 +435,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         this.tempFiles.push(configPath);
 
         // 6. Set environment variables for the OCI Terraform provider
+        neutralizeEnvironmentVariables(OCI_COMPETING_CREDENTIAL_ENV, "OCI Workload Identity Federation");
         EnvironmentVariableHelper.setEnvironmentVariable("OCI_CLI_CONFIG_FILE", configPath);
         EnvironmentVariableHelper.setEnvironmentVariable("OCI_CLI_PROFILE", "DEFAULT");
         EnvironmentVariableHelper.setEnvironmentVariable("OCI_CLI_AUTH", "security_token");

--- a/scripts/auth-parity-matrix.cjs
+++ b/scripts/auth-parity-matrix.cjs
@@ -1,0 +1,549 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * auth-parity-matrix.cjs -- executable signature for the provider-auth
+ * "fail-open credential handler" defect class.
+ *
+ * CLASS: a provider auth handler accepts an absent, empty or malformed
+ * credential input and proceeds -- degrading to ambient/instance credentials,
+ * to a different auth scheme, or to a silently skipped environment variable --
+ * instead of failing closed. Equivalently: a validation applied in one handler
+ * (or in ONE BRANCH of one handler) is absent from its siblings. Issue #97
+ * reopened precisely because its fix hardened `mapAuthorizationScheme` and the
+ * ServicePrincipal branch while the WIF branch of the same file kept reading
+ * `serviceprincipalid` as optional behind a non-null assertion.
+ *
+ * The unit of enumeration is therefore (handler x auth-branch x required-field),
+ * NOT (file x line). This script discovers every provider command handler in the
+ * repo, enumerates the branches inside each one, and prints a verdict for every
+ * cell. It is repo-agnostic -- it keys off `*-command-handler.ts` under
+ * `Tasks/<...>/src/`, so it runs unchanged in azure-pipelines-packer and in
+ * azure-pipelines-terraform.
+ *
+ *   node scripts/auth-parity-matrix.cjs [repoRoot] [--json] [--quiet]
+ *
+ * Exit 0 = every cell is GUARDED or EXEMPT. Exit 1 = at least one UNGUARDED cell.
+ *
+ * Cell kinds:
+ *   <fieldName>               a service-connection field read by an accessor.
+ *                             GUARDED when the read fails closed on absence AND
+ *                             (the field is a secret, or its value is run through
+ *                             a validating helper before it becomes an env var).
+ *   authorizationScheme       the auth-scheme mapper must throw on an absent
+ *                             scheme, never default to one (#97).
+ *   competing-credential-env  a branch that injects credentials must first clear
+ *                             the env vars of the schemes it is NOT using, or an
+ *                             ambient/passthrough value out-ranks it (#187).
+ *   roleSessionName           a federated session name must be derived from job
+ *                             context, not a fixed constant (#197).
+ *   serviceConnection         an empty service connection must fail closed, never
+ *                             silently skip the credential block or POST an empty id.
+ *   required-in-fallback      an `optional=false` accessor inside an `|| ''` chain
+ *                             hard-fails a legitimately-absent optional field and
+ *                             leaves an unreachable tail (#194).
+ *   no-credentials            a handler that injects nothing must say so with a
+ *                             `@credential-exempt` marker.
+ *
+ * A cell is EXEMPT only when the code carries a machine-readable
+ * `@credential-exempt: <reason>` marker in (or immediately above) the enclosing
+ * branch. Exemptions are thus code-verified and enumerated, never implicit.
+ *
+ * Tooling note: `rg` and `ast-grep` do not exist in this project's
+ * non-interactive shell (exit 127), so this signature is dependency-free node.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const argv = process.argv.slice(2);
+const AS_JSON = argv.includes('--json');
+const QUIET = argv.includes('--quiet');
+const ROOT = path.resolve(argv.find((a) => !a.startsWith('--')) || process.cwd());
+
+// --- discovery -------------------------------------------------------------
+
+/** Every `*-command-handler.ts` under any Tasks/<task>/<version>/src directory. */
+function discoverHandlers(root) {
+    const found = [];
+    const tasksDir = path.join(root, 'Tasks');
+    if (!fs.existsSync(tasksDir)) return found;
+    const walk = (dir, depth) => {
+        if (depth > 6) return;
+        let entries;
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+        for (const e of entries) {
+            if (e.name === 'node_modules' || e.name === '.git') continue;
+            const full = path.join(dir, e.name);
+            if (e.isDirectory()) walk(full, depth + 1);
+            else if (e.isFile() && /-command-handler\.ts$/.test(e.name) && path.basename(dir) === 'src') {
+                found.push(full);
+            }
+        }
+    };
+    walk(tasksDir, 0);
+    return found.sort();
+}
+
+// --- lexing helpers --------------------------------------------------------
+
+/** Blanks out comments (preserving offsets/newlines) so code scans never match prose. */
+function stripComments(src) {
+    let out = '';
+    let i = 0;
+    let state = 'code'; // code | line | block | sq | dq | tpl
+    while (i < src.length) {
+        const c = src[i];
+        const n = src[i + 1];
+        if (state === 'code') {
+            if (c === '/' && n === '/') { state = 'line'; out += '  '; i += 2; continue; }
+            if (c === '/' && n === '*') { state = 'block'; out += '  '; i += 2; continue; }
+            if (c === "'") state = 'sq';
+            else if (c === '"') state = 'dq';
+            else if (c === '`') state = 'tpl';
+            out += c; i++; continue;
+        }
+        if (state === 'line') {
+            if (c === '\n') { state = 'code'; out += c; } else out += ' ';
+            i++; continue;
+        }
+        if (state === 'block') {
+            if (c === '*' && n === '/') { state = 'code'; out += '  '; i += 2; continue; }
+            out += (c === '\n' ? '\n' : ' '); i++; continue;
+        }
+        if (c === '\\') { out += src.slice(i, i + 2); i += 2; continue; }
+        if ((state === 'sq' && c === "'") || (state === 'dq' && c === '"') || (state === 'tpl' && c === '`')) state = 'code';
+        out += c; i++;
+    }
+    return out;
+}
+
+/**
+ * Blanks string/template literal BODIES (offsets preserved). Used only for brace
+ * arithmetic: a literal like `'${'` in an injection-pattern denylist would
+ * otherwise unbalance the depth counter and mislabel every method after it.
+ */
+function blankStrings(src) {
+    let out = '';
+    let quote = null;
+    for (let i = 0; i < src.length; i++) {
+        const c = src[i];
+        if (quote) {
+            if (c === '\\') { out += '  '; i++; continue; }
+            if (c === quote) { quote = null; out += c; continue; }
+            out += (c === '\n' ? '\n' : ' ');
+            continue;
+        }
+        if (c === '"' || c === "'" || c === '`') { quote = c; out += c; continue; }
+        out += c;
+    }
+    return out;
+}
+
+function lineStartsOf(src) {
+    const starts = [0];
+    for (let i = 0; i < src.length; i++) if (src[i] === '\n') starts.push(i + 1);
+    return starts;
+}
+
+function lineOf(starts, offset) {
+    let lo = 0, hi = starts.length - 1;
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (starts[mid] <= offset) lo = mid; else hi = mid - 1;
+    }
+    return lo + 1; // 1-based
+}
+
+/** Returns the raw argument text of the call whose '(' is at `open`. */
+function callArgs(src, open) {
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const c = src[i];
+        if (c === '(') depth++;
+        else if (c === ')') { depth--; if (depth === 0) return src.slice(open + 1, i); }
+    }
+    return null;
+}
+
+function splitArgs(text) {
+    const out = [];
+    let depth = 0, cur = '', quote = null;
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (quote) { cur += ch; if (ch === quote && text[i - 1] !== '\\') quote = null; continue; }
+        if (ch === '"' || ch === "'" || ch === '`') { quote = ch; cur += ch; continue; }
+        if ('([{'.includes(ch)) depth++;
+        else if (')]}'.includes(ch)) depth--;
+        if (ch === ',' && depth === 0) { out.push(cur.trim()); cur = ''; continue; }
+        cur += ch;
+    }
+    if (cur.trim()) out.push(cur.trim());
+    return out;
+}
+
+function unquote(s) {
+    if (!s) return s;
+    const m = /^['"`](.*)['"`]$/.exec(s.trim());
+    return m ? m[1] : s.trim();
+}
+
+// --- scope map (method x branch, per line) ---------------------------------
+
+const METHOD_RE = /^\s*(?:export\s+)?(?:public|private|protected)?\s*(?:static\s+)?(?:async\s+)?(?:function\s+)?([A-Za-z_$][\w$]*)\s*\([^;]*$/;
+const CASE_RE = /\bcase\s+AuthorizationScheme\.(\w+)\s*:/;
+const WIF_IF_RE = /\bif\s*\(\s*(?:authScheme|authorizationScheme)\s*===\s*["']WorkloadIdentityFederation["']\s*\)/;
+
+/**
+ * Assigns every line a (method, branch) label. `branch` is the nearest enclosing
+ * `case AuthorizationScheme.X`, else the WIF conditional block, else the method
+ * name -- i.e. the auth-branch axis of the matrix.
+ */
+function scopeMap(code) {
+    const lines = code.split('\n');
+    const braceLines = blankStrings(code).split('\n');
+    const scopes = new Array(lines.length + 1).fill(null);
+    let depth = 0;
+    let method = null, methodDepth = -1;
+    let brCase = null, brCaseDepth = -1;
+    let wifDepth = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (methodDepth >= 0 && depth <= methodDepth) { method = null; methodDepth = -1; }
+        if (brCaseDepth >= 0 && depth < brCaseDepth) { brCase = null; brCaseDepth = -1; }
+        if (wifDepth >= 0 && depth <= wifDepth) wifDepth = -1;
+        // `} else {` closes the WIF block: the else arm is the static branch.
+        if (wifDepth >= 0 && depth === wifDepth + 1 && /^\s*\}\s*else\b/.test(line)) wifDepth = -1;
+
+        const mCase = CASE_RE.exec(line);
+        if (mCase) { brCase = mCase[1]; brCaseDepth = depth; }
+
+        const mMethod = METHOD_RE.exec(line);
+        if (mMethod && depth <= 1 && !/\b(if|for|while|switch|catch|return|new)\b/.test(mMethod[1])) {
+            method = mMethod[1]; methodDepth = depth;
+        }
+
+        const opensWif = WIF_IF_RE.test(line);
+        const branch = brCase || (wifDepth >= 0 ? 'WorkloadIdentityFederation' : null) || method || '<top>';
+        scopes[i + 1] = { method: method || '<top>', branch };
+
+        for (const ch of braceLines[i] || '') {
+            if (ch === '{') depth++;
+            else if (ch === '}') depth--;
+        }
+        if (opensWif) wifDepth = depth - 1;
+    }
+    return scopes;
+}
+
+/** Contiguous line runs per (method, branch) -- a branch region. */
+function branchRegions(scopes) {
+    const regions = [];
+    let cur = null;
+    for (let ln = 1; ln < scopes.length; ln++) {
+        const s = scopes[ln];
+        if (!s) continue;
+        if (cur && cur.method === s.method && cur.branch === s.branch) { cur.hi = ln; continue; }
+        cur = { method: s.method, branch: s.branch, lo: ln, hi: ln };
+        regions.push(cur);
+    }
+    return regions;
+}
+
+/** All lines carrying an `@credential-exempt:` marker, with their reason text. */
+function exemptionMarkers(rawSrc) {
+    const out = [];
+    const lines = rawSrc.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        const m = /@credential-exempt:\s*(.+?)\s*$/.exec(lines[i]);
+        if (m) out.push({ line: i + 1, reason: m[1].replace(/\*\/\s*$/, '').trim() });
+    }
+    return out;
+}
+
+// --- the matrix ------------------------------------------------------------
+
+const ACCESSORS = {
+    getEndpointAuthorizationParameter: { keyArg: 1, optArg: 2 },
+    getEndpointDataParameter: { keyArg: 1, optArg: 2 },
+    getEndpointAuthorizationScheme: { keyArg: null, optArg: 1 },
+    getEndpointUrl: { keyArg: null, optArg: 1 },
+};
+
+/** Helpers that fail closed on a missing/malformed value before it is injected. */
+const GUARD_HELPERS = [
+    'requireIdentityField', 'requireSecretField', 'requireField', 'assertIdentityValue',
+    'assertGoogleTokenUri', 'validateOciTenancyOcid', 'validateOciRegion', 'validateAndEscapeOciParUrl',
+];
+
+/** Fields whose VALUE is opaque: presence is the only checkable property. */
+const SECRET_KEY_RE = /(password|secret|privatekey|key$|accesstoken|token|jwt)/i;
+
+function analyzeHandler(file, root) {
+    const raw = fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+    const code = stripComments(raw);
+    const codeLines = code.split('\n');
+    const starts = lineStartsOf(code);
+    const scopes = scopeMap(code);
+    const regions = branchRegions(scopes);
+    const markers = exemptionMarkers(raw);
+    const rel = path.relative(root, file).split(path.sep).join('/');
+    const base = path.basename(file);
+    const handler = base.replace(/-(?:packer|terraform)-command-handler\.ts$/, '');
+    const isBase = /^base-/.test(base);
+    const cells = [];
+
+    const regionFor = (line) => regions.find((r) => line >= r.lo && line <= r.hi) || { lo: line, hi: line };
+    const regionText = (line, pad = 0) => {
+        const r = regionFor(line);
+        return codeLines.slice(r.lo - 1, Math.min(codeLines.length, r.hi + pad)).join('\n');
+    };
+    const exemptionFor = (line) => {
+        const r = regionFor(line);
+        const hit = markers.find((m) => m.line >= r.lo - 14 && m.line <= r.hi);
+        return hit ? hit.reason : null;
+    };
+
+    const add = (cellName, verdict, detail, line, branchOverride) => {
+        const sc = scopes[line] || { method: '<top>', branch: '<top>' };
+        const branch = branchOverride || sc.branch;
+        const exempt = verdict === 'UNGUARDED' ? exemptionFor(line) : null;
+        cells.push({
+            file: rel, handler, branch, cell: cellName,
+            site: `${handler}.${branch}.${cellName}`,
+            verdict: exempt ? 'EXEMPT' : verdict,
+            detail: exempt ? `exempt: ${exempt}` : detail,
+            line,
+        });
+    };
+
+    // ---- 0. Does this file's auth-scheme mapper fail closed? (#97)
+    let schemeMapperGuarded = null;
+    const declIdx = code.search(/(?:private|function)\s+mapAuthorizationScheme\s*\(/);
+    if (declIdx >= 0) {
+        const body = code.slice(declIdx, declIdx + 2600);
+        const undefGuard = /if\s*\(\s*(?:!\s*\w+|\w+\s*===\s*undefined)[^)]*\)\s*\{([\s\S]{0,1600}?)\n\s*\}/.exec(body);
+        let verdict, detail;
+        if (!undefGuard) { verdict = 'UNGUARDED'; detail = 'mapper has no absent-scheme guard at all'; }
+        else if (/\bthrow\b/.test(undefGuard[1])) { verdict = 'GUARDED'; detail = 'absent scheme throws'; }
+        else { verdict = 'UNGUARDED'; detail = 'absent scheme silently defaults to a scheme (warning only)'; }
+        schemeMapperGuarded = verdict === 'GUARDED';
+        add('authorizationScheme', verdict, detail, lineOf(starts, declIdx), 'schemeResolution');
+    }
+
+    // ---- 1. FIELD cells: every raw service-connection accessor read.
+    for (const [fn, meta] of Object.entries(ACCESSORS)) {
+        const re = new RegExp(`tasks\\.${fn}\\s*\\(`, 'g');
+        let m;
+        while ((m = re.exec(code))) {
+            const open = m.index + m[0].length - 1;
+            const argText = callArgs(code, open);
+            if (argText === null) continue;
+            const args = splitArgs(argText);
+            const key = meta.keyArg === null
+                ? fn.replace('getEndpointAuthorization', '').replace('getEndpoint', '').toLowerCase()
+                : unquote(args[meta.keyArg] || '?');
+            const opt = (args[meta.optArg] || '').trim();
+            const line = lineOf(starts, m.index);
+            const tail = code.slice(m.index, m.index + argText.length + 80);
+            const inFallbackChain = /\)\s*(\|\||\?\?)\s*(''|""|``)/.test(tail);
+
+            // #194: a required accessor inside a fallback chain hard-fails a
+            // legitimately-absent optional field, and its tail is unreachable.
+            if (opt === 'false' && inFallbackChain) {
+                add('required-in-fallback', 'UNGUARDED',
+                    `optional=false accessor for '${key}' inside an || '' chain: the tail is unreachable and an absent optional field hard-fails`,
+                    line);
+            }
+
+            // The accessor may sit on a continuation line of a multi-line
+            // declaration (`const x =` / an `||` fallback chain / a wrapping
+            // guard call), so walk back over statement-continuation lines.
+            let declLine = codeLines[line - 1] || '';
+            let decl = null;
+            for (let back = 0; back < 4 && line - 1 - back >= 0; back++) {
+                const candidate = codeLines[line - 1 - back] || '';
+                decl = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/.exec(candidate)
+                    || /^\s*([A-Za-z_$][\w$]*)\s*:\s*tasks\./.exec(candidate)
+                    || /^\s*(\w+)\s*=\s*tasks\./.exec(candidate);
+                if (decl) { declLine = candidate + '\n' + declLine; break; }
+                if (/;\s*$/.test(candidate.trim())) break; // previous statement ended
+            }
+            const varName = decl ? decl[1] : null;
+            const region = regionText(line, 30);
+            const validated = varName && GUARD_HELPERS.some((h) =>
+                new RegExp(`${h}\\s*\\([^;]*?\\b${varName}\\b`).test(region));
+            const presenceChecked = varName
+                && new RegExp(`if\\s*\\([^)]*!\\s*${varName}\\b[^)]*\\)\\s*\\{?[\\s\\S]{0,500}?throw`).test(region);
+            // Value validation is only required when the value ITSELF becomes an
+            // injected credential. A field that is merely parsed into something
+            // else (an endpoint URL -> host) is validated on the derived value.
+            const injected = varName
+                ? new RegExp(`(?:setEnvironmentVariable|backendConfig\\.set)\\s*\\([^;]*?\\b${varName}\\b`).test(region)
+                : /setEnvironmentVariable\s*\(|backendConfig\.set\s*\(/.test(declLine);
+
+            // The scheme read is guarded by the mapper it is handed to.
+            const isSchemeRead = fn === 'getEndpointAuthorizationScheme';
+
+            let verdict, detail;
+            if (isSchemeRead) {
+                verdict = schemeMapperGuarded ? 'GUARDED' : 'UNGUARDED';
+                detail = schemeMapperGuarded
+                    ? 'handed to a fail-closed mapAuthorizationScheme()'
+                    : 'optional read handed to a mapper that defaults instead of throwing';
+            } else if (opt !== 'false' && !presenceChecked && !validated) {
+                verdict = 'UNGUARDED';
+                detail = inFallbackChain
+                    ? `optional read with || '' -> env var silently skipped on absence`
+                    : 'optional read, no fail-closed check (non-null assertion hides it)';
+            } else if (!SECRET_KEY_RE.test(key) && injected && !validated) {
+                verdict = 'UNGUARDED';
+                detail = 'presence-guarded but the value is injected without charset/format validation';
+            } else {
+                verdict = 'GUARDED';
+                const why = SECRET_KEY_RE.test(key)
+                    ? 'secret field (value is opaque; presence is the checkable property)'
+                    : 'value is not injected directly (validated on the derived value)';
+                detail = validated
+                    ? 'presence + value validated before injection'
+                    : `${why}, ${opt === 'false' ? 'accessor optional=false (task-lib throws)' : 'explicit fail-closed throw'}`;
+            }
+            add(key, verdict, detail, line);
+        }
+    }
+
+    // ---- 2. HELPER cells: reads routed through a validating require* helper.
+    for (const fn of GUARD_HELPERS) {
+        const re = new RegExp(`\\b${fn}\\s*\\(`, 'g');
+        let m;
+        while ((m = re.exec(code))) {
+            const pre = code.slice(Math.max(0, m.index - 70), m.index);
+            if (/(function|private|public|protected|export)\s+$/.test(pre)) continue;
+            const argText = callArgs(code, m.index + m[0].length - 1);
+            if (argText === null) continue;
+            const args = splitArgs(argText);
+            const quoted = args.find((a) => /^['"]/.test(a));
+            if (!quoted) continue; // value-only validators are counted on the field cell
+            add(unquote(quoted), 'GUARDED', `validated via ${fn}()`, lineOf(starts, m.index));
+        }
+    }
+
+    // ---- 3. NEUTRALIZE cells: every credential branch must clear the env vars
+    //         of the auth schemes it is NOT using (the #187 shape: WIF defeated
+    //         by ambient/passthrough static keys that the branch never clears).
+    if (!isBase) {
+        for (const r of regions) {
+            if (r.branch === '<top>') continue;
+            const region = codeLines.slice(r.lo - 1, r.hi).join('\n');
+            if (!/setEnvironmentVariable\s*\(/.test(region)) continue;
+            const ok = /neutralizeEnvironmentVariables\s*\(/.test(region);
+            add('competing-credential-env', ok ? 'GUARDED' : 'UNGUARDED',
+                ok ? 'clears competing auth-scheme env vars before injecting'
+                   : 'injects credentials without clearing competing/ambient auth env vars',
+                r.lo, r.branch);
+        }
+    }
+
+    // ---- 4. SESSION cells: a constant role-session-name collapses CloudTrail
+    //         attribution across every federated build (#197).
+    {
+        const re = /(?:AWS_ROLE_SESSION_NAME"\s*,\s*|\bsessionName\s*:\s*)([^\n]*)/g;
+        let m;
+        while ((m = re.exec(code))) {
+            const expr = m[1].trim();
+            if (/^string\b/.test(expr)) continue; // interface member, not a value
+            // A bare parameter/property reference is the SINK of a value the caller
+            // already resolved; the caller's own cell carries the verdict.
+            if (/^[A-Za-z_$][\w$.]*\s*\)?\s*[;,]?$/.test(expr)) continue;
+            const ok = /resolveRoleSessionName\s*\(/.test(expr);
+            add('roleSessionName', ok ? 'GUARDED' : 'UNGUARDED',
+                ok ? 'derived from job context + charset-validated'
+                   : `fixed constant fallback: ${expr.slice(0, 60)}`,
+                lineOf(starts, m.index));
+        }
+    }
+
+    // ---- 5. CONNECTION cells: a missing service connection must fail closed,
+    //         never silently skip the whole credential block or POST an empty id.
+    if (!isBase) {
+        for (let i = 0; i < codeLines.length; i++) {
+            if (!/if\s*\(\s*(?:command\.)?serviceProviderName\s*\)/.test(codeLines[i])) continue;
+            const after = codeLines.slice(i, i + 60).join('\n');
+            const ok = /\}\s*else\s*\{[\s\S]{0,300}?throw/.test(after);
+            add('serviceConnection', ok ? 'GUARDED' : 'UNGUARDED',
+                ok ? 'missing service connection throws'
+                   : 'missing service connection silently skips the credential block',
+                i + 1);
+        }
+        // WIF paths that hand `command.serviceProviderName` straight to the ADO
+        // OIDC endpoint. A named parameter is excluded: it has already crossed a
+        // function boundary whose caller owns the check.
+        const oidcRe = /(?:generateIdToken|writeOidcTokenFile|applyWifEnvironment|writeWifCredentials)\s*\(/g;
+        let m;
+        while ((m = oidcRe.exec(code))) {
+            const pre = code.slice(Math.max(0, m.index - 90), m.index);
+            if (/(private|public|protected|function)\s+(async\s+)?$/.test(pre)) continue;
+            const argText = callArgs(code, m.index + m[0].length - 1) || '';
+            if (!/(^|[\s:,{])command\.serviceProviderName/.test(argText)) continue;
+            const line = lineOf(starts, m.index);
+            const r = regionFor(line);
+            const region = codeLines.slice(r.lo - 1, line).join('\n');
+            const ok = /if\s*\(\s*!\s*(?:command\.)?serviceProviderName\s*\)[\s\S]{0,300}?throw/.test(region);
+            add('serviceConnection', ok ? 'GUARDED' : 'UNGUARDED',
+                ok ? 'empty service connection throws before the OIDC request'
+                   : 'empty service connection reaches the OIDC/credential request unchecked',
+                line);
+        }
+    }
+
+    // ---- 6. Handlers with no credential cells at all must say so explicitly.
+    if (!isBase && cells.length === 0) {
+        const reason = markers.length ? markers[0].reason : null;
+        cells.push({
+            file: rel, handler, branch: 'handleProvider', cell: 'no-credentials',
+            site: `${handler}.handleProvider.no-credentials`,
+            verdict: reason ? 'EXEMPT' : 'UNGUARDED',
+            detail: reason ? `exempt: ${reason}` : 'handler injects no credentials and carries no @credential-exempt marker',
+            line: 1,
+        });
+    }
+
+    return cells;
+}
+
+// --- run -------------------------------------------------------------------
+
+const handlers = discoverHandlers(ROOT);
+let cells = [];
+for (const f of handlers) cells = cells.concat(analyzeHandler(f, ROOT));
+
+// A site may be reported by more than one detector; keep the strictest verdict.
+const bySite = new Map();
+for (const c of cells) {
+    const k = `${c.file}|${c.site}|${c.line}`;
+    const prev = bySite.get(k);
+    if (!prev || (prev.verdict !== 'UNGUARDED' && c.verdict === 'UNGUARDED')) bySite.set(k, c);
+}
+cells = [...bySite.values()].sort((a, b) => (a.file + a.site).localeCompare(b.file + b.site) || a.line - b.line);
+
+const unguarded = cells.filter((c) => c.verdict === 'UNGUARDED');
+
+if (AS_JSON) {
+    console.log(JSON.stringify({ root: ROOT, handlerFiles: handlers.length, cells, unguarded: unguarded.length }, null, 2));
+} else if (!QUIET) {
+    console.log(`auth-parity-matrix: ${handlers.length} handler file(s) under ${ROOT}`);
+    console.log('');
+    const w = (s, n) => String(s).padEnd(n).slice(0, n);
+    console.log(`${w('HANDLER', 9)} ${w('BRANCH', 30)} ${w('FIELD/CELL', 26)} ${w('VERDICT', 9)} ${w('LINE', 5)} DETAIL`);
+    console.log('-'.repeat(155));
+    for (const c of cells) {
+        console.log(`${w(c.handler, 9)} ${w(c.branch, 30)} ${w(c.cell, 26)} ${w(c.verdict, 9)} ${w(c.line, 5)} ${c.detail}`);
+    }
+    console.log('');
+    const g = cells.filter((c) => c.verdict === 'GUARDED').length;
+    const e = cells.filter((c) => c.verdict === 'EXEMPT').length;
+    console.log(`cells: ${cells.length}  GUARDED: ${g}  EXEMPT: ${e}  UNGUARDED: ${unguarded.length}`);
+}
+
+process.exit(unguarded.length ? 1 : 0);


### PR DESCRIPTION
Cross-repo half of a class remediated in the sibling packer extension (sethbacon/azure-pipelines-packer#228).

## The headline: this repo still carried packer's #97, verbatim

packer #97 ("Azure is the only fail-open auth path") was fixed there on **2026-07-04** and **never ported here**. On `main` today:

```ts
// azure-terraform-command-handler.ts:357
private mapAuthorizationScheme(authorizationScheme: string): AuthorizationScheme {
    if (authorizationScheme === undefined) {
        tasks.warning("The authorization scheme could not be found for your Service Connection, using Workload identity federation by default, but this could cause issues.");
        return AuthorizationScheme.WorkloadIdentityFederation;
    }
```

called through a non-null assertion on an optional accessor, at **both** the backend and provider entry points:

```ts
this.mapAuthorizationScheme(tasks.getEndpointAuthorizationScheme(serviceConnectionID, true)!)
```

Both Azure credential getters likewise read `serviceprincipalid`/`serviceprincipalkey` optional-behind-`!`, so a missing client id became a silently skipped `ARM_CLIENT_ID` and the provider fell through to the agent's own identity.

None of this is named in any issue in this repo. It was found by running the class signature here instead of scoping it to the repo whose audit reported it.

## Enumerated as a matrix, not a list

| | cells | UNGUARDED before | after |
| --- | --- | --- | --- |
| terraform | 62 | **55** | **0** (58 guarded, 4 exempt) |
| packer (companion PR) | 41 | 24 | 0 |

`scripts/auth-parity-matrix.cjs` is **byte-identical** in both repos (verified with `cmp`) and runs in CI here, so the two halves stay in lockstep executably rather than by convention.

## Also found by the matrix, named in no issue

- **The two backend-WIF parameter blocks were verbatim duplicates.** Fixing the session name at one site would have reproduced this batch's own defect class, so they are collapsed into one method.
- **`ARM_CLIENT_ID` could be inherited on the MSI path**, which no per-branch neutralize list can close — the MSI branch legitimately may set it. Hence a wholesale `ARM_*` clear in `setCommonVariables` before the scheme branch re-establishes what it needs.

## Exemptions are machine-checked

Each requires an `@credential-exempt: <reason>` marker in the branch, so the signature verifies them rather than assuming. The load-bearing one: an MSI-scheme connection leaves *Service Principal Id* blank for a **system-assigned** identity, so `undefined` is the correct secure outcome — requiring it would break every system-assigned connection. The compensating control is the wholesale `ARM_CLIENT_ID` clear above, covered by its own test row.

## ⚠ User-visible behaviour change

**A service connection with no authorization scheme now fails**, on both the backend and provider paths, instead of silently running as Workload Identity Federation. That is the point of the fix, but it will surface as a new hard failure for any pipeline that was relying on the warning-and-continue path.

## On the test fixtures

Changed for **realism, not weakening**. The OCI mocks used 5- and 6-octet fingerprints and `DummyFingerprint`/`DummyTenancy` — shapes OCI cannot emit, and which packer's fixtures never used. They are now a real 16-octet MD5 fingerprint and real OCIDs. No assertion was relaxed; two were **inverted** to match the corrected behaviour (the missing-scheme scenario now asserts failure and that terraform is never invoked; the AWS backend session name now asserts derivation rather than the constant).

## Gates

- **Class gate** — re-run by the orchestrator: exit 0, `UNGUARDED: 0`.
- **Mutation check** — 13 mutations, each recompiled first. M3 (restoring the #97 default) reddens both scheme rows; M5 (restoring the OCI `|| ''` skip) reddens 2 OCI rows plus the structural row.
- **Tests** — TerraformTaskV5 680 passing, lint clean, shared-module and version gates green.

Refs sethbacon/azure-pipelines-packer#97
Refs sethbacon/azure-pipelines-packer#187
Refs sethbacon/azure-pipelines-packer#199
Refs sethbacon/azure-pipelines-packer#194
Refs sethbacon/azure-pipelines-packer#197