### PR TITLE
ci: enforce the disciplines that were only documented

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,22 +494,27 @@ jobs:
           tenant-id: ${{ vars.AZDO_PUBLISH_TENANT_ID }}
           allow-no-subscriptions: true
       - name: Publish extension with a Microsoft Entra token
+        # scripts/publish-marketplace.js keeps the token on stdin (with --token
+        # omitted and --auth-type pat set, tfx-cli 0.23.2 reads it from its
+        # masked "Personal access token:" prompt, so it never appears in
+        # /proc/<pid>/cmdline or `ps` -- CWE-214) AND retries a transient
+        # upstream failure a bounded number of times. The sibling
+        # azure-pipelines-packer repo lost its v1.2.7 release to a single HTTP
+        # 503 here, leaving an orphaned draft release behind; this pipeline had
+        # the same single-shot publish. A deterministic rejection (bad manifest,
+        # auth failure, duplicate version on the first attempt) is never
+        # retried. Behaviour gated by scripts/test-publish-marketplace.js in CI.
         run: |
           VSIX_FILE=$(find . -maxdepth 1 -name "*.vsix" -print -quit)
           # 499b84ac-1321-427f-aa17-267ca6975798 is the Azure DevOps resource app.
-          ENTRA_TOKEN=$(az account get-access-token \
+          MARKETPLACE_TOKEN=$(az account get-access-token \
             --tenant "${VARS_AZDO_PUBLISH_TENANT_ID}" \
             --resource 499b84ac-1321-427f-aa17-267ca6975798 \
             --query accessToken -o tsv)
           # Mask the runtime-minted token so it is redacted from any log output.
-          echo "::add-mask::$ENTRA_TOKEN"
-          # Supply the token via stdin, NOT on argv: with --token omitted and
-          # --auth-type pat set, tfx-cli 0.23.2 reads the token from its masked
-          # "Personal access token:" prompt on stdin (verified against 0.23.2:
-          # getCredentials() -> token.val() -> qread/prompt), so the token never
-          # appears in /proc/<pid>/cmdline or `ps` (CWE-214). `printf` is a bash
-          # builtin, so it spawns no argv-visible helper process either.
-          printf '%s\n' "$ENTRA_TOKEN" | ./node_modules/.bin/tfx extension publish --vsix "$VSIX_FILE" --auth-type pat
+          echo "::add-mask::$MARKETPLACE_TOKEN"
+          export MARKETPLACE_TOKEN
+          node scripts/publish-marketplace.js --vsix "$VSIX_FILE"
         env:
           VARS_AZDO_PUBLISH_TENANT_ID: ${{ vars.AZDO_PUBLISH_TENANT_ID }}
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,6 +45,8 @@ jobs:
         run: node scripts/test-check-task-list.js
       - name: Self-test check-per-file-coverage.js
         run: node scripts/test-check-per-file-coverage.js
+      - name: Self-test publish-marketplace.js
+        run: node scripts/test-publish-marketplace.js
       - name: Check for mojibake encoding corruption
         shell: bash
         # Catches recurrence of the UTF-8-decoded-as-Windows-1252 corruption
@@ -76,6 +78,10 @@ jobs:
         run: node scripts/check-near-duplicate-modules.js
       - name: Validate egress authorization (SSRF class signature)
         run: node scripts/check-egress-authorization.js
+      - name: Validate enforced disciplines (documented-but-unenforced class signature)
+        run: node scripts/check-enforced-disciplines.js
+      - name: Self-test check-enforced-disciplines.js
+        run: node scripts/test-check-enforced-disciplines.js
 
   build-and-test-v5:
     name: Build and Test V5 (${{ matrix.os }})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Closes #12
 
 The release is a **public, publicly-listed** Marketplace extension: `npm run package:release` overrides the base manifest with `configs/release.json` (`"public": true`, `galleryFlags: ["Public"]`). The `"public": false` in `azure-devops-extension.json` (and in `configs/dev.json` / `configs/test.json`) is only the dev-safe default so a dev/test package can never accidentally ship a public listing — it is not the distribution model.
 
+The publish itself goes through `scripts/publish-marketplace.js`, which keeps the minted Entra token on tfx's stdin (never on argv, where it would be readable in `/proc/<pid>/cmdline`) and retries a transient upstream failure a bounded number of times — the sibling `azure-pipelines-packer` repo lost its v1.2.7 release to a single HTTP 503 at this step, leaving an orphaned draft release behind. A deterministic rejection is never retried. It runs as a step inside the `marketplace` environment job, so it neither changes nor bypasses that environment's gates.
+
 The `marketplace` environment (Settings → Environments) must have (1) at least one required reviewer so every VS Marketplace publish gets human approval, and (2) a deployment branch/ref policy so a publish can only run from an approved branch or tag (e.g. `main` / `v*`) even after a reviewer approves. Both are verified automatically by the `verify-marketplace-environment-protection` job in `weekly-security.yml` — which fails the scheduled run (filing an issue) if either rule, or the environment itself, is missing or removed — and, fail-closed at publish time, by the matching guard step in `release.yml`.
 
 ## Publisher Registration
@@ -379,7 +381,7 @@ npm test
 
 ### Test structure
 
-Tests are in `Tasks/TerraformTask/TerraformTaskV5/Tests/` and follow a mock-runner pattern. Test files come in pairs:
+Tests are in `Tasks/TerraformTask/TerraformTaskV5/Tests/` and follow a mock-runner pattern. The mock-runner entry must be the task's **real** `src/index.ts` (`path.join(__dirname, '..', 'src', 'index.js')`), never a re-implementation of it in `Tests/`, and `src/index.js` must not be excluded from `.nycrc.json` — a declared `execution` target that no test loads and no metric measures is unverified in production (#189, sibling `azure-pipelines-packer` #189). `scripts/check-enforced-disciplines.js` fails CI if either property regresses for any task. Test files come in pairs:
 
 - `<Name>.ts` - test data/mock setup (mock runner)
 - `<Name>L0.ts` - the actual mocha test using `MockTestRunner`
@@ -421,6 +423,8 @@ See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for the authoritative, per-
 - `.github/workflows/release-please.yml` — **Release automation.** Runs on push to `main`; uses a GitHub App token to open/update the Release PR (version bump + changelog).
 - `.github/workflows/release.yml` — **Release pipeline.** Triggered by semver tags (`v*.*.*`) or manual dispatch. Verifies tag is on `main`, runs full CI via `workflow_call`, builds release bundle, packages `.vsix`, generates CycloneDX SBOMs, signs with cosign (keyless), creates draft GitHub Release, publishes to VS Marketplace (requires `marketplace` environment approval), then undrafts the release.
 - `.github/workflows/codeql.yml` — **Code scanning.** CodeQL static analysis for TypeScript (GitHub Advanced Security).
+
+The `Check Shared Module Parity` job also runs `scripts/check-enforced-disciplines.js` — the signature for the "documented-but-unenforced discipline" class: every task's declared execution entry point must be loaded by a test and measured by its coverage config, every declared execution handler (`Node24`, `Node20_1`) must be exercised by a CI job for that task, the Minor-bump rule must be enforced in all three layers, and the Marketplace publish must retry transient failures and keep the token off argv. No new required status check was introduced — both it and its self-test are **steps inside existing required jobs**, so branch protection needs no change.
 
 ## Local Development Environment
 

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/.nycrc.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/.nycrc.json
@@ -11,8 +11,7 @@
     ],
     "exclude": [
         "src/**/*.d.ts",
-        "src/**/*.map",
-        "src/index.js"
+        "src/**/*.map"
     ],
     "check-coverage": true,
     "lines": 75,

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointFileList.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointFileList.ts
@@ -1,0 +1,46 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+
+// #189 (sibling azure-pipelines-packer #189): this task's suite was entirely
+// module-level — it imported converter/render/frontmatter directly and never
+// loaded src/index.ts, the file task.json's Node24/Node20_1 handlers point the
+// ADO agent at. index.js was also excluded from the coverage metric, so the
+// entry point's own input plumbing (mode dispatch, the title default, the
+// htmlFilePath output variable) shipped unverified.
+//
+// This scenario runs the REAL src/index.js under the mock runner on the
+// filelist path. The scratch directory is deterministic so Tests/L0.ts can
+// assert on the produced file rather than only on stdout.
+// mkdtempSync creates a unique 0700 directory atomically. A fixed name under the
+// shared temp dir is pre-creatable by any local user, so the writes below could be
+// redirected through a planted symlink (CWE-377/378) -- the same reason src/ uses
+// secure-temp.ts. Tests/L0.ts spawns this file rather than importing it, so nothing
+// outside this process needs the path to be predictable.
+// Scratch lives under the compiled Tests directory, not os.tmpdir(). The path must
+// stay deterministic because Tests/L0.ts reconstructs it independently to assert on
+// the produced file, and a fixed name in the shared temp dir is pre-creatable by any
+// local user, so the writes below could be redirected through a planted symlink
+// (CWE-377/378) -- the reason src/ uses secure-temp.ts.
+export const SCRATCH_DIR = path.join(__dirname, '.scratch', 'entrypoint-filelist');
+export const OUTPUT_FILE = path.join(SCRATCH_DIR, 'out.html');
+
+fs.mkdirSync(SCRATCH_DIR, { recursive: true });
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const markdownFile = path.join(SCRATCH_DIR, 'doc.md');
+fs.writeFileSync(markdownFile, '# Entry Point Heading\n\nBody text.\n');
+fs.rmSync(OUTPUT_FILE, { force: true });
+
+tr.setInput('mode', 'filelist');
+tr.setInput('inputFiles', markdownFile);
+tr.setInput('outputFile', OUTPUT_FILE);
+tr.setInput('title', 'Entry Point Test');
+tr.setInput('sections', 'false');
+tr.setInput('dividers', 'false');
+tr.setInput('debug', 'false');
+
+tr.run();

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointMissingPrimaryFile.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointMissingPrimaryFile.ts
@@ -1,0 +1,29 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+
+// #189, failure half: the REAL src/index.ts must fail closed — not throw out of
+// run() and not report Succeeded — when the front-matter primary file does not
+// exist. Exercises the entry point's frontMatter dispatch branch and its catch,
+// neither of which the module-level suite reaches.
+// Unique 0700 directory: a fixed name under the shared temp dir is pre-creatable by
+// any local user and the writes below could be redirected through a planted symlink.
+// Scratch lives under the compiled Tests directory, not os.tmpdir(). The path must
+// stay deterministic because Tests/L0.ts reconstructs it independently to assert on
+// the produced file, and a fixed name in the shared temp dir is pre-creatable by any
+// local user, so the writes below could be redirected through a planted symlink
+// (CWE-377/378) -- the reason src/ uses secure-temp.ts.
+const SCRATCH_DIR = path.join(__dirname, '.scratch', 'entrypoint-missing');
+
+fs.mkdirSync(SCRATCH_DIR, { recursive: true });
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+
+tr.setInput('mode', 'frontMatter');
+tr.setInput('primaryFile', path.join(SCRATCH_DIR, 'does-not-exist.md'));
+tr.setInput('outputFile', path.join(SCRATCH_DIR, 'out.html'));
+
+tr.run();

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -9,6 +9,7 @@ import os = require('os');
 import path = require('path');
 import * as cheerio from 'cheerio';
 import taskLib = require('azure-pipelines-task-lib/task');
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 // Pure-logic modules (no task harness required)
 import { parseFrontMatter } from '../src/frontmatter';
@@ -782,5 +783,56 @@ describe('processFrontMatterDriven', () => {
         const out = path.join(dir, 'out.html');
         const result = await processFrontMatterDriven(path.join(dir, 'basenamedoc.md'), out);
         assert.strictEqual(result.title, 'basenamedoc');
+    });
+});
+
+/**
+ * Entry-point suite (#189, sibling azure-pipelines-packer #189).
+ *
+ * Everything above imports src/ modules directly; nothing loaded src/index.ts,
+ * the file task.json's Node24/Node20_1 execution handlers actually point the ADO
+ * agent at, and .nycrc.json excluded it from the coverage metric on top of that.
+ * These two scenarios run the real entry point under the mock runner — the
+ * success path (filelist mode end to end, htmlFilePath output variable set) and
+ * the fail-closed path — and src/index.js is now measured like every other file.
+ * scripts/check-enforced-disciplines.js fails CI if either property regresses.
+ */
+describe('Markdown2Html entry point (src/index.ts)', function () {
+    before(() => {
+        delete process.env.NODE_OPTIONS;
+        (ttm.MockTestRunner.prototype as unknown as { getNodePath: () => string }).getNodePath = function () {
+            return process.execPath;
+        };
+    });
+
+    it('filelist mode: converts the input file, writes the output and sets htmlFilePath', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointFileList.js'));
+        await tr.runAsync();
+        const outputFile = path.join(__dirname, '.scratch', 'entrypoint-filelist', 'out.html');
+        try {
+            assert.ok(tr.succeeded, 'the entry point should have succeeded. errors: ' + tr.errorIssues + ' stdout: ' + tr.stdout);
+            assert.ok(fs.existsSync(outputFile), 'src/index.ts must write the converted HTML to outputFile');
+            assert.ok(
+                fs.readFileSync(outputFile, 'utf8').includes('Entry Point Heading'),
+                'the written HTML must contain the converted markdown heading'
+            );
+            assert.ok(
+                tr.stdout.includes('htmlFilePath'),
+                'src/index.ts must set the htmlFilePath output variable. stdout: ' + tr.stdout
+            );
+        } finally {
+            fs.rmSync(path.join(__dirname, '.scratch', 'entrypoint-filelist'), { recursive: true, force: true });
+        }
+    });
+
+    it('fails closed when the front-matter primary file does not exist', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointMissingPrimaryFile.js'));
+        await tr.runAsync();
+        try {
+            assert.ok(tr.failed, 'the entry point must fail closed, not throw or report success. stdout: ' + tr.stdout);
+            assert.ok(tr.errorIssues.length > 0, 'should have an error issue. stdout: ' + tr.stdout);
+        } finally {
+            fs.rmSync(path.join(os.tmpdir(), 'md2html-entrypoint-missing'), { recursive: true, force: true });
+        }
     });
 });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/.nycrc.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/.nycrc.json
@@ -12,7 +12,6 @@
     "exclude": [
         "src/**/*.d.ts",
         "src/**/*.map",
-        "src/index.js",
         "src/hashicorp-gpg-key.js"
     ],
     "check-coverage": true,

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/EntryPointInstallSuccess.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/EntryPointInstallSuccess.ts
@@ -1,0 +1,51 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #189 (sibling azure-pipelines-packer #189): every other scenario in this suite
+// runs Tests/RunInstaller.js — a re-implementation of the task entry point that
+// calls downloadPolicyAgent() and stops there. The REAL entry point (src/index.ts, the
+// file task.json's Node24/Node20_1 handlers point the ADO agent at) was loaded by
+// no test and excluded from the coverage metric, so its PATH-prepend decision and
+// its post-install `opa version` verification shipped unverified.
+//
+// This scenario points the mock runner at ../src/index.js itself. PATH is set to a
+// value that does NOT start with the install directory, so the prepend branch is
+// taken; `opa version` is answered so the verify step completes.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const installDir = path.join(path.sep + 'opt', 'hostedtoolcache', 'opa', '0.70.0', 'x64');
+const toolPath = path.join(installDir, 'opa');
+
+tr.setInput('version', '0.70.0');
+tr.setInput('policyAgent', 'opa');
+tr.setInput('downloadSource', 'official');
+
+// Download-strategy selection and verification are covered exhaustively by the
+// other scenarios via RunInstaller; this one is about the entry point's own wiring.
+tr.registerMock('./policy-agent-installer', {
+    downloadPolicyAgent: async (_version: string) => toolPath
+});
+
+// The prepend is asserted from Tests/L0.ts against this marker rather than after
+// tr.run() below: run() returns before the task's own async run() promise settles,
+// so an in-file assertion would always read the pre-call value.
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    prependPath: (target: string) => {
+        console.log(`EntryPoint test: prependPath(${target})`);
+    }
+});
+
+process.env['PATH'] = path.join(path.sep + 'usr', 'bin');
+
+const a: ma.TaskLibAnswers = {
+    which: { 'opa': toolPath },
+    checkPath: { [toolPath]: true },
+    exec: {
+        [`${toolPath} version`]: { code: 0, stdout: 'Version: 0.70.0', stderr: '' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/EntryPointVerifyFail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/EntryPointVerifyFail.ts
@@ -1,0 +1,47 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #189, failure half: the real src/index.ts must FAIL CLOSED when the
+// post-install `opa version` verification does not succeed — a download that
+// produced an unusable binary must not be reported as a successful install.
+// Exercises index.ts's catch branch, which the re-implemented
+// Tests/RunInstaller.js entry never covered.
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const installDir = path.join(path.sep + 'opt', 'hostedtoolcache', 'opa', '0.70.0', 'x64');
+const toolPath = path.join(installDir, 'opa');
+
+tr.setInput('version', '0.70.0');
+tr.setInput('policyAgent', 'opa');
+tr.setInput('downloadSource', 'official');
+
+// Download-strategy selection and verification are covered exhaustively by the
+// other scenarios via RunInstaller; this one is about the entry point's own wiring.
+tr.registerMock('./policy-agent-installer', {
+    downloadPolicyAgent: async (_version: string) => toolPath
+});
+
+// The prepend is asserted from Tests/L0.ts against this marker rather than after
+// tr.run() below: run() returns before the task's own async run() promise settles,
+// so an in-file assertion would always read the pre-call value.
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    prependPath: (target: string) => {
+        console.log(`EntryPoint test: prependPath(${target})`);
+    }
+});
+
+process.env['PATH'] = path.join(path.sep + 'usr', 'bin');
+
+const a: ma.TaskLibAnswers = {
+    which: { 'opa': toolPath },
+    checkPath: { [toolPath]: true },
+    exec: {
+        [`${toolPath} version`]: { code: 1, stdout: '', stderr: 'opa: cannot execute binary file' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -69,6 +69,35 @@ describe('PolicyAgentInstaller Test Suite', function () {
     }
 
     // --- Success cases ---
+    // #189: the two scenarios below point the mock runner at ../src/index.js
+    // itself, not at the RunInstaller.js re-implementation, so the declared
+    // task.json execution entry point is exercised (and measured — it is no
+    // longer excluded in .nycrc.json) on both its success and its fail-closed path.
+    it('EntryPointInstallSuccess', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointInstallSuccess.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+            assert.ok(
+                tr.stdout.includes('EntryPoint test: prependPath(' + path.join(path.sep + 'opt', 'hostedtoolcache', 'opa', '0.70.0', 'x64') + ')'),
+                'src/index.ts must prepend the install directory to PATH when PATH does not already start with it. stdout: ' + tr.stdout
+            );
+            assert.ok(
+                tr.stdout.includes('Version: 0.70.0'),
+                'src/index.ts must run the post-install `opa version` verification. stdout: ' + tr.stdout
+            );
+        }, tr);
+    });
+
+    it('EntryPointVerifyFail', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointVerifyFail.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.failed, 'src/index.ts must fail closed when the post-install verification fails');
+            assert.ok(tr.errorIssues.length > 0, 'should have an error issue. stdout: ' + tr.stdout);
+        }, tr);
+    });
+
     expectSuccess('SentinelOfficialSuccess');
     expectSuccess('OpaOfficialSuccess');
     expectSuccess('OpaLatestSuccess');

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/.nycrc.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/.nycrc.json
@@ -11,8 +11,7 @@
     ],
     "exclude": [
         "src/**/*.d.ts",
-        "src/**/*.map",
-        "src/index.js"
+        "src/**/*.map"
     ],
     "check-coverage": true,
     "lines": 75,

--- a/Tasks/TerraformDocs/TerraformDocsV1/.nycrc.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/.nycrc.json
@@ -11,8 +11,7 @@
   ],
   "exclude": [
     "src/**/*.d.ts",
-    "src/**/*.map",
-    "src/index.js"
+    "src/**/*.map"
   ],
   "check-coverage": true,
   "lines": 75,

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/.nycrc.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/.nycrc.json
@@ -11,8 +11,7 @@
   ],
   "exclude": [
     "src/**/*.d.ts",
-    "src/**/*.map",
-    "src/index.js"
+    "src/**/*.map"
   ],
   "check-coverage": true,
   "lines": 86,

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/EntryPointInstallSuccess.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/EntryPointInstallSuccess.ts
@@ -1,0 +1,50 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #189 (sibling azure-pipelines-packer #189): every other scenario in this suite
+// runs Tests/RunInstaller.js — a re-implementation of the task entry point that
+// calls downloadTerraformDocs() and stops there. The REAL entry point (src/index.ts, the
+// file task.json's Node24/Node20_1 handlers point the ADO agent at) was loaded by
+// no test and excluded from the coverage metric, so its PATH-prepend decision and
+// its post-install `terraform-docs version` verification shipped unverified.
+//
+// This scenario points the mock runner at ../src/index.js itself. PATH is set to a
+// value that does NOT start with the install directory, so the prepend branch is
+// taken; `terraform-docs version` is answered so the verify step completes.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const installDir = path.join(path.sep + 'opt', 'hostedtoolcache', 'terraform-docs', '0.19.0', 'x64');
+const toolPath = path.join(installDir, 'terraform-docs');
+
+tr.setInput('version', '0.19.0');
+tr.setInput('downloadSource', 'official');
+
+// Download-strategy selection and verification are covered exhaustively by the
+// other scenarios via RunInstaller; this one is about the entry point's own wiring.
+tr.registerMock('./terraform-docs-installer', {
+    downloadTerraformDocs: async (_version: string) => toolPath
+});
+
+// The prepend is asserted from Tests/L0.ts against this marker rather than after
+// tr.run() below: run() returns before the task's own async run() promise settles,
+// so an in-file assertion would always read the pre-call value.
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    prependPath: (target: string) => {
+        console.log(`EntryPoint test: prependPath(${target})`);
+    }
+});
+
+process.env['PATH'] = path.join(path.sep + 'usr', 'bin');
+
+const a: ma.TaskLibAnswers = {
+    which: { 'terraform-docs': toolPath },
+    checkPath: { [toolPath]: true },
+    exec: {
+        [`${toolPath} version`]: { code: 0, stdout: 'terraform-docs version v0.19.0', stderr: '' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/EntryPointVerifyFail.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/EntryPointVerifyFail.ts
@@ -1,0 +1,46 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #189, failure half: the real src/index.ts must FAIL CLOSED when the
+// post-install `terraform-docs version` verification does not succeed — a download that
+// produced an unusable binary must not be reported as a successful install.
+// Exercises index.ts's catch branch, which the re-implemented
+// Tests/RunInstaller.js entry never covered.
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const installDir = path.join(path.sep + 'opt', 'hostedtoolcache', 'terraform-docs', '0.19.0', 'x64');
+const toolPath = path.join(installDir, 'terraform-docs');
+
+tr.setInput('version', '0.19.0');
+tr.setInput('downloadSource', 'official');
+
+// Download-strategy selection and verification are covered exhaustively by the
+// other scenarios via RunInstaller; this one is about the entry point's own wiring.
+tr.registerMock('./terraform-docs-installer', {
+    downloadTerraformDocs: async (_version: string) => toolPath
+});
+
+// The prepend is asserted from Tests/L0.ts against this marker rather than after
+// tr.run() below: run() returns before the task's own async run() promise settles,
+// so an in-file assertion would always read the pre-call value.
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    prependPath: (target: string) => {
+        console.log(`EntryPoint test: prependPath(${target})`);
+    }
+});
+
+process.env['PATH'] = path.join(path.sep + 'usr', 'bin');
+
+const a: ma.TaskLibAnswers = {
+    which: { 'terraform-docs': toolPath },
+    checkPath: { [toolPath]: true },
+    exec: {
+        [`${toolPath} version`]: { code: 1, stdout: '', stderr: 'terraform-docs: cannot execute binary file' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
@@ -67,6 +67,35 @@ describe('TerraformDocsInstaller Test Suite', function () {
   }
 
   // --- Success cases ---
+    // #189: the two scenarios below point the mock runner at ../src/index.js
+    // itself, not at the RunInstaller.js re-implementation, so the declared
+    // task.json execution entry point is exercised (and measured — it is no
+    // longer excluded in .nycrc.json) on both its success and its fail-closed path.
+  it('EntryPointInstallSuccess', async () => {
+      const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointInstallSuccess.js'));
+      await tr.runAsync();
+      runValidations(() => {
+          assert.ok(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+          assert.ok(
+              tr.stdout.includes('EntryPoint test: prependPath(' + path.join(path.sep + 'opt', 'hostedtoolcache', 'terraform-docs', '0.19.0', 'x64') + ')'),
+              'src/index.ts must prepend the install directory to PATH when PATH does not already start with it. stdout: ' + tr.stdout
+          );
+          assert.ok(
+              tr.stdout.includes('terraform-docs version v0.19.0'),
+              'src/index.ts must run the post-install `terraform-docs version` verification. stdout: ' + tr.stdout
+          );
+      }, tr);
+  });
+
+  it('EntryPointVerifyFail', async () => {
+      const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointVerifyFail.js'));
+      await tr.runAsync();
+      runValidations(() => {
+          assert.ok(tr.failed, 'src/index.ts must fail closed when the post-install verification fails');
+          assert.ok(tr.errorIssues.length > 0, 'should have an error issue. stdout: ' + tr.stdout);
+      }, tr);
+  });
+
   expectSuccess('OfficialSuccess');
   expectSuccess('LatestSuccess');
   expectSuccess('RegistrySuccess');

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/.nycrc.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/.nycrc.json
@@ -11,8 +11,7 @@
     ],
     "exclude": [
         "src/**/*.d.ts",
-        "src/**/*.map",
-        "src/index.js"
+        "src/**/*.map"
     ],
     "check-coverage": true,
     "lines": 75,

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/.nycrc.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/.nycrc.json
@@ -12,7 +12,6 @@
     "exclude": [
         "src/**/*.d.ts",
         "src/**/*.map",
-        "src/index.js",
         "src/hashicorp-gpg-key.js"
     ],
     "check-coverage": true,

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/EntryPointInstallSuccess.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/EntryPointInstallSuccess.ts
@@ -1,0 +1,49 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #189 (sibling azure-pipelines-packer #189): every other scenario in this suite
+// runs Tests/RunInstaller.js — a re-implementation of the task entry point that
+// calls downloadTerraform() and stops there. The REAL entry point (src/index.ts, the
+// file task.json's Node24/Node20_1 handlers point the ADO agent at) was loaded by
+// no test and excluded from the coverage metric, so its PATH-prepend decision and
+// its post-install `terraform version` verification shipped unverified.
+//
+// This scenario points the mock runner at ../src/index.js itself. PATH is set to a
+// value that does NOT start with the install directory, so the prepend branch is
+// taken; `terraform version` is answered so the verify step completes.
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const installDir = path.join(path.sep + 'opt', 'hostedtoolcache', 'terraform', '1.9.5', 'x64');
+const toolPath = path.join(installDir, 'terraform');
+
+tr.setInput('terraformVersion', '1.9.5');
+
+// Download-strategy selection and verification are covered exhaustively by the
+// other scenarios via RunInstaller; this one is about the entry point's own wiring.
+tr.registerMock('./terraform-installer', {
+    downloadTerraform: async (_version: string) => toolPath
+});
+
+// The prepend is asserted from Tests/L0.ts against this marker rather than after
+// tr.run() below: run() returns before the task's own async run() promise settles,
+// so an in-file assertion would always read the pre-call value.
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    prependPath: (target: string) => {
+        console.log(`EntryPoint test: prependPath(${target})`);
+    }
+});
+
+process.env['PATH'] = path.join(path.sep + 'usr', 'bin');
+
+const a: ma.TaskLibAnswers = {
+    which: { 'terraform': toolPath },
+    checkPath: { [toolPath]: true },
+    exec: {
+        [`${toolPath} version`]: { code: 0, stdout: 'Terraform v1.9.5', stderr: '' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/EntryPointVerifyFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/EntryPointVerifyFail.ts
@@ -1,0 +1,45 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+// #189, failure half: the real src/index.ts must FAIL CLOSED when the
+// post-install `terraform version` verification does not succeed — a download that
+// produced an unusable binary must not be reported as a successful install.
+// Exercises index.ts's catch branch, which the re-implemented
+// Tests/RunInstaller.js entry never covered.
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+const installDir = path.join(path.sep + 'opt', 'hostedtoolcache', 'terraform', '1.9.5', 'x64');
+const toolPath = path.join(installDir, 'terraform');
+
+tr.setInput('terraformVersion', '1.9.5');
+
+// Download-strategy selection and verification are covered exhaustively by the
+// other scenarios via RunInstaller; this one is about the entry point's own wiring.
+tr.registerMock('./terraform-installer', {
+    downloadTerraform: async (_version: string) => toolPath
+});
+
+// The prepend is asserted from Tests/L0.ts against this marker rather than after
+// tr.run() below: run() returns before the task's own async run() promise settles,
+// so an in-file assertion would always read the pre-call value.
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    prependPath: (target: string) => {
+        console.log(`EntryPoint test: prependPath(${target})`);
+    }
+});
+
+process.env['PATH'] = path.join(path.sep + 'usr', 'bin');
+
+const a: ma.TaskLibAnswers = {
+    which: { 'terraform': toolPath },
+    checkPath: { [toolPath]: true },
+    exec: {
+        [`${toolPath} version`]: { code: 1, stdout: '', stderr: 'terraform: cannot execute binary file' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -51,6 +51,35 @@ describe('TerraformInstaller Test Suite', function () {
         }
     }
 
+    // #189: the two scenarios below point the mock runner at ../src/index.js
+    // itself, not at the RunInstaller.js re-implementation, so the declared
+    // task.json execution entry point is exercised (and measured — it is no
+    // longer excluded in .nycrc.json) on both its success and its fail-closed path.
+    it('EntryPointInstallSuccess', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointInstallSuccess.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.succeeded, 'task should have succeeded. errors: ' + tr.errorIssues);
+            assert.ok(
+                tr.stdout.includes('EntryPoint test: prependPath(' + path.join(path.sep + 'opt', 'hostedtoolcache', 'terraform', '1.9.5', 'x64') + ')'),
+                'src/index.ts must prepend the install directory to PATH when PATH does not already start with it. stdout: ' + tr.stdout
+            );
+            assert.ok(
+                tr.stdout.includes('Terraform v1.9.5'),
+                'src/index.ts must run the post-install `terraform version` verification. stdout: ' + tr.stdout
+            );
+        }, tr);
+    });
+
+    it('EntryPointVerifyFail', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'EntryPointVerifyFail.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert.ok(tr.failed, 'src/index.ts must fail closed when the post-install verification fails');
+            assert.ok(tr.errorIssues.length > 0, 'should have an error issue. stdout: ' + tr.stdout);
+        }, tr);
+    });
+
     // --- HashiCorp download source ---
 
     it('hashicorp latest: should resolve version from checkpoint API and download', async () => {

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/.nycrc.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/.nycrc.json
@@ -12,7 +12,6 @@
     "exclude": [
         "src/**/*.d.ts",
         "src/**/*.map",
-        "src/index.js",
         "src/types.js"
     ],
     "check-coverage": true,

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/.nycrc.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/.nycrc.json
@@ -12,7 +12,6 @@
     "exclude": [
         "src/**/*.d.ts",
         "src/**/*.map",
-        "src/index.js",
         "src/types.js"
     ],
     "check-coverage": true,

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/.nycrc.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/.nycrc.json
@@ -11,8 +11,7 @@
     ],
     "exclude": [
         "src/**/*.d.ts",
-        "src/**/*.map",
-        "src/index.js"
+        "src/**/*.map"
     ],
     "check-coverage": true,
     "lines": 75,

--- a/scripts/check-enforced-disciplines.js
+++ b/scripts/check-enforced-disciplines.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+// ===========================================================================
+// SIGNATURE for the "documented-but-unenforced discipline" defect class.
+//
+// The class: a rule the project relies on is written down (CLAUDE.md, a task
+// manifest, a .nycrc exclude list, a release checklist) but nothing in CI ever
+// asserts it, so it holds only while a human remembers it. Every instance in
+// this batch had that shape:
+//
+//   * task.json declares a Node20_1 fallback execution handler, but no CI leg
+//     ever ran the compiled output under Node 20 (packer #208).
+//   * .nycrc.json excludes src/index.js from the coverage metric AND no test
+//     file requires it, so the entry point -- including the SIGTERM/SIGINT
+//     credential-scrub wiring -- is neither measured nor executed (#189).
+//   * CLAUDE.md documents "bump the task.json Minor for every changed task"
+//     but check-versions.js only validates the fields are well-formed (#192).
+//   * the Marketplace publish passes a minted Entra token on argv and has no
+//     bounded retry, so one upstream 503 burns a release (#109 + the v1.2.7
+//     publish failure).
+//
+// Rather than fix four instances, this script ENUMERATES the whole class from
+// disk on every run and fails the build when any site regresses. Adding a task
+// automatically adds its rows; nothing has to be remembered.
+//
+// Usage: node scripts/check-enforced-disciplines.js [repoRoot]   (default: cwd)
+//
+// Exemptions live in EXEMPTIONS below and are BIDIRECTIONAL: an exemption whose
+// site now passes is itself a failure, so the table can never quietly outlive
+// the reason it was added.
+// ===========================================================================
+
+const fs = require('fs');
+const path = require('path');
+const { discoverTaskDirs } = require('./lib/task-dirs.js');
+
+const repoRoot = path.resolve(process.argv[2] || '.');
+
+// ---------------------------------------------------------------------------
+// Exemptions: `${checkId}::${site}` -> reason verified by reading code.
+// ---------------------------------------------------------------------------
+const EXEMPTIONS = {};
+
+// ---------------------------------------------------------------------------
+// Small helpers (no YAML/JSON5 dependency: these scripts run before any
+// `npm ci` in CI's check jobs, so they must stay dependency-free).
+// ---------------------------------------------------------------------------
+
+function readIfExists(file) {
+    const full = path.join(repoRoot, file);
+    return fs.existsSync(full) ? fs.readFileSync(full, 'utf8') : null;
+}
+
+function readJsonIfExists(file) {
+    const raw = readIfExists(file);
+    return raw === null ? null : JSON.parse(raw);
+}
+
+function walkFiles(dir, filter, out = []) {
+    if (!fs.existsSync(dir)) return out;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules') continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walkFiles(full, filter, out);
+        else if (filter(entry.name)) out.push(full);
+    }
+    return out;
+}
+
+/**
+ * Splits a workflow file into its top-level job blocks.
+ * Returns a Map of jobId -> the raw text of that job (including its `name:`),
+ * so callers can ask "does the job that builds <taskDir> also set up Node 20?"
+ * without pulling in a YAML parser.
+ */
+function parseJobs(text) {
+    const jobs = new Map();
+    if (!text) return jobs;
+    const lines = text.split(/\r?\n/);
+    const jobsAt = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+    if (jobsAt === -1) return jobs;
+    let current = null;
+    let buffer = [];
+    for (let i = jobsAt + 1; i < lines.length; i++) {
+        const line = lines[i];
+        const start = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+        if (start) {
+            if (current) jobs.set(current, buffer.join('\n'));
+            current = start[1];
+            buffer = [line];
+            continue;
+        }
+        if (/^\S/.test(line) && line.trim() !== '') break; // left the jobs: mapping
+        if (current) buffer.push(line);
+    }
+    if (current) jobs.set(current, buffer.join('\n'));
+    return jobs;
+}
+
+function escapeRe(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Does `text` reference the module at repo-relative `target` (e.g. 'src/index.js')?
+ *
+ * Both spellings the mock-runner suites in these repos actually use must match,
+ * or the signature reports a false FAIL on a task that IS exercising its entry
+ * point (this happened on the first run against azure-pipelines-terraform, whose
+ * PublishKbArticle/ModulePublish/ProviderMirror suites all use the second form):
+ *   1. a single path literal:   require('../src/index') / '../../src/index.js'
+ *   2. path.join segments:      path.join(__dirname, '..', 'src', 'index.js')
+ */
+function referencesTarget(text, target) {
+    const segments = target.split('/');
+    const joined = segments.map(escapeRe).join('[/\\\\]');
+    const singleLiteral = new RegExp(`['"\`][^'"\`]*${joined.replace(/\\\.js$/, '')}(\\.js)?['"\`]`);
+    const asSegments = new RegExp(
+        segments
+            .map((s, i) => `['"\`]${escapeRe(i === segments.length - 1 ? s.replace(/\.js$/, '') : s)}(\\.js)?['"\`]`)
+            .join('\\s*,\\s*'),
+    );
+    return singleLiteral.test(text) || asSegments.test(text);
+}
+
+/** All `node-version:` values declared inside a job block, as integer majors. */
+function nodeMajorsIn(jobText) {
+    const majors = new Set();
+    for (const m of jobText.matchAll(/node-version:\s*["']?(\d+)/g)) {
+        majors.add(parseInt(m[1], 10));
+    }
+    return majors;
+}
+
+// ---------------------------------------------------------------------------
+// Findings
+// ---------------------------------------------------------------------------
+const findings = [];
+function record(check, site, ok, detail) {
+    findings.push({ check, site, ok, detail });
+}
+
+const tasks = discoverTaskDirs(repoRoot);
+if (tasks.length === 0) {
+    console.error(`FAIL: no task directories found under ${path.join(repoRoot, 'Tasks')} — the signature would trivially pass over an empty universe.`);
+    process.exit(1);
+}
+
+const unitTestYml = readIfExists('.github/workflows/unit-test.yml') || '';
+const ciJobs = parseJobs(unitTestYml);
+
+for (const task of tasks) {
+    const manifest = readJsonIfExists(`${task}/task.json`);
+    const execution = (manifest && manifest.execution) || {};
+    const handlers = Object.keys(execution);
+
+    // --- DISCIPLINE 1: the declared entry point is actually exercised by a test.
+    // A task.json `execution` target is a production contract: it is the file the
+    // ADO agent runs. If no test ever loads it, its signal/cleanup wiring and its
+    // input plumbing are unverified no matter how well the modules it calls are
+    // covered.
+    const targets = [...new Set(handlers.map((h) => execution[h] && execution[h].target).filter(Boolean))];
+    const testFiles = walkFiles(path.join(repoRoot, task, 'Tests'), (n) => n.endsWith('.ts'));
+    for (const target of targets) {
+        const moduleRef = target.replace(/\.js$/, ''); // src/index.js -> src/index (for the message only)
+        const referenced = testFiles.some((f) => referencesTarget(fs.readFileSync(f, 'utf8'), target));
+        record(
+            'entry-point-exercised',
+            `${task} -> ${target}`,
+            referenced,
+            referenced
+                ? `referenced by a file under ${task}/Tests`
+                : `no file under ${task}/Tests references ${moduleRef}; the execution entry point is never loaded by any test`,
+        );
+    }
+
+    // --- DISCIPLINE 2: the entry point is inside the coverage metric.
+    // Excluding it makes the ratcheted floor silently stop describing the file
+    // the agent actually runs.
+    const nycPath = `${task}/.nycrc.json`;
+    const nyc = readJsonIfExists(nycPath);
+    if (nyc) {
+        const excludes = nyc.exclude || [];
+        for (const target of targets) {
+            const excluded = excludes.includes(target);
+            record(
+                'entry-point-in-coverage',
+                `${task} -> ${target}`,
+                !excluded,
+                excluded
+                    ? `${nycPath} excludes ${target} from the coverage metric`
+                    : `${target} is measured by ${nycPath}`,
+            );
+        }
+    }
+
+    // --- DISCIPLINE 3: every declared execution handler is exercised in CI.
+    // Shipping a Node20_1 fallback that CI never runs means the agents least
+    // able to recover (older/air-gapped, no Node 24 runner) are the ones that
+    // discover a Node-20-incompatible dependency first.
+    const jobsForTask = [...ciJobs.entries()].filter(([, text]) => text.includes(task));
+    const exercised = new Set();
+    for (const [, text] of jobsForTask) {
+        for (const major of nodeMajorsIn(text)) exercised.add(major);
+    }
+    for (const handler of handlers) {
+        const m = handler.match(/^Node(\d+)(?:_\d+)?$/);
+        if (!m) {
+            record('execution-handler-exercised', `${task} -> ${handler}`, true, 'non-Node handler: not a Node-runtime discipline');
+            continue;
+        }
+        const major = parseInt(m[1], 10);
+        const ok = exercised.has(major);
+        record(
+            'execution-handler-exercised',
+            `${task} -> ${handler}`,
+            ok,
+            ok
+                ? `unit-test.yml runs Node ${major} in ${jobsForTask.map(([id]) => id).join(', ')}`
+                : `task.json declares the ${handler} handler but no unit-test.yml job for ${task} sets up Node ${major} (jobs seen: ${jobsForTask.map(([id]) => id).join(', ') || 'none'})`,
+        );
+    }
+}
+
+// --- DISCIPLINE 4: the Minor-bump rule is machine-enforced, in depth.
+// ADO agents cache tasks by Major.Minor: a security fix published without a
+// Minor bump reaches the Marketplace but never a running agent. Three layers,
+// because the first two are advisory-in-practice (a broken auto-bump workflow
+// is invisible; a merge gate can be bypassed by an admin merge).
+{
+    const workflowsDir = path.join(repoRoot, '.github', 'workflows');
+    const workflowTexts = walkFiles(workflowsDir, (n) => n.endsWith('.yml') || n.endsWith('.yaml'))
+        .map((f) => ({ name: path.basename(f), text: fs.readFileSync(f, 'utf8') }));
+    const prChecks = readIfExists('.github/workflows/pr-checks.yml') || '';
+    const releaseYml = readIfExists('.github/workflows/release.yml') || '';
+
+    const layers = [
+        {
+            name: 'script',
+            ok: fs.existsSync(path.join(repoRoot, 'scripts', 'check-minor-bumps.js')),
+            detail: 'scripts/check-minor-bumps.js must exist (the rule itself)',
+        },
+        {
+            name: 'auto-bump-workflow',
+            ok: workflowTexts.some((w) => w.text.includes('bump-minor-versions.js')),
+            detail: 'a workflow must run scripts/bump-minor-versions.js on the Release PR',
+        },
+        {
+            name: 'pr-merge-gate',
+            ok: prChecks.includes('check-minor-bumps.js'),
+            detail: '.github/workflows/pr-checks.yml must run scripts/check-minor-bumps.js as a merge gate',
+        },
+        {
+            name: 'tag-time-guard',
+            ok: releaseYml.includes('check-minor-bumps.js'),
+            detail: '.github/workflows/release.yml must run scripts/check-minor-bumps.js before it builds',
+        },
+    ];
+    for (const layer of layers) {
+        record('minor-bump-enforced', `repo -> ${layer.name}`, layer.ok, layer.detail);
+    }
+}
+
+// --- DISCIPLINE 5: the Marketplace publish is resilient and keeps the token
+// off argv. Both are release-pipeline rules that were previously only comments.
+{
+    const releaseYml = readIfExists('.github/workflows/release.yml') || '';
+    const publishJobs = [...parseJobs(releaseYml).entries()].filter(
+        ([, text]) => /tfx\s+extension\s+publish|publish-marketplace\.js/.test(text),
+    );
+    if (publishJobs.length === 0) {
+        record('marketplace-publish-retry', 'release.yml -> publish job', false, 'no job in release.yml publishes the extension; the signature cannot verify the publish disciplines');
+    }
+    for (const [jobId, text] of publishJobs) {
+        const viaWrapper = text.includes('scripts/publish-marketplace.js');
+        record(
+            'marketplace-publish-retry',
+            `release.yml -> ${jobId}`,
+            viaWrapper,
+            viaWrapper
+                ? 'publishes through scripts/publish-marketplace.js (bounded retry on transient upstream failures)'
+                : 'invokes tfx directly with no bounded retry: one transient 5xx/timeout burns the release and orphans the draft (v1.2.7)',
+        );
+        const tokenOnArgv = /--token\s+["'$]/.test(text);
+        record(
+            'marketplace-token-off-argv',
+            `release.yml -> ${jobId}`,
+            !tokenOnArgv,
+            tokenOnArgv
+                ? 'the minted Entra token is passed as a CLI argument, exposing it in /proc/<pid>/cmdline for the process lifetime (CWE-214)'
+                : 'the token is not passed on argv',
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Report + exemption reconciliation
+// ---------------------------------------------------------------------------
+let failed = false;
+const usedExemptions = new Set();
+const byCheck = new Map();
+for (const f of findings) {
+    if (!byCheck.has(f.check)) byCheck.set(f.check, []);
+    byCheck.get(f.check).push(f);
+}
+
+for (const [check, rows] of byCheck) {
+    console.log(`\n[${check}]`);
+    for (const row of rows) {
+        const key = `${check}::${row.site}`;
+        const exemption = EXEMPTIONS[key];
+        if (row.ok) {
+            if (exemption) {
+                // Bidirectional: a stale exemption is itself a finding, so the
+                // table cannot outlive the reason it was added.
+                console.error(`  STALE-EXEMPTION ${row.site}: now passes, but is still exempted ("${exemption}"). Remove the EXEMPTIONS entry.`);
+                usedExemptions.add(key);
+                failed = true;
+            } else {
+                console.log(`  OK   ${row.site}: ${row.detail}`);
+            }
+            continue;
+        }
+        if (exemption) {
+            usedExemptions.add(key);
+            console.log(`  EXEMPT ${row.site}: ${row.detail} — exempted: ${exemption}`);
+            continue;
+        }
+        console.error(`  FAIL ${row.site}: ${row.detail}`);
+        failed = true;
+    }
+}
+
+for (const key of Object.keys(EXEMPTIONS)) {
+    if (!usedExemptions.has(key)) {
+        console.error(`\nFAIL: EXEMPTIONS has an entry for '${key}', but the signature enumerated no such site. Remove it (the site was renamed or deleted).`);
+        failed = true;
+    }
+}
+
+if (failed) {
+    console.error(
+        '\ncheck-enforced-disciplines: FAILED. A rule this project relies on is documented or declared but not enforced. ' +
+        'Enforce it (add the CI leg / the test / the guard) or add a justified EXEMPTIONS entry.',
+    );
+    process.exit(1);
+}
+
+console.log(`\ncheck-enforced-disciplines: all ${findings.length} enumerated disciplines are enforced (${tasks.length} task(s)).`);

--- a/scripts/publish-marketplace.js
+++ b/scripts/publish-marketplace.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Publishes the packaged .vsix to the VS Marketplace via tfx-cli, with the two
+// release-pipeline disciplines that were previously only comments in
+// release.yml enforced by construction:
+//
+//   1. THE TOKEN NEVER TOUCHES argv. tfx is spawned with --auth-type pat and NO
+//      --token, so it prompts for the token on stdin; the minted Entra access
+//      token is written to that stdin pipe. `::add-mask::` only redacts log
+//      output -- a token on argv is readable in /proc/<pid>/cmdline by anything
+//      else running in the job for the lifetime of the process (CWE-214, #109).
+//
+//   2. A TRANSIENT UPSTREAM FAILURE DOES NOT BURN THE RELEASE. v1.2.7's publish
+//      died on a single HTTP 503 from the Marketplace; with no retry the release
+//      job failed and left an orphaned draft GitHub Release behind. Retries are
+//      bounded and classify the failure: only transport/5xx/429 output is
+//      retried, never a deterministic rejection (bad manifest, auth failure,
+//      duplicate version), so a genuine error still fails fast.
+//
+//      Retrying a publish is only safe because of the "already published"
+//      handling below: if attempt N actually reached the Marketplace but the
+//      response was lost, attempt N+1 sees "already exists" and completes
+//      successfully rather than failing the release a second time. That check is
+//      deliberately gated on attempt >= 2, so publishing a version that really
+//      was already published still fails on a first attempt.
+//
+// This runs INSIDE the `marketplace` environment job; it does not change, skip
+// or weaken that environment's required-reviewer approval or its deployment
+// branch/ref policy -- those gate the job, and this is a step within it.
+//
+// Usage: node scripts/publish-marketplace.js --vsix <file> [--tfx <path>]
+//   MARKETPLACE_TOKEN       (required) the token to feed tfx on stdin
+//   PUBLISH_MAX_ATTEMPTS    default 4
+//   PUBLISH_RETRY_BASE_MS   default 5000 (exponential: base * 2^(attempt-1))
+
+const { spawn } = require('child_process');
+
+function arg(name) {
+    const i = process.argv.indexOf(name);
+    return i === -1 ? undefined : process.argv[i + 1];
+}
+
+const vsix = arg('--vsix');
+const tfx = arg('--tfx') || './node_modules/.bin/tfx';
+const token = process.env.MARKETPLACE_TOKEN;
+const maxAttempts = parseInt(process.env.PUBLISH_MAX_ATTEMPTS || '4', 10);
+const baseDelayMs = parseInt(process.env.PUBLISH_RETRY_BASE_MS || '5000', 10);
+
+// Transient: worth another attempt. Status codes are matched with explicit
+// non-digit boundaries so a version string like "1.503.0" cannot look like a 503.
+const TRANSIENT = /(?:^|[^\d.])(?:429|500|502|503|504)(?![\d.])|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|ECONNREFUSED|EPIPE|socket hang up|Service Unavailable|Bad Gateway|Gateway Time-?out|Internal Server Error|TooManyRequests|Too Many Requests|request timed out|network (?:error|timeout)/i;
+
+// The version is already on the Marketplace. Only meaningful on a RETRY, where
+// it means a previous attempt succeeded upstream and we lost the response.
+const ALREADY_PUBLISHED = /already exists|already been published|already published|version .{0,40}\bexists\b/i;
+
+function fail(message) {
+    console.error(`publish-marketplace: ${message}`);
+    process.exit(1);
+}
+
+if (!vsix) fail('missing --vsix <file>');
+if (!token) fail('MARKETPLACE_TOKEN is not set (the token is supplied via the environment and forwarded on stdin, never on argv)');
+if (!Number.isInteger(maxAttempts) || maxAttempts < 1) fail(`PUBLISH_MAX_ATTEMPTS must be a positive integer, got '${process.env.PUBLISH_MAX_ATTEMPTS}'`);
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * One tfx publish attempt. Resolves { code, output } — output is the combined
+ * stdout+stderr, which is also streamed through to this process's own streams so
+ * the job log still shows tfx's progress live.
+ */
+function publishOnce() {
+    return new Promise((resolve, reject) => {
+        // No --token here, by design: tfx-cli prompts for it on stdin when
+        // --auth-type pat is given without one.
+        const child = spawn(tfx, ['extension', 'publish', '--vsix', vsix, '--auth-type', 'pat'], {
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        let output = '';
+        child.stdout.on('data', (chunk) => { output += chunk; process.stdout.write(chunk); });
+        child.stderr.on('data', (chunk) => { output += chunk; process.stderr.write(chunk); });
+        child.on('error', reject);
+        child.on('close', (code) => resolve({ code: code === null ? 1 : code, output }));
+        child.stdin.on('error', () => { /* tfx may exit before reading stdin; the close handler decides the outcome */ });
+        child.stdin.end(`${token}\n`);
+    });
+}
+
+async function main() {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        console.log(`publish-marketplace: attempt ${attempt}/${maxAttempts}`);
+        const { code, output } = await publishOnce();
+
+        if (code === 0) {
+            console.log(`publish-marketplace: published on attempt ${attempt}.`);
+            return 0;
+        }
+
+        if (attempt > 1 && ALREADY_PUBLISHED.test(output)) {
+            console.log(
+                `publish-marketplace: attempt ${attempt} reports the version is already published — ` +
+                'a previous attempt reached the Marketplace and its response was lost. Treating the publish as complete.',
+            );
+            return 0;
+        }
+
+        if (!TRANSIENT.test(output)) {
+            console.error(`publish-marketplace: attempt ${attempt} failed with a non-retryable error (exit ${code}). Not retrying.`);
+            return code || 1;
+        }
+
+        if (attempt === maxAttempts) {
+            console.error(`publish-marketplace: attempt ${attempt} failed with a transient error and no attempts remain (exit ${code}).`);
+            return code || 1;
+        }
+
+        const delay = baseDelayMs * 2 ** (attempt - 1);
+        console.error(`publish-marketplace: attempt ${attempt} failed with a transient error (exit ${code}); retrying in ${delay}ms.`);
+        await sleep(delay);
+    }
+    /* c8 ignore next */
+    return 1;
+}
+
+main().then((code) => process.exit(code), (err) => fail(err instanceof Error ? err.message : String(err)));

--- a/scripts/test-check-enforced-disciplines.js
+++ b/scripts/test-check-enforced-disciplines.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// Table-driven self-test for scripts/check-enforced-disciplines.js — the
+// signature for the "documented-but-unenforced discipline" defect class.
+//
+// The whole point of that signature is to make a rule fail loudly instead of
+// depending on someone remembering it, so a signature that cannot itself be
+// SEEN failing is the same defect one level up. Every row below builds a
+// throwaway repo, violates exactly ONE discipline, and asserts the signature
+// exits non-zero naming that site — and the baseline row asserts a fully
+// compliant repo exits 0, so the rows are not passing because the script fails
+// on everything.
+//
+// The fixture is a miniature of the real repo layout (Tasks/<Family>/<Version>/
+// task.json + src + Tests, .github/workflows/{unit-test,pr-checks,release}.yml,
+// scripts/check-minor-bumps.js), which is why one `mutate` function per row is
+// enough to express a violation.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'check-enforced-disciplines.js');
+const libPath = path.join(repoRoot, 'scripts', 'lib', 'task-dirs.js');
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-enforced-disciplines-selftest-'));
+
+const TASK = 'Tasks/DemoTask/DemoTaskV1';
+let failed = false;
+
+function write(root, rel, content) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+}
+
+/** A fixture repo in which every enumerated discipline is enforced. */
+function makeCompliantRepo(name) {
+    const root = path.join(scratchDir, name);
+    // The signature requires its own scripts/lib/task-dirs.js next to it.
+    write(root, 'scripts/check-enforced-disciplines.js', fs.readFileSync(scriptPath, 'utf8'));
+    write(root, 'scripts/lib/task-dirs.js', fs.readFileSync(libPath, 'utf8'));
+    write(root, 'scripts/check-minor-bumps.js', '// stub: presence is what the signature checks\n');
+    write(root, 'scripts/bump-minor-versions.js', '// stub\n');
+    write(root, 'scripts/publish-marketplace.js', '// stub\n');
+
+    write(root, `${TASK}/task.json`, JSON.stringify({
+        id: 'demo',
+        version: { Major: 1, Minor: 2, Patch: 0 },
+        execution: { Node24: { target: 'src/index.js' }, Node20_1: { target: 'src/index.js' } },
+    }, null, 2));
+    write(root, `${TASK}/src/index.ts`, 'export const demo = 1;\n');
+    write(root, `${TASK}/.nycrc.json`, JSON.stringify({ exclude: ['src/**/*.d.ts'] }, null, 2));
+    write(root, `${TASK}/Tests/EntryPointL0.ts`, "import '../src/index';\n");
+
+    write(root, '.github/workflows/unit-test.yml', `---
+name: CI
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  build-and-test-demo:
+    name: Build and Test Demo
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${TASK}
+    steps:
+      - uses: actions/setup-node@v0
+        with:
+          node-version: "24"
+      - run: npm test
+      - uses: actions/setup-node@v0
+        with:
+          node-version: "20"
+      - run: node src/index.js
+`);
+    write(root, '.github/workflows/pr-checks.yml', `---
+name: PR Checks
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  release-pr-minor-bumps:
+    name: Release PR Minor Bumps
+    runs-on: ubuntu-latest
+    steps:
+      - run: node scripts/check-minor-bumps.js
+`);
+    write(root, '.github/workflows/release-pr-minor-bumps.yml', `---
+name: Auto-bump
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  auto-bump:
+    name: Auto-bump
+    runs-on: ubuntu-latest
+    steps:
+      - run: node scripts/bump-minor-versions.js
+`);
+    write(root, '.github/workflows/release.yml', `---
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  guard:
+    name: Guard
+    runs-on: ubuntu-latest
+    steps:
+      - run: node scripts/check-minor-bumps.js
+  publish-marketplace:
+    name: Publish to VS Marketplace
+    runs-on: ubuntu-latest
+    environment: marketplace
+    steps:
+      - run: node scripts/publish-marketplace.js --vsix "$VSIX_FILE"
+`);
+    return root;
+}
+
+function runSignature(root) {
+    const res = spawnSync(process.execPath, [path.join(root, 'scripts', 'check-enforced-disciplines.js'), root], { encoding: 'utf8' });
+    return { status: res.status, out: `${res.stdout}${res.stderr}` };
+}
+
+function check(cond, okMsg, failMsg, extra) {
+    if (cond) {
+        console.log(`OK: ${okMsg}`);
+    } else {
+        console.error(`FAIL: ${failMsg}`);
+        if (extra !== undefined) console.error(extra);
+        failed = true;
+    }
+}
+
+// Each row inverts ONE discipline. `expect` is a substring the failure output
+// must contain, so a row cannot pass on an unrelated failure.
+const CASES = [
+    {
+        name: 'entry-point-exercised',
+        why: 'a task whose declared execution target no test ever loads',
+        mutate: (root) => fs.rmSync(path.join(root, TASK, 'Tests', 'EntryPointL0.ts')),
+        expect: 'the execution entry point is never loaded by any test',
+    },
+    {
+        name: 'entry-point-in-coverage',
+        why: 'a task that carves its entry point out of the coverage metric',
+        mutate: (root) => write(root, `${TASK}/.nycrc.json`, JSON.stringify({ exclude: ['src/**/*.d.ts', 'src/index.js'] }, null, 2)),
+        expect: 'excludes src/index.js from the coverage metric',
+    },
+    {
+        name: 'execution-handler-exercised',
+        why: 'a declared Node20_1 fallback handler that no CI job ever runs',
+        mutate: (root) => {
+            const p = path.join(root, '.github/workflows/unit-test.yml');
+            fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace('          node-version: "20"\n      - run: node src/index.js\n', ''));
+        },
+        expect: 'declares the Node20_1 handler but no unit-test.yml job',
+    },
+    {
+        name: 'minor-bump-enforced/script',
+        why: 'the Minor-bump rule with no script implementing it',
+        mutate: (root) => fs.rmSync(path.join(root, 'scripts', 'check-minor-bumps.js')),
+        expect: 'scripts/check-minor-bumps.js must exist',
+    },
+    {
+        name: 'minor-bump-enforced/auto-bump-workflow',
+        why: 'the Minor bumps left to a human to apply on the Release PR',
+        mutate: (root) => fs.rmSync(path.join(root, '.github/workflows/release-pr-minor-bumps.yml')),
+        expect: 'must run scripts/bump-minor-versions.js on the Release PR',
+    },
+    {
+        name: 'minor-bump-enforced/pr-merge-gate',
+        why: 'a Release PR that can merge without the bumps',
+        mutate: (root) => {
+            const p = path.join(root, '.github/workflows/pr-checks.yml');
+            fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace('node scripts/check-minor-bumps.js', 'echo skip'));
+        },
+        expect: 'pr-checks.yml must run scripts/check-minor-bumps.js as a merge gate',
+    },
+    {
+        name: 'minor-bump-enforced/tag-time-guard',
+        why: 'a tag that can build and publish without the bumps',
+        mutate: (root) => {
+            const p = path.join(root, '.github/workflows/release.yml');
+            fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace('      - run: node scripts/check-minor-bumps.js\n', '      - run: echo skip\n'));
+        },
+        expect: 'release.yml must run scripts/check-minor-bumps.js before it builds',
+    },
+    {
+        name: 'marketplace-publish-retry',
+        why: 'a publish with no bounded retry (the v1.2.7 503 that burned a release)',
+        mutate: (root) => {
+            const p = path.join(root, '.github/workflows/release.yml');
+            fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace(
+                '      - run: node scripts/publish-marketplace.js --vsix "$VSIX_FILE"',
+                '      - run: ./node_modules/.bin/tfx extension publish --vsix "$VSIX_FILE" --auth-type pat',
+            ));
+        },
+        expect: 'no bounded retry',
+    },
+    {
+        name: 'marketplace-token-off-argv',
+        why: 'the minted Entra token passed to tfx as a CLI argument',
+        mutate: (root) => {
+            const p = path.join(root, '.github/workflows/release.yml');
+            fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace(
+                '      - run: node scripts/publish-marketplace.js --vsix "$VSIX_FILE"',
+                '      - run: ./node_modules/.bin/tfx extension publish --vsix "$VSIX_FILE" --auth-type pat --token "$ENTRA_TOKEN"',
+            ));
+        },
+        expect: 'passed as a CLI argument',
+    },
+];
+
+try {
+    // Baseline: a compliant fixture must PASS, or every row below is vacuous.
+    {
+        const root = makeCompliantRepo('compliant');
+        const { status, out } = runSignature(root);
+        check(status === 0, 'a fully compliant repo passes the signature', `the compliant baseline fixture failed (exit ${status})`, out);
+    }
+
+    for (const c of CASES) {
+        const root = makeCompliantRepo(c.name.replace(/\//g, '-'));
+        c.mutate(root);
+        const { status, out } = runSignature(root);
+        check(
+            status !== 0 && out.includes(c.expect),
+            `${c.name}: the signature fires on ${c.why}`,
+            `${c.name}: expected a non-zero exit mentioning '${c.expect}', got exit ${status}`,
+            out,
+        );
+    }
+
+    // An empty universe must not pass silently: a signature that enumerates
+    // nothing is indistinguishable from one that found no problems.
+    {
+        const root = path.join(scratchDir, 'no-tasks');
+        write(root, 'scripts/check-enforced-disciplines.js', fs.readFileSync(scriptPath, 'utf8'));
+        write(root, 'scripts/lib/task-dirs.js', fs.readFileSync(libPath, 'utf8'));
+        const { status, out } = runSignature(root);
+        check(
+            status !== 0 && out.includes('empty universe'),
+            'a repo with no task directories fails rather than trivially passing',
+            `expected a non-zero exit on an empty universe, got exit ${status}`,
+            out,
+        );
+    }
+} finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+}
+
+if (failed) {
+    console.error('\ncheck-enforced-disciplines.js self-test: FAILED.');
+    process.exit(1);
+}
+console.log('\ncheck-enforced-disciplines.js self-test: all cases passed.');

--- a/scripts/test-publish-marketplace.js
+++ b/scripts/test-publish-marketplace.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Table-driven self-test for scripts/publish-marketplace.js.
+//
+// A retry wrapper nobody has watched fail is not a guard, so every row below
+// drives the REAL script against a fake `tfx` that records how it was invoked
+// and can be scripted to fail transiently, fail permanently, or succeed. The
+// rows assert the two disciplines the wrapper exists to enforce -- the token
+// arrives on stdin and never on argv, and a transient upstream failure is
+// retried while a deterministic one is not -- plus the attempt counts, so a
+// change that silently stops retrying (or starts retrying a hard rejection)
+// goes red here.
+//
+// Runs with PUBLISH_RETRY_BASE_MS=0 so the backoff does not slow CI down; the
+// backoff arithmetic itself is not under test, the retry DECISIONS are.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'publish-marketplace.js');
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'publish-marketplace-selftest-'));
+const TOKEN = 'fake-entra-access-token-value';
+
+let failed = false;
+
+function check(cond, okMsg, failMsg, extra) {
+    if (cond) {
+        console.log(`OK: ${okMsg}`);
+    } else {
+        console.error(`FAIL: ${failMsg}`);
+        if (extra !== undefined) console.error(extra);
+        failed = true;
+    }
+}
+
+/**
+ * Writes a fake tfx that appends one JSON line per invocation (argv + the stdin
+ * it received) to `logFile`, then emits `script[n]` for its nth invocation.
+ * Each entry is { out, code }.
+ */
+function makeFakeTfx(dir, logFile, script) {
+    const file = path.join(dir, 'fake-tfx.js');
+    fs.writeFileSync(
+        file,
+        `#!/usr/bin/env node
+const fs = require('fs');
+const logFile = ${JSON.stringify(logFile)};
+const script = ${JSON.stringify(script)};
+let stdin = '';
+process.stdin.on('data', (c) => { stdin += c; });
+process.stdin.on('end', () => {
+  const priorCalls = fs.existsSync(logFile) ? fs.readFileSync(logFile, 'utf8').split('\\n').filter(Boolean).length : 0;
+  fs.appendFileSync(logFile, JSON.stringify({ argv: process.argv.slice(2), stdin }) + '\\n');
+  const step = script[Math.min(priorCalls, script.length - 1)];
+  process.stdout.write(step.out + '\\n');
+  process.exit(step.code);
+});
+`,
+        { mode: 0o755 },
+    );
+    return file;
+}
+
+function run(name, script, env = {}) {
+    const dir = fs.mkdtempSync(path.join(scratchDir, `${name}-`));
+    const logFile = path.join(dir, 'calls.jsonl');
+    const tfx = makeFakeTfx(dir, logFile, script);
+    const res = spawnSync(
+        process.execPath,
+        [scriptPath, '--vsix', path.join(dir, 'fake.vsix'), '--tfx', tfx],
+        {
+            encoding: 'utf8',
+            env: {
+                ...process.env,
+                MARKETPLACE_TOKEN: TOKEN,
+                PUBLISH_RETRY_BASE_MS: '0',
+                PUBLISH_MAX_ATTEMPTS: '3',
+                ...env,
+            },
+        },
+    );
+    const calls = fs.existsSync(logFile)
+        ? fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l))
+        : [];
+    return { res, calls, out: `${res.stdout}${res.stderr}` };
+}
+
+const OK = { out: 'Extension published successfully', code: 0 };
+const TRANSIENT_503 = { out: 'Error: Request failed with status code 503 Service Unavailable', code: 1 };
+const TRANSIENT_RESET = { out: 'Error: read ECONNRESET', code: 1 };
+const PERMANENT = { out: 'Error: TF400898: manifest is invalid: missing publisher', code: 1 };
+const ALREADY = { out: 'Error: The extension version 1.2.7 already exists.', code: 1 };
+
+// Each row is one enumerated behaviour of the wrapper.
+const CASES = [
+    {
+        name: 'success-first-attempt',
+        script: [OK],
+        expectExit: 0,
+        expectCalls: 1,
+        why: 'a clean publish runs tfx exactly once',
+    },
+    {
+        name: 'transient-then-success',
+        script: [TRANSIENT_503, OK],
+        expectExit: 0,
+        expectCalls: 2,
+        why: 'a transient 503 (the v1.2.7 failure) is retried and the release completes',
+    },
+    {
+        name: 'transient-transport-then-success',
+        script: [TRANSIENT_RESET, OK],
+        expectExit: 0,
+        expectCalls: 2,
+        why: 'a transport-level failure (ECONNRESET) is retried too, not just HTTP 5xx',
+    },
+    {
+        name: 'transient-exhausted',
+        script: [TRANSIENT_503],
+        expectExit: 1,
+        expectCalls: 3,
+        why: 'retries are BOUNDED: PUBLISH_MAX_ATTEMPTS attempts, then the release fails',
+    },
+    {
+        name: 'permanent-not-retried',
+        script: [PERMANENT, OK],
+        expectExit: 1,
+        expectCalls: 1,
+        why: 'a deterministic rejection (invalid manifest) fails fast and is NEVER retried',
+    },
+    {
+        name: 'already-published-after-retry',
+        script: [TRANSIENT_503, ALREADY],
+        expectExit: 0,
+        expectCalls: 2,
+        why: 'a retry that finds the version already published means the lost first response succeeded',
+    },
+    {
+        name: 'already-published-first-attempt',
+        script: [ALREADY],
+        expectExit: 1,
+        expectCalls: 1,
+        why: 'the same message on the FIRST attempt is a real duplicate-version error and still fails',
+    },
+];
+
+try {
+    for (const c of CASES) {
+        const { res, calls, out } = run(c.name, c.script);
+        check(
+            res.status === c.expectExit && calls.length === c.expectCalls,
+            `${c.name}: exit ${res.status}, ${calls.length} tfx invocation(s) — ${c.why}`,
+            `${c.name}: expected exit ${c.expectExit} and ${c.expectCalls} invocation(s), got exit ${res.status} and ${calls.length}`,
+            out,
+        );
+        for (const call of calls) {
+            check(
+                !call.argv.some((a) => a.includes(TOKEN)),
+                `${c.name}: the token never appears on tfx's argv (${call.argv.join(' ')})`,
+                `${c.name}: the token LEAKED onto tfx's argv: ${call.argv.join(' ')}`,
+            );
+            check(
+                call.stdin.trim() === TOKEN,
+                `${c.name}: the token is delivered on tfx's stdin`,
+                `${c.name}: expected the token on stdin, got '${call.stdin.trim()}'`,
+            );
+            check(
+                !call.argv.includes('--token'),
+                `${c.name}: tfx is invoked without --token, so it prompts on stdin`,
+                `${c.name}: tfx was invoked with --token`,
+            );
+        }
+    }
+
+    // A missing token must fail before tfx is ever spawned.
+    {
+        const dir = fs.mkdtempSync(path.join(scratchDir, 'no-token-'));
+        const logFile = path.join(dir, 'calls.jsonl');
+        const tfx = makeFakeTfx(dir, logFile, [OK]);
+        const env = { ...process.env, PUBLISH_RETRY_BASE_MS: '0' };
+        delete env.MARKETPLACE_TOKEN;
+        const res = spawnSync(process.execPath, [scriptPath, '--vsix', 'fake.vsix', '--tfx', tfx], { encoding: 'utf8', env });
+        check(
+            res.status !== 0 && !fs.existsSync(logFile),
+            'missing MARKETPLACE_TOKEN: fails before tfx is spawned',
+            `missing MARKETPLACE_TOKEN: expected a non-zero exit and no tfx invocation, got exit ${res.status}`,
+            `${res.stdout}${res.stderr}`,
+        );
+    }
+} finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+}
+
+if (failed) {
+    console.error('\npublish-marketplace.js self-test: FAILED.');
+    process.exit(1);
+}
+console.log('\npublish-marketplace.js self-test: all cases passed.');


### PR DESCRIPTION
Cross-repo half of a class remediated in the sibling packer extension (sethbacon/azure-pipelines-packer#230).

This repo was already ahead on most of it — the Minor-bump layers and the per-task Node 20 load-only smoke step both exist here and were **ported to packer**, not changed here. The gaps on this side were coverage/entry-point and the publish retry.

## What was live here

**Ten tasks declared an entry point that `.nycrc.json` excluded from the coverage metric**, and four of those (`Markdown2Html`, `PolicyAgentInstaller`, `TerraformDocsInstaller`, `TerraformInstaller`) were loaded by **no test at all**. Those four now have entry-point scenarios driving the real `src/index.js` — success and fail-closed — and `src/index.js` is un-excluded in all ten, each re-measured green including the `posttest` per-file gate.

`TerraformTaskV5` was already compliant (`SignalHandlerL0.ts` loads it, and it was never excluded) — recorded as already-compliant rather than touched.

**Marketplace publishing had no retry.** The sibling lost `v1.2.7` to a transient HTTP 503 on a single-shot `tfx` invocation. Publishing now goes through `scripts/publish-marketplace.js` with bounded, classified retry (transport/5xx/429 only, never a received 4xx) and already-published reconciliation. **The `marketplace` environment approval gate is untouched.**

## The signature

`scripts/check-enforced-disciplines.js` is the executable form of the class. It fails on a task whose declared execution handler no CI job runs, whose entry point no test loads or coverage measures, on a missing Minor-bump layer, and on a publish without retry or with a token on argv. It also fails on an **empty task universe** and on a **stale exemption** (bidirectionally), so it cannot pass by enumerating nothing.

It runs as a **step inside an already-required job**, so this PR needs no branch-protection change.

Result here: **50/50 disciplines enforced across 11 tasks.**

Worth knowing for future work: this repo family uses **two spellings** for the entry-point module path — a single path literal and the `path.join(__dirname, '..', 'src', 'index.js')` segment form. The signature's first pass reported three false failures until it matched both.

## Verification

- TerraformInstaller 282, PolicyAgentInstaller 241, TerraformDocsInstaller 222, Markdown2Html 124 — all passing; all 10 un-excluded tasks re-measured green.
- The signature's self-test inverts each discipline in a fixture repo and asserts it fires on exactly that one.
- `actionlint` and `zizmor` clean.

## Two things deliberately NOT done

**No repo settings were changed** — no branch protection, rulesets, or environments. Nothing here needs a new required context.

**The actionlint/zizmor install steps were not "harmonized".** This repo downloads the release asset and verifies its published SHA256, which is stronger than packer's SHA-pinned installer script. Packer's form satisfies its issue's recommendation; converging them is a separate supply-chain decision, not a drive-by in a CI batch.

Refs sethbacon/azure-pipelines-packer#192
Refs sethbacon/azure-pipelines-packer#189
Refs sethbacon/azure-pipelines-packer#109