### PR TITLE
fix: publish outputs before failing, and validate response-derived values

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/url-secret-redaction.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/url-secret-redaction.ts
@@ -154,9 +154,20 @@ export function extractUrlUserInfoSecrets(url: string): string[] {
  * when there is no userinfo to strip.
  */
 export function redactUrlUserInfo(url: string): string {
-    const userInfo = rawUserInfo(url);
-    if (userInfo === null) return url;
-    const authorityStart = url.indexOf('://') + 3;
+    // Neutralize C0/DEL control characters BEFORE anything else. This value is
+    // echoed into pipeline output variables (packerDownloadedFrom /
+    // terraformDownloadedFrom / terraformDocsDownloadedFrom /
+    // policyAgentDownloadedFrom), and setVariable emits
+    // `##vso[task.setvariable variable=x]VALUE` -- a CR/LF inside VALUE forges a
+    // second logging command on the next line. Upstream `new URL()` validation
+    // does NOT catch it: the WHATWG parser silently STRIPS tab/CR/LF while
+    // parsing, so 'https://ex\nample.com' validates cleanly while the raw input
+    // string the callers keep passing around still carries the newline. Stripping
+    // first also keeps the index arithmetic below aligned with the value returned.
+    const safeUrl = url.replace(/[\u0000-\u001F\u007F]/g, '');
+    const userInfo = rawUserInfo(safeUrl);
+    if (userInfo === null) return safeUrl;
+    const authorityStart = safeUrl.indexOf('://') + 3;
     // authorityStart + userInfo.length points at the delimiting '@'; +1 drops it.
-    return url.slice(0, authorityStart) + url.slice(authorityStart + userInfo.length + 1);
+    return safeUrl.slice(0, authorityStart) + safeUrl.slice(authorityStart + userInfo.length + 1);
 }

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -27,6 +27,9 @@ import './RetryL0';
 // Direct unit tests for the shared html-sanitizer.ts allowlist policy and
 // sanitizeHtmlForPublish's full-document <body> extraction/splice (#820/#835).
 import './AllowlistSanitizerL0';
+// This task's behavioural rows of the cross-task output-boundary class table
+// (the structural half lives in TerraformTaskV5/Tests/OutputBoundaryClassL0.ts).
+import './OutputBoundaryClassL0';
 
 const INSTANCE = 'testinstance';
 const BASE_URL = `https://${INSTANCE}.service-now.com`;
@@ -2188,12 +2191,34 @@ describe('manifest.emitArticleOutput / findKbArticleJson', () => {
         const cwd = process.cwd();
         process.chdir(tmpDir());
         try {
-            // A number containing a path separator into a directory that does not
-            // exist makes writeFileSync throw (ENOENT) on every platform.
-            assert.doesNotThrow(() => manifest.outputArticleInfoToJson({ ...article, number: 'no-such-dir/KB0001' }));
+            // Pre-create a DIRECTORY at the target name so writeFileSync throws
+            // (EISDIR) on every platform. The previous fixture used a number
+            // containing a path separator ('no-such-dir/KB0001') to force ENOENT,
+            // but a separator-bearing number is now rejected before the write --
+            // it can never reach writeFileSync, so it would no longer exercise
+            // the failure path this test exists for. The assertion is unchanged.
+            fs.mkdirSync('KB0001.json');
+            assert.doesNotThrow(() => manifest.outputArticleInfoToJson(article));
             assert.ok(
                 capturedWarnings.some(w => /ArticleInfoSaveFailed|Error saving article information/.test(w)),
                 `expected the KB-json save failure to surface via tasks.warning: ${capturedWarnings}`,
+            );
+        } finally {
+            process.chdir(cwd);
+        }
+    });
+
+    it('a ServiceNow article number that is not a safe file name cannot steer the legacy KB-json write', () => {
+        const cwd = process.cwd();
+        const dir = tmpDir();
+        process.chdir(dir);
+        try {
+            manifest.outputArticleInfoToJson({ ...article, number: '../escaped' });
+            assert.ok(!fs.existsSync(`${dir}/../escaped.json`), 'the write must not escape the working directory');
+            assert.ok(fs.existsSync('article_info.json'), 'it must fall back to the in-directory default name');
+            assert.ok(
+                capturedWarnings.some(w => /is not a safe file name/.test(w)),
+                `expected the rejected article number to surface via tasks.warning: ${capturedWarnings}`,
             );
         } finally {
             process.chdir(cwd);

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/OutputBoundaryClassL0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/OutputBoundaryClassL0.ts
@@ -1,0 +1,102 @@
+/**
+ * Output-boundary defect class — the PublishKbArticleV1 rows.
+ *
+ * The class: "a value that originates in template-, tool- or remote-service-
+ * controlled output crosses a trust boundary (a pipeline output variable, a
+ * file path, a parsed file) without content validation or containment."
+ *
+ * These are the BEHAVIOURAL rows for this task's sinks in the cross-task class
+ * table maintained at Tasks/TerraformTask/TerraformTaskV5/Tests/
+ * OutputBoundaryClassL0.ts. They live HERE rather than there because every task
+ * directory is an independent npm package with its own node_modules, and
+ * src/manifest.ts imports `azure-pipelines-task-lib/task` — which does not
+ * resolve from TerraformTaskV5's package, so importing this module across the
+ * task boundary only ever compiled on a machine where both trees happened to be
+ * installed. V5 keeps the STRUCTURAL rows for these same three sinks (it reads
+ * this task's sources as text, which needs no import); the executable
+ * assertions are the ones below.
+ *
+ * Every row is mutation-provable: inverting that row's own guard predicate in
+ * src/manifest.ts turns that row RED and leaves the others green.
+ *
+ * Registered via Tests/L0.ts, which mocha actually runs.
+ */
+
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as nodePath from 'path';
+import { appendToManifest, outputArticleInfoToJson, sanitizeOutputVariableValue } from '../src/manifest';
+
+function classTmpDir(prefix: string): string {
+    return fs.mkdtempSync(nodePath.join(os.tmpdir(), prefix));
+}
+
+describe('Output-boundary defect class (PublishKbArticleV1 sinks: S1 output variables / S2 path writes / S4 unbounded parse)', () => {
+
+    // --- S1: pipeline output variables ------------------------------------
+
+    it('S1 setVariable(kbArticleId/kbArticleNumber/kbWorkflowState) — a ServiceNow-response field carrying CR/LF or a ##vso[ payload is rejected', () => {
+        // The console echoes of these same three fields were newline-neutralized
+        // (#693) while the sibling setVariable calls had no validation at all --
+        // "the guard exists and one sink is missing from it".
+        assert.strictEqual(
+            sanitizeOutputVariableValue('a1b2c3\n##vso[task.setvariable variable=pwned]1'),
+            null,
+            'a control-char-bearing ServiceNow value must not become an output variable',
+        );
+        assert.strictEqual(sanitizeOutputVariableValue('\r\n'), null);
+        // A cast (`article['sys_id'] as string`) is erased at runtime, so a
+        // non-string response field used to reach setVariable unchanged.
+        assert.strictEqual(sanitizeOutputVariableValue({ nested: true }), null);
+        assert.strictEqual(sanitizeOutputVariableValue('x'.repeat(1025)), null);
+        // Real values still pass.
+        assert.strictEqual(sanitizeOutputVariableValue('a1b2c3d4e5f6'), 'a1b2c3d4e5f6');
+        assert.strictEqual(sanitizeOutputVariableValue('KB0010023'), 'KB0010023');
+    });
+
+    // --- S2: path write sinks ---------------------------------------------
+
+    it('S2 outputArticleInfoToJson — a ServiceNow-supplied article number cannot steer the write out of the working directory', () => {
+        const dir = classTmpDir('kb-class-kbjson-');
+        const outside = nodePath.join(dir, 'outside');
+        const cwd = nodePath.join(dir, 'cwd');
+        fs.mkdirSync(outside);
+        fs.mkdirSync(cwd);
+        const previous = process.cwd();
+        try {
+            process.chdir(cwd);
+            outputArticleInfoToJson({ number: '../outside/pwned', sys_id: 'a1b2c3' });
+            assert.ok(!fs.existsSync(nodePath.join(outside, 'pwned.json')), 'the write must not escape the working directory');
+            assert.ok(fs.existsSync(nodePath.join(cwd, 'article_info.json')), 'it must fall back to the in-directory default name');
+        } finally {
+            process.chdir(previous);
+        }
+    });
+
+    // --- S4: unbounded parse of tool-written content ----------------------
+
+    it('S4 kb-manifest read — an over-cap manifest is never buffered or parsed', () => {
+        const dir = classTmpDir('kb-class-kbmanifest-');
+        const manifestPath = nodePath.join(dir, 'kb-manifest.json');
+        // VALID JSON, deliberately over the 5 MiB cap: an invalid blob would be
+        // rejected by JSON.parse itself and could not distinguish "the cap ran"
+        // from "the parse failed", so the mutation would survive.
+        const oversized = JSON.stringify(new Array(700_000).fill('xxxxxx'));
+        assert.ok(oversized.length > 5 * 1024 * 1024, 'fixture must exceed the cap');
+        fs.writeFileSync(manifestPath, oversized);
+
+        appendToManifest(manifestPath, { sys_id: 'new' });
+
+        // The cap rejects the read before JSON.parse, so the oversized file is
+        // preserved as a .bak and the manifest restarts with only the new entry.
+        // Without the cap it would parse cleanly and keep all 700k entries.
+        const entries = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        assert.strictEqual(entries.length, 1, 'an over-cap manifest must not be parsed and re-serialized');
+        assert.ok(
+            fs.readdirSync(dir).some((f) => f.includes('.corrupt-') && f.endsWith('.bak')),
+            'the unread oversized manifest must be preserved as a .bak, never silently discarded',
+        );
+    });
+});

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
@@ -10,7 +10,7 @@ import {
     findArticleBySourceKey,
 } from './servicenow-client';
 import { validateHtmlContent, readHtmlFile, sanitizeHtmlForPublish } from './html-validate';
-import { emitArticleOutput, findKbArticleJson, readFrontMatterKey, sanitizeForSingleLineEcho } from './manifest';
+import { emitArticleOutput, findKbArticleJson, readFrontMatterKey, sanitizeForSingleLineEcho, sanitizeOutputVariableValue } from './manifest';
 import { DryRunPlan, PlannedAction, formatDryRunReport } from './dry-run';
 import { processArticleImages } from './attachments';
 import { updateArticleBody } from './servicenow-client';
@@ -356,9 +356,24 @@ async function run() {
         // -----------------------------------------------------------------
         emitArticleOutput(article, sourceKey, emitManifest, kbId);
 
-        tasks.setVariable('kbArticleId', article['sys_id'] as string, false, true);
-        tasks.setVariable('kbArticleNumber', article['number'] as string, false, true);
-        tasks.setVariable('kbWorkflowState', article['workflow_state'] as string, false, true);
+        // The console echoes above were newline-neutralized (#693) but these three
+        // sibling output variables -- the SAME ServiceNow-response fields -- went
+        // to setVariable raw. Route them through the output-variable guard so a
+        // response field carrying CR/LF (or a non-string value the `as string`
+        // cast silently accepted) can never forge a `##vso[...]` logging command
+        // or land unvalidated in a downstream `$(kbArticleId)` expansion.
+        for (const [variableName, field] of [
+            ['kbArticleId', 'sys_id'],
+            ['kbArticleNumber', 'number'],
+            ['kbWorkflowState', 'workflow_state'],
+        ] as const) {
+            const safeValue = sanitizeOutputVariableValue(article[field]);
+            if (safeValue === null) {
+                tasks.warning(`ServiceNow response field '${field}' failed output-variable validation (length/printable-ASCII); skipping the ${variableName} output variable.`);
+                continue;
+            }
+            tasks.setVariable(variableName, safeValue, false, true);
+        }
 
         // -----------------------------------------------------------------
         // Phase 2: upload referenced images as attachments and rewrite the body.

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/manifest.ts
@@ -17,6 +17,34 @@ export function sanitizeForSingleLineEcho(value: string): string {
     return value.replace(/\r\n|[\r\n\u2028\u2029]/g, ' ');
 }
 
+/** Upper bound on a ServiceNow-supplied value before it becomes a pipeline output variable. */
+const OUTPUT_VAR_MAX_LENGTH = 1024;
+
+/**
+ * The output-variable counterpart of sanitizeForSingleLineEcho.
+ *
+ * sanitizeForSingleLineEcho only ever guarded the console ECHO of sys_id /
+ * number / workflow_state; the sibling `tasks.setVariable` calls for the same
+ * three ServiceNow-response fields had no validation at all, not even the
+ * `as string` cast they carried (a cast is erased at runtime -- a JSON object
+ * or number in that field reached setVariable unchanged). An ADO output
+ * variable is a real trust boundary: it is emitted as
+ * `##vso[task.setvariable variable=x]VALUE` and later steps macro-expand
+ * `$(x)` into scripts, so a CR/LF in VALUE forges a second logging command and
+ * the raw value lands in a shell. Caps length and requires printable ASCII,
+ * matching BasePackerCommandHandler/BaseTerraformCommandHandler's guard of the
+ * same name. Returns null (caller skips the variable) when validation fails.
+ */
+export function sanitizeOutputVariableValue(value: unknown): string | null {
+    if (typeof value !== 'string' && typeof value !== 'number') return null;
+    const text = String(value);
+    if (!text || text.length > OUTPUT_VAR_MAX_LENGTH) return null;
+    return /^[\x20-\x7E]+$/.test(text) ? text : null;
+}
+
+/** Upper bound on a kb-manifest file before it is read into memory and parsed. */
+const MANIFEST_MAX_BYTES = 5 * 1024 * 1024;
+
 /** Append an article entry to the kb-manifest JSON file. */
 export function appendToManifest(manifestPath: string, entry: Record<string, unknown>): void {
     let entries: unknown[] = [];
@@ -32,6 +60,15 @@ export function appendToManifest(manifestPath: string, entry: Record<string, unk
     }
     if (fd !== undefined) {
         try {
+            // Bound the read before buffering it whole: the descriptor points at an
+            // operator-chosen path, so the file is not necessarily this task's own
+            // manifest. fstat (not stat) so the size is measured on the SAME
+            // descriptor that is about to be read, preserving the TOCTOU property
+            // the openSync above exists for. A real manifest is a few KB.
+            const size = fs.fstatSync(fd).size;
+            if (size > MANIFEST_MAX_BYTES) {
+                throw new Error(`manifest ${manifestPath} is ${size} bytes, above the ${MANIFEST_MAX_BYTES}-byte cap`);
+            }
             entries = JSON.parse(fs.readFileSync(fd, 'utf-8'));
         } catch (e: unknown) {
             // The manifest exists but is unreadable/corrupt. Do NOT silently reset it
@@ -66,7 +103,19 @@ export function appendToManifest(manifestPath: string, entry: Record<string, unk
 
 /** Write article info to a KB<number>.json file (legacy mode). */
 export function outputArticleInfoToJson(article: Record<string, unknown>): void {
-    const number = (article['number'] as string) || 'article_info';
+    // `number` comes straight from the ServiceNow response and is used here as a
+    // FILE PATH relative to the working directory. Unvalidated, a response field
+    // of the form '../../evil' (or one carrying a separator or NUL) would steer
+    // this write outside the working directory entirely. Constrain it to the
+    // shape the task's own reader can find again -- KB_ARTICLE_JSON_NAME_RE
+    // below only ever matches `KB<...>.json` / `article_info.json` in the
+    // current directory -- so anything else is not merely unsafe, it is a file
+    // findKbArticleJson could never resolve.
+    const rawNumber = (article['number'] as string) || 'article_info';
+    const number = /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(rawNumber) ? rawNumber : 'article_info';
+    if (number !== rawNumber) {
+        tasks.warning(`ServiceNow article number '${sanitizeForSingleLineEcho(String(rawNumber))}' is not a safe file name; writing article_info.json instead.`);
+    }
     const filename = `${number}.json`;
     const info = {
         article_id: article['sys_id'],

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/url-secret-redaction.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/url-secret-redaction.ts
@@ -154,9 +154,20 @@ export function extractUrlUserInfoSecrets(url: string): string[] {
  * when there is no userinfo to strip.
  */
 export function redactUrlUserInfo(url: string): string {
-    const userInfo = rawUserInfo(url);
-    if (userInfo === null) return url;
-    const authorityStart = url.indexOf('://') + 3;
+    // Neutralize C0/DEL control characters BEFORE anything else. This value is
+    // echoed into pipeline output variables (packerDownloadedFrom /
+    // terraformDownloadedFrom / terraformDocsDownloadedFrom /
+    // policyAgentDownloadedFrom), and setVariable emits
+    // `##vso[task.setvariable variable=x]VALUE` -- a CR/LF inside VALUE forges a
+    // second logging command on the next line. Upstream `new URL()` validation
+    // does NOT catch it: the WHATWG parser silently STRIPS tab/CR/LF while
+    // parsing, so 'https://ex\nample.com' validates cleanly while the raw input
+    // string the callers keep passing around still carries the newline. Stripping
+    // first also keeps the index arithmetic below aligned with the value returned.
+    const safeUrl = url.replace(/[\u0000-\u001F\u007F]/g, '');
+    const userInfo = rawUserInfo(safeUrl);
+    if (userInfo === null) return safeUrl;
+    const authorityStart = safeUrl.indexOf('://') + 3;
     // authorityStart + userInfo.length points at the delimiting '@'; +1 drops it.
-    return url.slice(0, authorityStart) + url.slice(authorityStart + userInfo.length + 1);
+    return safeUrl.slice(0, authorityStart) + safeUrl.slice(authorityStart + userInfo.length + 1);
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/url-secret-redaction.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/url-secret-redaction.ts
@@ -154,9 +154,20 @@ export function extractUrlUserInfoSecrets(url: string): string[] {
  * when there is no userinfo to strip.
  */
 export function redactUrlUserInfo(url: string): string {
-    const userInfo = rawUserInfo(url);
-    if (userInfo === null) return url;
-    const authorityStart = url.indexOf('://') + 3;
+    // Neutralize C0/DEL control characters BEFORE anything else. This value is
+    // echoed into pipeline output variables (packerDownloadedFrom /
+    // terraformDownloadedFrom / terraformDocsDownloadedFrom /
+    // policyAgentDownloadedFrom), and setVariable emits
+    // `##vso[task.setvariable variable=x]VALUE` -- a CR/LF inside VALUE forges a
+    // second logging command on the next line. Upstream `new URL()` validation
+    // does NOT catch it: the WHATWG parser silently STRIPS tab/CR/LF while
+    // parsing, so 'https://ex\nample.com' validates cleanly while the raw input
+    // string the callers keep passing around still carries the newline. Stripping
+    // first also keeps the index arithmetic below aligned with the value returned.
+    const safeUrl = url.replace(/[\u0000-\u001F\u007F]/g, '');
+    const userInfo = rawUserInfo(safeUrl);
+    if (userInfo === null) return safeUrl;
+    const authorityStart = safeUrl.indexOf('://') + 3;
     // authorityStart + userInfo.length points at the delimiting '@'; +1 drops it.
-    return url.slice(0, authorityStart) + url.slice(authorityStart + userInfo.length + 1);
+    return safeUrl.slice(0, authorityStart) + safeUrl.slice(authorityStart + userInfo.length + 1);
 }

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/url-secret-redaction.ts
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/url-secret-redaction.ts
@@ -154,9 +154,20 @@ export function extractUrlUserInfoSecrets(url: string): string[] {
  * when there is no userinfo to strip.
  */
 export function redactUrlUserInfo(url: string): string {
-    const userInfo = rawUserInfo(url);
-    if (userInfo === null) return url;
-    const authorityStart = url.indexOf('://') + 3;
+    // Neutralize C0/DEL control characters BEFORE anything else. This value is
+    // echoed into pipeline output variables (packerDownloadedFrom /
+    // terraformDownloadedFrom / terraformDocsDownloadedFrom /
+    // policyAgentDownloadedFrom), and setVariable emits
+    // `##vso[task.setvariable variable=x]VALUE` -- a CR/LF inside VALUE forges a
+    // second logging command on the next line. Upstream `new URL()` validation
+    // does NOT catch it: the WHATWG parser silently STRIPS tab/CR/LF while
+    // parsing, so 'https://ex\nample.com' validates cleanly while the raw input
+    // string the callers keep passing around still carries the newline. Stripping
+    // first also keeps the index arithmetic below aligned with the value returned.
+    const safeUrl = url.replace(/[\u0000-\u001F\u007F]/g, '');
+    const userInfo = rawUserInfo(safeUrl);
+    if (userInfo === null) return safeUrl;
+    const authorityStart = safeUrl.indexOf('://') + 3;
     // authorityStart + userInfo.length points at the delimiting '@'; +1 drops it.
-    return url.slice(0, authorityStart) + url.slice(authorityStart + userInfo.length + 1);
+    return safeUrl.slice(0, authorityStart) + safeUrl.slice(authorityStart + userInfo.length + 1);
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -18,6 +18,8 @@ import './SecureFileLoaderL0';
 import './SecureTempL0';
 // Direct unit tests for the bounded stdout-capture guard (#632).
 import './ExecStdoutCaptureL0';
+// Table-driven CLASS test for the output-boundary defect class (batch E).
+import './OutputBoundaryClassL0';
 import './ExecWithTimeoutL0';
 // Direct unit tests for the emergency-only output-file cleanup split (#650).
 import './EmergencyOnlyCleanupL0';

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryClassL0.ts
@@ -1,0 +1,197 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
+
+/**
+ * CLASS TEST — "a value that originates in template-, tool- or remote-service-
+ * controlled output crosses a trust boundary (a pipeline output variable, a file
+ * path, a parsed file) without content validation or containment, or is DROPPED
+ * before it can cross because the producing exec rejected."
+ *
+ * Cross-repo counterpart of azure-pipelines-packer's
+ * Tests/OutputBoundaryClassL0.ts (issues #101/#202/#203/#110 were filed there;
+ * the same idioms are copied between the two extensions, so the class is
+ * enumerated and fixed in both).
+ *
+ * The rows are the ENUMERATED SINKS produced by the re-runnable signature
+ * `signatures/batch-E-output-boundary-signature.cjs` (S1 output variables, S2
+ * path writes, S3 exec-dropped crossings, S4 unbounded parses) -- not one test
+ * per reported call site.
+ *
+ * Every behavioural row is mutation-provable: inverting that row's own guard
+ * predicate turns that row RED and leaves the others green. EXEMPT rows assert
+ * the structural property the exemption rests on.
+ *
+ * Rows whose sink lives in a SIBLING task package are asserted structurally
+ * here and behaviourally there. Each task directory is an independent npm
+ * package with its own node_modules, so a sibling's module cannot be imported
+ * from this package (PublishKbArticleV1/src/manifest.ts imports
+ * `azure-pipelines-task-lib/task`, which does not resolve here) -- reading that
+ * package's source as TEXT needs no import and always resolves. The executable
+ * counterparts of the three PublishKbArticleV1 rows below live in
+ * Tasks/PublishKbArticle/PublishKbArticleV1/Tests/OutputBoundaryClassL0.ts.
+ */
+
+const SRC = path.resolve(__dirname, '..', 'src');
+const TASKS_ROOT = path.resolve(__dirname, '..', '..', '..');
+const KB_SRC = path.join(TASKS_ROOT, 'PublishKbArticle', 'PublishKbArticleV1', 'src');
+
+async function runScenario(relative: string): Promise<ttm.MockTestRunner> {
+    const tr = new ttm.MockTestRunner(path.join(__dirname, relative));
+    await tr.runAsync();
+    return tr;
+}
+
+function report(tr: ttm.MockTestRunner, message: string): string {
+    return `${message}\n--- STDOUT ---\n${tr.stdout}\n--- STDERR ---\n${tr.stderr}`;
+}
+
+describe('Output-boundary defect class (S1 output variables / S2 path writes / S3 dropped crossings / S4 unbounded parse)', function () {
+
+    // --- S1: pipeline output variables ------------------------------------
+
+    it('S1 setVariable(TF_OUT_*) — a provider/module-controlled output value carrying CR/LF never reaches the variable', async () => {
+        const tr = await runScenario('./OutputTests/AWSOutputControlCharsRejected.js');
+        assert.ok(tr.succeeded, report(tr, 'the output command itself should still succeed'));
+        assert.ok(tr.stdout.includes('TF_OUT_safe_output'), report(tr, 'the clean output must still be exported'));
+        assert.ok(!tr.stdout.includes('variable=TF_OUT_malicious_output'), report(tr, 'a control-char-bearing output must be skipped'));
+        assert.ok(
+            tr.warningIssues.some((w) => w.includes('failed output-variable validation')),
+            report(tr, 'the rejection must be visible as a warning')
+        );
+    });
+
+    it('S1 setVariable(showFilePath) — a control-char-bearing resolved path is rejected, not exported', async function () {
+        if (process.platform === 'win32') {
+            // NTFS cannot hold '\n' in a directory name, so the behavioural form of
+            // this row is POSIX-only. Assert the wiring structurally instead of
+            // pending the row (the suite runs with --forbid-pending).
+            const base = fs.readFileSync(path.join(SRC, 'base-terraform-command-handler.ts'), 'utf8');
+            assert.ok(
+                /const safeShowFilePath = this\.sanitizeOutputVariableValue\(showFilePath\);[\s\S]{0,200}?tasks\.setVariable\('showFilePath', safeShowFilePath/.test(base),
+                'showFilePath must be exported only through the output-variable guard'
+            );
+            return;
+        }
+        const tr = await runScenario('./OutputBoundaryTests/ShowFilePathControlCharsRejected.js');
+        assert.ok(!tr.stdout.includes('variable=showFilePath'), report(tr, 'showFilePath must be skipped when the resolved path is not printable-ASCII'));
+        assert.ok(
+            tr.warningIssues.some((w) => w.includes('failed output-variable validation')),
+            report(tr, 'the rejection must be visible as a warning')
+        );
+    });
+
+    it('S1 setVariable(kbArticleId/kbArticleNumber/kbWorkflowState) — SIBLING PACKAGE: every PublishKbArticleV1 output variable is emitted only as the output-variable guard\'s return value', () => {
+        // The console echoes of these same three fields were newline-neutralized
+        // (#693) while the sibling setVariable calls had no validation at all --
+        // "the guard exists and one sink is missing from it".
+        const index = fs.readFileSync(path.join(KB_SRC, 'index.ts'), 'utf8');
+        for (const variableName of ['kbArticleId', 'kbArticleNumber', 'kbWorkflowState']) {
+            assert.ok(
+                new RegExp(`\\['${variableName}', '\\w+'\\]`).test(index),
+                `${variableName} must be declared in the guarded output-variable table`
+            );
+        }
+        assert.ok(
+            /const safeValue = sanitizeOutputVariableValue\(article\[field\]\);[\s\S]{0,400}?tasks\.setVariable\(variableName, safeValue,/.test(index),
+            'the three ServiceNow-response fields must reach setVariable only as the guard\'s return value'
+        );
+        // ...and there is no OTHER setVariable call in the task that bypasses it.
+        const setVariableCalls = index.match(/tasks\.setVariable\(/g) || [];
+        assert.strictEqual(setVariableCalls.length, 1, 'every PublishKbArticleV1 output variable must go through the single guarded table');
+        // The guard itself: unknown-typed (an `as string` cast is erased at
+        // runtime, so a JSON object in that field used to reach setVariable),
+        // length-capped, printable-ASCII-only.
+        const manifestSrc = fs.readFileSync(path.join(KB_SRC, 'manifest.ts'), 'utf8');
+        assert.ok(/export function sanitizeOutputVariableValue\(value: unknown\)/.test(manifestSrc), 'the guard must accept unknown, not a cast-erased string');
+        assert.ok(/text\.length > OUTPUT_VAR_MAX_LENGTH/.test(manifestSrc), 'the guard must cap the value length');
+        assert.ok(/return \/\^\[\\x20-\\x7E\]\+\$\/\.test\(text\) \? text : null;/.test(manifestSrc), 'the guard must require printable ASCII and return null otherwise');
+    });
+
+    it('S1 setVariable(*Location) — EXEMPT: the exported path is <tools dir>/<literal tool>/<cleanVersion-validated semver>', () => {
+        for (const relative of [
+            'TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts',
+            'TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts',
+            'PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts',
+        ]) {
+            const src = fs.readFileSync(path.join(TASKS_ROOT, relative), 'utf8');
+            assert.ok(/tools\.cleanVersion\(resolvedVersion\)/.test(src), `${relative}: the remote-resolved version must pass through tools.cleanVersion()`);
+            assert.ok(/if \(!version\) \{[\s\S]{0,240}?throw new Error/.test(src), `${relative}: an unparseable version must fail closed`);
+            // The executable basename is `<literal tool name> + <platform extension>`,
+            // matched by tasks.match against the extracted tree -- never a name read
+            // out of the downloaded archive.
+            assert.ok(
+                /path\.join\(rootFolder, (toolName|exeName) \+ (getExecutableExtension\(\)|\(isWindows \? "\.exe" : ""\))\)/.test(src),
+                `${relative}: the executable basename must be a literal, not archive-supplied`
+            );
+        }
+    });
+
+    // --- S3: crossings dropped by a rejecting exec ------------------------
+
+    it('S3 show(outputTo=file) — the output file and showFilePath are published even when terraform show exits non-zero (task still fails)', async () => {
+        const tr = await runScenario('./OutputBoundaryTests/ShowFileFailureStillPublishes.js');
+        assert.ok(tr.failed, report(tr, 'a non-zero terraform show must still fail the task'));
+        assert.ok(tr.stdout.includes('variable=showFilePath'), report(tr, 'showFilePath must still be published from the captured output'));
+    });
+
+    it('S3 output() — jsonOutputVariablesPath is published even when terraform output exits non-zero (task still fails)', async () => {
+        const tr = await runScenario('./OutputBoundaryTests/OutputFailureStillPublishes.js');
+        assert.ok(tr.failed, report(tr, 'a non-zero terraform output must still fail the task'));
+        assert.ok(tr.stdout.includes('variable=jsonOutputVariablesPath'), report(tr, 'jsonOutputVariablesPath must still be published'));
+    });
+
+    it('S3 custom(outputTo=file) — customFilePath is published even when the custom command exits non-zero (task still fails)', async () => {
+        const tr = await runScenario('./OutputBoundaryTests/CustomFileFailureStillPublishes.js');
+        assert.ok(tr.failed, report(tr, 'a non-zero custom command must still fail the task'));
+        assert.ok(tr.stdout.includes('variable=customFilePath'), report(tr, 'customFilePath must still be published'));
+    });
+
+    // --- S2: path write sinks ---------------------------------------------
+
+    it('S2 writeCommandOutputFile — EXEMPT: every command-output write goes through the unlink-then-O_EXCL primitive, so no planted symlink is followed', () => {
+        const base = fs.readFileSync(path.join(SRC, 'base-terraform-command-handler.ts'), 'utf8');
+        assert.ok(
+            /private writeCommandOutputFile\([\s\S]{0,300}?replaceSecretFile\(filePath, content\);/.test(base),
+            'writeCommandOutputFile must delegate to replaceSecretFile'
+        );
+        const secureTemp = fs.readFileSync(path.join(SRC, 'secure-temp.ts'), 'utf8');
+        assert.ok(/flag: 'wx'/.test(secureTemp), "writeSecretFile must create with O_EXCL ('wx')");
+        assert.ok(
+            /export function replaceSecretFile\([\s\S]{0,900}?writeSecretFile\(filePath, content\);/.test(secureTemp),
+            'replaceSecretFile must re-create exclusively rather than write through an existing entry'
+        );
+        // Every command-output write in the handler uses that wrapper, never a
+        // bare fs.writeFileSync into an operator-supplied path.
+        const bareWrites = base.match(/fs\.writeFileSync\(/g) || [];
+        assert.strictEqual(bareWrites.length, 1, 'only the Agent.TempDirectory digest write may use a bare fs.writeFileSync');
+    });
+
+    it('S2 outputArticleInfoToJson — SIBLING PACKAGE: the ServiceNow-supplied article number is constrained to a separator-free basename before it becomes a write path', () => {
+        const manifestSrc = fs.readFileSync(path.join(KB_SRC, 'manifest.ts'), 'utf8');
+        // `number` comes straight from the ServiceNow response and is used as a
+        // FILE PATH relative to the working directory, so it must be pinned to
+        // the shape this task's own reader can find again -- anything else falls
+        // back to the in-directory default rather than steering the write.
+        assert.ok(
+            /const number = \/\^\[A-Za-z0-9\]\[A-Za-z0-9\._-\]\*\$\/\.test\(rawNumber\)\s*\?\s*rawNumber\s*:\s*'article_info';/.test(manifestSrc),
+            'a ServiceNow-supplied article number must pass a separator-free basename check or fall back to article_info'
+        );
+        assert.ok(/const filename = `\$\{number\}\.json`;/.test(manifestSrc), 'the write must use the validated name, never the raw response field');
+    });
+
+    // --- S4: unbounded parse of tool-written content ----------------------
+
+    it('S4 kb-manifest read — SIBLING PACKAGE: the byte cap is measured on the already-open descriptor and rejects before the file is buffered and parsed', () => {
+        const src = fs.readFileSync(path.join(KB_SRC, 'manifest.ts'), 'utf8');
+        assert.ok(/const MANIFEST_MAX_BYTES = 5 \* 1024 \* 1024;/.test(src), 'the manifest read must be bounded by a byte cap');
+        // The cap is measured on the SAME descriptor the read uses (no re-open).
+        assert.ok(/fs\.fstatSync\(fd\)\.size/.test(src), 'the size must be measured via fstat on the already-open descriptor (no TOCTOU re-open)');
+        // ...and it rejects BEFORE the buffer+parse, not after.
+        assert.ok(
+            /const size = fs\.fstatSync\(fd\)\.size;\s*if \(size > MANIFEST_MAX_BYTES\) \{[\s\S]{0,300}?throw new Error[\s\S]{0,300}?entries = JSON\.parse\(fs\.readFileSync\(fd, 'utf-8'\)\);/.test(src),
+            'the cap must reject before the manifest is buffered and parsed'
+        );
+    });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/CustomFileFailureStillPublishes.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/CustomFileFailureStillPublishes.ts
@@ -1,0 +1,40 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// CLASS ROW — custom(outputTo=file). The existing try/finally only guaranteed
+// the afterPlanFileWritten hook on a rejecting exec; the write and the
+// customFilePath export sat AFTER the await inside the try, so a non-zero exit
+// discarded both.
+const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'tf-class-customfail-'));
+
+const tp = path.join(__dirname, './CustomFileFailureStillPublishesL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'custom');
+tr.setInput('customCommand', 'graph');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('outputTo', 'file');
+tr.setInput('filename', 'graph.txt');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'which': { 'terraform': 'terraform' },
+    'checkPath': { 'terraform': true },
+    'exec': {
+        'terraform graph': { 'code': 1, 'stdout': 'digraph { partial }' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/CustomFileFailureStillPublishesL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/CustomFileFailureStillPublishesL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'custom', 'CustomFileFailureStillPublishesL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/OutputFailureStillPublishes.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/OutputFailureStillPublishes.ts
@@ -1,0 +1,37 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// CLASS ROW — the output() sibling of the show() sink: a non-zero
+// `terraform output -json` must not swallow the captured JSON or the
+// jsonOutputVariablesPath contract downstream steps read.
+const agentTempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'tf-class-outputfail-'));
+process.env['AGENT_TEMPDIRECTORY'] = agentTempDirectory;
+
+const tp = path.join(__dirname, './OutputFailureStillPublishesL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'output');
+tr.setInput('workingDirectory', 'DummyWorkingDirectory');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'which': { 'terraform': 'terraform' },
+    'checkPath': { 'terraform': true },
+    'exec': {
+        'terraform output -json': { 'code': 1, 'stdout': '{ "safe_output": { "value": "hello" } }' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/OutputFailureStillPublishesL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/OutputFailureStillPublishesL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'output', 'OutputFailureStillPublishesL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFileFailureStillPublishes.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFileFailureStillPublishes.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// CLASS ROW (#202/#203 class, terraform instance) — a non-zero `terraform show`
+// used to REJECT inside execWithStdoutCapture, so the already-captured stdout
+// was discarded: the operator's `filename` was never written and showFilePath
+// was never exported. The task must still fail, but only AFTER the file and the
+// output variable exist.
+const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'tf-class-showfail-'));
+
+const tp = path.join(__dirname, './ShowFileFailureStillPublishesL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'show');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('outputTo', 'file');
+tr.setInput('outputFormat', 'json');
+tr.setInput('filename', 'show.json');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'which': { 'terraform': 'terraform' },
+    'checkPath': { 'terraform': true },
+    'exec': {
+        'terraform show -json': { 'code': 1, 'stdout': '{"format_version":"1.0","partial":true}' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFileFailureStillPublishesL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFileFailureStillPublishesL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'show', 'ShowFileFailureStillPublishesL0', false);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFilePathControlCharsRejected.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFilePathControlCharsRejected.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+// CLASS ROW — setVariable('showFilePath'). The exported value is the RESOLVED
+// output path; a working directory whose own name carries a newline (legal on
+// POSIX) makes it control-char-bearing, so the same guard that protects
+// TF_OUT_* has to reject it here rather than emit a value that would forge a
+// second `##vso[...]` logging command. POSIX-only: NTFS cannot hold '\n'.
+const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'tf-class-nl\n-'));
+
+const tp = path.join(__dirname, './ShowFilePathControlCharsRejectedL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('provider', 'azurerm');
+tr.setInput('command', 'show');
+tr.setInput('workingDirectory', workingDirectory);
+tr.setInput('outputTo', 'file');
+tr.setInput('outputFormat', 'json');
+tr.setInput('filename', 'show.json');
+tr.setInput('commandOptions', '');
+tr.setInput('environmentServiceNameAzureRM', 'AzureRM');
+
+process.env['ENDPOINT_AUTH_SCHEME_AzureRM'] = 'ServicePrincipal';
+process.env['ENDPOINT_DATA_AzureRM_SUBSCRIPTIONID'] = 'DummmySubscriptionId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServicePrincipalId';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
+process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'which': { 'terraform': 'terraform' },
+    'checkPath': { 'terraform': true },
+    'exec': {
+        'terraform show -json': { 'code': 0, 'stdout': '{"format_version":"1.0"}' }
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFilePathControlCharsRejectedL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OutputBoundaryTests/ShowFilePathControlCharsRejectedL0.ts
@@ -1,0 +1,4 @@
+import { TerraformCommandHandlerAzureRM } from './../../src/azure-terraform-command-handler';
+import { runCommand } from '../test-l0-helpers';
+
+runCommand(new TerraformCommandHandlerAzureRM(), 'show', 'ShowFilePathControlCharsRejectedL0', true);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -927,12 +927,24 @@ export abstract class BaseTerraformCommandHandler {
             result = commandOutput.code;
         } else if (outputTo === "file") {
             const showFilePath = path.resolve(showCommand.workingDirectory, tasks.getInput("filename") || '');
+            // ignoreReturnCode mirrors packer's build()/fix() fix (#202/#203, same
+            // class): without it a non-zero `terraform show` REJECTS here and the
+            // already-captured stdout is discarded, so the file the operator asked
+            // for is never written and showFilePath is never exported -- even
+            // though the output exists. The non-zero code is re-surfaced as an
+            // explicit failure below, after the file and variable are in place.
             const commandOutput = await this.execWithStdoutCapture(terraformTool, {
                 cwd: showCommand.workingDirectory,
+                ignoreReturnCode: true,
             });
 
             this.writeCommandOutputFile(showFilePath, commandOutput.stdout);
-            tasks.setVariable('showFilePath', showFilePath, false, true);
+            const safeShowFilePath = this.sanitizeOutputVariableValue(showFilePath);
+            if (safeShowFilePath) {
+                tasks.setVariable('showFilePath', safeShowFilePath, false, true);
+            } else {
+                tasks.warning(`showFilePath '${showFilePath}' failed output-variable validation (length/printable-ASCII); skipping the showFilePath output variable.`);
+            }
 
             // Detect destroy changes in JSON plan output
             if (outputFormat === "json") {
@@ -958,6 +970,12 @@ export abstract class BaseTerraformCommandHandler {
             }
 
             result = commandOutput.code;
+            if (result !== 0) {
+                // Re-raised only now that the output file and showFilePath exist
+                // (#202/#203 class): failing is still the right outcome, losing the
+                // captured output on the way there was not.
+                throw new Error(`Terraform show failed with exit code ${result}.`);
+            }
         } else {
             throw new Error("Invalid outputTo value. Must be 'console' or 'file'.");
         }
@@ -1001,12 +1019,21 @@ export abstract class BaseTerraformCommandHandler {
         // contract), so the relocation is transparent to them.
         const outputFileDirectory = tasks.getVariable("Agent.TempDirectory") || os.tmpdir();
         const jsonOutputVariablesFilePath = path.join(outputFileDirectory, `output-${uuidV4()}.json`);
+        // Same #202/#203 class as show()/custom(): a rejecting exec would discard
+        // the captured stdout before it is written and before
+        // jsonOutputVariablesPath is exported. Capture the code, persist, then fail.
         const commandOutput = await this.execWithStdoutCapture(terraformTool, {
             cwd: outputCommand.workingDirectory,
+            ignoreReturnCode: true,
         });
 
         this.writeCommandOutputFile(jsonOutputVariablesFilePath, commandOutput.stdout);
-        tasks.setVariable('jsonOutputVariablesPath', jsonOutputVariablesFilePath, false, true);
+        const safeOutputVariablesPath = this.sanitizeOutputVariableValue(jsonOutputVariablesFilePath);
+        if (safeOutputVariablesPath) {
+            tasks.setVariable('jsonOutputVariablesPath', safeOutputVariablesPath, false, true);
+        } else {
+            tasks.warning(`jsonOutputVariablesPath '${jsonOutputVariablesFilePath}' failed output-variable validation (length/printable-ASCII); skipping the jsonOutputVariablesPath output variable.`);
+        }
         const hasSensitiveOutputs = this.warnIfSensitiveOutputFile(commandOutput.stdout, jsonOutputVariablesFilePath);
 
         // #650: a file containing sensitive output values is auto-registered for
@@ -1030,6 +1057,9 @@ export abstract class BaseTerraformCommandHandler {
         // Auto-set pipeline variables from terraform output
         this.setOutputVariables(commandOutput.stdout);
 
+        if (commandOutput.code !== 0) {
+            throw new Error(`Terraform output failed with exit code ${commandOutput.code}.`);
+        }
         return commandOutput.code;
     }
 
@@ -1338,8 +1368,9 @@ export abstract class BaseTerraformCommandHandler {
         // parsing needed since afterPlanFileWritten() is already a safe no-op
         // (via fs.existsSync) when planFilePath doesn't exist -- i.e. every
         // non-plan custom command. Wrapped in try/catch/finally mirroring
-        // init()'s identical afterInit() pattern: neither exec path below sets
-        // ignoreReturnCode, so a failing custom command REJECTS -- the hook
+        // init()'s identical afterInit() pattern: a failing custom command still
+        // leaves this block by throwing (the console path REJECTS, the file path
+        // re-raises its own captured code after persisting its output) -- the hook
         // must still run on that path, and the original error is re-thrown
         // unchanged afterward.
         const planFilePath = extractOutFlagPath(commandOptions);
@@ -1352,13 +1383,27 @@ export abstract class BaseTerraformCommandHandler {
                 });
             } else if (outputTo === "file") {
                 const customFilePath = path.resolve(customCommand.workingDirectory, tasks.getInput("filename") || '');
+                // #202/#203 class: the try/finally above only guarantees the
+                // afterPlanFileWritten hook on a rejecting exec -- the write and
+                // the customFilePath export sit AFTER the await inside the try, so
+                // a non-zero exit skipped both and silently discarded the captured
+                // output. Persist first, then re-raise the failure below.
                 const commandOutput = await this.execWithStdoutCapture(terraformTool, {
-                    cwd: customCommand.workingDirectory
+                    cwd: customCommand.workingDirectory,
+                    ignoreReturnCode: true,
                 });
 
                 this.writeCommandOutputFile(customFilePath, commandOutput.stdout);
-                tasks.setVariable('customFilePath', customFilePath, false, true);
+                const safeCustomFilePath = this.sanitizeOutputVariableValue(customFilePath);
+                if (safeCustomFilePath) {
+                    tasks.setVariable('customFilePath', safeCustomFilePath, false, true);
+                } else {
+                    tasks.warning(`customFilePath '${customFilePath}' failed output-variable validation (length/printable-ASCII); skipping the customFilePath output variable.`);
+                }
                 result = commandOutput.code;
+                if (result !== 0) {
+                    throw new Error(`Terraform custom command failed with exit code ${result}.`);
+                }
             } else {
                 throw new Error("Invalid outputTo value. Must be 'console' or 'file'.");
             }


### PR DESCRIPTION
Cross-repo half of a class remediated in the sibling packer extension (sethbacon/azure-pipelines-packer#232). **The instances here were found by running the packer signature in this repo — none is named in any issue filed against it.**

## The class

> A value that originates in template-, tool- or remote-controlled output crosses a trust boundary without validation; **or the crossing is silently dropped** because `ToolRunner` rejects on a non-zero exit before the sink is reached.

## Outputs were being discarded on failure

`show(outputTo=file)`, `output()` and `custom(outputTo=file)` all ran their exec without `ignoreReturnCode`, so a non-zero terraform exit rejected **before** the output file was written and before `showFilePath` / `jsonOutputVariablesPath` / `customFilePath` were set. Each now publishes, then re-raises the failure explicitly.

## Three unreported instances in PublishKbArticle

| | |
| --- | --- |
| `kbArticleId`, `kbArticleNumber`, `kbWorkflowState` | went to `setVariable` **straight from the ServiceNow HTTP response** — while the sibling console echoes of those same three fields were already newline-neutralized. The "guard exists, one sink missing" shape this run keeps finding. |
| the ServiceNow-supplied article `number` | used **directly as a relative file path** — a traversal sink. Now an anchored filename allowlist with an `article_info` fallback. |
| the kb manifest | parsed with no size bound. Now capped via `fstat` on the **already-open descriptor**, preserving the existing TOCTOU-free open rather than reintroducing a stat-then-open race. |

`redactUrlUserInfo`'s lexical-slice defect (see the companion PR — `new URL()` looks like validation, but the caller keeps the raw string) is fixed here too, in all four byte-identical copies.

## Gates

- **Class gate** — re-run by the orchestrator: **90 sinks, 7 UNGUARDED**, every one exempted with a code-verified reason: 4 operator-authored task-input paths (`outputFile`, `modulePath` — the trusted side of this threat model), 2 agent-temp+uuid paths, 1 operator manifest path.
- **Mutation** — 8 mutations, each recompiled first. Dropping `ignoreReturnCode` from show/output/custom reddens exactly that one row each; inverting the kb guard reddens only the kb row; routing `writeCommandOutputFile` around `O_EXCL` reddens only the exemption row that asserts the primitive.
- **Tests** — TerraformTaskV5 701 (re-run 4× for flake confidence), PublishKbArticleV1 241, plus four installers; 0 failing.

## One existing test was modified — and not weakened

PublishKbArticle's #564 test forced its write failure using a path-separator-bearing article number, which the **new allowlist now rejects before the write** — so the old fixture could no longer reach the code it was testing. It was re-induced with a pre-created directory at the target name (EISDIR, cross-platform) with **the assertion unchanged**, and a separate new test covers the rejection itself.

## Why `writeCommandOutputFile` needs no containment re-check here

It delegates to `replaceSecretFile`, which unlinks then re-creates with `flag: 'wx'` (`O_CREAT|O_EXCL`), so it structurally refuses to follow a planted symlink — unlike packer's plain `tasks.writeFile`, which is why only that side needed an explicit check. Asserted by a class-test row and mutation-proved.

Refs sethbacon/azure-pipelines-packer#101
Refs sethbacon/azure-pipelines-packer#202
Refs sethbacon/azure-pipelines-packer#203