### PR TITLE
security: discard unverified artifacts and validate cache records

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitTruncatedMarkerDegrades.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitTruncatedMarkerDegrades.ts
@@ -1,0 +1,65 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('policyAgent', 'opa');
+tr.setInput('version', '1.17.1');
+tr.setInput('downloadSource', 'official');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => { throw new Error('fetchJson should not be called for a specific version: ' + url); },
+    fetchTextAllow404: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while fetching ${url}`); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
+
+// #198: the stored integrity marker exists and is READABLE but is TRUNCATED -- a
+// previous run's write was interrupted (disk full, cancelled job, container kill).
+// Feeding that fragment to the hash comparison produced a
+// CachedToolVerificationFailed, which reads as binary TAMPERING and permanently
+// bricked that version on the agent: every later install failed the same way. A
+// malformed marker is UNVERIFIABLE, not a mismatch, so it is now treated exactly like
+// a missing one -- escalate to a remote re-verification and, when the source is
+// unreachable (here), degrade with a warning instead of failing.
+// No USABLE stored integrity marker exists (e.g. cached by an installer version that
+// predates this check, or cached with checksum verification disabled), so the
+// installer attempts a remote re-verification — but the source is unreachable
+// (offline/air-gapped agent, simulated by downloadTool throwing a network
+// error). The install must degrade gracefully to the pre-existing
+// trust-the-cache behavior with a warning, never fail: offline cache reuse is
+// an explicitly supported scenario.
+tr.registerMock('fs', {
+    existsSync: (p: string) => String(p).includes('.installer-verified.sha256'),
+    readFileSync: (p: string, _enc?: string) => {
+        // A torn write: the first 12 characters of a 64-character digest.
+        if (String(p).includes('.installer-verified.sha256')) return 'aabbccddeeff';
+        throw new Error('readFileSync should not be called on anything but the marker when the re-verification download failed');
+    },
+    writeFileSync: () => { throw new Error('writeFileSync should not be called when re-verification was degraded'); },
+    chmodSync: () => { },
+    mkdirSync: () => undefined,
+    copyFileSync: () => { }
+});
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid' });
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: () => '/tmp/opa-cached',
+    downloadTool: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while downloading ${url}`); },
+    extractZip: async () => { throw new Error('extractZip should not be called when the re-verification download failed'); },
+    cacheDir: async () => { throw new Error('cacheDir should not be called on a cache hit'); },
+    cleanVersion: (v: string) => v,
+    prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    find: { '/tmp/opa-cached': ['/tmp/opa-cached/opa'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitVerifyFail.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/CacheHitVerifyFail.ts
@@ -19,6 +19,11 @@ tr.registerMock('./http-client', {
 tr.registerMock('undici', { ProxyAgent: class { } });
 tr.registerMock('./gpg-verifier', { verifyGpgSignature: async () => { } });
 
+// NOTE: both digests below are FULL 64-character SHA256 hex strings on purpose. A
+// SHORT (truncated) marker is not a mismatch at all -- it is an UNVERIFIABLE marker,
+// which verifyCachedTool now reports as "no usable marker" instead of failing with a
+// tampering-shaped error (#198); CacheHitTruncatedMarkerDegrades covers that state.
+// This fixture must exercise a genuine, well-formed mismatch.
 // The stored integrity marker does NOT match the (mocked) hash of the cached
 // executable's current on-disk content: the cached copy was modified/corrupted
 // since it was last verified, and the cache-hit re-verification must reject it.
@@ -26,7 +31,7 @@ tr.registerMock('fs', {
     existsSync: (p: string) => p.includes('.installer-verified.sha256'),
     readFileSync: (p: string, _enc?: string) => {
         if (p.includes('.installer-verified.sha256')) {
-            return 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+            return 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
         }
         return Buffer.from('tampered-exe-content');
     },
@@ -41,7 +46,7 @@ tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid',
     createHash: () => {
         const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
-        hash.digest = () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+        hash.digest = () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
         return hash;
     }
 });

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/Tests/L0.ts
@@ -180,7 +180,32 @@ describe('PolicyAgentInstaller Test Suite', function () {
         }, tr);
     });
 
-    it('cache hit, no marker, source unreachable, requireOnlineReverification=true: fails closed instead of degrading (#778)', async () => {
+  
+  // #198: a TRUNCATED integrity marker (an interrupted write: disk full, cancelled
+  // job, container kill) is UNVERIFIABLE, not a mismatch. Feeding the fragment to the
+  // hash comparison used to fail every subsequent install of that version with a
+  // tampering-shaped CachedToolVerificationFailed. It must instead be treated exactly
+  // like a missing marker: escalate, and degrade with a warning when the source is
+  // unreachable. Sibling of the same row in TerraformInstallerV1's class test.
+  it('cache hit, TRUNCATED marker, source unreachable: degrades instead of reporting tampering (#198)', async () => {
+    const tp = path.join(__dirname, 'CacheHitTruncatedMarkerDegrades.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    await tr.runAsync();
+    runValidations(() => {
+      assert(tr.succeeded, 'task should have succeeded');
+      assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+      assert(
+        !tr.stdout.includes('CachedToolVerificationFailed'),
+        'a torn marker must never be reported as tampering. stdout: ' + tr.stdout
+      );
+      assert(
+        tr.warningIssues.some((w) => w.includes('CachedToolReverificationUnavailable')),
+        'should degrade through the unavailable-re-verification warning. warnings: ' + tr.warningIssues
+      );
+    }, tr);
+  });
+
+  it('cache hit, no marker, source unreachable, requireOnlineReverification=true: fails closed instead of degrading (#778)', async () => {
         const tp = path.join(__dirname, 'CacheHitHashUnavailableStrict.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         await tr.runAsync();

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/artifact-discard.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/artifact-discard.ts
@@ -1,0 +1,48 @@
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src, and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay byte-identical,
+// failing the build on any divergence, so a change here MUST be applied to ALL
+// THREE copies. This duplication is deliberate (each task bundles independently)
+// — not drift to be flagged.
+//
+// Also carried, with a provenance header instead of this one, by
+// azure-pipelines-packer's PackerInstallerV1/src. The same defect class covers
+// both extensions.
+
+import fs = require('fs');
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * Runs `verify` over a freshly downloaded artifact and, if any check inside it
+ * throws, DELETES the artifact before rethrowing.
+ *
+ * http-client.ts's downloadToFile already unlinks its destination when the
+ * TRANSFER fails, but verification is a separate, later step: an archive whose
+ * SHA256 does not match — i.e. one that may have been tampered with — was
+ * otherwise left in Agent.TempDirectory/os.tmpdir() indefinitely on a persistent
+ * self-hosted agent. EVERY verification of a freshly downloaded artifact goes
+ * through this wrapper, so a rejected artifact never outlives the check that
+ * rejected it. The unlink is best-effort and never masks the verification error
+ * that triggered it.
+ *
+ * Deliberately NOT used for the agent's CACHED executable: that file belongs to
+ * the tool cache and other jobs may be using it, so a failed cache re-verification
+ * fails the task without evicting it.
+ *
+ * Also deliberately NOT used for a checksum that is merely UNAVAILABLE (a source
+ * that published no checksum file, or a checksum file that does not list the
+ * requested asset) when the operator has opted out of requiring one: that install
+ * legitimately proceeds, so the artifact must survive. Wrap the comparison, not
+ * the lookup.
+ */
+export async function discardArtifactOnFailure<T>(artifactPath: string, verify: () => Promise<T>): Promise<T> {
+    try {
+        return await verify();
+    } catch (error) {
+        try {
+            fs.unlinkSync(artifactPath);
+            tasks.debug(`Discarded ${artifactPath}: it failed integrity verification.`);
+        } catch { /* best effort — the verification error is what matters */ }
+        throw error;
+    }
+}

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -14,6 +14,8 @@ import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from './url-secret-redaction';
 import { VerificationFailure, isVerificationFailure } from './verification-failure';
+import { discardArtifactOnFailure } from './artifact-discard';
+import { retryAsync } from './retry';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
 
 /**
@@ -39,6 +41,21 @@ const isWindows = os.type().match(/^Win/);
 // File name of the local, per-cached-tool-directory integrity marker written after
 // a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
 const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
+
+// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
+// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
+// was tampered with; see verifyCachedTool (#198).
+const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
+
+/**
+ * Bounded retry for the binary download itself (#78): tools.downloadTool performs a
+ * single HTTP GET with no retry of its own, so a single transient blip during the
+ * largest and slowest fetch of the install failed the whole task. The metadata and
+ * checksum fetches already retry inside http-client.ts. Verification is deliberately
+ * OUTSIDE the retry -- a checksum or signature failure is deterministic and must
+ * never be repeated.
+ */
+const DOWNLOAD_RETRY = { retries: 2, baseDelayMs: 250, maxBackoffMs: 2000 };
 
 /**
  * Downloads the requested policy agent (Sentinel or OPA), verifies it, caches it
@@ -203,10 +220,12 @@ async function downloadSentinelOfficial(version: string): Promise<{ path: string
     const sha256SumsUrl = `https://releases.hashicorp.com/sentinel/${version}/sentinel_${version}_SHA256SUMS`;
     const sha256SumsContent = await fetchText(sha256SumsUrl);
     const requireGpg = getBoolInputDefaultTrue("requireGpgSignature");
-    await verifyGpgSignature(sha256SumsContent, `${sha256SumsUrl}.sig`, requireGpg);
-
-    const expectedHash = parseSha256(sha256SumsContent, zipFileName);
-    await verifySha256(zipPath, expectedHash);
+    // A failed signature or checksum check DELETES the zip rather than leaving a
+    // rejected — possibly tampered — artifact in the agent's temp directory (#204).
+    await discardArtifactOnFailure(zipPath, async () => {
+        await verifyGpgSignature(sha256SumsContent, `${sha256SumsUrl}.sig`, requireGpg);
+        await verifySha256(zipPath, parseSha256(sha256SumsContent, zipFileName));
+    });
     return { path: zipPath, verified: true };
 }
 
@@ -238,7 +257,7 @@ async function downloadOpaOfficial(version: string): Promise<{ path: string; ver
         tasks.warning(`SHA256 verification skipped for OPA download: no checksum file published at ${sha256Url}.`);
         return { path: binaryPath, verified: false };
     }
-    await verifySha256(binaryPath, parseFirstSha256(sha256Body, assetName));
+    await discardArtifactOnFailure(binaryPath, () => verifySha256(binaryPath, parseFirstSha256(sha256Body, assetName)));
     return { path: binaryPath, verified: true };
 }
 
@@ -324,7 +343,7 @@ async function downloadFromRegistry(agent: string, version: string, registryUrl:
     }
 
     if (data.sha256) {
-        await verifySha256(filePath, data.sha256);
+        await discardArtifactOnFailure(filePath, () => verifySha256(filePath, data.sha256));
         return { path: filePath, verified: true };
     } else if (getBoolInputDefaultTrue("requireChecksum")) {
         // Empty sha256 means no local integrity check is possible. Fail closed when
@@ -375,7 +394,7 @@ async function downloadFromMirror(agent: string, version: string, mirrorBaseUrl:
         tasks.warning(`SHA256 verification skipped for mirror download: no checksum file published at ${sha256Url}.`);
         return { path: binaryPath, verified: false };
     }
-    await verifySha256(binaryPath, parseFirstSha256(sha256Body, assetName));
+    await discardArtifactOnFailure(binaryPath, () => verifySha256(binaryPath, parseFirstSha256(sha256Body, assetName)));
     return { path: binaryPath, verified: true };
 }
 
@@ -405,8 +424,10 @@ async function verifyMirrorChecksum(filePath: string, sha256SumsUrl: string, fil
     // The file exists: verify its GPG signature against HashiCorp's pinned key
     // (a missing .sig is fatal only when requireGpgSignature is set), then verify
     // the hash. A missing asset entry or a hash mismatch is always fatal.
-    await verifyGpgSignature(body, `${sha256SumsUrl}.sig`, requireGpg);
-    await verifySha256(filePath, parseSha256(body, fileName));
+    await discardArtifactOnFailure(filePath, async () => {
+        await verifyGpgSignature(body, `${sha256SumsUrl}.sig`, requireGpg);
+        await verifySha256(filePath, parseSha256(body, fileName));
+    });
     return true;
 }
 
@@ -414,7 +435,7 @@ async function verifyMirrorChecksum(filePath: string, sha256SumsUrl: string, fil
 
 async function downloadTo(url: string, fileName: string): Promise<string> {
     try {
-        return await tools.downloadTool(url, fileName);
+        return await retryAsync(() => tools.downloadTool(url, fileName), DOWNLOAD_RETRY);
     } catch (exception) {
         // A mirror download URL can embed operator basic-auth userinfo; strip it from
         // the interpolated message (no-op for the official releases/GitHub URLs) (#586).
@@ -550,10 +571,21 @@ async function hashFile(filePath: string): Promise<string> {
  * trust-the-cache behavior.
  */
 async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
+    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
+    // a container kill -- leaves a marker that exists and is readable but is empty or
+    // truncated, and every later install of that version then compares the real digest
+    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
+    // permanently bricking the version on that agent (#198). Renaming into place means
+    // a reader only ever sees a complete digest or no marker at all.
+    const tempPath = `${markerPath}.${uuidV4()}.tmp`;
     try {
-        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), await hashFile(exePath), 'utf8');
+        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
+        fs.renameSync(tempPath, markerPath);
     } catch (err) {
         tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
+        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
     }
 }
 
@@ -567,10 +599,17 @@ async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Prom
  *   verification was disabled): returns false — the caller escalates to a remote
  *   re-verification against a freshly downloaded release (see
  *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
+ * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
+ *   an interrupted write (#198): returns false, exactly like a missing marker. An
+ *   unverifiable record is not evidence of tampering; feeding the fragment to the
+ *   comparison would fail every subsequent install of that version with a
+ *   tampering-shaped error and send an operator down a security-incident path for
+ *   what is a torn file. The marker is NOT healed here — healing happens only after
+ *   the escalated re-verification actually proves the cached executable.
  * - Marker present and it matches the cached executable's current hash: passes
  *   silently, returns true.
- * - Marker present but it does not match: the cached executable changed since it
- *   was verified (tampering or corruption on a shared agent) — fail closed.
+ * - Marker present, well-formed, and it does not match: the cached executable changed
+ *   since it was verified (tampering or corruption on a shared agent) — fail closed.
  *
  * Trust-boundary note: the marker lives next to the executable it protects, so an
  * attacker who can rewrite the cached binary under the agent account can rewrite
@@ -585,6 +624,10 @@ async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: str
         return false;
     }
     const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
+    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
+        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
+        return false;
+    }
     const actualHash = (await hashFile(exePath)).toLowerCase();
     if (actualHash !== storedHash) {
         throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitTruncatedMarkerDegrades.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitTruncatedMarkerDegrades.ts
@@ -1,0 +1,61 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, 'RunInstaller.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('version', '0.24.0');
+tr.setInput('downloadSource', 'official');
+
+tr.registerMock('os', { type: () => 'Linux', arch: () => 'x64', tmpdir: () => '/tmp' });
+
+tr.registerMock('./http-client', {
+  fetchJson: async (url: string) => { throw new Error('fetchJson should not be called for a specific version: ' + url); },
+  fetchTextAllow404: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while fetching ${url}`); }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+// #198: the stored integrity marker exists and is READABLE but is TRUNCATED -- a
+// previous run's write was interrupted (disk full, cancelled job, container kill).
+// Feeding that fragment to the hash comparison produced a
+// CachedToolVerificationFailed, which reads as binary TAMPERING and permanently
+// bricked that version on the agent: every later install failed the same way. A
+// malformed marker is UNVERIFIABLE, not a mismatch, so it is now treated exactly like
+// a missing one -- escalate to a remote re-verification and, when the source is
+// unreachable (here), degrade with a warning instead of failing.
+// No USABLE stored integrity marker exists (e.g. cached by an installer version that
+// predates this check, or cached with checksum verification disabled), so the
+// installer attempts a remote re-verification — but the source is unreachable
+// (offline/air-gapped agent, simulated by downloadTool throwing a network
+// error). The install must degrade gracefully to the pre-existing
+// trust-the-cache behavior with a warning, never fail: offline cache reuse is
+// an explicitly supported scenario.
+tr.registerMock('fs', {
+  existsSync: (p: string) => String(p).includes('.installer-verified.sha256'),
+  readFileSync: (p: string) => {
+    if (String(p).includes('.installer-verified.sha256')) return 'aabbccddeeff';
+    throw new Error('readFileSync should not be called on anything but the marker when the re-verification download failed');
+  },
+  writeFileSync: () => { throw new Error('writeFileSync should not be called when re-verification was degraded'); },
+  chmodSync: () => { }
+});
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid' });
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+  findLocalTool: () => '/tmp/terraform-docs-cached',
+  downloadTool: async (url: string) => { throw new Error(`getaddrinfo ENOTFOUND while downloading ${url}`); },
+  extractTar: async () => { throw new Error('extractTar should not be called when the re-verification download failed'); },
+  extractZip: async () => { throw new Error('extractZip should not be called when the re-verification download failed'); },
+  cacheDir: async () => { throw new Error('cacheDir should not be called on a cache hit'); },
+  cleanVersion: (v: string) => v,
+  prependPath: () => { }
+});
+
+const a: ma.TaskLibAnswers = {
+  find: { '/tmp/terraform-docs-cached': ['/tmp/terraform-docs-cached/terraform-docs'] }
+};
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitVerifyFail.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/CacheHitVerifyFail.ts
@@ -17,6 +17,11 @@ tr.registerMock('./http-client', {
 
 tr.registerMock('undici', { ProxyAgent: class { } });
 
+// NOTE: both digests below are FULL 64-character SHA256 hex strings on purpose. A
+// SHORT (truncated) marker is not a mismatch at all -- it is an UNVERIFIABLE marker,
+// which verifyCachedTool now reports as "no usable marker" instead of failing with a
+// tampering-shaped error (#198); CacheHitTruncatedMarkerDegrades covers that state.
+// This fixture must exercise a genuine, well-formed mismatch.
 // The stored integrity marker does NOT match the (mocked) hash of the cached
 // executable's current on-disk content: the cached copy was modified/corrupted
 // since it was last verified, and the cache-hit re-verification must reject it.
@@ -24,7 +29,7 @@ tr.registerMock('fs', {
   existsSync: (p: string) => p.includes('.installer-verified.sha256'),
   readFileSync: (p: string, _enc?: string) => {
     if (p.includes('.installer-verified.sha256')) {
-      return 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+      return 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
     }
     return Buffer.from('tampered-exe-content');
   },
@@ -37,7 +42,7 @@ tr.registerMock('crypto', {
   randomUUID: () => 'test-uuid',
   createHash: () => {
     const hash: any = new (require('stream').Writable)({ write(_c: any, _e: any, cb: any) { cb(); } });
-    hash.digest = () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+    hash.digest = () => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
     return hash;
   }
 });

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/Tests/L0.ts
@@ -137,6 +137,31 @@ describe('TerraformDocsInstaller Test Suite', function () {
     }, tr);
   });
 
+
+  // #198: a TRUNCATED integrity marker (an interrupted write: disk full, cancelled
+  // job, container kill) is UNVERIFIABLE, not a mismatch. Feeding the fragment to the
+  // hash comparison used to fail every subsequent install of that version with a
+  // tampering-shaped CachedToolVerificationFailed. It must instead be treated exactly
+  // like a missing marker: escalate, and degrade with a warning when the source is
+  // unreachable. Sibling of the same row in TerraformInstallerV1's class test.
+  it('cache hit, TRUNCATED marker, source unreachable: degrades instead of reporting tampering (#198)', async () => {
+    const tp = path.join(__dirname, 'CacheHitTruncatedMarkerDegrades.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+    await tr.runAsync();
+    runValidations(() => {
+      assert(tr.succeeded, 'task should have succeeded');
+      assert(tr.errorIssues.length === 0, 'should have no errors. errors: ' + tr.errorIssues);
+      assert(
+        !tr.stdout.includes('CachedToolVerificationFailed'),
+        'a torn marker must never be reported as tampering. stdout: ' + tr.stdout
+      );
+      assert(
+        tr.warningIssues.some((w) => w.includes('CachedToolReverificationUnavailable')),
+        'should degrade through the unavailable-re-verification warning. warnings: ' + tr.warningIssues
+      );
+    }, tr);
+  });
+
   it('cache hit, no marker, source unreachable, requireOnlineReverification=true: fails closed instead of degrading (#778)', async () => {
     const tp = path.join(__dirname, 'CacheHitHashUnavailableStrict.js');
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/artifact-discard.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/artifact-discard.ts
@@ -1,0 +1,48 @@
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src, and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay byte-identical,
+// failing the build on any divergence, so a change here MUST be applied to ALL
+// THREE copies. This duplication is deliberate (each task bundles independently)
+// — not drift to be flagged.
+//
+// Also carried, with a provenance header instead of this one, by
+// azure-pipelines-packer's PackerInstallerV1/src. The same defect class covers
+// both extensions.
+
+import fs = require('fs');
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * Runs `verify` over a freshly downloaded artifact and, if any check inside it
+ * throws, DELETES the artifact before rethrowing.
+ *
+ * http-client.ts's downloadToFile already unlinks its destination when the
+ * TRANSFER fails, but verification is a separate, later step: an archive whose
+ * SHA256 does not match — i.e. one that may have been tampered with — was
+ * otherwise left in Agent.TempDirectory/os.tmpdir() indefinitely on a persistent
+ * self-hosted agent. EVERY verification of a freshly downloaded artifact goes
+ * through this wrapper, so a rejected artifact never outlives the check that
+ * rejected it. The unlink is best-effort and never masks the verification error
+ * that triggered it.
+ *
+ * Deliberately NOT used for the agent's CACHED executable: that file belongs to
+ * the tool cache and other jobs may be using it, so a failed cache re-verification
+ * fails the task without evicting it.
+ *
+ * Also deliberately NOT used for a checksum that is merely UNAVAILABLE (a source
+ * that published no checksum file, or a checksum file that does not list the
+ * requested asset) when the operator has opted out of requiring one: that install
+ * legitimately proceeds, so the artifact must survive. Wrap the comparison, not
+ * the lookup.
+ */
+export async function discardArtifactOnFailure<T>(artifactPath: string, verify: () => Promise<T>): Promise<T> {
+    try {
+        return await verify();
+    } catch (error) {
+        try {
+            fs.unlinkSync(artifactPath);
+            tasks.debug(`Discarded ${artifactPath}: it failed integrity verification.`);
+        } catch { /* best effort — the verification error is what matters */ }
+        throw error;
+    }
+}

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -13,6 +13,8 @@ import { validateUrlPathSegment } from './url-path-segment';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from './url-secret-redaction';
 import { VerificationFailure, isVerificationFailure } from './verification-failure';
+import { discardArtifactOnFailure } from './artifact-discard';
+import { retryAsync } from './retry';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
 
 /**
@@ -39,6 +41,21 @@ const isWindows = os.type().match(/^Win/);
 // File name of the local, per-cached-tool-directory integrity marker written after
 // a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
 const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
+
+// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
+// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
+// was tampered with; see verifyCachedTool (#198).
+const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
+
+/**
+ * Bounded retry for the binary download itself (#78): tools.downloadTool performs a
+ * single HTTP GET with no retry of its own, so a single transient blip during the
+ * largest and slowest fetch of the install failed the whole task. The metadata and
+ * checksum fetches already retry inside http-client.ts. Verification is deliberately
+ * OUTSIDE the retry -- a checksum or signature failure is deterministic and must
+ * never be repeated.
+ */
+const DOWNLOAD_RETRY = { retries: 2, baseDelayMs: 250, maxBackoffMs: 2000 };
 
 /**
  * Downloads the requested terraform-docs version, verifies its SHA256 checksum,
@@ -260,7 +277,7 @@ async function downloadFromRegistry(version: string, registryUrl: string, mirror
     }
 
     if (data.sha256) {
-        await verifySha256(filePath, data.sha256);
+        await discardArtifactOnFailure(filePath, () => verifySha256(filePath, data.sha256));
         return { path: filePath, verified: true };
     } else if (getBoolInputDefaultTrue("requireChecksum")) {
         // Empty sha256 means no local integrity check is possible. Fail closed when
@@ -312,8 +329,10 @@ async function verifyChecksumOrSkip(filePath: string, sha256Url: string, assetNa
         tasks.warning(`SHA256 verification skipped for ${sourceLabel} download: no checksum file published at ${sha256Url}.`);
         return false;
     }
-    // The checksum file exists: a missing asset entry or a hash mismatch is always fatal.
-    await verifySha256(filePath, parseSha256(sumsBody, assetName));
+    // The checksum file exists: a missing asset entry or a hash mismatch is always
+    // fatal — and DELETES the archive rather than leaving a rejected, possibly
+    // tampered artifact in the agent's temp directory (#204).
+    await discardArtifactOnFailure(filePath, () => verifySha256(filePath, parseSha256(sumsBody, assetName)));
     return true;
 }
 
@@ -321,7 +340,7 @@ async function verifyChecksumOrSkip(filePath: string, sha256Url: string, assetNa
 
 async function downloadTo(url: string, fileName: string): Promise<string> {
     try {
-        return await tools.downloadTool(url, fileName);
+        return await retryAsync(() => tools.downloadTool(url, fileName), DOWNLOAD_RETRY);
     } catch (exception) {
         // A mirror download URL can embed operator basic-auth userinfo; strip it from
         // the interpolated message (no-op for the official GitHub release URLs) (#586).
@@ -420,10 +439,21 @@ async function hashFile(filePath: string): Promise<string> {
  * trust-the-cache behavior.
  */
 async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
+    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
+    // a container kill -- leaves a marker that exists and is readable but is empty or
+    // truncated, and every later install of that version then compares the real digest
+    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
+    // permanently bricking the version on that agent (#198). Renaming into place means
+    // a reader only ever sees a complete digest or no marker at all.
+    const tempPath = `${markerPath}.${uuidV4()}.tmp`;
     try {
-        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), await hashFile(exePath), 'utf8');
+        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
+        fs.renameSync(tempPath, markerPath);
     } catch (err) {
         tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
+        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
     }
 }
 
@@ -437,10 +467,17 @@ async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Prom
  *   verification was disabled): returns false — the caller escalates to a remote
  *   re-verification against a freshly downloaded release (see
  *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
+ * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
+ *   an interrupted write (#198): returns false, exactly like a missing marker. An
+ *   unverifiable record is not evidence of tampering; feeding the fragment to the
+ *   comparison would fail every subsequent install of that version with a
+ *   tampering-shaped error and send an operator down a security-incident path for
+ *   what is a torn file. The marker is NOT healed here — healing happens only after
+ *   the escalated re-verification actually proves the cached executable.
  * - Marker present and it matches the cached executable's current hash: passes
  *   silently, returns true.
- * - Marker present but it does not match: the cached executable changed since it
- *   was verified (tampering or corruption on a shared agent) — fail closed.
+ * - Marker present, well-formed, and it does not match: the cached executable changed
+ *   since it was verified (tampering or corruption on a shared agent) — fail closed.
  *
  * Trust-boundary note: the marker lives next to the executable it protects, so an
  * attacker who can rewrite the cached binary under the agent account can rewrite
@@ -455,6 +492,10 @@ async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: str
         return false;
     }
     const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
+    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
+        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
+        return false;
+    }
     const actualHash = (await hashFile(exePath)).toLowerCase();
     if (actualHash !== storedHash) {
         throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/ArtifactTrustL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/ArtifactTrustL0.ts
@@ -1,0 +1,366 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { execFileSync } from 'child_process';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import { verifySha256, verifyCachedTool, writeCacheIntegrityMarker } from '../src/terraform-installer';
+import { discardArtifactOnFailure } from '../src/artifact-discard';
+import { VerificationFailure } from '../src/verification-failure';
+
+/**
+ * CLASS TEST — artifact trust (#65 / #78 / #136 / #198 / #204), sibling of
+ * azure-pipelines-packer's Tests/ArtifactTrustL0.ts.
+ *
+ * Defect class: an installed artifact is trusted without the verification the task
+ * advertises, or the verification's failure/edge state leaves the install path
+ * unrecoverable or silently degraded.
+ *
+ * Three tables:
+ *   A. SITE_ROWS — every trust site the re-runnable signature
+ *      (scripts/check-artifact-trust.js) enumerates across the WHOLE repo: all three
+ *      installer tasks, not just this one. A new download strategy or cache path in
+ *      any of them shows up here automatically and fails the enumeration assertion
+ *      until it is accounted for.
+ *   B. the failure/edge STATES themselves, driven through the real exported helpers:
+ *      a checksum mismatch (the artifact must be gone), a zero-length / truncated /
+ *      non-hex cache marker, a marker that matches, a marker that does not.
+ *   C. the same states end-to-end through the task.
+ *
+ * Every row is mutation-provable: inverting the guard it exercises turns that row —
+ * and only that row's group — RED.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const TF = 'Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts';
+const PA = 'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts';
+const TD = 'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts';
+
+type SiteRow = { file: string; fn: string; kind: string; verdict: string };
+
+/**
+ * Table A. Grouped by task. `VERIFIED` acquisition + `DISCARDS-ON-FAILURE`
+ * verification is the shape every fresh-download path must have; the EXEMPT verdicts
+ * are the code-verified exceptions, each of which is a real difference in the source's
+ * trust root (see the notes on the SUMS-ABSENT rows) rather than a hole.
+ */
+const SITE_ROWS: SiteRow[] = [
+    // ---------------- TerraformInstallerV1: terraform (GPG) + OpenTofu (cosign) ----
+    { file: TF, fn: 'downloadTerraform', kind: 'CACHE-ADMIT', verdict: 'REVERIFIES-AND-GATES' },
+    { file: TF, fn: 'resolveVersionFromHashiCorp', kind: 'LATEST', verdict: 'FAILS-CLOSED' },
+    { file: TF, fn: 'downloadZipFromHashiCorp', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: TF, fn: 'downloadZipFromHashiCorp', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TF, fn: 'downloadZipFromHashiCorp', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TF, fn: 'downloadZipFromRegistry', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: TF, fn: 'downloadZipFromRegistry', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TF, fn: 'downloadZipFromMirror', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    // The reported site of #65 in this repo: a mirror that publishes no SHA256SUMS
+    // also publishes nothing for the .sig to sign, so requireGpgSignature is read on
+    // that branch too.
+    { file: TF, fn: 'downloadZipFromMirror', kind: 'SUMS-ABSENT', verdict: 'HONORS-SIGNATURE-TOGGLE' },
+    { file: TF, fn: 'downloadZipFromMirror', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TF, fn: 'downloadZipFromMirror', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TF, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
+    { file: TF, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
+    { file: TF, fn: 'downloadTofu', kind: 'CACHE-ADMIT', verdict: 'REVERIFIES-AND-GATES' },
+    { file: TF, fn: 'resolveVersionFromOpenTofu', kind: 'LATEST', verdict: 'FAILS-CLOSED' },
+    { file: TF, fn: 'downloadZipFromOpenTofu', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: TF, fn: 'downloadZipFromOpenTofu', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TF, fn: 'downloadZipFromOpenTofu', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+
+    // ---------------- PolicyAgentInstallerV1: Sentinel (GPG) + OPA (sha256 only) ---
+    { file: PA, fn: 'downloadPolicyAgent', kind: 'CACHE-ADMIT', verdict: 'REVERIFIES-AND-GATES' },
+    { file: PA, fn: 'downloadSentinelOfficial', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: PA, fn: 'downloadSentinelOfficial', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: PA, fn: 'downloadSentinelOfficial', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: PA, fn: 'downloadOpaOfficial', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    // OPA ships no detached signature — its trust root is the sha256 published beside
+    // the asset on the same GitHub release. There is no signature toggle to honor
+    // here, and flattening this into the HashiCorp shape would invent one.
+    { file: PA, fn: 'downloadOpaOfficial', kind: 'SUMS-ABSENT', verdict: 'EXEMPT-NO-SIGNATURE-TRUST-ROOT' },
+    { file: PA, fn: 'downloadOpaOfficial', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: PA, fn: 'downloadFromRegistry', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: PA, fn: 'downloadFromRegistry', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: PA, fn: 'downloadFromMirror', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: PA, fn: 'downloadFromMirror', kind: 'SUMS-ABSENT', verdict: 'EXEMPT-NO-SIGNATURE-TRUST-ROOT' },
+    { file: PA, fn: 'downloadFromMirror', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    // Sentinel IS GPG-rooted, so the same mirror branch that is exempt for OPA above
+    // must honor requireGpgSignature here. Same file, two different trust roots.
+    { file: PA, fn: 'verifyMirrorChecksum', kind: 'SUMS-ABSENT', verdict: 'HONORS-SIGNATURE-TOGGLE' },
+    { file: PA, fn: 'verifyMirrorChecksum', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: PA, fn: 'verifyMirrorChecksum', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: PA, fn: 'downloadTo', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
+    { file: PA, fn: 'downloadFromMirrorUrl', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
+    { file: PA, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
+    { file: PA, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
+
+    // ---------------- TerraformDocsInstallerV1: sha256 only, no signature ----------
+    { file: TD, fn: 'downloadTerraformDocs', kind: 'CACHE-ADMIT', verdict: 'REVERIFIES-AND-GATES' },
+    { file: TD, fn: 'downloadOfficial', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: TD, fn: 'downloadFromRegistry', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    { file: TD, fn: 'downloadFromRegistry', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TD, fn: 'downloadFromMirror', kind: 'ACQUIRE', verdict: 'VERIFIED' },
+    // terraform-docs publishes a .sha256sum and no signature at all: same legitimate
+    // exemption as OPA.
+    { file: TD, fn: 'verifyChecksumOrSkip', kind: 'SUMS-ABSENT', verdict: 'EXEMPT-NO-SIGNATURE-TRUST-ROOT' },
+    { file: TD, fn: 'verifyChecksumOrSkip', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
+    { file: TD, fn: 'downloadTo', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
+    { file: TD, fn: 'downloadFromMirrorUrl', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
+    { file: TD, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
+    { file: TD, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
+];
+
+// --- Table B: the cache-integrity marker's edge states ----------------------
+
+type MarkerRow = {
+    what: string;
+    /** Marker content; undefined = no marker file. 'MATCH' = the executable's real digest. */
+    marker?: string;
+    /** verifyCachedTool outcome: false = unverifiable (escalate), true = verified, 'throws' = real mismatch. */
+    expect: true | false | 'throws';
+};
+
+/**
+ * Rows expecting `false` go RED if CACHE_INTEGRITY_MARKER_PATTERN validation is
+ * removed or inverted — they then throw a tampering-shaped CachedToolVerificationFailed,
+ * which is exactly the brick #198 describes. The `'throws'` row goes RED if the
+ * validation is widened so far that a genuine mismatch stops failing.
+ */
+const MARKER_ROWS: MarkerRow[] = [
+    { what: 'no marker at all (legacy cache entry)', marker: undefined, expect: false },
+    { what: 'a zero-length marker (interrupted write)', marker: '', expect: false },
+    { what: 'a whitespace-only marker', marker: '   \n', expect: false },
+    { what: 'a truncated marker (12 of 64 hex characters)', marker: 'aabbccddeeff', expect: false },
+    { what: 'an over-long marker (65 hex characters)', marker: 'a'.repeat(65), expect: false },
+    { what: 'a 64-character marker that is not hex', marker: 'z'.repeat(64), expect: false },
+    { what: 'a marker carrying a filename as well as a digest', marker: `${'a'.repeat(64)}  terraform`, expect: false },
+    { what: 'a well-formed marker that matches the cached executable', marker: 'MATCH', expect: true },
+    { what: 'a well-formed marker that does NOT match (real tampering)', marker: 'b'.repeat(64), expect: 'throws' },
+];
+
+// --- Table C: end-to-end through the task ----------------------------------
+
+type FlowRow = { fixture: string; what: string; outcome: 'success' | 'failure'; forbidText?: string };
+
+const FLOW_ROWS: FlowRow[] = [
+    {
+        fixture: 'CacheHitVerifyFail',
+        what: 'a cache hit whose WELL-FORMED marker does not match the executable (#136)',
+        outcome: 'failure',
+    },
+    {
+        fixture: 'CacheHitTruncatedMarkerDegrades',
+        what: 'a TRUNCATED marker + an unreachable source degrades instead of bricking the version (#198)',
+        outcome: 'success',
+        forbidText: 'CachedToolVerificationFailed',
+    },
+    {
+        fixture: 'CacheHitHashUnavailable',
+        what: 'a cache hit with no marker and an unreachable source degrades with a warning (#136 must not over-block)',
+        outcome: 'success',
+    },
+    {
+        fixture: 'CacheHitReverifyMismatch',
+        what: 'a cache hit with no marker whose executable differs from the freshly verified release (#136)',
+        outcome: 'failure',
+    },
+    {
+        fixture: 'CacheHitReverifyMirrorWithheld',
+        what: 'a reachable MIRROR withholding required material during re-verification — fail closed, not degrade (#136)',
+        outcome: 'failure',
+    },
+    {
+        fixture: 'CacheHitReverifyRegistryWithheld',
+        what: 'a reachable REGISTRY withholding a required sha256 during re-verification — fail closed (#136)',
+        outcome: 'failure',
+    },
+    {
+        fixture: 'CacheHitReverifyGpgFail',
+        what: 'a reachable source serving a SHA256SUMS whose signature does not verify during re-verification (#136)',
+        outcome: 'failure',
+    },
+    {
+        fixture: 'CacheHitVerifyPass',
+        what: 'a cache hit whose marker matches installs offline (#136 must not over-block)',
+        outcome: 'success',
+    },
+];
+
+describe('artifact trust (class test #65/#78/#136/#198/#204)', function () {
+    this.timeout(30000);
+
+    describe('A. every enumerated trust site in this repo', () => {
+        let stdout: string;
+        try {
+            stdout = execFileSync(
+                process.execPath,
+                [path.join(REPO_ROOT, 'scripts/check-artifact-trust.js'), REPO_ROOT, '--json'],
+                { encoding: 'utf8' },
+            );
+        } catch (err) {
+            stdout = String((err as { stdout?: string }).stdout ?? '');
+            assert.ok(stdout.trim().startsWith('{'), `signature produced no JSON: ${String(err)}`);
+        }
+        const report = JSON.parse(stdout) as {
+            sites: Array<{ rel: string; fn: string; kind: string; verdict: string; why: string; line: number }>;
+            failures: number;
+        };
+
+        it('leaves no residual instance of the class anywhere in src/', () => {
+            assert.strictEqual(
+                report.failures, 0,
+                `residual artifact-trust sites:\n${JSON.stringify(report.sites, null, 2)}`,
+            );
+        });
+
+        it('enumerates exactly the sites this table accounts for', () => {
+            const key = (s: { rel?: string; file?: string; kind: string; fn: string; verdict: string }) =>
+                `${s.rel ?? s.file}:${s.kind}:${s.fn}:${s.verdict}`;
+            assert.deepStrictEqual(
+                report.sites.map(key).sort(), SITE_ROWS.map(key).sort(),
+                'a trust site appeared, vanished, or changed verdict — add it to SITE_ROWS with its verdict',
+            );
+        });
+
+        for (const row of SITE_ROWS) {
+            it(`${row.file.split('/')[1]} ${row.fn}() [${row.kind}] is ${row.verdict}`, () => {
+                const site = report.sites.find(s => s.rel === row.file && s.fn === row.fn && s.kind === row.kind && s.verdict === row.verdict);
+                assert.ok(site, `site not found with that verdict: ${row.file} ${row.fn} [${row.kind}] ${row.verdict}`);
+            });
+        }
+    });
+
+    describe('B1. a verification failure discards the artifact (#204)', () => {
+        // mkdtempSync creates a unique 0700 directory atomically. A Math.random()
+        // name in the shared temp dir is guessable and the write is not O_EXCL, so
+        // a local user could pre-plant a symlink at that path and redirect it
+        // (CWE-377/378) -- the reason src/ uses secure-temp.ts.
+        function tempArtifact(content: string): string {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-trust-'));
+            const file = path.join(dir, 'artifact.zip');
+            fs.writeFileSync(file, content);
+            return file;
+        }
+
+        it('a checksum MISMATCH deletes the downloaded artifact', async () => {
+            const artifact = tempArtifact('tampered-zip-bytes');
+            try {
+                await assert.rejects(
+                    discardArtifactOnFailure(artifact, () => verifySha256(artifact, 'a'.repeat(64))),
+                    /SHA256|Sha256/,
+                );
+                assert.ok(!fs.existsSync(artifact), 'a checksum-mismatched artifact must not be left on disk');
+            } finally {
+                try { fs.unlinkSync(artifact); } catch { /* already gone, which is the point */ }
+            }
+        });
+
+        it('a SIGNATURE failure deletes the downloaded artifact', async () => {
+            const artifact = tempArtifact('unsigned-zip-bytes');
+            try {
+                await assert.rejects(
+                    discardArtifactOnFailure(artifact, async () => { throw new VerificationFailure('GPG signature verification failed for SHA256SUMS'); }),
+                    /GPG signature verification failed/,
+                );
+                assert.ok(!fs.existsSync(artifact), 'an artifact whose signature failed must not be left on disk');
+            } finally {
+                try { fs.unlinkSync(artifact); } catch { /* already gone */ }
+            }
+        });
+
+        it('a PASSING verification keeps the artifact (the guard must not delete good downloads)', async () => {
+            const artifact = tempArtifact('good-zip-bytes');
+            const digest = crypto.createHash('sha256').update(fs.readFileSync(artifact)).digest('hex');
+            try {
+                await discardArtifactOnFailure(artifact, () => verifySha256(artifact, digest));
+                assert.ok(fs.existsSync(artifact), 'a verified artifact must survive');
+            } finally {
+                try { fs.unlinkSync(artifact); } catch { /* best effort */ }
+            }
+        });
+
+        it('an unlink failure does not mask the verification error', async () => {
+            const missing = path.join(os.tmpdir(), `artifact-trust-absent-${process.pid}.zip`);
+            await assert.rejects(
+                discardArtifactOnFailure(missing, async () => { throw new VerificationFailure('checksum mismatch'); }),
+                /checksum mismatch/,
+            );
+        });
+    });
+
+    describe('B2. the cache-integrity marker\'s edge states (#198/#136)', () => {
+        const MARKER = '.installer-verified.sha256';
+        let dir: string;
+        let exe: string;
+
+        beforeEach(() => {
+            dir = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-trust-cache-'));
+            exe = path.join(dir, 'terraform');
+            fs.writeFileSync(exe, 'cached-terraform-binary');
+        });
+        afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+        const actualDigest = () => crypto.createHash('sha256').update(fs.readFileSync(exe)).digest('hex');
+
+        for (const row of MARKER_ROWS) {
+            it(`${row.expect === 'throws' ? 'fails on' : `reports ${row.expect} for`} ${row.what}`, async () => {
+                if (row.marker !== undefined) {
+                    fs.writeFileSync(path.join(dir, MARKER), row.marker === 'MATCH' ? actualDigest() : row.marker);
+                }
+                if (row.expect === 'throws') {
+                    await assert.rejects(verifyCachedTool(dir, exe, 'terraform 1.9.8'));
+                    return;
+                }
+                assert.strictEqual(await verifyCachedTool(dir, exe, 'terraform 1.9.8'), row.expect);
+            });
+        }
+
+        it('writes the marker atomically, leaving no temp file behind', async () => {
+            await writeCacheIntegrityMarker(dir, exe);
+            assert.strictEqual(fs.readFileSync(path.join(dir, MARKER), 'utf8'), actualDigest());
+            assert.deepStrictEqual(
+                fs.readdirSync(dir).filter(f => f.endsWith('.tmp')), [],
+                'an atomic write must not leave a temp file behind',
+            );
+        });
+
+        it('heals a torn marker: re-writing restores a verifiable entry', async () => {
+            fs.writeFileSync(path.join(dir, MARKER), 'aabbccddeeff');
+            assert.strictEqual(await verifyCachedTool(dir, exe, 'terraform 1.9.8'), false, 'a torn marker must read as unverifiable');
+            await writeCacheIntegrityMarker(dir, exe);
+            assert.strictEqual(await verifyCachedTool(dir, exe, 'terraform 1.9.8'), true, 're-writing must restore a verifiable entry');
+        });
+    });
+
+    describe('C. the same states end-to-end through the task', () => {
+        before(() => {
+            delete process.env.NODE_OPTIONS;
+            (ttm.MockTestRunner.prototype as unknown as { getNodePath: () => string }).getNodePath = function () {
+                return process.execPath;
+            };
+        });
+
+        for (const row of FLOW_ROWS) {
+            it(`${row.outcome === 'failure' ? 'fails' : 'installs'} when ${row.what}`, async () => {
+                const tr = new ttm.MockTestRunner(path.join(__dirname, `${row.fixture}.js`));
+                await tr.runAsync();
+                const detail = `\nSTDOUT: ${tr.stdout}\nSTDERR: ${tr.stderr}`;
+                if (row.outcome === 'failure') {
+                    assert.ok(tr.failed, `task should have failed (${row.fixture})${detail}`);
+                    assert.ok(tr.errorIssues.length > 0, `should have an error issue (${row.fixture})${detail}`);
+                } else {
+                    assert.ok(tr.succeeded, `task should have succeeded (${row.fixture})${detail}`);
+                    assert.strictEqual(tr.errorIssues.length, 0, `should have no errors (${row.fixture})${detail}`);
+                }
+                if (row.forbidText) {
+                    assert.ok(
+                        !tr.stdout.includes(row.forbidText),
+                        `"${row.forbidText}" must not appear — an unverifiable marker must not be reported as tampering (${row.fixture})${detail}`,
+                    );
+                }
+            });
+        }
+    });
+});

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitTruncatedMarkerDegrades.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitTruncatedMarkerDegrades.ts
@@ -1,0 +1,87 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const tp = path.join(__dirname, 'CacheHitHashUnavailableL0.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('terraformVersion', '1.9.8');
+tr.setInput('downloadSource', 'hashicorp');
+
+tr.registerMock('os', {
+    type: () => 'Windows_NT',
+    arch: () => 'x64'
+});
+
+tr.registerMock('./http-client', {
+    fetchJson: async (url: string) => {
+        throw new Error('fetchJson should not be called for a specific version. Called with: ' + url);
+    },
+    fetchText: async (url: string) => {
+        throw new Error(`getaddrinfo ENOTFOUND while fetching ${url}`);
+    }
+});
+
+tr.registerMock('undici', { ProxyAgent: class { } });
+
+tr.registerMock('./gpg-verifier', {
+    verifyGpgSignature: async (_sha256SumsContent: string, _signatureUrl: string) => { }
+});
+
+tr.registerMock('./cosign-verifier', {
+    verifyCosignSignature: async () => { }
+});
+
+// #198: the stored integrity marker exists and is READABLE but is TRUNCATED -- a
+// previous run's write was interrupted (disk full, cancelled job, container kill).
+// Feeding that fragment to the hash comparison produced a
+// CachedToolVerificationFailed, which reads as binary TAMPERING and permanently
+// bricked that version on the agent: every later install failed the same way. A
+// malformed marker is UNVERIFIABLE, not a mismatch, so it is now treated exactly like
+// a missing one -- escalate to a remote re-verification and, when the source is
+// unreachable (here), degrade with a warning instead of failing.
+// No USABLE stored integrity marker exists (e.g. cached by an installer version that
+// predates this check, or cached with checksum verification disabled), so the
+// installer attempts a remote re-verification — but the source is unreachable
+// (offline/air-gapped agent, simulated by downloadTool throwing a network
+// error). The install must degrade gracefully to the pre-existing
+// trust-the-cache behavior with a warning, never fail: offline cache reuse is
+// an explicitly supported scenario.
+tr.registerMock('fs', {
+    existsSync: (p: string) => String(p).includes('.installer-verified.sha256'),
+    readFileSync: (p: string, _enc?: string) => {
+        // A torn write: the first 12 characters of a 64-character digest.
+        if (String(p).includes('.installer-verified.sha256')) return 'aabbccddeeff';
+        throw new Error('readFileSync should not be called on anything but the marker when the re-verification download failed');
+    },
+    writeFileSync: () => {
+        throw new Error('writeFileSync should not be called when re-verification was degraded');
+    },
+    chmodSync: (_path: string, _mode: string) => { }
+});
+
+tr.registerMock('crypto', { randomUUID: () => 'test-uuid-1234' });
+
+tr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: (_toolName: string, _version: string) => '/tmp/terraform-cached',
+    downloadTool: async (url: string, _fileName: string) => {
+        throw new Error(`getaddrinfo ENOTFOUND while downloading ${url}`);
+    },
+    extractZip: async (_zipPath: string) => {
+        throw new Error('extractZip should not be called when the re-verification download failed');
+    },
+    cacheDir: async (_srcPath: string, _tool: string, _version: string) => {
+        throw new Error('cacheDir should not be called on a cache hit');
+    },
+    cleanVersion: (version: string) => version,
+    prependPath: (_toolPath: string) => { }
+});
+
+const a: ma.TaskLibAnswers = {
+    'find': {
+        '/tmp/terraform-cached': ['/tmp/terraform-cached/terraform.exe']
+    }
+};
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitVerifyFail.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/CacheHitVerifyFail.ts
@@ -32,6 +32,11 @@ tr.registerMock('./cosign-verifier', {
     verifyCosignSignature: async () => { }
 });
 
+// NOTE: both digests below are FULL 64-character SHA256 hex strings on purpose. A
+// SHORT (truncated) marker is not a mismatch at all -- it is an UNVERIFIABLE marker,
+// which verifyCachedTool now reports as "no usable marker" instead of failing with a
+// tampering-shaped error (#198); CacheHitTruncatedMarkerDegrades covers that state.
+// This fixture must exercise a genuine, well-formed mismatch.
 // The stored integrity marker does NOT match the (mocked) hash of the cached
 // executable's current on-disk content: the cached copy was modified/corrupted
 // since it was last verified, and the cache-hit re-verification must reject it.
@@ -39,7 +44,7 @@ tr.registerMock('fs', {
     existsSync: (p: string) => p.includes('.installer-verified.sha256'),
     readFileSync: (p: string, _enc?: string) => {
         if (p.includes('.installer-verified.sha256')) {
-            return 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+            return 'aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
         }
         return Buffer.from('tampered-exe-content');
     },
@@ -54,7 +59,7 @@ tr.registerMock('crypto', {
     randomUUID: () => 'test-uuid-1234',
     createHash: (_algorithm: string) => {
         const hash: any = new (require('stream').Writable)({ write(_chunk: any, _enc: any, cb: any) { cb(); } });
-        hash.digest = (_encoding: string) => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd001122';
+        hash.digest = (_encoding: string) => 'ffffffff00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233';
         return hash;
     }
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/L0.ts
@@ -27,6 +27,10 @@ import './UrlSecretRedactionL0';
 // (#161/#191/#200/#201, sibling azure-pipelines-packer #161). Imported for its
 // side effect of registering the suite.
 import './EgressAuthorizationL0';
+// Table-driven class test for the artifact-trust defect class (#65/#78/#136/#198/#204):
+// every path by which a binary becomes trusted, across ALL THREE installer tasks, plus
+// the failure/edge states of the verification itself.
+import './ArtifactTrustL0';
 
 describe('TerraformInstaller Test Suite', function () {
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/artifact-discard.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/artifact-discard.ts
@@ -1,0 +1,48 @@
+// SHARED MODULE — intentionally duplicated across TerraformInstallerV1/src,
+// PolicyAgentInstallerV1/src, and TerraformDocsInstallerV1/src. CI
+// (scripts/check-shared-modules.js) enforces that the copies stay byte-identical,
+// failing the build on any divergence, so a change here MUST be applied to ALL
+// THREE copies. This duplication is deliberate (each task bundles independently)
+// — not drift to be flagged.
+//
+// Also carried, with a provenance header instead of this one, by
+// azure-pipelines-packer's PackerInstallerV1/src. The same defect class covers
+// both extensions.
+
+import fs = require('fs');
+import tasks = require('azure-pipelines-task-lib/task');
+
+/**
+ * Runs `verify` over a freshly downloaded artifact and, if any check inside it
+ * throws, DELETES the artifact before rethrowing.
+ *
+ * http-client.ts's downloadToFile already unlinks its destination when the
+ * TRANSFER fails, but verification is a separate, later step: an archive whose
+ * SHA256 does not match — i.e. one that may have been tampered with — was
+ * otherwise left in Agent.TempDirectory/os.tmpdir() indefinitely on a persistent
+ * self-hosted agent. EVERY verification of a freshly downloaded artifact goes
+ * through this wrapper, so a rejected artifact never outlives the check that
+ * rejected it. The unlink is best-effort and never masks the verification error
+ * that triggered it.
+ *
+ * Deliberately NOT used for the agent's CACHED executable: that file belongs to
+ * the tool cache and other jobs may be using it, so a failed cache re-verification
+ * fails the task without evicting it.
+ *
+ * Also deliberately NOT used for a checksum that is merely UNAVAILABLE (a source
+ * that published no checksum file, or a checksum file that does not list the
+ * requested asset) when the operator has opted out of requiring one: that install
+ * legitimately proceeds, so the artifact must survive. Wrap the comparison, not
+ * the lookup.
+ */
+export async function discardArtifactOnFailure<T>(artifactPath: string, verify: () => Promise<T>): Promise<T> {
+    try {
+        return await verify();
+    } catch (error) {
+        try {
+            fs.unlinkSync(artifactPath);
+            tasks.debug(`Discarded ${artifactPath}: it failed integrity verification.`);
+        } catch { /* best effort — the verification error is what matters */ }
+        throw error;
+    }
+}

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -15,6 +15,8 @@ import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';
 import { extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from './url-secret-redaction';
 import { VerificationFailure, isVerificationFailure } from './verification-failure';
+import { discardArtifactOnFailure } from './artifact-discard';
+import { retryAsync } from './retry';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
 
 /**
@@ -42,6 +44,21 @@ const isWindows = os.type().match(/^Win/);
 // File name of the local, per-cached-tool-directory integrity marker written after
 // a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
 const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
+
+// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
+// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
+// was tampered with; see verifyCachedTool (#198).
+const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
+
+/**
+ * Bounded retry for the binary download itself (#78): tools.downloadTool performs a
+ * single HTTP GET with no retry of its own, so a single transient blip during the
+ * largest and slowest fetch of the install failed the whole task. The metadata and
+ * checksum fetches already retry inside http-client.ts. Verification is deliberately
+ * OUTSIDE the retry -- a checksum or signature failure is deterministic and must
+ * never be repeated.
+ */
+const DOWNLOAD_RETRY = { retries: 2, baseDelayMs: 250, maxBackoffMs: 2000 };
 
 export async function downloadTerraform(inputVersion: string): Promise<string> {
     const binary = tasks.getInput("binary") || "terraform";
@@ -185,7 +202,7 @@ async function downloadZipFromHashiCorp(version: string): Promise<string> {
     const fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
     let zipPath: string;
     try {
-        zipPath = await tools.downloadTool(downloadUrl, fileName);
+        zipPath = await retryAsync(() => tools.downloadTool(downloadUrl, fileName), DOWNLOAD_RETRY);
     } catch (exception) {
         throw new Error(tasks.loc("TerraformDownloadFailed", downloadUrl, exception));
     }
@@ -198,10 +215,12 @@ async function downloadZipFromHashiCorp(version: string): Promise<string> {
 
     const sha256SumsContent = await fetchText(sha256SumsUrl);
     const requireGpg = getBoolInputDefaultTrue("requireGpgSignature");
-    await verifyGpgSignature(sha256SumsContent, sha256SumsSigUrl, requireGpg);
-
-    const expectedHash = parseSha256(sha256SumsContent, zipFileName);
-    await verifySha256(zipPath, expectedHash);
+    // A failed signature or checksum check DELETES the zip rather than leaving a
+    // rejected — possibly tampered — artifact in the agent's temp directory (#204).
+    await discardArtifactOnFailure(zipPath, async () => {
+        await verifyGpgSignature(sha256SumsContent, sha256SumsSigUrl, requireGpg);
+        await verifySha256(zipPath, parseSha256(sha256SumsContent, zipFileName));
+    });
 
     return zipPath;
 }
@@ -289,7 +308,7 @@ async function downloadZipFromRegistry(version: string, registryUrl: string, mir
     }
 
     if (data.sha256) {
-        await verifySha256(zipPath, data.sha256);
+        await discardArtifactOnFailure(zipPath, () => verifySha256(zipPath, data.sha256));
         return { zipPath, verified: true };
     } else if (getBoolInputDefaultTrue("requireChecksum")) {
         // Empty sha256 means no local integrity check is possible. Fail closed when
@@ -388,8 +407,10 @@ async function downloadZipFromMirror(version: string, mirrorBaseUrl: string): Pr
     // The SHA256SUMS exists: verify its GPG signature against HashiCorp's pinned
     // key (a missing .sig is fatal only when requireGpgSignature is set), then
     // verify the zip's hash. A missing asset entry or a hash mismatch is fatal.
-    await verifyGpgSignature(sumsBody, sha256SumsSigUrl, requireGpg);
-    await verifySha256(zipPath, parseSha256(sumsBody, zipFileName));
+    await discardArtifactOnFailure(zipPath, async () => {
+        await verifyGpgSignature(sumsBody, sha256SumsSigUrl, requireGpg);
+        await verifySha256(zipPath, parseSha256(sumsBody, zipFileName));
+    });
     return { zipPath, verified: true };
 }
 
@@ -448,11 +469,22 @@ async function hashFile(filePath: string): Promise<string> {
  * only means a future cache hit for this tool degrades to the pre-existing
  * trust-the-cache behavior.
  */
-async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
+export async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
+    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
+    // a container kill -- leaves a marker that exists and is readable but is empty or
+    // truncated, and every later install of that version then compares the real digest
+    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
+    // permanently bricking the version on that agent (#198). Renaming into place means
+    // a reader only ever sees a complete digest or no marker at all.
+    const tempPath = `${markerPath}.${uuidV4()}.tmp`;
     try {
-        fs.writeFileSync(path.join(toolDir, CACHE_INTEGRITY_MARKER), await hashFile(exePath), 'utf8');
+        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
+        fs.renameSync(tempPath, markerPath);
     } catch (err) {
         tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
+        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
     }
 }
 
@@ -466,10 +498,17 @@ async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Prom
  *   verification was disabled): returns false — the caller escalates to a remote
  *   re-verification against a freshly downloaded release (see
  *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
+ * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
+ *   an interrupted write (#198): returns false, exactly like a missing marker. An
+ *   unverifiable record is not evidence of tampering; feeding the fragment to the
+ *   comparison would fail every subsequent install of that version with a
+ *   tampering-shaped error and send an operator down a security-incident path for
+ *   what is a torn file. The marker is NOT healed here — healing happens only after
+ *   the escalated re-verification actually proves the cached executable.
  * - Marker present and it matches the cached executable's current hash: passes
  *   silently, returns true.
- * - Marker present but it does not match: the cached executable changed since it
- *   was verified (tampering or corruption on a shared agent) — fail closed.
+ * - Marker present, well-formed, and it does not match: the cached executable changed
+ *   since it was verified (tampering or corruption on a shared agent) — fail closed.
  *
  * Trust-boundary note: the marker lives next to the executable it protects, so an
  * attacker who can rewrite the cached binary under the agent account can rewrite
@@ -477,13 +516,17 @@ async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Prom
  * cross-job verification-policy mixing, not against an attacker who already has
  * write access to the agent's tool cache (who effectively owns the agent).
  */
-async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
+export async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
     const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
     if (!fs.existsSync(markerPath)) {
         tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
         return false;
     }
     const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
+    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
+        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
+        return false;
+    }
     const actualHash = (await hashFile(exePath)).toLowerCase();
     if (actualHash !== storedHash) {
         throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
@@ -636,8 +679,15 @@ async function downloadTofu(inputVersion: string): Promise<string> {
     let cachedToolPath = tools.findLocalTool(tofuToolName, version);
     const cacheHit = !!cachedToolPath;
 
+    // Mirrors downloadTerraform: the cache-integrity marker is written only for an
+    // artifact this run actually verified. downloadZipFromOpenTofu verifies the zip's
+    // SHA256 unconditionally (cosign only gates the AUTHENTICITY of the SHA256SUMS
+    // itself), so reaching the line below means the artifact was verified — stated
+    // explicitly rather than left as an invariant a future edit could quietly break.
+    let verified = false;
     if (!cachedToolPath) {
         const zipPath = await downloadZipFromOpenTofu(version);
+        verified = true;
         const unzippedPath = await tools.extractZip(zipPath);
         cachedToolPath = await tools.cacheDir(unzippedPath, tofuToolName, version);
         tasks.setVariable('terraformDownloadedFrom', 'opentofu');
@@ -666,9 +716,7 @@ async function downloadTofu(inputVersion: string): Promise<string> {
                 (rootFolder) => findExecutable(rootFolder, tofuToolName),
             );
         }
-    } else {
-        // downloadZipFromOpenTofu always verifies the zip's SHA256 unconditionally
-        // (cosign only gates authenticity of the SHA256SUMS itself).
+    } else if (verified) {
         await writeCacheIntegrityMarker(cachedToolPath, tofuPath);
     }
 
@@ -708,7 +756,7 @@ async function downloadZipFromOpenTofu(version: string): Promise<string> {
     const fileName = `${tofuToolName}-${version}-${uuidV4()}.zip`;
     let zipPath: string;
     try {
-        zipPath = await tools.downloadTool(downloadUrl, fileName);
+        zipPath = await retryAsync(() => tools.downloadTool(downloadUrl, fileName), DOWNLOAD_RETRY);
     } catch (exception) {
         throw new Error(tasks.loc("TerraformDownloadFailed", downloadUrl, exception));
     }
@@ -728,10 +776,11 @@ async function downloadZipFromOpenTofu(version: string): Promise<string> {
     // against an operator-supplied hash before trusting it, closing the ambient
     // PATH-lookup trust gap. Unset (default), behavior is unchanged.
     const cosignSha256 = tasks.getInput("cosignSha256", false);
-    await verifyCosignSignature(sha256SumsContent, signatureUrl, certificateUrl, version, requireCosign, cosignSha256 || undefined);
-
-    const expectedHash = parseSha256(sha256SumsContent, zipFileName);
-    await verifySha256(zipPath, expectedHash);
+    // As on the hashicorp path: a failed cosign or checksum check discards the zip (#204).
+    await discardArtifactOnFailure(zipPath, async () => {
+        await verifyCosignSignature(sha256SumsContent, signatureUrl, certificateUrl, version, requireCosign, cosignSha256 || undefined);
+        await verifySha256(zipPath, parseSha256(sha256SumsContent, zipFileName));
+    });
 
     return zipPath;
 }

--- a/scripts/check-artifact-trust.js
+++ b/scripts/check-artifact-trust.js
@@ -1,0 +1,494 @@
+#!/usr/bin/env node
+// ARTIFACT-TRUST SIGNATURE (#65 / #78 / #136 / #198 / #204).
+//
+// Defect class
+// ------------
+//   An installed artifact is trusted without the verification the task
+//   advertises, or the verification's failure/edge state leaves the install
+//   path unrecoverable or silently degraded.
+//
+// The five reported instances are five *different* points on the same seam, so
+// a signature that matched only "the mirror path" would restate one instance
+// instead of enumerating the class. This script enumerates EVERY path by which
+// a binary becomes trusted and verdicts each one:
+//
+//   ACQUIRE       a function that pulls an artifact off the network. Must reach
+//                 a verifier (or be a pure wrapper whose caller verifies).
+//   VERIFY        a function that checks a downloaded artifact's hash/signature.
+//                 A failed check must DISCARD the artifact (#204) — a
+//                 checksum-mismatched (i.e. possibly tampered) file must not be
+//                 left on a persistent agent's disk.
+//   SUMS-ABSENT   the branch that handles "the source published no checksum
+//                 file". If the SAME function verifies a signature elsewhere,
+//                 the source's trust root is signature-based and this branch
+//                 must honour the require-signature toggle too, or the toggle is
+//                 inert exactly where it matters most (#65). A function with no
+//                 signature call has a sha256-only trust root (OPA,
+//                 terraform-docs) — that difference is legitimate and is
+//                 reported as an EXEMPT verdict, never flattened.
+//   CACHE-ADMIT   a function that admits a tool from the agent's tool cache. It
+//                 must re-verify on a hit, and must only record a cache
+//                 integrity marker for an artifact that was actually verified
+//                 (#136).
+//   RECORD-READ   the read of that integrity marker. A zero-length/truncated
+//                 marker is UNVERIFIABLE, not a mismatch: it must be validated
+//                 as a 64-hex digest before use, or every later install of that
+//                 version dies with a tampering-shaped error (#198).
+//   RECORD-WRITE  the write of the marker. Must be atomic (temp + rename), or a
+//                 killed job leaves exactly the truncated marker above (#198).
+//   LATEST        'latest' version resolution. Falling back to a pinned constant
+//                 on failure silently hands a security-currency-seeking caller a
+//                 stale binary (#78).
+//
+// Discovery is by CODE SHAPE, not by call-site name: sites are found by walking
+// **/src/**/*.ts, splitting each file into top-level functions, and following an
+// in-file call graph. A newly added download strategy is enumerated automatically.
+//
+// Repo-agnostic — runs unchanged in azure-pipelines-terraform and
+// azure-pipelines-packer:
+//
+//     node scripts/check-artifact-trust.js [repoRoot] [--json]
+//
+// Exit 0 = no residual instances of the class. Exit 1 = residuals, listed.
+
+const fs = require('fs');
+const path = require('path');
+
+const JSON_OUTPUT = process.argv.includes('--json');
+const ROOT = path.resolve(process.argv.filter((a) => a !== '--json')[2] || process.cwd());
+
+// Network sinks that put bytes on disk. Anything here makes its enclosing
+// function an ACQUIRE site.
+const DOWNLOAD_PRIMITIVES = ['downloadTool', 'downloadToolWithTimeout', 'downloadToFile'];
+
+// The checks that establish trust in a downloaded artifact.
+const VERIFIERS = ['verifySha256', 'verifyGpgSignature', 'verifyCosignSignature'];
+
+// Signature verification specifically (as opposed to a bare checksum): its
+// presence in a function is what makes that function's trust root signature-based.
+const SIGNATURE_VERIFIERS = ['verifyGpgSignature', 'verifyCosignSignature'];
+
+// The helper that IS the #204 fix: it runs the verification and deletes the
+// artifact if the verification throws.
+const DISCARD_GUARD = 'discardArtifactOnFailure';
+
+// The tool-cache lookup that makes a function a CACHE-ADMIT site.
+const CACHE_LOOKUP = 'findLocalTool';
+
+// A require-toggle whose subject is a SIGNATURE (not a bare checksum).
+const SIGNATURE_TOGGLE = /require(?:Gpg|Cosign)/;
+
+// The verification-status token a cache-admit site must gate its marker write on.
+const VERIFIED_STATUS = /\bverified\b/;
+
+function walk(dir, out = []) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return out;
+    }
+    for (const entry of entries) {
+        if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'build') continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, out);
+        else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts') && full.includes(`${path.sep}src${path.sep}`)) out.push(full);
+    }
+    return out;
+}
+
+/**
+ * Returns a copy of `source` with every comment and string/template literal
+ * blanked out (offsets preserved), so a name appearing in prose is never read as
+ * a call. All structural scanning below runs on this masked text.
+ */
+function maskCommentsAndStrings(source) {
+    const out = source.split('');
+    let inLine = false, inBlock = false, quote = null;
+    for (let i = 0; i < source.length; i++) {
+        const c = source[i], next = source[i + 1];
+        if (inLine) { if (c === '\n') inLine = false; else out[i] = ' '; continue; }
+        if (inBlock) { if (c === '*' && next === '/') { out[i] = out[i + 1] = ' '; inBlock = false; i++; } else if (c !== '\n') out[i] = ' '; continue; }
+        if (quote) {
+            if (c === '\\') { out[i] = ' '; if (source[i + 1] !== '\n') out[i + 1] = ' '; i++; continue; }
+            if (c === quote) { out[i] = ' '; quote = null; continue; }
+            if (c !== '\n') out[i] = ' ';
+            continue;
+        }
+        if (c === '/' && next === '/') { out[i] = out[i + 1] = ' '; inLine = true; i++; continue; }
+        if (c === '/' && next === '*') { out[i] = out[i + 1] = ' '; inBlock = true; i++; continue; }
+        if (c === '"' || c === "'" || c === '`') { out[i] = ' '; quote = c; continue; }
+    }
+    return out.join('');
+}
+
+/** Splits a file into its top-level function bodies by brace depth over the masked text. */
+function topLevelFunctions(source, masked) {
+    const ranges = [];
+    let depth = 0;
+    let openIndex = -1;
+    for (let i = 0; i < masked.length; i++) {
+        const c = masked[i];
+        if (c === '{') {
+            if (depth === 0) openIndex = i;
+            depth++;
+        } else if (c === '}') {
+            depth--;
+            if (depth === 0 && openIndex >= 0) {
+                const headerStart = source.lastIndexOf('\n', source.lastIndexOf('\n', openIndex) - 1) + 1;
+                const header = masked.slice(headerStart, openIndex);
+                const named = header.match(/(?:function\s+(\w+)|const\s+(\w+)\s*[:=])/);
+                ranges.push({
+                    name: named ? (named[1] || named[2]) : '<anonymous>',
+                    start: openIndex,
+                    end: i + 1,
+                    text: masked.slice(openIndex, i + 1),
+                    raw: source.slice(openIndex, i + 1),
+                    header,
+                    params: (header.match(/\(([^)]*)\)/) || [, ''])[1]
+                        .split(',').map((p) => p.trim().split(':')[0].trim()).filter(Boolean),
+                });
+                openIndex = -1;
+            }
+        }
+    }
+    return ranges;
+}
+
+/** Every `name(` call index inside `text` (offsets relative to `text`). */
+function callIndices(text, name) {
+    const re = new RegExp(`(?<![.\\w])(?:\\w+\\.)?${name}\\s*(?:<[^>(]*>)?\\s*\\(`, 'g');
+    const out = [];
+    let m;
+    while ((m = re.exec(text)) !== null) out.push({ index: m.index, open: m.index + m[0].length - 1 });
+    return out;
+}
+
+/** Index of the matching ')' for the '(' at `open`. */
+function matchParen(text, open) {
+    let depth = 0;
+    for (let i = open; i < text.length; i++) {
+        const c = text[i];
+        if (c === '(' || c === '[' || c === '{') depth++;
+        else if (c === ')' || c === ']' || c === '}') {
+            depth--;
+            if (depth === 0) return i;
+        }
+    }
+    return text.length;
+}
+
+/** Spans [start,end) covered by every `name(...)` call in `text`. */
+function callSpans(text, name) {
+    return callIndices(text, name).map(({ index, open }) => [index, matchParen(text, open) + 1]);
+}
+
+/** Names called (in-file) from a function body. */
+function calleesOf(fnText, definedNames) {
+    const out = new Set();
+    for (const name of definedNames) {
+        if (callIndices(fnText, name).length > 0) out.add(name);
+    }
+    return out;
+}
+
+/** Transitive in-file closure of `start` over the call graph. */
+function closure(start, graph) {
+    const seen = new Set([start]);
+    const stack = [start];
+    while (stack.length) {
+        for (const next of graph.get(stack.pop()) || []) {
+            if (!seen.has(next)) { seen.add(next); stack.push(next); }
+        }
+    }
+    return seen;
+}
+
+/**
+ * Condition text of the innermost block enclosing `index` inside `fnText`,
+ * i.e. everything between the previous statement boundary and the block's `{`.
+ * Used to prove a cache-marker write is gated on a verification status.
+ */
+function enclosingConditionText(fnText, index) {
+    let depth = 0;
+    for (let i = index; i >= 0; i--) {
+        const c = fnText[i];
+        if (c === '}') depth++;
+        else if (c === '{') {
+            if (depth === 0) {
+                const from = Math.max(0, i - 240);
+                return fnText.slice(from, i);
+            }
+            depth--;
+        }
+    }
+    return '';
+}
+
+/** Body text of the block that follows `index` (the `{ ... }` after an `if (...)`). */
+function blockAfter(fnText, index) {
+    const open = fnText.indexOf('{', index);
+    if (open < 0) return fnText.slice(index, index + 400);
+    let depth = 0;
+    for (let i = open; i < fnText.length; i++) {
+        const c = fnText[i];
+        if (c === '{') depth++;
+        else if (c === '}') {
+            depth--;
+            if (depth === 0) return fnText.slice(open, i + 1);
+        }
+    }
+    return fnText.slice(open);
+}
+
+const files = walk(ROOT);
+if (files.length === 0) {
+    console.error(`FAIL: no **/src/**/*.ts files found under ${ROOT} — the signature would pass vacuously.`);
+    process.exit(1);
+}
+
+const sites = [];
+
+for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    const masked = maskCommentsAndStrings(source);
+    // Site identities must be byte-stable across platforms.
+    const rel = path.relative(ROOT, file).split(path.sep).join('/');
+    const fns = topLevelFunctions(source, masked);
+    if (fns.length === 0) continue;
+    const lineOf = (absIndex) => source.slice(0, absIndex).split('\n').length;
+
+    const byName = new Map(fns.filter((f) => f.name !== '<anonymous>').map((f) => [f.name, f]));
+    const definedNames = [...byName.keys()];
+    const graph = new Map(fns.map((f) => [f.name, calleesOf(f.text, definedNames)]));
+
+    // 64-hex validators declared at module scope, e.g. `const SHA256_HEX_PATTERN = /^[a-fA-F0-9]{64}$/;`
+    const hexConsts = [...masked.matchAll(/(?:const|let)\s+(\w+)\s*(?::[^=]+)?=\s*(\/[^/\n]*\{64\}[^/\n]*\/[a-z]*)/g)].map((m) => m[1]);
+    const validatesHex = (fnText) =>
+        /\/\^?\[[^\]]*a-f[^\]]*\]\{64\}\$?\/[a-z]*\s*\.test\s*\(/i.test(fnText)
+        || hexConsts.some((name) => new RegExp(`\\b${name}\\s*\\.test\\s*\\(`).test(fnText));
+
+    const add = (kind, fn, verdict, why, index) =>
+        sites.push({ kind, rel, fn: fn.name, verdict, why, line: lineOf(index) });
+
+    /**
+     * A pure download WRAPPER: it calls a primitive with a URL that is one of its
+     * own parameters, so the verification decision belongs to whoever calls it.
+     * Discovered, not listed — a new wrapper is picked up automatically, and its
+     * callers are then enumerated as ACQUIRE sites in their own right.
+     */
+    const acquireWrappers = new Set(fns.filter((fn) =>
+        DOWNLOAD_PRIMITIVES.some((p) => fn.name !== p && callIndices(fn.text, p).some(({ open }) =>
+            fn.params.includes(fn.text.slice(open + 1, matchParen(fn.text, open)).split(',')[0].trim())))
+    ).map((fn) => fn.name));
+
+    // Phases: sites discovered later depend on classifications made earlier
+    // (a cache-admit verdict needs to know which functions read/write the
+    // integrity record), so the same function set is walked three times.
+    for (const phase of [1, 2, 3]) for (const fn of fns) {
+        if (fn.name === '<anonymous>') continue;
+        const reach = closure(fn.name, graph);
+        const reaches = (names) => names.some((n) =>
+            [...reach].some((r) => (byName.get(r) ? callIndices(byName.get(r).text, n).length > 0 : false)));
+
+        const discardSpans = callSpans(fn.text, DISCARD_GUARD);
+        const inDiscardSpan = (i) => discardSpans.some(([s, e]) => i >= s && i < e);
+
+        if (phase === 1) {
+        // ---------------- VERIFY sites ----------------
+        // Every direct verification of a downloaded artifact in this function.
+        const verifierCalls = VERIFIERS.flatMap((v) => callIndices(fn.text, v).map((c) => ({ ...c, v })));
+        // A function that reads a cache-integrity marker is verifying the AGENT'S
+        // CACHED TOOL, not a fresh download: deleting it there would evict another
+        // job's cache entry, so the discard requirement deliberately does not apply.
+        const readsMarker = /(\w+)\s*=\s*(?:await\s+)?fs\.readFileSync\s*\(/.test(fn.text)
+            && (VERIFIERS.some((v) => callIndices(fn.text, v).length > 0) || /!==|===/.test(fn.text))
+            && /marker|sidecar|Marker|Sidecar/i.test(fn.text);
+        for (const call of verifierCalls) {
+            if (readsMarker) {
+                add('VERIFY', fn, 'EXEMPT-CACHE-VERIFY',
+                    'verifies the agent-cached executable against its recorded marker; discarding here would evict another job\'s cache entry',
+                    fn.start + call.index);
+            } else if (inDiscardSpan(call.index)) {
+                add('VERIFY', fn, 'DISCARDS-ON-FAILURE', `${call.v} runs inside ${DISCARD_GUARD}()`, fn.start + call.index);
+            } else {
+                add('VERIFY', fn, 'RETAINS-ON-FAILURE',
+                    `${call.v} is not wrapped in ${DISCARD_GUARD}() — a failed check leaves the artifact on disk (#204)`,
+                    fn.start + call.index);
+            }
+        }
+
+        // ---------------- SUMS-ABSENT branches ----------------
+        // The "this source published no checksum file" branch: a value assigned
+        // from fetch{Text,Buffer}Allow404() (which returns null on a genuine 404,
+        // never on a transient failure) that the function then null-checks. Only
+        // counted in a function that itself verifies the artifact, so the branch
+        // really does decide whether verification happens.
+        const absentVars = [...fn.text.matchAll(/(\w+)\s*=\s*(?:await\s+)?fetch(?:Text|Buffer)Allow404\s*\(/g)].map((m) => m[1]);
+        const verifiesHere = VERIFIERS.some((v) => callIndices(fn.text, v).length > 0);
+        if (verifiesHere) {
+            // The toggle governing SIGNATURE verification is whatever this
+            // function passes as the `required` argument of its signature check —
+            // read off the call, never hardcoded, so a rename cannot blind this.
+            const signatureCall = SIGNATURE_VERIFIERS.flatMap((v) => callIndices(fn.text, v))[0];
+            const signatureToggle = signatureCall
+                ? (fn.text.slice(signatureCall.open + 1, matchParen(fn.text, signatureCall.open)).split(',').pop() || '').trim()
+                : null;
+            for (const v of absentVars) {
+                const m = fn.text.match(new RegExp(`\\b${v}\\s*===\\s*null`));
+                if (!m || m.index === undefined) continue;
+                const block = blockAfter(fn.text, m.index);
+                if (!signatureToggle) {
+                    add('SUMS-ABSENT', fn, 'EXEMPT-NO-SIGNATURE-TRUST-ROOT',
+                        'this source is sha256-rooted (it publishes no detached signature), so a require-signature toggle has nothing to check here',
+                        fn.start + m.index);
+                } else if (new RegExp(`\\b${signatureToggle}\\b`).test(block) || SIGNATURE_TOGGLE.test(block)) {
+                    add('SUMS-ABSENT', fn, 'HONORS-SIGNATURE-TOGGLE',
+                        `the no-checksum-file branch consults ${signatureToggle} before installing`,
+                        fn.start + m.index);
+                } else {
+                    add('SUMS-ABSENT', fn, 'SIGNATURE-TOGGLE-INERT',
+                        `a signature-rooted source published no checksum file and this branch never reads ${signatureToggle} — the toggle is inert exactly where verification is missing (#65)`,
+                        fn.start + m.index);
+                }
+            }
+        }
+
+        // ---------------- RECORD-READ / RECORD-WRITE ----------------
+        const readAssign = [...fn.text.matchAll(/(\w+)\s*=\s*(?:await\s+)?fs\.readFileSync\s*\(/g)];
+        for (const m of readAssign) {
+            const v = m[1];
+            const after = fn.text.slice(m.index);
+            const usedAsExpectedHash =
+                new RegExp(`verifySha256\\s*\\([^)]*,\\s*${v}\\b`).test(after)
+                || new RegExp(`(?:!==|===)\\s*${v}\\b`).test(after)
+                || new RegExp(`\\b${v}\\s*(?:!==|===)`).test(after);
+            if (!usedAsExpectedHash) continue;
+            add('RECORD-READ', fn, validatesHex(fn.text) ? 'VALIDATES-RECORD' : 'TRUSTS-MALFORMED-RECORD',
+                validatesHex(fn.text)
+                    ? 'the stored digest is validated as 64 hex characters before it is used as an expectation'
+                    : 'a zero-length or truncated marker is fed straight to the comparison, so an unverifiable record reads as tampering and bricks the version (#198)',
+                fn.start + m.index);
+        }
+        const writeCalls = callIndices(fn.text, 'writeFileSync');
+        for (const call of writeCalls) {
+            const args = fn.text.slice(call.open + 1, matchParen(fn.text, call.open));
+            if (!/hash|digest/i.test(args)) continue;
+            add('RECORD-WRITE', fn, callIndices(fn.text, 'renameSync').length > 0 ? 'ATOMIC-WRITE' : 'TORN-WRITE',
+                callIndices(fn.text, 'renameSync').length > 0
+                    ? 'written to a temp name in the same directory and renamed into place, so no reader ever sees a partial digest'
+                    : 'a non-atomic write leaves a truncated marker behind if the job is killed mid-write (#198)',
+                fn.start + call.index);
+        }
+
+        } // end phase 1
+
+        // ---------------- ACQUIRE sites ----------------
+        // Any function that pulls an artifact off the network, whether through a
+        // primitive directly or through a discovered wrapper.
+        if (phase === 2) {
+        const downloadCalls = [...DOWNLOAD_PRIMITIVES, ...acquireWrappers].flatMap((p) =>
+            (fn.name === p ? [] : callIndices(fn.text, p)).map((c) => ({ ...c, p })));
+        if (downloadCalls.length > 0) {
+            const verifies = reaches(VERIFIERS);
+            const verdict = verifies ? 'VERIFIED'
+                : acquireWrappers.has(fn.name) ? 'EXEMPT-DELEGATES-TO-CALLER'
+                    : 'UNVERIFIED';
+            add('ACQUIRE', fn, verdict,
+                verdict === 'VERIFIED' ? `reaches ${VERIFIERS.join('/')} before the artifact is used`
+                    : verdict === 'EXEMPT-DELEGATES-TO-CALLER' ? 'pure download wrapper: the URL is a parameter, so the caller owns verification'
+                        : 'downloads an artifact that no verification on this path ever checks',
+                fn.start + downloadCalls[0].index);
+        }
+        } // end phase 2
+
+        // ---------------- CACHE-ADMIT ----------------
+        if (phase === 3) for (const call of callIndices(fn.text, CACHE_LOOKUP)) {
+            const recordReaders = [...byName.keys()].filter((n) =>
+                sites.some((s) => s.rel === rel && s.fn === n && s.kind === 'RECORD-READ'));
+            const reverifies = recordReaders.some((n) => reach.has(n));
+            const writerNames = [...byName.keys()].filter((n) =>
+                sites.some((s) => s.rel === rel && s.fn === n && s.kind === 'RECORD-WRITE'));
+            const writerCalls = writerNames.flatMap((n) => callIndices(fn.text, n));
+            const gated = writerCalls.every((w) => VERIFIED_STATUS.test(enclosingConditionText(fn.text, w.index)));
+            // "There is no record for this cache entry" is a THIRD outcome,
+            // distinct from verified and from mismatched. The reader must hand it
+            // back and the admit site must act on it; a call whose result is
+            // thrown away silently admits an entry nothing ever verified (#136).
+            const consumesVerdict = recordReaders.some((n) =>
+                new RegExp(`(?:const|let|var)\\s+\\w+\\s*(?::[^=]+)?=\\s*(?:await\\s+)?${n}\\s*\\(`).test(fn.text));
+            const verdict = !reverifies ? 'TRUSTS-CACHE-BLINDLY'
+                : !consumesVerdict ? 'TRUSTS-UNMARKED-CACHE'
+                    : !gated ? 'RECORDS-UNVERIFIED'
+                        : 'REVERIFIES-AND-GATES';
+            const WHY = {
+                'REVERIFIES-AND-GATES': 'a cache hit is re-verified against the recorded marker, an unmarked entry is escalated, and a marker is only recorded for an artifact that was actually verified',
+                'TRUSTS-CACHE-BLINDLY': 'a cache hit is used with no re-verification of any kind (#136)',
+                'TRUSTS-UNMARKED-CACHE': 'the re-verification result is discarded, so a cache entry with NO integrity record is admitted with no verification at all (#136)',
+                'RECORDS-UNVERIFIED': 'an integrity marker is recorded even when the fresh download was never verified, so a later cache hit "verifies" an unverified binary (#136)',
+            };
+            add('CACHE-ADMIT', fn, verdict, WHY[verdict], fn.start + call.index);
+        }
+
+        // ---------------- LATEST resolution ----------------
+        const resolvesLatest = /['"]latest['"]/i.test(fn.raw)
+            && /toLowerCase\s*\(\s*\)\s*(?:!==|===)/.test(fn.text)
+            && /\bcatch\b/.test(fn.text);
+        if (phase === 1 && resolvesLatest) {
+            const catchBlocks = [...fn.text.matchAll(/catch\s*(?:\([^)]*\))?\s*\{/g)]
+                .map((m) => blockAfter(fn.text, m.index));
+            // A catch that RETURNS a version instead of rethrowing is a stale
+            // fallback, whatever it returns — a pinned constant, a literal, or a
+            // cached value. Only rethrowing counts as failing closed.
+            const fallsBack = catchBlocks.some((b) => /\breturn\b/.test(b) && !/\bthrow\b/.test(b));
+            add('LATEST', fn, fallsBack ? 'STALE-FALLBACK' : 'FAILS-CLOSED',
+                fallsBack
+                    ? 'an unreachable version endpoint silently installs a pinned, potentially stale version instead of failing (#78)'
+                    : 'an unresolvable "latest" fails the task instead of silently installing a pinned stale version',
+                fn.start + fn.text.indexOf('catch'));
+        }
+    }
+}
+
+const FAIL_VERDICTS = new Set([
+    'UNVERIFIED',
+    'RETAINS-ON-FAILURE',
+    'SIGNATURE-TOGGLE-INERT',
+    'TRUSTS-MALFORMED-RECORD',
+    'TORN-WRITE',
+    'TRUSTS-CACHE-BLINDLY',
+    'TRUSTS-UNMARKED-CACHE',
+    'RECORDS-UNVERIFIED',
+    'STALE-FALLBACK',
+]);
+
+const seen = new Set();
+const unique = sites.filter((s) => {
+    const key = `${s.rel}:${s.kind}:${s.fn}:${s.line}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+}).sort((a, b) => a.rel.localeCompare(b.rel) || a.line - b.line || a.kind.localeCompare(b.kind));
+
+const failures = unique.filter((s) => FAIL_VERDICTS.has(s.verdict));
+
+if (JSON_OUTPUT) {
+    console.log(JSON.stringify({ root: ROOT, sites: unique, failures: failures.length }, null, 2));
+    process.exit(failures.length > 0 ? 1 : 0);
+}
+
+console.log(`artifact-trust signature — ${path.basename(ROOT)} (${files.length} src file(s), ${unique.length} trust site(s))\n`);
+for (const kind of ['ACQUIRE', 'VERIFY', 'SUMS-ABSENT', 'CACHE-ADMIT', 'RECORD-READ', 'RECORD-WRITE', 'LATEST']) {
+    const rows = unique.filter((s) => s.kind === kind);
+    if (rows.length === 0) continue;
+    console.log(`${kind} (${rows.length}):`);
+    for (const r of rows) console.log(`  ${FAIL_VERDICTS.has(r.verdict) ? 'FAIL ' : '     '}${r.rel}:${r.line}  ${r.fn}()  ${r.verdict}`);
+    console.log('');
+}
+
+if (failures.length > 0) {
+    console.error(`FAIL: ${failures.length} residual instance(s) of the artifact-trust class.`);
+    for (const f of failures) console.error(`  ${f.rel}:${f.line} ${f.fn}() [${f.kind}] ${f.verdict}\n      ${f.why}`);
+    process.exit(1);
+}
+console.log('OK: every path by which an artifact becomes trusted verifies it, discards it on failure, and degrades legibly.');

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -89,6 +89,24 @@ const FAMILIES = [
         ],
     },
     {
+        // Discard-on-failed-verification wrapper: a downloaded archive whose
+        // checksum or signature does NOT verify is deleted rather than left sitting
+        // in the agent's temp directory, where on a persistent self-hosted agent a
+        // rejected — possibly tampered — artifact would otherwise stay indefinitely.
+        // The distinction it encodes (a failed COMPARISON discards; a merely
+        // UNAVAILABLE checksum the operator opted out of requiring does not) is the
+        // kind of thing that drifts if each installer keeps its own copy, so keep it
+        // byte-identical across the three installer tasks.
+        dirs: [
+            'Tasks/TerraformInstaller/TerraformInstallerV1/src',
+            'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src',
+            'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src',
+        ],
+        modules: [
+            'artifact-discard.ts',
+        ],
+    },
+    {
         // Registry/mirror EGRESS AUTHORIZATION (SSRF-relevant): shared across all
         // three installer tasks that accept a registryAllowedHosts/mirrorAllowedHosts
         // input. Carries the numeric (not textual) private/reserved-address


### PR DESCRIPTION
Cross-repo half of a class remediated in the sibling packer extension (sethbacon/azure-pipelines-packer#233). Found by running the class signature here, not from issues filed against this repo.

## What was live across all three installers

- **#204** — a checksum- or signature-mismatched artifact was **left on disk** after verification failed. Every verification of a freshly downloaded artifact now runs inside `discardArtifactOnFailure` — a new byte-identical family across the three installer tasks — which unlinks then rethrows without letting the unlink mask the verification error.
- **#198** — a zero-length or truncated cache-integrity marker was read as **tampering** rather than as *unverifiable*, so every later install of that version failed with a misleading `CachedToolVerificationFailed`. The marker is now hex-validated on read and written **atomically**.
- **#136** — `downloadTofu` recorded a marker without an explicit verification verdict — an implicit invariant rather than a checked one. Now gated on `verified`.

## The trust-root difference is preserved, not flattened

OPA and terraform-docs publish a `.sha256` beside the asset on the same GitHub release and **no detached signature**, so those paths have no require-signature toggle to honour — demanding one would invent a check upstream cannot satisfy.

The signature derives this **from code shape** (a function is signature-rooted only if it itself calls a signature verifier) rather than from a hardcoded list, which is what lets the *same file's* Sentinel path still be **required** to honour `requireGpgSignature` while the OPA path is exempt.

## A test that was only ever passing by accident

Three `CacheHitVerifyFail` fixtures asserted a **62-character** digest as a "mismatch". Under the corrected #198 semantics that is an *unverifiable* marker, not a mismatch — so those fixtures were passing for the wrong reason. Padded to real 64-hex digests so they exercise a genuine well-formed mismatch, with a note explaining why.

## Gates

- **Class gate** — 48 sites across all three installer tasks, **0 residual** (was 23).
- **Mutation** — 8/8 redden only their own rows. Notably, deleting the PolicyAgent hex check reddens both the aggregate row in the TerraformInstaller suite **and** that task's own truncated-marker row, so a per-task regression cannot hide behind the aggregate.
- **Tests** — TerraformInstallerV1 353 (from 280), PolicyAgentInstallerV1 240, TerraformDocsInstallerV1 221; 0 failing. Per-file coverage gate passes in all three.

`task.json` versions were deliberately **not** touched here — this repo auto-bumps them.

Refs sethbacon/azure-pipelines-packer#204
Refs sethbacon/azure-pipelines-packer#198
Refs sethbacon/azure-pipelines-packer#136