### PR TITLE
security: look up attacker-influenceable keys without inheriting from Object

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -34,6 +34,7 @@ import './DataImageSvgXmlStrippingL0';
 import './CssEscapeBypassL0';
 import './AllowlistSanitizerL0';
 import './MetaRefreshExternalOriginL0';
+import './PrototypeSafeLookupClassL0';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/PrototypeSafeLookupClassL0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/PrototypeSafeLookupClassL0.ts
@@ -1,0 +1,79 @@
+/**
+ * Class test (issues #884/#897): an attacker-influenceable string used as a
+ * key into a plain object literal resolves __proto__/constructor/toString/
+ * valueOf/hasOwnProperty to an INHERITED Object.prototype member instead of
+ * falling through to the not-found branch. This file covers converter.ts's
+ * SEP_MAP, keyed by the front-matter `include-options.separator` value.
+ */
+import assert = require('assert');
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
+import { processFrontMatterDriven } from '../src/converter';
+
+function writeTmpDir(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'md2html-proto-'));
+  for (const [name, content] of Object.entries(files)) {
+    const fullPath = path.join(dir, name);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content, 'utf8');
+  }
+  return dir;
+}
+
+async function renderWithSeparator(separator: string): Promise<string> {
+  const dir = writeTmpDir({
+    'main.md': [
+      '---',
+      'includes:',
+      '  - part1.md',
+      'include-options:',
+      `  separator: ${separator}`,
+      '---',
+      '# Intro',
+      '',
+    ].join('\n'),
+    'part1.md': '# Part One\n\nContent one.\n',
+  });
+  const out = path.join(dir, 'out.html');
+  await processFrontMatterDriven(path.join(dir, 'main.md'), out);
+  return fs.readFileSync(out, 'utf8');
+}
+
+// The document template's <style> block unconditionally defines a
+// `.file-divider { ... }` CSS rule regardless of whether any divider is
+// actually used in the body, so assertions below check for the MARKUP tag
+// (as SEP_MAP actually emits it), not the bare class-name substring, which
+// the CSS rule alone would satisfy even when no divider was rendered.
+const HR_DIVIDER_MARKUP = '<hr class="file-divider">';
+const PAGEBREAK_DIVIDER_MARKUP = '<div class="page-break"';
+
+describe('converter: SEP_MAP separator lookup (prototype-pollution class)', () => {
+  it("renders the 'hr' divider between includes", async () => {
+    const html = await renderWithSeparator('hr');
+    assert.ok(html.includes(HR_DIVIDER_MARKUP), `expected the hr divider in: ${html}`);
+  });
+
+  it("renders the 'pagebreak' divider between includes", async () => {
+    const html = await renderWithSeparator('pagebreak');
+    assert.ok(html.includes(PAGEBREAK_DIVIDER_MARKUP), `expected the pagebreak divider in: ${html}`);
+  });
+
+  it("renders no divider for the legitimate 'none' separator", async () => {
+    const html = await renderWithSeparator('none');
+    assert.ok(
+      !html.includes(HR_DIVIDER_MARKUP) && !html.includes(PAGEBREAK_DIVIDER_MARKUP),
+      `expected no divider markup in: ${html}`,
+    );
+  });
+
+  const prototypePollutionSeparators = ['__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty'];
+  for (const separator of prototypePollutionSeparators) {
+    it(`falls back to the default hr divider for separator '${separator}' (an Object.prototype member, not a real option) instead of leaking it into the document`, async () => {
+      const html = await renderWithSeparator(separator);
+      assert.ok(html.includes(HR_DIVIDER_MARKUP), `expected the default hr divider, not a dropped/leaked prototype member, in: ${html}`);
+      assert.ok(!html.includes('[object Object]'), `must not leak '[object Object]' into the document: ${html}`);
+      assert.ok(!/native code/.test(html), `must not leak a function's source into the document: ${html}`);
+    });
+  }
+});

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/converter.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/converter.ts
@@ -74,12 +74,14 @@ export async function processFrontMatterDriven(
     const headingShift = Number(incOpts['heading-shift'] ?? 0);
     const sectionAnchors = Boolean(incOpts['section-anchors'] ?? false);
 
-    const SEP_MAP: Record<string, string> = {
-        hr: '<hr class="file-divider">',
-        pagebreak: '<div class="page-break" style="page-break-after: always;"></div>',
-        none: '',
-    };
-    const sepHtml = SEP_MAP[separator] ?? '<hr class="file-divider">';
+    // A Map (not an object literal) so separator='__proto__'/'constructor'/etc.
+    // can never resolve to an inherited Object.prototype member instead of undefined.
+    const SEP_MAP: ReadonlyMap<string, string> = new Map([
+        ['hr', '<hr class="file-divider">'],
+        ['pagebreak', '<div class="page-break" style="page-break-after: always;"></div>'],
+        ['none', ''],
+    ]);
+    const sepHtml = SEP_MAP.get(separator) ?? '<hr class="file-divider">';
 
     // Resolve includes
     const includePaths = resolveIncludes(absPrimary, frontMatter);

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -30,6 +30,8 @@ import './AllowlistSanitizerL0';
 // This task's behavioural rows of the cross-task output-boundary class table
 // (the structural half lives in TerraformTaskV5/Tests/OutputBoundaryClassL0.ts).
 import './OutputBoundaryClassL0';
+// Prototype-pollution-safe lookup class test (issues #884/#897).
+import './PrototypeSafeLookupClassL0';
 
 const INSTANCE = 'testinstance';
 const BASE_URL = `https://${INSTANCE}.service-now.com`;

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/PrototypeSafeLookupClassL0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/PrototypeSafeLookupClassL0.ts
@@ -1,0 +1,94 @@
+/**
+ * Class test (issues #884/#897): an attacker-influenceable string used as a
+ * key into a plain object literal resolves __proto__/constructor/toString/
+ * valueOf/hasOwnProperty to an INHERITED Object.prototype member instead of
+ * falling through to the not-found branch. This file covers
+ * servicenow-client.ts's WORKFLOW_STATE_MAP (createKnowledgeArticle) and
+ * STATE_VALUE_MAP (changeWorkflowState), both keyed by the task's
+ * `workflowState` input.
+ */
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import nock = require('nock');
+import * as client from '../src/servicenow-client';
+
+const INSTANCE = 'testinstance';
+const BASE_URL = `https://${INSTANCE}.service-now.com`;
+const HEADERS = {
+  Authorization: 'Bearer test-token',
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};
+
+describe('servicenow-client: workflow-state lookup (prototype-pollution class)', () => {
+  const legitimateStates: Array<[string, string]> = [
+    ['draft', 'draft'],
+    ['review', 'review'],
+    ['publish', 'published'],
+  ];
+
+  for (const [input, expected] of legitimateStates) {
+    it(`createKnowledgeArticle maps workflowState='${input}' to workflow_state='${expected}'`, async () => {
+      let capturedBody: Record<string, unknown> = {};
+      nock(BASE_URL)
+        .post('/api/now/table/kb_knowledge', (body: Record<string, unknown>) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(201, { result: { sys_id: `art_${input}`, number: 'KB0090', workflow_state: expected } });
+
+      await client.createKnowledgeArticle(
+        INSTANCE, HEADERS, 'kb123', 'Title', '<p>HTML</p>', 'author',
+        undefined, undefined, input,
+      );
+      assert.strictEqual(capturedBody['workflow_state'], expected);
+    });
+
+    it(`changeWorkflowState maps workflowState='${input}' to workflow_state='${expected}'`, async () => {
+      const articleId = `state_${input}`;
+      let capturedBody: Record<string, unknown> = {};
+      nock(BASE_URL)
+        .patch(`/api/now/table/kb_knowledge/${articleId}`, (body: Record<string, unknown>) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(200, { result: { sys_id: articleId, workflow_state: expected } });
+
+      await client.changeWorkflowState(INSTANCE, HEADERS, articleId, input);
+      assert.strictEqual(capturedBody['workflow_state'], expected);
+    });
+  }
+
+  const prototypePollutionKeys = ['__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty'];
+  for (const workflowState of prototypePollutionKeys) {
+    it(`createKnowledgeArticle passes workflowState='${workflowState}' through as the literal string (an Object.prototype member, not a real state)`, async () => {
+      let capturedBody: Record<string, unknown> = {};
+      nock(BASE_URL)
+        .post('/api/now/table/kb_knowledge', (body: Record<string, unknown>) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(201, { result: { sys_id: 'art_x', number: 'KB0091', workflow_state: workflowState } });
+
+      await client.createKnowledgeArticle(
+        INSTANCE, HEADERS, 'kb123', 'Title', '<p>HTML</p>', 'author',
+        undefined, undefined, workflowState,
+      );
+      assert.strictEqual(capturedBody['workflow_state'], workflowState);
+    });
+
+    it(`changeWorkflowState passes workflowState='${workflowState}' through as the literal string (an Object.prototype member, not a real state)`, async () => {
+      const articleId = `state_proto_${workflowState.replace(/[^a-z]/gi, '')}`;
+      let capturedBody: Record<string, unknown> = {};
+      nock(BASE_URL)
+        .patch(`/api/now/table/kb_knowledge/${articleId}`, (body: Record<string, unknown>) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(200, { result: { sys_id: articleId, workflow_state: workflowState } });
+
+      await client.changeWorkflowState(INSTANCE, HEADERS, articleId, workflowState);
+      assert.strictEqual(capturedBody['workflow_state'], workflowState);
+    });
+  }
+});

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-client.ts
@@ -1,11 +1,13 @@
 import { snRequest, withRetry, nonIdempotentCreateRetryError } from './servicenow-http';
 import tasks = require('azure-pipelines-task-lib/task');
 
-const WORKFLOW_STATE_MAP: Record<string, string> = {
-    draft: 'draft',
-    review: 'review',
-    publish: 'published',
-};
+// A Map (not an object literal) so workflowState='__proto__'/'constructor'/etc.
+// can never resolve to an inherited Object.prototype member instead of undefined.
+const WORKFLOW_STATE_MAP: ReadonlyMap<string, string> = new Map([
+    ['draft', 'draft'],
+    ['review', 'review'],
+    ['publish', 'published'],
+]);
 
 export interface KbArticle {
     sys_id: string;
@@ -126,7 +128,7 @@ export async function createKnowledgeArticle(
         kb_knowledge_base: kbId,
         short_description: title,
         text: text,
-        workflow_state: WORKFLOW_STATE_MAP[workflowState] ?? workflowState,
+        workflow_state: WORKFLOW_STATE_MAP.get(workflowState) ?? workflowState,
         author: author,
     };
 
@@ -198,7 +200,7 @@ export async function updateKnowledgeArticle(
     }
 
     if (workflowState) {
-        payload['workflow_state'] = WORKFLOW_STATE_MAP[workflowState] ?? workflowState;
+        payload['workflow_state'] = WORKFLOW_STATE_MAP.get(workflowState) ?? workflowState;
     }
     if (author) payload['author'] = author;
 
@@ -246,18 +248,20 @@ export async function changeWorkflowState(
     articleId: string,
     workflowState: string,
 ): Promise<KbArticle> {
-    const STATE_VALUE_MAP: Record<string, string> = {
-        draft: 'draft',
-        review: 'review',
-        publish: 'published',
-    };
+    // A Map (not an object literal) so workflowState='__proto__'/'constructor'/etc.
+    // can never resolve to an inherited Object.prototype member instead of undefined.
+    const STATE_VALUE_MAP: ReadonlyMap<string, string> = new Map([
+        ['draft', 'draft'],
+        ['review', 'review'],
+        ['publish', 'published'],
+    ]);
 
     // encodeURIComponent guards the path segment: an unencoded articleId containing
     // '/', '?', or '#' could otherwise alter the effective REST path/query.
     const url = `${baseUrl(instance)}/api/now/table/kb_knowledge/${encodeURIComponent(articleId)}`;
     const response = await withRetry(() => snRequest('PATCH', url, {
         headers,
-        body: { workflow_state: STATE_VALUE_MAP[workflowState] ?? workflowState },
+        body: { workflow_state: STATE_VALUE_MAP.get(workflowState) ?? workflowState },
     }), {
         log: (message) => console.log(`[WARN] ${message}`),
     });

--- a/Tasks/TerraformDocs/TerraformDocsV1/Tests/ArgsBuilderL0.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/Tests/ArgsBuilderL0.ts
@@ -29,6 +29,18 @@ describe('args-builder: resolveFormatter', () => {
   it('throws on an unsupported formatter', () => {
     assert.throws(() => resolveFormatter('bogus'), /Unsupported terraform-docs formatter: bogus/);
   });
+
+  // Class test (issues #884/#897): FORMATTER_SUBCOMMANDS is a Map, so a
+  // formatter equal to an Object.prototype member name must fall through to
+  // the same "unsupported formatter" error as any other unrecognized value,
+  // rather than resolving to an inherited member and later throwing a
+  // confusing "subcommand is not iterable" TypeError out of the spread below.
+  const prototypePollutionFormatters = ['__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty'];
+  for (const formatter of prototypePollutionFormatters) {
+    it(`throws the same clear error on formatter '${formatter}' (an Object.prototype member, not a real formatter)`, () => {
+      assert.throws(() => resolveFormatter(formatter), new RegExp(`Unsupported terraform-docs formatter: ${formatter}`));
+    });
+  }
 });
 
 describe('args-builder: buildTerraformDocsArgs', () => {

--- a/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
+++ b/Tasks/TerraformDocs/TerraformDocsV1/src/args-builder.ts
@@ -24,22 +24,24 @@ export interface TerraformDocsConfig {
  * Keeping this as the single source of truth means an unknown formatter fails
  * fast with a clear error rather than being passed through to the CLI.
  */
-const FORMATTER_SUBCOMMANDS: Record<string, string[]> = {
-    'markdown-table': ['markdown', 'table'],
-    'markdown-document': ['markdown', 'document'],
-    'json': ['json'],
-    'yaml': ['yaml'],
-    'toml': ['toml'],
-    'pretty': ['pretty'],
-    'asciidoc-table': ['asciidoc', 'table'],
-    'asciidoc-document': ['asciidoc', 'document'],
-    'tfvars-hcl': ['tfvars', 'hcl'],
-    'tfvars-json': ['tfvars', 'json'],
-};
+// A Map (not an object literal) so formatter='__proto__'/'constructor'/etc. can
+// never resolve to an inherited Object.prototype member instead of undefined.
+const FORMATTER_SUBCOMMANDS: ReadonlyMap<string, readonly string[]> = new Map([
+    ['markdown-table', ['markdown', 'table']],
+    ['markdown-document', ['markdown', 'document']],
+    ['json', ['json']],
+    ['yaml', ['yaml']],
+    ['toml', ['toml']],
+    ['pretty', ['pretty']],
+    ['asciidoc-table', ['asciidoc', 'table']],
+    ['asciidoc-document', ['asciidoc', 'document']],
+    ['tfvars-hcl', ['tfvars', 'hcl']],
+    ['tfvars-json', ['tfvars', 'json']],
+]);
 
 /** Resolves a picklist formatter option to its terraform-docs subcommand tokens. */
 export function resolveFormatter(formatter: string): string[] {
-    const subcommand = FORMATTER_SUBCOMMANDS[formatter];
+    const subcommand = FORMATTER_SUBCOMMANDS.get(formatter);
     if (!subcommand) {
         throw new Error(`Unsupported terraform-docs formatter: ${formatter}`);
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/BackendDetectionTests/BackendDetectionL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/BackendDetectionTests/BackendDetectionL0.ts
@@ -47,6 +47,19 @@ describe('detectBackendCloud', function () {
     });
   }
 
+  // Class test (issues #884/#897): BACKEND_TYPE_TO_CLOUD is a Map, so a
+  // backend.type equal to an Object.prototype member name must fall through
+  // to the not-found (null) branch exactly like any other unrecognized
+  // backend type, never resolving to an inherited member.
+  const prototypePollutionKeys = ['__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty'];
+  for (const backendType of prototypePollutionKeys) {
+    it(`returns null for backend type '${backendType}' (an Object.prototype member, not a real backend)`, () => {
+      const dir = makeWorkingDirectory();
+      writeTfstate(dir, JSON.stringify({ backend: { type: backendType } }));
+      assert.strictEqual(detectBackendCloud(dir), null);
+    });
+  }
+
   const noCredentialBackends = ['local', 'http', 'oci', 'pg', 'consul', 'kubernetes', 'oss'];
   for (const backendType of noCredentialBackends) {
     it(`returns null for backend type '${backendType}' (no cloud credentials to inject)`, () => {

--- a/Tasks/TerraformTask/TerraformTaskV5/src/backend-detection.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/backend-detection.ts
@@ -20,13 +20,15 @@ export const MAX_BACKEND_STATE_BYTES = 10 * 1024 * 1024; // 10 MB
  * kubernetes, oci's PAR-based http backend, ...) are intentionally absent —
  * `detectBackendCloud` returns null for them.
  */
-const BACKEND_TYPE_TO_CLOUD: Readonly<Record<string, BackendCloud>> = {
-  azurerm: 'azurerm',
-  s3: 'aws',
-  gcs: 'gcp',
-  cloud: 'hcp',
-  remote: 'hcp',
-};
+// A Map (not an object literal) so a backend.type of '__proto__'/'constructor'/etc.
+// can never resolve to an inherited Object.prototype member instead of undefined.
+const BACKEND_TYPE_TO_CLOUD: ReadonlyMap<string, BackendCloud> = new Map([
+  ['azurerm', 'azurerm'],
+  ['s3', 'aws'],
+  ['gcs', 'gcp'],
+  ['cloud', 'hcp'],
+  ['remote', 'hcp'],
+]);
 
 /**
  * Detects which cloud's credentials the *state backend* needs, by reading the
@@ -104,7 +106,7 @@ export function detectBackendCloud(workingDirectory: string): BackendCloud | nul
     return null;
   }
 
-  const cloud = BACKEND_TYPE_TO_CLOUD[backendType];
+  const cloud = BACKEND_TYPE_TO_CLOUD.get(backendType);
   if (!cloud) {
     tasks.debug(`Backend detection: backend type '${backendType}' has no managed cloud credentials to inject; skipping.`);
     return null;


### PR DESCRIPTION
`BACKEND_TYPE_TO_CLOUD[backendType]` indexed a plain object literal with a
string parsed out of Terraform backend config. Its only upstream validation was
`typeof backendType !== 'string'`, which `__proto__`, `constructor`, `toString`
and friends all pass -- so instead of falling through to the "no managed cloud
credentials for this backend" branch, the lookup returned an inherited member
and the caller treated it as a real result. That sits on the cross-cloud
credential-injection path (#884, #897).

Fixed structurally rather than by denying magic key names -- a denylist is the
same bug wearing a different hat, and the next inherited member nobody thought
of walks straight through it.

The sibling sweep found the same shape elsewhere and it is fixed too, not just
the two sites the issues name. Every site is covered by a table-driven class
test whose rows include `__proto__`, `constructor`, `toString`, `valueOf` and
`hasOwnProperty` alongside the legitimate keys, so an inherited member must
resolve to the not-found branch and a real key must still resolve to its value.

Closes #884
Closes #897

