### PR TITLE
test: type-check the test trees, and prove SARIF survives hostile input

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/tsconfig.tests.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "skipLibCheck": true
+        "target": "ES6"
     },
     "include": [
         "Tests/**/*",

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/tsconfig.tests.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "skipLibCheck": true
+        "target": "ES6"
     },
     "include": [
         "Tests/**/*",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/tsconfig.tests.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "skipLibCheck": true
+        "target": "ES6"
     },
     "include": [
         "Tests/**/*",

--- a/Tasks/TerraformDocs/TerraformDocsV1/tsconfig.tests.json
+++ b/Tasks/TerraformDocs/TerraformDocsV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES6",
-    "module": "commonjs",
-    "skipLibCheck": true
+    "target": "ES6"
   },
   "include": [
     "Tests/**/*",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/tsconfig.tests.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES6",
-    "module": "commonjs",
-    "skipLibCheck": true
+    "target": "ES6"
   },
   "include": [
     "Tests/**/*",

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportSarifHostile.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportSarifHostile.ts
@@ -1,0 +1,57 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+import fs = require('fs');
+import {
+  CONTROL_CHARS_ADDRESS,
+  ANSI_ESCAPE_ADDRESS,
+  SCRIPT_MARKUP_ADDRESS,
+  QUOTES_BACKSLASH_ADDRESS,
+  LONG_ADDRESS,
+  DIRECTION_OVERRIDE_ADDRESS,
+  HOSTILE_ATTR_NAME,
+  HOSTILE_ATTR_ADDRESS,
+} from './sarif-hostile-fixtures';
+
+// Pushes genuinely hostile resource addresses/attribute names through the real
+// buildDriftSarif/writeSarif path (#898). sarifPath is deliberately left unset
+// so writeSarif auto-generates its own unique uuid-named path (see sarif.ts) --
+// this fixture only needs mkdtempSync for the plan.json it writes.
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdr-sarif-hostile-'));
+
+function updateChange(address: string, attrName: string) {
+  return {
+    address,
+    change: {
+      actions: ['update'],
+      before: { [attrName]: 'old' },
+      after: { [attrName]: 'new' },
+    },
+  };
+}
+
+const planFile = path.join(dir, 'plan.json');
+fs.writeFileSync(
+  planFile,
+  JSON.stringify({
+    resource_changes: [
+      updateChange(CONTROL_CHARS_ADDRESS, 'normal_attr'),
+      updateChange(ANSI_ESCAPE_ADDRESS, 'normal_attr'),
+      updateChange(SCRIPT_MARKUP_ADDRESS, 'normal_attr'),
+      updateChange(QUOTES_BACKSLASH_ADDRESS, 'normal_attr'),
+      updateChange(LONG_ADDRESS, 'normal_attr'),
+      updateChange(DIRECTION_OVERRIDE_ADDRESS, 'normal_attr'),
+      updateChange(HOSTILE_ATTR_ADDRESS, HOSTILE_ATTR_NAME),
+    ],
+  }),
+);
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('planJsonFile', planFile);
+tr.setInput('includeModuleProvenance', 'false');
+tr.setInput('failOnDrift', 'false');
+tr.setInput('sarifOutput', 'true');
+
+tr.run();

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -10,6 +10,16 @@ import { postJson, postJsonWithRetry, truncateBody } from '../src/callback';
 import { createHttpsClient } from '../src/https-client';
 import { TLS_CERT, TLS_KEY } from './loopback-tls';
 import { startConnectProxy, startRefusingConnectProxy, startHangingConnectProxy } from './proxy-connect-server';
+import {
+    CONTROL_CHARS_ADDRESS,
+    ANSI_ESCAPE_ADDRESS,
+    SCRIPT_MARKUP_ADDRESS,
+    QUOTES_BACKSLASH_ADDRESS,
+    LONG_ADDRESS,
+    DIRECTION_OVERRIDE_ADDRESS,
+    HOSTILE_ATTR_NAME,
+    HOSTILE_ATTR_ADDRESS,
+} from './sarif-hostile-fixtures';
 
 // Direct unit tests for the fail-secure rejectUnauthorized default.
 import './RejectUnauthorizedDefaultL0';
@@ -565,6 +575,81 @@ describe('TerraformDriftReport Test Suite', function () {
                 assert(r.message.text.length > 0, 'message text is set');
                 assert(run.tool.driver.rules.some(rule => rule.id === r.ruleId), 'result references a catalogued rule');
             });
+        }, tr);
+    });
+
+    it('DriftReportSarifHostile — hostile resource addresses/attribute names survive the real SARIF path as safely-escaped JSON data, not raw control bytes or broken structure (#898)', async () => {
+        const tr = new ttm.MockTestRunner(path.join(__dirname, 'DriftReportSarifHostile.js'));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should have succeeded (failOnDrift=false)');
+
+            // No fixed sarifPath input was given -- recover the auto-generated,
+            // uuid-named path the task actually wrote from its own output-variable
+            // logging command rather than assuming any particular location.
+            const varLine = tr.stdout.split('\n').find(l => l.includes('##vso[task.setvariable variable=sarifFilePath;'));
+            assert(varLine, `sarifFilePath output variable line not found in stdout: ${tr.stdout}`);
+            const sarifPath = varLine!.slice(varLine!.indexOf(']') + 1).trim();
+            assert(fs.existsSync(sarifPath), `SARIF report should exist at ${sarifPath}`);
+
+            const raw = fs.readFileSync(sarifPath, 'utf-8');
+
+            // The control characters/ANSI escape must appear only as their escaped
+            // JSON forms (\u0000, \u001b, ...) -- never as a literal raw control
+            // byte -- proving JSON.stringify (not manual concatenation) serialized
+            // them. \x09/\x0A/\x0D are excluded: those are the file's own legitimate
+            // pretty-printing whitespace, not hostile content under test here.
+            assert(!/[\x00-\x08\x0B\x0C\x0E-\x1F]/.test(raw), 'raw SARIF file must not contain a literal unescaped control byte');
+            assert(raw.includes('\\u0000'), 'NUL must survive as an escaped \\u0000 sequence');
+            assert(raw.toLowerCase().includes('\\u001b'), 'the ANSI ESC byte must survive as an escaped \\u001b sequence');
+
+            // Must still be valid JSON that round-trips (a broken/truncated
+            // structure would throw here or fail the re-stringify comparison).
+            const sarif = JSON.parse(raw) as {
+                version: string;
+                runs: Array<{
+                    results: Array<{
+                        message: { text: string };
+                        locations: Array<{ logicalLocations: Array<{ fullyQualifiedName: string }> }>;
+                    }>;
+                }>;
+            };
+            assert.strictEqual(
+                JSON.stringify(JSON.parse(JSON.stringify(sarif))),
+                JSON.stringify(sarif),
+                'SARIF must round-trip through JSON unchanged',
+            );
+            assert.strictEqual(sarif.version, '2.1.0', 'SARIF version must be 2.1.0');
+
+            const run = sarif.runs[0];
+            assert.strictEqual(run.results.length, 7, 'one result per hostile resource change');
+            const byAddr = new Map(run.results.map(r => [r.locations[0].logicalLocations[0].fullyQualifiedName, r]));
+
+            // Every hostile address must be preserved EXACTLY as data -- no
+            // truncation, no mangling -- proving it never escaped its JSON string.
+            for (const addr of [
+                CONTROL_CHARS_ADDRESS,
+                ANSI_ESCAPE_ADDRESS,
+                SCRIPT_MARKUP_ADDRESS,
+                QUOTES_BACKSLASH_ADDRESS,
+                LONG_ADDRESS,
+                DIRECTION_OVERRIDE_ADDRESS,
+                HOSTILE_ATTR_ADDRESS,
+            ]) {
+                assert(byAddr.has(addr), `expected a result for hostile address (len ${addr.length})`);
+            }
+            assert.strictEqual(
+                byAddr.get(LONG_ADDRESS)!.locations[0].logicalLocations[0].fullyQualifiedName.length,
+                LONG_ADDRESS.length,
+                'the very long address must not be truncated',
+            );
+
+            // The hostile attribute name must be carried through message.text as data too.
+            const hostileAttrResult = byAddr.get(HOSTILE_ATTR_ADDRESS)!;
+            assert(
+                hostileAttrResult.message.text.includes(HOSTILE_ATTR_NAME),
+                'hostile attribute name must appear verbatim in the message text',
+            );
         }, tr);
     });
 

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/sarif-hostile-fixtures.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/sarif-hostile-fixtures.ts
@@ -1,0 +1,12 @@
+// Hostile resource-address / attribute-name literals shared between the
+// DriftReportSarifHostile scenario script (writes them into a plan.json and
+// runs the real task) and L0.ts (which asserts on the resulting SARIF file).
+// Defining them once here means the two sides can never drift apart (#898).
+export const CONTROL_CHARS_ADDRESS = 'aws_instance.ctrl_\u0000\u0007\u001f_end';
+export const ANSI_ESCAPE_ADDRESS = 'aws_instance.ansi_\u001b[31mRED\u001b[0m_end';
+export const SCRIPT_MARKUP_ADDRESS = 'module."<script>alert(1)</script>".aws_instance.web';
+export const QUOTES_BACKSLASH_ADDRESS = 'aws_instance.quote_"_and_backslash_\\_end';
+export const LONG_ADDRESS = 'aws_instance.' + 'a'.repeat(100000);
+export const DIRECTION_OVERRIDE_ADDRESS = 'aws_instance.file\u202egnp.exe';
+export const HOSTILE_ATTR_NAME = '<img src=x onerror=alert(1)>\u0000\u001b[31m';
+export const HOSTILE_ATTR_ADDRESS = 'aws_instance.hostile_attr_name_case';

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/tsconfig.tests.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "skipLibCheck": true
+        "target": "ES6"
     },
     "include": [
         "Tests/**/*",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissingL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureRequiredButMissingL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'GpgSignatureRequiredButMissingL0 should not have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'GpgSignatureRequiredButMissingL0 should have failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'GpgSignatureRequiredButMissingL0 should have failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailableL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgSignatureUnavailableL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'GpgSignatureUnavailableL0 should have succeeded with a warning.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'GpgSignatureUnavailableL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'GpgSignatureUnavailableL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationFailL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationFailL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'GpgVerificationFailL0 should have failed but succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'GpgVerificationFailL0 failed as expected: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'GpgVerificationFailL0 failed as expected: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/GpgVerificationSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'GpgVerificationSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'GpgVerificationSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'GpgVerificationSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointDownFallbackL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointDownFallbackL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('latest');
         tl.setResult(tl.TaskResult.Succeeded, 'HashiCorpLatestCheckpointDownFallbackL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointDownFallbackL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointDownFallbackL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointInvalidResponseFailL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestCheckpointInvalidResponseFailL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('latest');
         tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointInvalidResponseFailL0 should have failed but succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointInvalidResponseFailL0 failed as expected: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestCheckpointInvalidResponseFailL0 failed as expected: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpLatestSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('latest');
         tl.setResult(tl.TaskResult.Succeeded, 'HashiCorpLatestSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'HashiCorpLatestSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/HashiCorpSpecificVersionSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'HashiCorpSpecificVersionSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'HashiCorpSpecificVersionSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'HashiCorpSpecificVersionSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/InsecureUrlRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Failed, 'InsecureUrlRejectL0 should have failed but succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, error.message);
+        tl.setResult(tl.TaskResult.Failed, error instanceof Error ? error.message : String(error));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorAllowedHostAcceptL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorAllowedHostAcceptL0.ts
@@ -9,7 +9,7 @@ async function run() {
     await downloadTerraform('1.9.8');
     tl.setResult(tl.TaskResult.Succeeded, 'MirrorAllowedHostAcceptL0 should have succeeded.');
   } catch (error) {
-    tl.setResult(tl.TaskResult.Failed, 'MirrorAllowedHostAcceptL0 failed: ' + error.message);
+    tl.setResult(tl.TaskResult.Failed, 'MirrorAllowedHostAcceptL0 failed: ' + (error instanceof Error ? error.message : String(error)));
   }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorCustomUrlSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'MirrorCustomUrlSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'MirrorCustomUrlSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'MirrorCustomUrlSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostIsPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostIsPrivateRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
     await downloadTerraform('1.9.8');
     tl.setResult(tl.TaskResult.Succeeded, 'MirrorHostIsPrivateRejectL0 should have succeeded.');
   } catch (error) {
-    tl.setResult(tl.TaskResult.Failed, 'MirrorHostIsPrivateRejectL0 failed: ' + error.message);
+    tl.setResult(tl.TaskResult.Failed, 'MirrorHostIsPrivateRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
   }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostResolvesPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorHostResolvesPrivateRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
     await downloadTerraform('1.9.8');
     tl.setResult(tl.TaskResult.Succeeded, 'MirrorHostResolvesPrivateRejectL0 should have succeeded.');
   } catch (error) {
-    tl.setResult(tl.TaskResult.Failed, 'MirrorHostResolvesPrivateRejectL0 failed: ' + error.message);
+    tl.setResult(tl.TaskResult.Failed, 'MirrorHostResolvesPrivateRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
   }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectDnsResolvesPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectDnsResolvesPrivateRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
     await downloadTerraform('1.9.8');
     tl.setResult(tl.TaskResult.Succeeded, 'MirrorRedirectDnsResolvesPrivateRejectL0 should have succeeded.');
   } catch (error) {
-    tl.setResult(tl.TaskResult.Failed, 'MirrorRedirectDnsResolvesPrivateRejectL0 failed: ' + error.message);
+    tl.setResult(tl.TaskResult.Failed, 'MirrorRedirectDnsResolvesPrivateRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
   }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectToPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/MirrorRedirectToPrivateRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
     await downloadTerraform('1.9.8');
     tl.setResult(tl.TaskResult.Succeeded, 'MirrorRedirectToPrivateRejectL0 should have succeeded.');
   } catch (error) {
-    tl.setResult(tl.TaskResult.Failed, 'MirrorRedirectToPrivateRejectL0 failed: ' + error.message);
+    tl.setResult(tl.TaskResult.Failed, 'MirrorRedirectToPrivateRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
   }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuCachedSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.11.6');
         tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuCachedSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'OpenTofuCachedSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'OpenTofuCachedSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuLatestSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('latest');
         tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuLatestSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'OpenTofuLatestSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'OpenTofuLatestSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/OpenTofuSpecificVersionSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.11.6');
         tl.setResult(tl.TaskResult.Succeeded, 'OpenTofuSpecificVersionSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'OpenTofuSpecificVersionSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'OpenTofuSpecificVersionSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/PathPrependedOnInstallL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/PathPrependedOnInstallL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'PathPrependedOnInstallL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'PathPrependedOnInstallL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'PathPrependedOnInstallL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAcceptL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostAcceptL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'RegistryAllowedHostAcceptL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'RegistryAllowedHostAcceptL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'RegistryAllowedHostAcceptL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryAllowedHostRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'RegistryAllowedHostRejectL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'RegistryAllowedHostRejectL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'RegistryAllowedHostRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectDnsResolvesPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectDnsResolvesPrivateRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
     await downloadTerraform('1.9.8');
     tl.setResult(tl.TaskResult.Succeeded, 'RegistryDefaultPathRedirectDnsResolvesPrivateRejectL0 should have succeeded.');
   } catch (error) {
-    tl.setResult(tl.TaskResult.Failed, 'RegistryDefaultPathRedirectDnsResolvesPrivateRejectL0 failed: ' + error.message);
+    tl.setResult(tl.TaskResult.Failed, 'RegistryDefaultPathRedirectDnsResolvesPrivateRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
   }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectToPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDefaultPathRedirectToPrivateRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
     await downloadTerraform('1.9.8');
     tl.setResult(tl.TaskResult.Succeeded, 'RegistryDefaultPathRedirectToPrivateRejectL0 should have succeeded.');
   } catch (error) {
-    tl.setResult(tl.TaskResult.Failed, 'RegistryDefaultPathRedirectToPrivateRejectL0 failed: ' + error.message);
+    tl.setResult(tl.TaskResult.Failed, 'RegistryDefaultPathRedirectToPrivateRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
   }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMaskedL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryDownloadTokenMaskedL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'RegistryDownloadTokenMaskedL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'RegistryDownloadTokenMaskedL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'RegistryDownloadTokenMaskedL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksumL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256RequireChecksumL0.ts
@@ -11,7 +11,7 @@ async function run() {
         // surface as success so the integration test's `tr.failed` assertion catches it.
         tl.setResult(tl.TaskResult.Succeeded, 'RegistryEmptySha256RequireChecksumL0 should have failed closed.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, error.message);
+        tl.setResult(tl.TaskResult.Failed, error instanceof Error ? error.message : String(error));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256WarnsL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryEmptySha256WarnsL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'RegistryEmptySha256WarnsL0 succeeded with a skipped-verification warning.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'RegistryEmptySha256WarnsL0 should have succeeded: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'RegistryEmptySha256WarnsL0 should have succeeded: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryHostResolvesPrivateRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryHostResolvesPrivateRejectL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'RegistryHostResolvesPrivateRejectL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'RegistryHostResolvesPrivateRejectL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'RegistryHostResolvesPrivateRejectL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryInsecureUrlRejectL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistryInsecureUrlRejectL0.ts
@@ -11,7 +11,7 @@ async function run() {
         // so the integration test's `tr.failed` assertion catches the regression.
         tl.setResult(tl.TaskResult.Succeeded, 'RegistryInsecureUrlRejectL0 should have rejected the http download_url.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, error.message);
+        tl.setResult(tl.TaskResult.Failed, error instanceof Error ? error.message : String(error));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccessL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/RegistrySpecificVersionSuccessL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Succeeded, 'RegistrySpecificVersionSuccessL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'RegistrySpecificVersionSuccessL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'RegistrySpecificVersionSuccessL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFailL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/Sha256VerificationFailL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.9.8');
         tl.setResult(tl.TaskResult.Failed, 'Sha256VerificationFailL0 should have failed but succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, error.message);
+        tl.setResult(tl.TaskResult.Failed, error instanceof Error ? error.message : String(error));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/TofuPathPrependedOnInstallL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/TofuPathPrependedOnInstallL0.ts
@@ -9,7 +9,7 @@ async function run() {
         await downloadTerraform('1.11.6');
         tl.setResult(tl.TaskResult.Succeeded, 'TofuPathPrependedOnInstallL0 should have succeeded.');
     } catch (error) {
-        tl.setResult(tl.TaskResult.Failed, 'TofuPathPrependedOnInstallL0 failed: ' + error.message);
+        tl.setResult(tl.TaskResult.Failed, 'TofuPathPrependedOnInstallL0 failed: ' + (error instanceof Error ? error.message : String(error)));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/tsconfig.tests.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "skipLibCheck": true
+        "target": "ES6"
     },
     "include": [
         "Tests/**/*",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/tsconfig.tests.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "skipLibCheck": true
+        "target": "ES6"
     },
     "include": [
         "Tests/**/*",

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentity.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentity.ts
@@ -36,7 +36,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 var mock = {
-    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+    "generateIdToken": function (_command: string) { return Promise.resolve('12345'); }
 }
 
 tr.registerMock('./id-token-generator', mock);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentityAndDefaultSettings.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeManagedServiceIdentityAndDefaultSettings.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 var mock = {
-    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+    "generateIdToken": function (_command: string) { return Promise.resolve('12345'); }
 }
 
 tr.registerMock('./id-token-generator', mock);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederation.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederation.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 var mock = {
-    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+    "generateIdToken": function (_command: string) { return Promise.resolve('12345'); }
 }
 
 tr.registerMock('./id-token-generator', mock);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndCLIFlags.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndCLIFlags.ts
@@ -39,7 +39,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 var mock = {
-    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+    "generateIdToken": function (_command: string) { return Promise.resolve('12345'); }
 }
 
 tr.registerMock('./id-token-generator', mock);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndDefaultSettings.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessAuthenticationSchemeWorkloadIdentityFederationAndDefaultSettings.ts
@@ -39,7 +39,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 var mock = {
-    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+    "generateIdToken": function (_command: string) { return Promise.resolve('12345'); }
 }
 
 tr.registerMock('./id-token-generator', mock);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessManagedServiceIdentityUserAssigned.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/InitTests/Azure/AzureInitSuccessManagedServiceIdentityUserAssigned.ts
@@ -41,7 +41,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 var mock = {
-    "generateIdToken": function (_command) { return Promise.resolve('12345'); }
+    "generateIdToken": function (_command: string) { return Promise.resolve('12345'); }
 }
 
 tr.registerMock('./id-token-generator', mock);

--- a/Tasks/TerraformTask/TerraformTaskV5/tsconfig.tests.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/tsconfig.tests.json
@@ -1,8 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "skipLibCheck": true
+        "target": "ES6"
     },
     "include": [
         "Tests/**/*",


### PR DESCRIPTION
Two long-standing gaps in what the test suite actually checks.

Nine of the eleven tasks' `tsconfig.tests.json` inlined their own compiler
options with no `strict` and no `extends`, while every task's PRODUCTION
tsconfig extends `Tasks/tsconfig.base.json` -- so test code was held to a
materially weaker standard than the code it tests, and only
TerraformModulePublish and TerraformProviderMirror were strict (#890). Turning
strict on surfaced real type errors in existing test files; those are fixed
properly, not silenced with `any` or `@ts-ignore`.

The drift-report SARIF renderer had no hostile-input test at all: every fixture
used benign identifiers like `aws_instance.web` (#898). It now gets control
characters, ANSI escapes, markup, quotes/backslashes, an over-long address and a
Unicode direction override pushed through the real render path, asserting the
output is valid JSON that round-trips and carries the hostile text as DATA
rather than as structure. The renderer already relied on JSON.stringify rather
than string concatenation, so this pins existing correct behaviour in place
instead of fixing a live defect -- which is worth having precisely because
nothing stopped a future change from switching to concatenation.

Closes #890
Closes #898

