### PR TITLE
fix: honour directExcludePatterns when directIncludePatterns is also set

### DIFF
--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/Tests/L0.ts
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/Tests/L0.ts
@@ -141,18 +141,29 @@ describe('config-generator', () => {
             );
         });
 
-        it('should prefer include over exclude when both are provided', () => {
+        // Previously asserted the opposite ("should prefer include over exclude"),
+        // pinning the else-if defect of #872 as if it were intended behaviour.
+        it('should emit both include and exclude when both are provided', () => {
             const config: ProviderMirrorConfig = {
                 mirrorUrl: 'https://registry.example.com',
                 allowDirectFallback: true,
-                directExcludePatterns: ['registry.terraform.io/foo/*'],
-                directIncludePatterns: ['registry.terraform.io/hashicorp/*'],
+                directExcludePatterns: ['registry.terraform.io/company-internal/*'],
+                directIncludePatterns: ['registry.terraform.io/*/*'],
             };
 
             const result = generateProviderInstallationConfig(config);
 
-            assert.ok(result.includes('include = '));
-            assert.ok(!result.includes('exclude = '));
+            assert.strictEqual(result,
+                'provider_installation {\n' +
+                '  network_mirror {\n' +
+                '    url = "https://registry.example.com/"\n' +
+                '  }\n' +
+                '  direct {\n' +
+                '    include = ["registry.terraform.io/*/*"]\n' +
+                '    exclude = ["registry.terraform.io/company-internal/*"]\n' +
+                '  }\n' +
+                '}\n'
+            );
         });
 
         it('should strip trailing slashes from mirror URL before appending one', () => {

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/config-generator.ts
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/config-generator.ts
@@ -66,10 +66,13 @@ export function generateProviderInstallationConfig(config: ProviderMirrorConfig)
     if (config.allowDirectFallback) {
         hcl += '  direct {\n';
 
+        // Terraform accepts both on one installation method and lets exclude win
+        // (#872); emitting only one silently discards the operator's other list.
         if (config.directIncludePatterns.length > 0) {
             const formatted = config.directIncludePatterns.map(p => `"${escapeHclString(p)}"`).join(', ');
             hcl += `    include = [${formatted}]\n`;
-        } else if (config.directExcludePatterns.length > 0) {
+        }
+        if (config.directExcludePatterns.length > 0) {
             const formatted = config.directExcludePatterns.map(p => `"${escapeHclString(p)}"`).join(', ');
             hcl += `    exclude = [${formatted}]\n`;
         }


### PR DESCRIPTION
The .terraformrc generator emitted include OR exclude, never both, so an
operator who wrote a broad include plus a targeted exclude -- the documented way
to keep an internal namespace off the public registry -- silently got a config
permitting exactly the direct downloads they meant to forbid. No warning, no log
line, and index.ts echoes the same truncated HCL, so the build output agreed with
the mistake (#872).

Terraform accepts both on one installation method and gives exclusion priority
(verified against the CLI config docs: 'If you set both include and exclude for a
particular installation method, the exclusion patterns take priority'), so the
fix is to emit both and let Terraform apply its own semantics rather than
inventing a precedence here.

The task.json help text already promised the corrected behaviour
('These providers will only be fetched from the mirror') -- it was the code that
disagreed with the documentation, so no doc change is needed.

A test named 'should prefer include over exclude when both are provided' had
pinned the defect as if it were intended behaviour, asserting the exclude line
was absent. It is replaced by one asserting the full generated HCL for the
both-supplied case; that test is the reason the bug survived review.

Swept the rest of the tasks for the same shape -- two independent operator
inputs joined by an else-if. The only other else-if chains on input values are
the three installers' sha256/requireChecksum fallbacks, which are a genuine
three-way fallback rather than two inputs made mutually exclusive.

Closes #872

