### PR TITLE
fix: parse commandOptions the way ToolRunner actually parses it

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CommandArgsTests/CommandArgsL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CommandArgsTests/CommandArgsL0.ts
@@ -1,5 +1,5 @@
 import tl = require('azure-pipelines-task-lib');
-import { parseVarFileTokens, parseTargetTokens, extractOutFlagPath, commandOptionsContainsJsonFlag } from '../../src/base-terraform-command-handler';
+import { parseVarFileTokens, parseTargetTokens, extractOutFlagPath, commandOptionsContainsJsonFlag, hasPositionalCommandArg, splitCommandOptions } from '../../src/base-terraform-command-handler';
 
 let failed = false;
 
@@ -90,6 +90,14 @@ checkOut(extractOutFlagPath('-refresh-only -no-color'), undefined, 'out absent')
 checkOut(extractOutFlagPath('-timeout=5m'), undefined, 'out lookalike not matched');
 // A dangling -out with no following token yields undefined (no crash).
 checkOut(extractOutFlagPath('-out'), undefined, 'out dangling');
+// #875: the EQUALS form with a quoted path used to split at the space inside the
+// quotes and return the truncated 'my', so afterPlanFileWritten() was handed a
+// path that does not exist and silently skipped the OCI plan-file hardening.
+checkOut(extractOutFlagPath('-out="my plan.tfplan"'), 'my plan.tfplan', 'out quoted equals form');
+checkOut(extractOutFlagPath('--out="my plan.tfplan"'), 'my plan.tfplan', 'out quoted equals form double-dash');
+// A fully-quoted flag token is the flag, exactly as ToolRunner passes it on.
+checkOut(extractOutFlagPath('"-out=plan.tfplan"'), 'plan.tfplan', 'out fully-quoted token');
+checkOut(extractOutFlagPath('-refresh-only -out="out dir/plan.tfplan" -no-color'), 'out dir/plan.tfplan', 'out quoted equals form among other flags');
 
 // commandOptionsContainsJsonFlag (#492 follow-up): detect a standalone -json flag
 // so plan()'s publishPlanResults path can fail closed rather than echo raw,
@@ -105,6 +113,25 @@ checkBool(commandOptionsContainsJsonFlag('-refresh-only -no-color'), false, 'jso
 checkBool(commandOptionsContainsJsonFlag('-var=myjsonvalue'), false, 'json lookalike substring in flag value');
 checkBool(commandOptionsContainsJsonFlag('-var-file=json.tfvars'), false, 'json lookalike substring in path');
 checkBool(commandOptionsContainsJsonFlag('"-json-ish"'), false, 'json lookalike token with suffix');
+// #875: a fully-quoted -json is still -json to ToolRunner. Reading it as a
+// literal `"-json"` token missed it and failed OPEN -- the publishPlanResults
+// guard exists precisely to stop raw NDJSON reaching the console.
+checkBool(commandOptionsContainsJsonFlag('"-json"'), true, 'json fully-quoted token');
+
+// hasPositionalCommandArg (#875): the same mis-split made the fragment
+// `plan.tfplan"` look like a positional plan-file argument, so a `show` with a
+// quoted -out= wrongly skipped the state-summary attachment.
+checkBool(hasPositionalCommandArg('-out="my plan.tfplan"'), false, 'quoted equals form is not positional');
+checkBool(hasPositionalCommandArg('-no-color tfplan.out'), true, 'genuine positional still detected');
+checkBool(hasPositionalCommandArg('-refresh-only -no-color'), false, 'flags only');
+
+// splitCommandOptions must agree with task-lib's ToolRunner._argStringToArray,
+// which is the parser that actually builds the argv these helpers reason about.
+check(splitCommandOptions('-out="my plan.tfplan"'), ['-out=my plan.tfplan'], 'split quoted equals form');
+check(splitCommandOptions('-out "my plan.tfplan"'), ['-out', 'my plan.tfplan'], 'split quoted space form');
+check(splitCommandOptions('a  b'), ['a', 'b'], 'split collapses repeated spaces');
+check(splitCommandOptions('""'), [''], 'split empty quoted token');
+check(splitCommandOptions('-var="a=\\"quoted\\""'), ['-var=a="quoted"'], 'split backslash-escaped quote inside quotes');
 
 if (failed) {
     tl.setResult(tl.TaskResult.Failed, 'Command arg token parsing failed');

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -64,6 +64,74 @@ export function parseTargetTokens(targetResources: string | undefined): string[]
 }
 
 /**
+ * Splits `commandOptions` into argv the way ToolRunner's `.line()` does, by
+ * mirroring task-lib's own `_argStringToArray`: a `"` toggles quoting anywhere
+ * in a token (not only at its start) and is stripped, `\` escapes inside
+ * quotes, and only unquoted whitespace separates arguments.
+ *
+ * The helpers below inspect `commandOptions` to make decisions about an argv
+ * that ToolRunner -- not they -- ultimately builds, so any disagreement between
+ * the two parsers is a bug by construction. The previous regex tokenizer only
+ * recognized a token that was quoted in its entirety, so `-out="my plan.tfplan"`
+ * split into `-out="my` + `plan.tfplan"` and every helper drew a different
+ * conclusion than Terraform did (#875).
+ */
+export function splitCommandOptions(commandOptions: string): string[] {
+    const args: string[] = [];
+    let inQuotes = false;
+    let escaped = false;
+    let lastCharWasSpace = true;
+    let arg = '';
+
+    const append = (c: string): void => {
+        // task-lib only treats a backslash as an escape for a double quote.
+        if (escaped && c !== '"') {
+            arg += '\\';
+        }
+        arg += c;
+        escaped = false;
+    };
+
+    // Indexed rather than for..of so surrogate pairs are handled as task-lib does.
+    for (let i = 0; i < commandOptions.length; i++) {
+        const c = commandOptions.charAt(i);
+
+        if (c === ' ' && !inQuotes) {
+            if (!lastCharWasSpace) {
+                args.push(arg);
+                arg = '';
+            }
+            lastCharWasSpace = true;
+            continue;
+        }
+        lastCharWasSpace = false;
+
+        if (c === '"') {
+            if (!escaped) {
+                inQuotes = !inQuotes;
+            } else {
+                append(c);
+            }
+            continue;
+        }
+        if (c === '\\' && escaped) {
+            append(c);
+            continue;
+        }
+        if (c === '\\' && inQuotes) {
+            escaped = true;
+            continue;
+        }
+        append(c);
+    }
+
+    if (!lastCharWasSpace) {
+        args.push(arg.trim());
+    }
+    return args;
+}
+
+/**
  * Best-effort heuristic (Phase 5 §5.5) for whether a `show` command's
  * `commandOptions` carries a positional plan-file argument (e.g. `tfplan.out`,
  * or `-no-color tfplan.out`) as opposed to flags only. Terraform's `show`
@@ -77,26 +145,22 @@ export function parseTargetTokens(targetResources: string | undefined): string[]
  * is a planfile show, so the state-summary attachment is skipped even if
  * `publishStateResults` is set (documented in the task's helpMarkDown).
  *
- * Deliberately NOT a full shell parser -- it recognizes double-quoted tokens
- * (`"a plan file.out"`) but not single quotes or backslash escapes, matching
- * ToolRunner's own `.line()` closely enough for this best-effort gate. A
- * value that isn't a flag (doesn't start with `-`) is treated as positional.
+ * Tokenized with {@link splitCommandOptions}, so quoting is read exactly as
+ * ToolRunner's `.line()` reads it. A value that isn't a flag (doesn't start
+ * with `-`) is treated as positional.
  */
 export function hasPositionalCommandArg(commandOptions: string | undefined): boolean {
     if (!commandOptions) return false;
-    const tokens = commandOptions.match(/"[^"]*"|\S+/g) || [];
-    return tokens.some(t => !t.startsWith('-'));
+    return splitCommandOptions(commandOptions).some(t => !t.startsWith('-'));
 }
 
 /**
  * Returns the plan-file path from a user-supplied `-out=<path>` / `-out <path>`
  * (double-dash `--out` accepted too, as Terraform does) token in
- * `commandOptions`, or undefined if none is present. Uses the SAME best-effort
- * tokenizer as {@link hasPositionalCommandArg} (double-quoted whole tokens are
- * recognized -- and their quotes stripped so the returned path matches what
- * ToolRunner's `.line()` passes to Terraform -- single quotes / backslash
- * escapes / an `-out="quoted value with spaces"` equals-form are not, matching
- * that helper's documented limits).
+ * `commandOptions`, or undefined if none is present. Tokenized with
+ * {@link splitCommandOptions}, so the returned path is byte-for-byte the one
+ * ToolRunner passes to Terraform -- including quoted paths containing spaces,
+ * in both the `-out="a b.tfplan"` and `-out "a b.tfplan"` forms (#875).
  *
  * Used by plan() UNCONDITIONALLY (#675 2nd follow-up) to detect a user-supplied
  * `-out=` so its plan file can be permission-tightened via afterPlanFileWritten()
@@ -112,15 +176,14 @@ export function hasPositionalCommandArg(commandOptions: string | undefined): boo
  */
 export function extractOutFlagPath(commandOptions: string | undefined): string | undefined {
     if (!commandOptions) return undefined;
-    const tokens = commandOptions.match(/"[^"]*"|\S+/g) || [];
-    const stripQuotes = (s: string): string => s.replace(/"/g, '');
+    const tokens = splitCommandOptions(commandOptions);
     for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i];
         const eq = token.match(/^--?out=(.*)$/);
-        if (eq) return stripQuotes(eq[1]);
+        if (eq) return eq[1];
         if (token === '-out' || token === '--out') {
             const next = tokens[i + 1];
-            if (next !== undefined) return stripQuotes(next);
+            if (next !== undefined) return next;
         }
     }
     return undefined;
@@ -140,8 +203,7 @@ export function extractOutFlagPath(commandOptions: string | undefined): string |
  */
 export function commandOptionsContainsJsonFlag(commandOptions: string | undefined): boolean {
     if (!commandOptions) return false;
-    const tokens = commandOptions.match(/"[^"]*"|\S+/g) || [];
-    return tokens.some((token) => token === '-json' || token === '--json');
+    return splitCommandOptions(commandOptions).some((token) => token === '-json' || token === '--json');
 }
 
 // `warnIfSensitiveOutputs`'s sensitivity detection is the SAME predicate the WP-1

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -270,14 +270,25 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
      * produces is a safe, idempotent action, the same "safe even if this
      * working directory turns out not to have an OCI PAR backend after all"
      * reasoning `registerOciBackendCacheForCleanup` above already relies on --
-     * a no-op via the `fs.existsSync` guard if `planFilePath` doesn't exist.
+     * a no-op via the `fs.existsSync` guard if `planFilePath` doesn't exist --
+     * though a successful command whose plan file is missing warns rather than
+     * returning silently, so a mis-derived path cannot quietly disable this.
      *
      * `commandFailed` mirrors afterInit()'s `initFailed`: fail-closed (throws)
      * when the command that produced this plan file succeeded, best-effort/warn
      * (never masks the command's own error) when it did not.
      */
     protected async afterPlanFileWritten(planFilePath: string, commandFailed: boolean): Promise<void> {
-        if (!fs.existsSync(planFilePath)) return;
+        if (!fs.existsSync(planFilePath)) {
+            // After a SUCCESSFUL command the file should be there; its absence means the
+            // path we derived disagrees with what Terraform actually wrote, and the real
+            // plan file keeps the agent's default permissions (#875). On the failure path
+            // an absent plan file is expected, so stay silent there.
+            if (!commandFailed) {
+                tasks.warning(`Could not tighten permissions on the saved Terraform plan file: nothing exists at "${planFilePath}". A plan file saved elsewhere keeps the agent's default permissions and embeds the active backend config, including the OCI PAR bearer URL.`);
+            }
+            return;
+        }
         if (commandFailed) {
             try {
                 tightenFilePermissions(planFilePath);


### PR DESCRIPTION
Three helpers inspected `commandOptions` with a regex that only recognised a
token quoted in its entirety, while the argv they reason about is built by
ToolRunner's `.line()`, which toggles quoting anywhere in a token. Any
disagreement between those two parsers is a bug by construction, and all three
manifested differently on `-out="my plan.tfplan"`:

- extractOutFlagPath returned the truncated `my`, so afterPlanFileWritten() was
  handed a path that does not exist. Its fs.existsSync guard then made the OCI
  plan-file permission hardening a silent no-op -- and a saved plan embeds the
  active backend config, including the OCI PAR bearer URL (#875).
- hasPositionalCommandArg saw the fragment `plan.tfplan"` as a positional plan
  file, so a `show` wrongly skipped the state-summary attachment.
- commandOptionsContainsJsonFlag missed a fully-quoted `"-json"`, failing OPEN on
  the guard that exists to stop raw NDJSON reaching the console.

All three now share splitCommandOptions(), which mirrors task-lib's own
_argStringToArray. Rather than trust a reading of that function, the
implementation was differentially tested against the real ToolRunner.line():
23 hand-picked inputs plus 20k randomised strings over the characters that drive
the state machine (space, quote, backslash, ordinary chars) -- zero disagreements.

The issue's second half is also addressed: a mis-derived path could disable the
hardening with no trace. The OCI override now warns when a SUCCESSFUL command
leaves nothing at the derived path, and stays silent on the failure path where an
absent plan file is expected.

Doc comments that recorded the old quoting limitation as a deliberate
best-effort limit are corrected; that framing is what made the truncation look
like a known parsing nicety rather than a disabled security control.

Closes #875

