### PR TITLE
security: declare every credential input a secret, and register every masked value

### DIFF
--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -59,7 +59,7 @@
         },
         {
             "name": "clientSecret",
-            "type": "string",
+            "type": "password",
             "label": "OAuth Client Secret",
             "defaultValue": "",
             "required": false,
@@ -78,7 +78,7 @@
         },
         {
             "name": "password",
-            "type": "string",
+            "type": "password",
             "label": "Password",
             "defaultValue": "",
             "required": false,

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/task.json
@@ -63,7 +63,7 @@
     },
     {
       "name": "callbackToken",
-      "type": "string",
+      "type": "password",
       "label": "TSM callback token",
       "required": false,
       "isSecret": true,

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/task.json
@@ -94,7 +94,7 @@
         },
         {
             "name": "apiKey",
-            "type": "string",
+            "type": "password",
             "label": "API key",
             "groupName": "private",
             "defaultValue": "",
@@ -167,7 +167,7 @@
         },
         {
             "name": "hcpToken",
-            "type": "string",
+            "type": "password",
             "label": "HCP API token",
             "groupName": "hcp",
             "defaultValue": "",

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/task.json
@@ -120,7 +120,7 @@
         },
         {
             "name": "policyRepoToken",
-            "type": "string",
+            "type": "password",
             "label": "Repo access token",
             "defaultValue": "",
             "required": false,

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CredentialInputTypeClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CredentialInputTypeClassL0.ts
@@ -1,0 +1,104 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * CLASS TEST -- credential inputs must be declared `type: password` (#867).
+ *
+ * Defect class: "an input whose own label/help text describes it as a
+ * credential is declared `type: string`, so the classic designer renders it as
+ * an ordinary textbox and persists the value in the pipeline definition in
+ * cleartext, readable by anyone with pipeline-read."
+ *
+ * #867 reported ONE instance (backendOCIPar). Sweeping every task.json for
+ * credential-shaped inputs found eight. Rather than pin the eight by name, this
+ * test RE-DERIVES the set from the manifests on every run: any input whose
+ * name/label/help matches the credential vocabulary must be `password`, so a
+ * newly added token input fails here instead of shipping mis-declared.
+ *
+ * EXEMPT records the inputs that match the vocabulary but are NOT bearer
+ * credentials, each with the reason -- an exemption must be a decision, not an
+ * omission.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const TASKS_DIR = path.join(REPO_ROOT, 'Tasks');
+
+const CREDENTIAL_WORDS = /password|token|secret|credential|api ?key|bearer|passphrase|private key/i;
+
+/** Inputs that read as credentials but are not, with the reason they stay non-secret. */
+const EXEMPT: Record<string, string> = {
+  'TerraformModulePublishV1:vcsOauthTokenId':
+    'An identifier (ot-xxxxxxxx) naming an OAuth connection stored in HCP, not the token itself -- it confers no access without the separately-declared hcpToken.',
+  'TerraformDriftReportV1:callbackUrl':
+    'The callback endpoint. The bearer material sent to it is callbackToken, which IS declared password.',
+  'TerraformTaskV5:secureVarsFile':
+    'A secureFile input: the file is delivered by the agent secure-files store, which is already a secret channel.',
+  'TerraformTaskV5:terraformVariables':
+    'A multiLine list of NAME=VALUE pairs whose help directs sensitive values to secureVarsFile; password type cannot render multi-line.',
+  'TerraformTaskV5:ociWifClientId':
+    'A client identifier, not a client secret -- the OCI WIF exchange authenticates with a federated token, never a static client credential.',
+  'TerraformTaskV5:publishApplyResults':
+    'The NAME given to the published apply summary (e.g. "production"). It matches only because its help text explains how secrets are redacted in that summary.',
+  'PublishKbArticleV1:serviceConnection':
+    'A connectedService input; the credential lives in the service connection, not in the pipeline definition.',
+};
+
+type Row = { task: string; input: string; type: string };
+
+function collectCredentialInputs(): Row[] {
+  const rows: Row[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+      } else if (entry.name === 'task.json') {
+        const manifest = JSON.parse(fs.readFileSync(p, 'utf8')) as {
+          inputs?: { name?: string; type?: string; label?: string; helpMarkDown?: string }[];
+        };
+        const taskDir = path.basename(path.dirname(p));
+        for (const input of manifest.inputs ?? []) {
+          const blob = `${input.name ?? ''} ${input.label ?? ''} ${input.helpMarkDown ?? ''}`;
+          // Booleans/pickLists can't hold a credential regardless of wording.
+          if (input.type === 'boolean' || input.type === 'pickList' || input.type === 'radio') continue;
+          if (!CREDENTIAL_WORDS.test(blob)) continue;
+          rows.push({ task: taskDir, input: input.name ?? '(unnamed)', type: input.type ?? '(none)' });
+        }
+      }
+    }
+  };
+  walk(TASKS_DIR);
+  return rows;
+}
+
+describe('credential inputs are declared as secrets (class test #867)', function () {
+  const rows = collectCredentialInputs();
+
+  it('finds credential-shaped inputs to check (guards against the sweep silently matching nothing)', () => {
+    assert.ok(rows.length >= 8, `expected the manifest sweep to find credential inputs; found ${rows.length}`);
+  });
+
+  it('every credential-shaped input is either type=password or explicitly exempt', () => {
+    const offenders = rows
+      .filter((r) => r.type !== 'password' && !(`${r.task}:${r.input}` in EXEMPT))
+      .map((r) => `${r.task}:${r.input} (type=${r.type})`);
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `these inputs read as credentials but are not declared "type": "password". Declare them password, or add an entry to EXEMPT stating why the value is not a bearer credential:\n  ${offenders.join('\n  ')}`,
+    );
+  });
+
+  it('every EXEMPT entry still corresponds to a real input (no stale exemptions)', () => {
+    const present = new Set(rows.map((r) => `${r.task}:${r.input}`));
+    const stale = Object.keys(EXEMPT).filter((k) => !present.has(k));
+    assert.deepStrictEqual(stale, [], `EXEMPT names inputs that no longer exist: ${stale.join(', ')}`);
+  });
+
+  it('no EXEMPT entry is silently covering a password-typed input', () => {
+    const byKey = new Map(rows.map((r) => [`${r.task}:${r.input}`, r.type]));
+    const redundant = Object.keys(EXEMPT).filter((k) => byKey.get(k) === 'password');
+    assert.deepStrictEqual(redundant, [], `these are already password and need no exemption: ${redundant.join(', ')}`);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -73,6 +73,7 @@ import './CaptureOutputProtectionClassL0';
 // Table-driven CLASS test: hardened temp-file writes for plan/state/output/
 // verification-derived content -- a whole-repo site enumeration (#881/#882/#887).
 import './HardenedTempWritesClassL0';
+import './CredentialInputTypeClassL0';
 // Direct unit tests for the plan/apply digest REDACTION CORE (WP-1, the single
 // most security-critical unit): recursive redaction, digest builders, freeform
 // diagnostic scrub, and the golden-fixture regression + no-leak tripwire.

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -61,7 +61,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
         // and exactly what the provider path already refused to do.
         const accessKey = requireIdentityField(backendServiceName, "username");
         const secretKey = requireSecretField(backendServiceName, "password");
-        tasks.setSecret(secretKey);
+        EnvironmentVariableHelper.registerSecret(secretKey);
 
         neutralizeEnvironmentVariables(AWS_FEDERATED_CREDENTIAL_ENV, "AWS static backend");
         EnvironmentVariableHelper.setEnvironmentVariable("AWS_ACCESS_KEY_ID", accessKey);
@@ -90,7 +90,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
         tokenFilePrefix: string;
     }): Promise<void> {
         const oidcToken = await generateIdToken(params.serviceConnection);
-        tasks.setSecret(oidcToken);
+        EnvironmentVariableHelper.registerSecret(oidcToken);
 
         const tokenFilePath = path.join(resolveWifTempDir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
         writeSecretFile(tokenFilePath, oidcToken);
@@ -174,7 +174,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
                 // the instance profile instead. Both now fail closed.
                 const accessKeyId = requireIdentityField(command.serviceProviderName, "username");
                 const secretAccessKey = requireSecretField(command.serviceProviderName, "password");
-                tasks.setSecret(secretAccessKey);
+                EnvironmentVariableHelper.registerSecret(secretAccessKey);
                 neutralizeEnvironmentVariables(AWS_FEDERATED_CREDENTIAL_ENV, "AWS static");
                 EnvironmentVariableHelper.setEnvironmentVariable("AWS_ACCESS_KEY_ID", accessKeyId);
                 EnvironmentVariableHelper.setEnvironmentVariable("AWS_SECRET_ACCESS_KEY", secretAccessKey, true);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/azure-terraform-command-handler.ts
@@ -249,7 +249,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             case AuthorizationScheme.WorkloadIdentityFederation: {
                 const spnId = requireIdentityField(serviceConnectionID, "serviceprincipalid");
                 const oidcToken = await generateIdToken(serviceConnectionID);
-                tasks.setSecret(oidcToken);
+                EnvironmentVariableHelper.registerSecret(oidcToken);
 
                 const loginTool: ToolRunner = tasks.tool(azPath);
                 loginTool.arg(["login", "--service-principal",
@@ -264,7 +264,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
             case AuthorizationScheme.ServicePrincipal: {
                 const spnId = requireIdentityField(serviceConnectionID, "serviceprincipalid");
                 const spnKey = requireSecretField(serviceConnectionID, "serviceprincipalkey");
-                tasks.setSecret(spnKey);
+                EnvironmentVariableHelper.registerSecret(spnKey);
 
                 const loginTool: ToolRunner = tasks.tool(azPath);
                 loginTool.arg(["login", "--service-principal",
@@ -414,7 +414,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                     if (!accessToken) {
                         throw new Error("AccessToken not found in SystemVssConnection. Ensure the pipeline has OIDC enabled.");
                     }
-                    tasks.setSecret(accessToken);
+                    EnvironmentVariableHelper.registerSecret(accessToken);
                     EnvironmentVariableHelper.setEnvironmentVariable("ARM_OIDC_REQUEST_TOKEN", accessToken, true);
                 }
 
@@ -425,7 +425,7 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                 tasks.warning("Client secret authentication is not secure and will be deprecated in the next major version of this task. Please use Workload identity federation authentication instead.");
 
                 const servicePrincipalCredentials = this.getServicePrincipalCredentials(serviceConnectionID);
-                tasks.setSecret(servicePrincipalCredentials.servicePrincipalKey);
+                EnvironmentVariableHelper.registerSecret(servicePrincipalCredentials.servicePrincipalKey);
                 neutralizeEnvironmentVariables(
                     [ARM_IDENTITY_SELECTORS.oidcToken, ARM_IDENTITY_SELECTORS.certPath, ARM_IDENTITY_SELECTORS.cert, ARM_IDENTITY_SELECTORS.useMsi, ARM_IDENTITY_SELECTORS.useOidc],
                     "Azure service principal");

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -1686,18 +1686,16 @@ export abstract class BaseTerraformCommandHandler {
             // console log.
             includeDiagnostics,
             includeDiagnosticDetail: tasks.getBoolInput('includeDiagnosticDetail', false),
-            // §5.4 / #694: exact-match redaction now also covers every credential
-            // this task itself injected via EnvironmentVariableHelper's
-            // isSecret=true path (the standard mechanism the provider handlers use
-            // for cloud credentials) -- closing the gap for a SHORT injected secret
-            // that the PEM/high-entropy heuristic alone would miss. A value passed
-            // directly to tasks.setSecret() elsewhere (e.g. an ephemeral WIF token
-            // exchanged mid-command) is not tracked by this helper and still relies
-            // on the heuristic alone; this narrows, but does not eliminate, the
-            // documented residual (SECURITY.md / design §5.10). Mitigated further
-            // by includeDiagnostics (above) and by includeDiagnosticDetail
-            // defaulting to false so the more leak-prone 'detail' field is omitted
-            // unless opted in.
+            // §5.4 / #694 / #886: exact-match redaction covers every credential this
+            // task has masked, including the federated ones minted mid-command (the
+            // ADO OIDC JWT, the OCI UPST, the ephemeral RSA key, the PAR URL) that
+            // never become environment variables. Those previously reached this
+            // attachment covered only by the 40-char entropy heuristic -- incidental
+            // coverage that a shorter token, or one the heuristic fragments on a `.`
+            // or `:`, would have slipped through. Build attachments are not
+            // agent-masked (SECURITY.md), so on this path the heuristic was the only
+            // control. Mitigated further by includeDiagnostics (above) and by
+            // includeDiagnosticDetail defaulting to false.
             knownSecrets: EnvironmentVariableHelper.getTrackedSecretValues(),
         };
 

--- a/Tasks/TerraformTask/TerraformTaskV5/src/endpoint-data-secret.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/endpoint-data-secret.ts
@@ -1,4 +1,5 @@
 import tasks = require('azure-pipelines-task-lib/task');
+import { EnvironmentVariableHelper } from './environment-variables';
 
 /**
  * Registers every non-empty line of a (possibly multi-line) credential with the
@@ -17,7 +18,7 @@ export function maskSecretLines(value: string): void {
     for (const line of value.split('\n')) {
         const trimmed = line.trim();
         if (trimmed) {
-            tasks.setSecret(trimmed);
+            EnvironmentVariableHelper.registerSecret(trimmed);
         }
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/endpoint-data-secret.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/endpoint-data-secret.ts
@@ -1,4 +1,3 @@
-import tasks = require('azure-pipelines-task-lib/task');
 import { EnvironmentVariableHelper } from './environment-variables';
 
 /**

--- a/Tasks/TerraformTask/TerraformTaskV5/src/environment-variables.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/environment-variables.ts
@@ -2,16 +2,27 @@ import tasks = require('azure-pipelines-task-lib/task');
 
 export class EnvironmentVariableHelper {
     private static readonly trackedVariables: Set<string> = new Set();
-    // Every VALUE (not just variable name) this helper has setSecret()'d during
-    // the current command, so a later consumer (e.g. the apply-summary's
+    // Every VALUE (not just variable name) this task has setSecret()'d during the
+    // current command, so a later consumer (e.g. the apply-summary's
     // freeform-diagnostic scrub, #694) can thread them into an exact-match
     // redaction pass instead of relying solely on a length/entropy heuristic.
-    // Covers only credentials injected via THIS helper's isSecret=true path
-    // (the standard mechanism the provider handlers use for cloud
-    // credentials) -- a value passed directly to tasks.setSecret() elsewhere
-    // (e.g. an ephemeral WIF token) is not tracked here and still relies on
-    // the heuristic alone, same as before.
+    // Populated both by this helper's isSecret=true path and by registerSecret()
+    // below, which every direct masking site calls (#886).
     private static readonly trackedSecretValues: Set<string> = new Set();
+
+    /**
+     * Masks `value` and records it for the exact-match scrub. Federated
+     * credentials (the ADO OIDC JWT, the OCI UPST, the ephemeral RSA key, the PAR
+     * URL) are minted mid-command and never become environment variables, so
+     * before this they were masked but invisible to scrubSecrets() and covered
+     * only by its 40-char entropy heuristic -- on build attachments, which are
+     * not agent-masked, that heuristic was the sole control (#886).
+     */
+    public static registerSecret(value: string | undefined | null): void {
+        if (!value) return;
+        tasks.setSecret(value);
+        this.trackedSecretValues.add(value);
+    }
 
     public static setEnvironmentVariable(name: string, value: string, isSecret: boolean = false): void {
         if (!name) {
@@ -23,15 +34,14 @@ export class EnvironmentVariableHelper {
             return;
         }
         if (isSecret) {
-            tasks.setSecret(value);
-            this.trackedSecretValues.add(value);
+            this.registerSecret(value);
         }
         process.env[name] = value;
         this.trackedVariables.add(name);
         tasks.debug(`Set environment variable: ${name}${isSecret ? ' (secret)' : ''}`);
     }
 
-    /** Every secret value registered via setEnvironmentVariable(..., true) so far this command. */
+    /** Every secret value this task has masked so far this command. */
     public static getTrackedSecretValues(): string[] {
         return [...this.trackedSecretValues];
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -81,7 +81,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         // so no boundary-line filtering here.
         for (const line of privateKey.split('\n')) {
             const trimmed = line.trim();
-            if (trimmed) tasks.setSecret(trimmed);
+            if (trimmed) EnvironmentVariableHelper.registerSecret(trimmed);
         }
         const normalized = normalizePem(privateKey);
         // ADO's log masker matches per line, not across embedded newlines, so
@@ -90,7 +90,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         // this byte-different on-disk form if it were ever echoed to a log.
         for (const line of normalized.split('\n')) {
             const trimmed = line.trim();
-            if (trimmed && !trimmed.startsWith('-----')) tasks.setSecret(trimmed);
+            if (trimmed && !trimmed.startsWith('-----')) EnvironmentVariableHelper.registerSecret(trimmed);
         }
 
         // Create json string and write it to the file
@@ -154,7 +154,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
         credentialsFilePrefix: string;
     }): Promise<string> {
         const oidcToken = await generateIdToken(params.serviceConnection);
-        tasks.setSecret(oidcToken);
+        EnvironmentVariableHelper.registerSecret(oidcToken);
 
         const tokenFilePath = path.join(resolveWifTempDir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
         writeSecretFile(tokenFilePath, oidcToken);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/hcp-terraform-command-handler.ts
@@ -23,7 +23,7 @@ export class TerraformCommandHandlerHCP extends BaseTerraformCommandHandler {
      */
     private applyBackendEnv(): void {
         const token = tasks.getInput("backendHCPToken", true)!;
-        if (token) { tasks.setSecret(token); }
+        if (token) { EnvironmentVariableHelper.registerSecret(token); }
         EnvironmentVariableHelper.setEnvironmentVariable("TF_TOKEN_app_terraform_io", token, true);
 
         const organization = tasks.getInput("backendHCPOrganization", false);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts
@@ -1,6 +1,7 @@
 import tasks = require("azure-pipelines-task-lib/task");
 import { buildProxyFetchOptions } from './proxy-config';
 import { retryAsync, parseRetryAfterMs } from './retry';
+import { EnvironmentVariableHelper } from './environment-variables';
 
 export async function generateIdToken(serviceConnectionID: string): Promise<string> {
     const tokenGenerator = new TokenGenerator();
@@ -168,7 +169,7 @@ export class TokenGenerator {
         // The agent OAuth token is a bearer credential. Register it as a secret
         // in-module so masking does not depend on the agent's implicit
         // System.AccessToken registration, matching the token-refresh path.
-        tasks.setSecret(accessToken);
+        EnvironmentVariableHelper.registerSecret(accessToken);
 
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 30000);
@@ -230,7 +231,7 @@ export class TokenGenerator {
         }
 
         const oidcToken = oidcObject.oidcToken;
-        tasks.setSecret(oidcToken);
+        EnvironmentVariableHelper.registerSecret(oidcToken);
         return oidcToken;
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -128,7 +128,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         // so no boundary-line filtering here.
         for (const line of privateKey.split('\n')) {
             const trimmed = line.trim();
-            if (trimmed) tasks.setSecret(trimmed);
+            if (trimmed) EnvironmentVariableHelper.registerSecret(trimmed);
         }
         const normalized = normalizePem(privateKey);
         // ADO's log masker matches per line, not across embedded newlines, so
@@ -137,7 +137,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         // this byte-different on-disk form if it were ever echoed to a log.
         for (const line of normalized.split('\n')) {
             const trimmed = line.trim();
-            if (trimmed && !trimmed.startsWith('-----')) tasks.setSecret(trimmed);
+            if (trimmed && !trimmed.startsWith('-----')) EnvironmentVariableHelper.registerSecret(trimmed);
         }
         const privateKeyFilePath = path.join(resolveWifTempDir(), `keyfile-${uuidV4()}.pem`);
         writeSecretFile(privateKeyFilePath, normalized);
@@ -165,9 +165,8 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
             // masked in build logs, matching how every other credential in this task is
             // handled.
             if (parUrl) {
-                tasks.setSecret(parUrl);
+                EnvironmentVariableHelper.registerSecret(parUrl);
             }
-
             // Validate the PAR URL (https-only, reject template-injection syntax) and
             // escape it for safe interpolation into the generated HCL address string.
             // parUrl was tasks.setSecret()'d above, so validation errors never leak it.
@@ -386,7 +385,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         }
         // 1. Get OIDC JWT from Azure DevOps
         const oidcToken = await generateIdToken(command.serviceProviderName);
-        tasks.setSecret(oidcToken);
+        EnvironmentVariableHelper.registerSecret(oidcToken);
 
         // 2. Generate ephemeral RSA-2048 key pair
         const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
@@ -401,7 +400,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         for (const keyLine of privateKey.split('\n')) {
             const trimmed = keyLine.trim();
             if (trimmed && !trimmed.startsWith('-----')) {
-                tasks.setSecret(trimmed);
+                EnvironmentVariableHelper.registerSecret(trimmed);
             }
         }
 
@@ -409,7 +408,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         const identityDomainUrl = tasks.getInput("ociWifIdentityDomainUrl", true)!;
         const clientId = tasks.getInput("ociWifClientId", true)!;
         const upst = await exchangeOidcForUpst(oidcToken, identityDomainUrl, clientId, publicKey);
-        tasks.setSecret(upst);
+        EnvironmentVariableHelper.registerSecret(upst);
 
         // 4. Compute fingerprint of ephemeral public key
         const keyObject = crypto.createPublicKey(publicKey);

--- a/Tasks/TerraformTask/TerraformTaskV5/src/proxy-config.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/proxy-config.ts
@@ -1,5 +1,6 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import { ProxyAgent } from 'undici';
+import { EnvironmentVariableHelper } from './environment-variables';
 
 /**
  * Builds fetch() RequestInit options that route the request through the
@@ -19,7 +20,7 @@ export function buildProxyFetchOptions(): RequestInit {
   let proxyUrl = proxy.proxyUrl;
   if (proxy.proxyUsername) {
     if (proxy.proxyPassword) {
-      tasks.setSecret(proxy.proxyPassword);
+      EnvironmentVariableHelper.registerSecret(proxy.proxyPassword);
     }
     let url: URL;
     try {
@@ -38,7 +39,7 @@ export function buildProxyFetchOptions(): RequestInit {
     // module-publish transport helpers already do for their own credential
     // URLs (#684).
     if (url.password) {
-      tasks.setSecret(url.password);
+      EnvironmentVariableHelper.registerSecret(url.password);
     }
     proxyUrl = url.toString();
   }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/secure-var-file-masking.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/secure-var-file-masking.ts
@@ -1,5 +1,6 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import fs = require('fs');
+import { EnvironmentVariableHelper } from './environment-variables';
 
 /**
  * The task manifest documents `secureVarsFile` as THE place to put sensitive
@@ -116,7 +117,7 @@ export function maskSecureVarFileValues(filePath: string): void {
         for (const line of value.split(/\r?\n/)) {
             const trimmed = line.trim();
             if (trimmed.length >= MIN_MASKABLE_VALUE_LENGTH) {
-                tasks.setSecret(trimmed);
+                EnvironmentVariableHelper.registerSecret(trimmed);
             }
         }
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/task.json
@@ -1118,7 +1118,7 @@
         },
         {
             "name": "backendOCIPar",
-            "type": "string",
+            "type": "password",
             "label": "PAR for Terraform remote state file",
             "required": false,
             "helpMarkDown": "The OCI object storage PAR configuration for the Terraform remote state file (optional).<br><br>This PAR URL is a bearer credential (its /p/&lt;token&gt;/ path segment grants read/write to the state bucket). It is written into a generated <code>config-&lt;uuid&gt;.tf</code> file inside the 'Configuration directory' below -- Terraform only loads <code>*.tf</code> files from the working directory, so this file cannot be relocated to a purged temp directory like the task's other credential files. It is written with restrictive permissions and its contents are scrubbed (overwritten) before deletion at the end of the step, but a host crash before that cleanup runs can still leave it on disk. <b>Security-sensitive:</b> <code>terraform init</code> also copies this PAR URL into <code>&lt;Configuration directory&gt;/.terraform/terraform.tfstate</code>, a cache this task does not scrub by default because later plan/apply/etc. steps against the same working directory need it. See the 'Scrub cached backend PAR on cleanup' input (enable only on the last state-touching step), use short-lived/narrowly-scoped PARs, and prefer ephemeral working directories on self-hosted agents.",
@@ -1215,11 +1215,11 @@
         "OutputSensitiveOutputsStrictFailure": "%s contains %d sensitive Terraform output(s) in cleartext (%s) and 'failOnSensitiveOutputs' is enabled; the file will be deleted at the end of this step. Set 'cleanupOutputFile' to true to delete the file automatically instead of failing, or disable 'failOnSensitiveOutputs' to downgrade this to a warning.",
         "ShowSensitiveOutputsStrictFailure": "%s contains %d sensitive Terraform output(s) in cleartext (%s) and 'failOnSensitiveOutputs' is enabled; the file will be deleted at the end of this step. Disable 'failOnSensitiveOutputs' to downgrade this to a warning.",
         "ShowSensitiveOutputsConsoleStrictFailure": "The captured 'terraform show -json' output contains %d sensitive Terraform output(s) in cleartext (%s) and 'failOnSensitiveOutputs' is enabled; failing before the output is echoed to the console. Disable 'failOnSensitiveOutputs' to downgrade this to a warning, or set outputTo to 'file' for the existing file-based handling.",
-      "TerraformCommandTimedOut": "Terraform command timed out after %d minute(s) and was terminated. Increase 'commandTimeoutMinutes' if this operation is expected to take longer.",
-      "TerraformAzLoginTimedOut": "'az login'/'az account set' timed out after %d minute(s) and was terminated. This call is expected to complete quickly; a hang usually indicates the Azure CLI is unresponsive or an identity/metadata endpoint (e.g. for managed identity) is unreachable.",
-      "TerraformFmtNotFormatted": "%d file(s) are not correctly formatted; run terraform fmt",
-      "TerraformFmtFailed": "Terraform fmt failed with exit code %s",
-      "TerraformTestFailed": "Terraform test failed with exit code %s",
-      "Error_FederatedTokenAquisitionFailed": "Failed to acquire a federated (OIDC) ID token for the service connection. Verify the service connection is configured for Workload Identity Federation and that the pipeline is authorized to use it."
-}
+        "TerraformCommandTimedOut": "Terraform command timed out after %d minute(s) and was terminated. Increase 'commandTimeoutMinutes' if this operation is expected to take longer.",
+        "TerraformAzLoginTimedOut": "'az login'/'az account set' timed out after %d minute(s) and was terminated. This call is expected to complete quickly; a hang usually indicates the Azure CLI is unresponsive or an identity/metadata endpoint (e.g. for managed identity) is unreachable.",
+        "TerraformFmtNotFormatted": "%d file(s) are not correctly formatted; run terraform fmt",
+        "TerraformFmtFailed": "Terraform fmt failed with exit code %s",
+        "TerraformTestFailed": "Terraform test failed with exit code %s",
+        "Error_FederatedTokenAquisitionFailed": "Failed to acquire a federated (OIDC) ID token for the service connection. Verify the service connection is configured for Workload Identity Federation and that the pipeline is authorized to use it."
+    }
 }


### PR DESCRIPTION
Two halves of the same class: a credential the task handles through an ad-hoc
path instead of the mechanism that guarantees the property.

#867 reported that `backendOCIPar` -- whose own help text calls it a bearer
credential granting read/write to the state bucket -- was declared
`"type": "string"` while `backendHCPToken`, a credential of identical character,
was `"type": "password"`. Sweeping every manifest for credential-shaped inputs
found the reported site was one of EIGHT. Seven are genuine and are now declared
password:

  PublishKbArticle      clientSecret, password
  TerraformModulePublish apiKey, hcpToken
  TerraformPolicyCheck  policyRepoToken
  TerraformDriftReport  callbackToken
  TerraformTaskV5       backendOCIPar

`vcsOauthTokenId` is deliberately NOT retyped: it is an identifier
(ot-xxxxxxxx) naming an OAuth connection stored in HCP, and confers no access
without the separately-declared hcpToken. Retyping it would be following the
keyword rather than the trust model.

This is not a breaking change for YAML pipelines: the declared type does not
affect how an input is passed or bound, only how the classic designer renders it
and how the value is persisted in the pipeline definition. Verified against real
consumers -- `backendHCPToken` (already password) and PublishKbArticle's
`password` (previously string) are written identically in YAML, both as
`$(secretVariable)`. What changes is that the designer no longer stores these in
cleartext in the definition, where anyone with pipeline-read could see them.

#886: `scrubSecrets()` redacts published plan/apply/state digests using an
exact-match pass over the tracked-secret set plus a 40-char entropy heuristic.
Only values injected through `setEnvironmentVariable(..., isSecret=true)` were
tracked, so every federated credential -- the ADO OIDC JWT on the AWS/GCP/OCI
paths, the OCI UPST, the ephemeral RSA private key, the PAR URL -- was masked but
invisible to the exact-match pass, leaving the heuristic as the only control.
That matters because build attachments are NOT agent-masked (SECURITY.md), and a
shorter token, or one the heuristic fragments on a `.` or `:`, would have gone
through intact. The coverage was incidental, not designed.

`EnvironmentVariableHelper.registerSecret()` now masks AND records in one step,
and all 23 direct `tasks.setSecret()` call sites across 9 files route through it.
The only remaining raw call in the task is the one inside registerSecret itself,
so there is a single chokepoint rather than two parallel notions of "masked".
Comments that documented the old residual are corrected rather than left to
describe a gap that no longer exists.

The class test re-derives rather than pins: CredentialInputTypeClassL0 re-scans
every task.json on each run and fails on any credential-shaped input that is not
password, with an EXEMPT map carrying a written reason per exclusion, plus checks
that reject stale and redundant exemptions. A hardcoded list of seven would have
gone out of date the first time someone added a token input -- which is exactly
how this class reached eight instances. It immediately earned its keep by
flagging `publishApplyResults`, which matches the credential vocabulary only
because its help text explains how secrets are redacted in the summary; that is
recorded as an exemption with the reason, not silenced by loosening the pattern.

Closes #867
Closes #886

