### PR TITLE
feat: follow HashiCorp's automation guidance for every terraform invocation

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/AutomationEnvL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/AutomationEnvL0.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import { applyAutomationEnvironment } from '../src/terraform';
+
+/**
+ * #896: HashiCorp's "Running Terraform in Automation" guidance for CI wrappers.
+ * Both variables are opt-OUT via the mechanism Terraform documents -- an operator
+ * value on the job or step wins -- so these tests pin the precedence, not just
+ * the defaults.
+ */
+describe('automation environment defaults (#896)', function () {
+  it('sets both variables when the operator set neither', () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyAutomationEnvironment(env);
+    assert.strictEqual(env.TF_IN_AUTOMATION, '1');
+    assert.strictEqual(env.CHECKPOINT_DISABLE, '1');
+  });
+
+  it('never overwrites an operator-supplied value', () => {
+    const env: NodeJS.ProcessEnv = { TF_IN_AUTOMATION: 'yes', CHECKPOINT_DISABLE: 'true' };
+    applyAutomationEnvironment(env);
+    assert.strictEqual(env.TF_IN_AUTOMATION, 'yes');
+    assert.strictEqual(env.CHECKPOINT_DISABLE, 'true');
+  });
+
+  it('preserves an EMPTY operator value, which Terraform reads as off', () => {
+    // The opt-out for a variable whose semantics are "any non-empty value" is to
+    // set it empty; treating empty as unset would silently re-enable both.
+    const env: NodeJS.ProcessEnv = { TF_IN_AUTOMATION: '', CHECKPOINT_DISABLE: '' };
+    applyAutomationEnvironment(env);
+    assert.strictEqual(env.TF_IN_AUTOMATION, '');
+    assert.strictEqual(env.CHECKPOINT_DISABLE, '');
+  });
+
+  it('fills only the variable the operator left unset', () => {
+    const env: NodeJS.ProcessEnv = { CHECKPOINT_DISABLE: '' };
+    applyAutomationEnvironment(env);
+    assert.strictEqual(env.TF_IN_AUTOMATION, '1');
+    assert.strictEqual(env.CHECKPOINT_DISABLE, '');
+  });
+
+  it('is idempotent across the repeated calls every command path makes', () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyAutomationEnvironment(env);
+    applyAutomationEnvironment(env);
+    assert.strictEqual(env.TF_IN_AUTOMATION, '1');
+    assert.strictEqual(env.CHECKPOINT_DISABLE, '1');
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -31,6 +31,7 @@ import './OciWifTempDirL0';
 import './EmergencyCleanupNoHandlerL0';
 // Direct unit tests for tool-path resolution (terraformLocation vs PATH).
 import './ResolveToolPathL0';
+import './AutomationEnvL0';
 // Direct unit tests for OCI WIF synthetic-config field validation.
 import './OciWifConfigValidationL0';
 // Direct unit tests for the generated OCI backend config file's secret-file write.

--- a/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/terraform.ts
@@ -50,6 +50,25 @@ export interface ITerraformToolHandler {
     createToolRunner(command?: TerraformBaseCommandInitializer): ToolRunner;
 }
 
+/**
+ * HashiCorp's "Running Terraform in Automation" guidance for CI wrappers (#896):
+ * suppress the interactive "next command" suggestions, and stop the
+ * per-invocation call to checkpoint-api.hashicorp.com.
+ *
+ * Neither is forced. An operator who sets either variable on the job or step
+ * keeps their value -- including an empty one, which Terraform reads as off --
+ * so the opt-out is the mechanism Terraform itself documents rather than a task
+ * input only this task would honour.
+ */
+export function applyAutomationEnvironment(env: NodeJS.ProcessEnv = process.env): void {
+    if (env.TF_IN_AUTOMATION === undefined) {
+        env.TF_IN_AUTOMATION = '1';
+    }
+    if (env.CHECKPOINT_DISABLE === undefined) {
+        env.CHECKPOINT_DISABLE = '1';
+    }
+}
+
 export class TerraformToolHandler implements ITerraformToolHandler {
     private readonly tasks: typeof import('azure-pipelines-task-lib/task');
 
@@ -60,6 +79,10 @@ export class TerraformToolHandler implements ITerraformToolHandler {
     public createToolRunner(command?: TerraformBaseCommandInitializer): ToolRunner {
         const binaryName = getBinaryName(this.tasks);
         const toolPath = resolveToolPath(this.tasks, binaryName);
+
+        // Every terraform/tofu invocation in this task is built here, so this is the
+        // one place that cannot be bypassed by a future command path.
+        applyAutomationEnvironment();
 
         const toolRunner: ToolRunner = this.tasks.tool(toolPath);
         if (command) {


### PR DESCRIPTION
TF_IN_AUTOMATION and CHECKPOINT_DISABLE were set nowhere in the repo, on any of
the terraform commands this task wraps (#896).

Both are applied at createToolRunner(), which is the one place every
terraform/tofu argv in this task is built -- so a command path added later
cannot bypass them by construction, which a per-command call site could.

Neither is forced. An operator value on the job or step wins, including an EMPTY
one: both variables are read by Terraform as "any non-empty value means on", so
empty is the documented way to turn them back off. That is the opt-out rather
than a new task input, which only this task would honour and which would need
its own plumbing to reach the same place. AutomationEnvL0 pins that precedence,
not just the defaults -- including the empty-value case, because treating empty
as unset would silently re-enable both and read as correct in every other test.

Stating the trade rather than presenting this as free: CHECKPOINT_DISABLE also
turns off Terraform's SECURITY BULLETIN check for the running version, not just
the version-update ping. In a pipeline that is the right default -- the bulletin
lands in a log nobody reads, this repo pins its own versions and runs drift
canaries over the installer paths, and the outbound call is exactly the kind of
unrequested egress the rest of the codebase works to remove -- but an operator
who wants those bulletins turns it back on with an empty value, and that is why
the opt-out exists rather than the variable being set unconditionally.

TF_IN_AUTOMATION is cosmetic by HashiCorp's own description: it drops the
"next command to run" suggestions, which are addressed to a human at a terminal
and are noise in a pipeline log and in the published summaries this task builds.
It is included because the issue is about matching the documented CI posture,
not because it hardens anything.

Closes #896

