### PR TITLE
refactor: extract TempFileManager from BaseTerraformCommandHandler (#878 PR 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,32 +141,33 @@ azure-pipelines-terraform/
 
 ### Source files: `Tasks/TerraformTask/TerraformTaskV5/src/`
 
-| File                                 | Role                                                                                           |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `index.ts`                           | Entry point - reads `provider` and `command` inputs, delegates to `ParentCommandHandler`       |
-| `parent-handler.ts`                  | Routes provider/backend name to the correct handler class                                      |
-| `base-terraform-command-handler.ts`  | Abstract base with shared command implementations                                              |
-| `terraform.ts`                       | `TerraformToolHandler` - locates terraform binary and builds `ToolRunner`                      |
-| `terraform-commands.ts`              | Data classes: `TerraformBaseCommandInitializer`, `TerraformAuthorizationCommandInitializer`    |
-| `azure-terraform-command-handler.ts` | AzureRM-specific backend and provider auth (MSI, WorkloadIdentityFederation, ServicePrincipal) |
-| `aws-terraform-command-handler.ts`   | AWS-specific backend and provider auth                                                         |
-| `gcp-terraform-command-handler.ts`   | GCP-specific backend and provider auth                                                         |
-| `oci-terraform-command-handler.ts`   | OCI-specific backend (HTTP backend via PAR URL) and provider auth                              |
-| `environment-variables.ts`           | Helper for setting environment variables with tracking and cleanup                             |
-| `secure-file-loader.ts`              | Downloads secure var files from ADO Secure Files library                                       |
-| `id-token-generator.ts`              | Generates OIDC ID tokens for Workload Identity Federation fallback                             |
-| `secure-temp.ts`                     | Secure temp-file primitives: owner-only 0600 + O_EXCL on Unix, a restrictive icacls DACL on Windows (both fail closed), plus symlink-guarded `scrubFile()` zero-overwrite-before-unlink (#595) — canonical source; byte-identical copy also in TerraformDriftReportV1 and TerraformPolicyCheckV1, gated by `scripts/check-shared-modules.js` |
-| `retry.ts`                           | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
-| `generic-terraform-command-handler.ts` | `TerraformCommandHandlerGeneric` — generic backend (`backendType: generic`) wired via `-backend-config` file/args |
-| `hcp-terraform-command-handler.ts`     | `TerraformCommandHandlerHCP` — HCP Terraform / Terraform Cloud backend (sets `TF_TOKEN_app_terraform_io` from `backendHCPToken`) |
-| `backend-detection.ts`                 | Maps a Terraform `backend.type` (from `.terraform/terraform.tfstate`) to the cloud whose credentials the backend needs — enables cross-cloud state-backend credential injection (bounded state-file read) |
-| `oci-token-exchange.ts`                | Exchanges the ADO OIDC token for an OCI UPST (User Principal Session Token) — the second hop of the OCI WIF flow; classifies retryable vs. deterministic failures + capped `Retry-After` |
-| `pem-normalizer.ts`                    | Normalizes a single-line ADO-delivered PEM private key to RFC 7468 format and validates it via `crypto.createPrivateKey()` (OCI and GCP private-key auth) |
-| `proxy-config.ts`                      | Builds `fetch()` options routing the OIDC/OCI outbound HTTPS calls through the agent's configured proxy (`Agent.ProxyUrl`/`Agent.ProxyUsername`/`Agent.ProxyPassword`) |
-| `temp-dir.ts`                          | Resolves the directory for ephemeral WIF credential/token files (prefers agent-purged `Agent.TempDirectory` over `os.tmpdir()`); shared by the AWS/GCP/OCI handlers |
-| `credential-guards.ts`                 | Fail-closed credential guards: clears inherited identity-selecting env vars before a handler applies its own, and derives the per-run AWS role session name (`resolveRoleSessionName`) instead of a fixed constant |
-| `endpoint-data-secret.ts`              | Reads `ENDPOINT_DATA_*` service-connection parameters without the task-lib read path that logs the value (`ENDPOINT_DATA_*` is not vaulted, unlike `AUTH`/`SECRET`/`INPUT`) |
-| `secure-var-file-masking.ts`           | Registers the values inside a downloaded secure var file as secrets, line-wise, before terraform can echo them |
+| File                                   | Role                                                                                                                                                                                                                                                                                                                                         |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`                             | Entry point - reads `provider` and `command` inputs, delegates to `ParentCommandHandler`                                                                                                                                                                                                                                                     |
+| `parent-handler.ts`                    | Routes provider/backend name to the correct handler class                                                                                                                                                                                                                                                                                    |
+| `base-terraform-command-handler.ts`    | Abstract base with shared command implementations                                                                                                                                                                                                                                                                                            |
+| `terraform.ts`                         | `TerraformToolHandler` - locates terraform binary and builds `ToolRunner`                                                                                                                                                                                                                                                                    |
+| `terraform-commands.ts`                | Data classes: `TerraformBaseCommandInitializer`, `TerraformAuthorizationCommandInitializer`                                                                                                                                                                                                                                                  |
+| `azure-terraform-command-handler.ts`   | AzureRM-specific backend and provider auth (MSI, WorkloadIdentityFederation, ServicePrincipal)                                                                                                                                                                                                                                               |
+| `aws-terraform-command-handler.ts`     | AWS-specific backend and provider auth                                                                                                                                                                                                                                                                                                       |
+| `gcp-terraform-command-handler.ts`     | GCP-specific backend and provider auth                                                                                                                                                                                                                                                                                                       |
+| `oci-terraform-command-handler.ts`     | OCI-specific backend (HTTP backend via PAR URL) and provider auth                                                                                                                                                                                                                                                                            |
+| `environment-variables.ts`             | Helper for setting environment variables with tracking and cleanup                                                                                                                                                                                                                                                                           |
+| `temp-file-manager.ts`                 | Owns the command handler's temp-file lifecycle: the two tracking tiers (normal-completion vs cancellation-only, #650), scrub-then-unlink of each tracked path (#595), and the secure var file's scrub-before-delete (#662)                                                                                                                   |
+| `secure-file-loader.ts`                | Downloads secure var files from ADO Secure Files library                                                                                                                                                                                                                                                                                     |
+| `id-token-generator.ts`                | Generates OIDC ID tokens for Workload Identity Federation fallback                                                                                                                                                                                                                                                                           |
+| `secure-temp.ts`                       | Secure temp-file primitives: owner-only 0600 + O_EXCL on Unix, a restrictive icacls DACL on Windows (both fail closed), plus symlink-guarded `scrubFile()` zero-overwrite-before-unlink (#595) — canonical source; byte-identical copy also in TerraformDriftReportV1 and TerraformPolicyCheckV1, gated by `scripts/check-shared-modules.js` |
+| `retry.ts`                             | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js`                                                                                                                    |
+| `generic-terraform-command-handler.ts` | `TerraformCommandHandlerGeneric` — generic backend (`backendType: generic`) wired via `-backend-config` file/args                                                                                                                                                                                                                            |
+| `hcp-terraform-command-handler.ts`     | `TerraformCommandHandlerHCP` — HCP Terraform / Terraform Cloud backend (sets `TF_TOKEN_app_terraform_io` from `backendHCPToken`)                                                                                                                                                                                                             |
+| `backend-detection.ts`                 | Maps a Terraform `backend.type` (from `.terraform/terraform.tfstate`) to the cloud whose credentials the backend needs — enables cross-cloud state-backend credential injection (bounded state-file read)                                                                                                                                    |
+| `oci-token-exchange.ts`                | Exchanges the ADO OIDC token for an OCI UPST (User Principal Session Token) — the second hop of the OCI WIF flow; classifies retryable vs. deterministic failures + capped `Retry-After`                                                                                                                                                     |
+| `pem-normalizer.ts`                    | Normalizes a single-line ADO-delivered PEM private key to RFC 7468 format and validates it via `crypto.createPrivateKey()` (OCI and GCP private-key auth)                                                                                                                                                                                    |
+| `proxy-config.ts`                      | Builds `fetch()` options routing the OIDC/OCI outbound HTTPS calls through the agent's configured proxy (`Agent.ProxyUrl`/`Agent.ProxyUsername`/`Agent.ProxyPassword`)                                                                                                                                                                       |
+| `temp-dir.ts`                          | Resolves the directory for ephemeral WIF credential/token files (prefers agent-purged `Agent.TempDirectory` over `os.tmpdir()`); shared by the AWS/GCP/OCI handlers                                                                                                                                                                          |
+| `credential-guards.ts`                 | Fail-closed credential guards: clears inherited identity-selecting env vars before a handler applies its own, and derives the per-run AWS role session name (`resolveRoleSessionName`) instead of a fixed constant                                                                                                                           |
+| `endpoint-data-secret.ts`              | Reads `ENDPOINT_DATA_*` service-connection parameters without the task-lib read path that logs the value (`ENDPOINT_DATA_*` is not vaulted, unlike `AUTH`/`SECRET`/`INPUT`)                                                                                                                                                                  |
+| `secure-var-file-masking.ts`           | Registers the values inside a downloaded secure var file as secrets, line-wise, before terraform can echo them                                                                                                                                                                                                                               |
 
 ### Manifest (`task.json`) size & organization convention
 
@@ -182,15 +183,15 @@ New inputs should extend an existing group rather than adding a parallel section
 
 Builds the redacted JSON digests published to the **Terraform** tab (see `docs/design/plan-apply-digest-spec.md` for the frozen schema/redaction contract):
 
-| File                | Role                                                                                                     |
-| -------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `digest-schema.ts`  | The `PlanDigest`/`ApplyDigest`/`StateDigest` TypeScript shape (schemaVersion 1) — byte-identical copy in `src/tab/`, gated by `scripts/check-shared-modules.js` |
-| `caps.ts`           | Size/DoS caps (max resources, max attribute changes, byte ceilings, etc.) — byte-identical copy in `src/tab/`, same gate |
-| `redact.ts`         | The recursive redaction core: converts a raw value + its `*_sensitive`/`*_unknown` mask maps into a `RedactedValue`, fail-closed on mask/value shape mismatch |
-| `plan-digest.ts`    | Builds a `PlanDigest` from a parsed `terraform show -json <planfile>` object; also accepts an optional `mode: 'destroy'` (Phase 5) so a destroy plan is tagged `planMode: "destroy"` for the tab to label — same builder, same shape, no new type |
-| `apply-digest.ts`   | Builds an `ApplyDigest` from the `terraform apply -json` NDJSON event stream                               |
-| `state-digest.ts`   | (Phase 5) Builds a `StateDigest` from a parsed `terraform show -json` of the **current state** — a point-in-time resource/data-source/output inventory (no change actions, no before/after, no unknown), redacted against each resource's own `sensitive_values` via the same `redact.ts` core |
-| `secret-scrub.ts`   | Freeform-text scrub for apply diagnostics (known-secret string replacement + entropy/format heuristic) and attachment-name sanitization |
+| File               | Role                                                                                                                                                                                                                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `digest-schema.ts` | The `PlanDigest`/`ApplyDigest`/`StateDigest` TypeScript shape (schemaVersion 1) — byte-identical copy in `src/tab/`, gated by `scripts/check-shared-modules.js`                                                                                                                                |
+| `caps.ts`          | Size/DoS caps (max resources, max attribute changes, byte ceilings, etc.) — byte-identical copy in `src/tab/`, same gate                                                                                                                                                                       |
+| `redact.ts`        | The recursive redaction core: converts a raw value + its `*_sensitive`/`*_unknown` mask maps into a `RedactedValue`, fail-closed on mask/value shape mismatch                                                                                                                                  |
+| `plan-digest.ts`   | Builds a `PlanDigest` from a parsed `terraform show -json <planfile>` object; also accepts an optional `mode: 'destroy'` (Phase 5) so a destroy plan is tagged `planMode: "destroy"` for the tab to label — same builder, same shape, no new type                                              |
+| `apply-digest.ts`  | Builds an `ApplyDigest` from the `terraform apply -json` NDJSON event stream                                                                                                                                                                                                                   |
+| `state-digest.ts`  | (Phase 5) Builds a `StateDigest` from a parsed `terraform show -json` of the **current state** — a point-in-time resource/data-source/output inventory (no change actions, no before/after, no unknown), redacted against each resource's own `sensitive_values` via the same `redact.ts` core |
+| `secret-scrub.ts`  | Freeform-text scrub for apply diagnostics (known-secret string replacement + entropy/format heuristic) and attachment-name sanitization                                                                                                                                                        |
 
 `redact.ts` and `state-digest.ts` have only one copy each (task-side); neither is duplicated into `src/tab/` — the task produces a digest, the tab only ever consumes an already-redacted one — so they are intentionally not in the `check-shared-modules.js` parity families. `digest-schema.ts`/`caps.ts` remain the byte-identical parity families; the Phase 5 `StateDigest` type and `MAX_STATE_RESOURCES`/`MAX_STATE_ATTRS_PER_RESOURCE` caps were added to those two existing files (no new family needed).
 
@@ -249,11 +250,11 @@ Source: `Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/src/`
 - Pure config generation — no network calls, no credentials needed
 - Intended to run once per agent job, before `terraform init`
 
-| File                  | Role                                                       |
-| --------------------- | ---------------------------------------------------------- |
-| `index.ts`            | Entry point — reads inputs, validates URL, writes config   |
-| `config-generator.ts` | Pure function generating HCL `provider_installation` block |
-| `secure-temp.ts`      | Restrictive temp-file primitives (owner-only 0600 + `O_EXCL` on Unix, a restrictive icacls DACL on Windows; both fail closed) used for the generated `.terraformrc` |
+| File                      | Role                                                                                                                                                                                                                   |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`                | Entry point — reads inputs, validates URL, writes config                                                                                                                                                               |
+| `config-generator.ts`     | Pure function generating HCL `provider_installation` block                                                                                                                                                             |
+| `secure-temp.ts`          | Restrictive temp-file primitives (owner-only 0600 + `O_EXCL` on Unix, a restrictive icacls DACL on Windows; both fail closed) used for the generated `.terraformrc`                                                    |
 | `url-secret-redaction.ts` | Redacts credential-bearing query parameters (Azure `sig=`, AWS `X-Amz-Signature`/`X-Amz-Credential`/`X-Amz-Security-Token`, GCS `X-Goog-*`) and `user:password@` userinfo from a URL before it can reach the build log |
 
 ## TerraformDocsInstaller Task (TerraformDocsInstallerV1)
@@ -272,18 +273,18 @@ Source: `Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/`. Installs a pol
 
 Source: `Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/src/`. Evaluates policies against Terraform plan JSON (`terraform show -json` output). Engine dispatch in `index.ts`:
 
-| File                 | Role                                                                                                                                                              |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `index.ts`           | Orchestrator — resolves source, runs engine, sets outputs, publishes JUnit, cleans up temp dirs                                                                   |
-| `opa-engine.ts`      | `opa exec --decision <path> --bundle <dir> <input>`; parses JSON result, gates on `failMode` (nonEmpty/defined)                                                   |
-| `sentinel-engine.ts` | Generates `sentinel.hcl` (static import + policies), runs `sentinel apply`, maps exit code (0/1/2/3/9), applies enforcement level (advisory/soft/hard + override) |
+| File                 | Role                                                                                                                                                                                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`           | Orchestrator — resolves source, runs engine, sets outputs, publishes JUnit, cleans up temp dirs                                                                                                                                                                           |
+| `opa-engine.ts`      | `opa exec --decision <path> --bundle <dir> <input>`; parses JSON result, gates on `failMode` (nonEmpty/defined)                                                                                                                                                           |
+| `sentinel-engine.ts` | Generates `sentinel.hcl` (static import + policies), runs `sentinel apply`, maps exit code (0/1/2/3/9), applies enforcement level (advisory/soft/hard + override)                                                                                                         |
 | `policy-source.ts`   | `path` (local dir) or `gitUrl` (HTTPS shallow clone / SHA checkout, token delivered as an `http.extraheader` Authorization header via per-invocation `GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` env vars, not argv, so it never appears in the child process's command line) |
-| `results.ts`         | Raw output file + JUnit XML + `results.publish` logging command                                                                                                   |
-| `exec-timeout.ts`    | Wall-clock ceiling for a local policy-engine subprocess — task-lib's `execAsync` bounds captured output size but not time, so a hung engine would otherwise run to the ADO job timeout |
-| `output-cap.ts`      | Bounded stdout/stderr capture (`attachBoundedCapture`) so a runaway engine cannot grow one JS string until the agent OOMs (#632)                                    |
-| `secure-temp.ts`     | Restrictive temp-file primitives (owner-only 0600 + `O_EXCL` on Unix, a restrictive icacls DACL on Windows; both fail closed) — byte-identical copy of TerraformTaskV5's |
-| `retry.ts`           | Bounded-backoff retry loop for the policy-repo git clone — byte-identical copy shared with TerraformTaskV5 and the installer family, gated by `scripts/check-shared-modules.js` |
-| `types.ts`           | Shared type definitions for the engines and the orchestrator                                                                                                       |
+| `results.ts`         | Raw output file + JUnit XML + `results.publish` logging command                                                                                                                                                                                                           |
+| `exec-timeout.ts`    | Wall-clock ceiling for a local policy-engine subprocess — task-lib's `execAsync` bounds captured output size but not time, so a hung engine would otherwise run to the ADO job timeout                                                                                    |
+| `output-cap.ts`      | Bounded stdout/stderr capture (`attachBoundedCapture`) so a runaway engine cannot grow one JS string until the agent OOMs (#632)                                                                                                                                          |
+| `secure-temp.ts`     | Restrictive temp-file primitives (owner-only 0600 + `O_EXCL` on Unix, a restrictive icacls DACL on Windows; both fail closed) — byte-identical copy of TerraformTaskV5's                                                                                                  |
+| `retry.ts`           | Bounded-backoff retry loop for the policy-repo git clone — byte-identical copy shared with TerraformTaskV5 and the installer family, gated by `scripts/check-shared-modules.js`                                                                                           |
+| `types.ts`           | Shared type definitions for the engines and the orchestrator                                                                                                                                                                                                              |
 
 The standalone Sentinel CLI does NOT gate on `enforcement_level` (HCP-only) — the task applies it off the exit code. Policies see the raw `terraform show -json` schema (not the TFC `tfplan/v2` mock). Output variables: `policyResult`, `violationCount`, `resultsFilePath`.
 
@@ -291,14 +292,14 @@ The standalone Sentinel CLI does NOT gate on `enforcement_level` (HCP-only) — 
 
 Source: `Tasks/TerraformDriftReport/TerraformDriftReportV1/src/`. Parses a Terraform/OpenTofu plan JSON (`terraform show -json` output) into drift counts (create/update/delete) and a changed-resource summary, and optionally POSTs it to a Terraform State Manager (TSM) drift callback URL.
 
-| File              | Role                                                                                                                               |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `index.ts`        | Entry point — computes drift counts, orchestrates the callback and SARIF report                                                    |
-| `callback.ts`     | POSTs the drift summary to TSM; retries transport failures/5xx only, never after a received response (`callbackToken` is one-shot) |
+| File              | Role                                                                                                                                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`        | Entry point — computes drift counts, orchestrates the callback and SARIF report                                                                                                                                           |
+| `callback.ts`     | POSTs the drift summary to TSM; retries transport failures/5xx only, never after a received response (`callbackToken` is one-shot)                                                                                        |
 | `retry.ts`        | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
-| `sarif.ts`        | Generates a SARIF 2.1.0 report of drift findings (opt-in)                                                                          |
-| `secure-temp.ts`  | Restrictive temp-file primitives (owner-only 0600 + `O_EXCL` on Unix, a restrictive icacls DACL on Windows; both fail closed) — byte-identical copy of TerraformTaskV5's |
-| `https-client.ts` | Shared HTTPS client, HTTPS-only (shared with TerraformModulePublish)                                                               |
+| `sarif.ts`        | Generates a SARIF 2.1.0 report of drift findings (opt-in)                                                                                                                                                                 |
+| `secure-temp.ts`  | Restrictive temp-file primitives (owner-only 0600 + `O_EXCL` on Unix, a restrictive icacls DACL on Windows; both fail closed) — byte-identical copy of TerraformTaskV5's                                                  |
+| `https-client.ts` | Shared HTTPS client, HTTPS-only (shared with TerraformModulePublish)                                                                                                                                                      |
 
 Output variables: `driftDetected`, `addedCount`/`changedCount`/`destroyedCount`, `summaryFilePath` (opt-in `cleanupSummaryFile` removes it after use), `sarifFilePath`.
 
@@ -306,31 +307,31 @@ Output variables: `driftDetected`, `addedCount`/`changedCount`/`destroyedCount`,
 
 Source: `Tasks/TerraformModulePublish/TerraformModulePublishV1/src/`. Publishes a Terraform module version to HCP Terraform (private module registry) or a private/self-hosted Terraform registry.
 
-| File                   | Role                                                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| `index.ts`             | Entry point — reads inputs, dispatches to the chosen `registryType`                                     |
-| `hcp-publisher.ts`     | Publishes via the HCP Terraform module registry API; polls ingest status                                |
-| `private-publisher.ts` | Publishes to a private registry via its API (`apiKey` auth); auto-creates the module if absent          |
-| `http.ts`              | Shared HTTP client with bounded retry (`retryHttp()` — the reference implementation other tasks mirror) |
+| File                   | Role                                                                                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`             | Entry point — reads inputs, dispatches to the chosen `registryType`                                                                                                                                                       |
+| `hcp-publisher.ts`     | Publishes via the HCP Terraform module registry API; polls ingest status                                                                                                                                                  |
+| `private-publisher.ts` | Publishes to a private registry via its API (`apiKey` auth); auto-creates the module if absent                                                                                                                            |
+| `http.ts`              | Shared HTTP client with bounded retry (`retryHttp()` — the reference implementation other tasks mirror)                                                                                                                   |
 | `retry.ts`             | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
-| `https-client.ts`      | Shared HTTPS client, HTTPS-only (shared with TerraformDriftReport)                                      |
-| `types.ts`             | Shared type definitions for both publishers                                                             |
+| `https-client.ts`      | Shared HTTPS client, HTTPS-only (shared with TerraformDriftReport)                                                                                                                                                        |
+| `types.ts`             | Shared type definitions for both publishers                                                                                                                                                                               |
 
 ## Markdown2Html Task (Markdown2HtmlV1)
 
 Source: `Tasks/Markdown2Html/Markdown2HtmlV1/src/`. Converts Markdown files to HTML for publishing as ServiceNow knowledge base articles — parses YAML front matter, renders via `markdown-it` with `highlight.js` syntax highlighting, and resolves `{% include %}`-style file includes.
 
-| File                  | Role                                                                                        |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| `index.ts`            | Entry point — orchestrates the conversion pipeline                                          |
-| `converter.ts`        | Markdown → HTML conversion pipeline                                                         |
-| `frontmatter.ts`      | YAML front-matter parsing (`js-yaml`)                                                       |
-| `includes.ts`         | Resolves `{% include %}`-style file includes                                                |
-| `highlight-theme.ts`  | Syntax-highlighting theme wiring for `highlight.js`                                         |
-| `document.ts`         | Document model / metadata                                                                   |
-| `render.ts`           | HTML rendering + sanitization (uses `uri-scheme-guard.ts`)                                  |
-| `html-sanitizer.ts`   | Shared HTML allowlist sanitizer (`sanitize-html`) — byte-identical copy also in PublishKbArticleV1, gated by `scripts/check-shared-modules.js` |
-| `uri-scheme-guard.ts` | Shared XSS-prevention URI/scheme allowlist — byte-identical copy also in PublishKbArticleV1 |
+| File                  | Role                                                                                                                                                                 |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`            | Entry point — orchestrates the conversion pipeline                                                                                                                   |
+| `converter.ts`        | Markdown → HTML conversion pipeline                                                                                                                                  |
+| `frontmatter.ts`      | YAML front-matter parsing (`js-yaml`)                                                                                                                                |
+| `includes.ts`         | Resolves `{% include %}`-style file includes                                                                                                                         |
+| `highlight-theme.ts`  | Syntax-highlighting theme wiring for `highlight.js`                                                                                                                  |
+| `document.ts`         | Document model / metadata                                                                                                                                            |
+| `render.ts`           | HTML rendering + sanitization (uses `uri-scheme-guard.ts`)                                                                                                           |
+| `html-sanitizer.ts`   | Shared HTML allowlist sanitizer (`sanitize-html`) — byte-identical copy also in PublishKbArticleV1, gated by `scripts/check-shared-modules.js`                       |
+| `uri-scheme-guard.ts` | Shared XSS-prevention URI/scheme allowlist — byte-identical copy also in PublishKbArticleV1                                                                          |
 | `html-sanitizer.ts`   | Shared `sanitize-html` allowlist — the final stored-XSS defense before HTML reaches ServiceNow's `text` field; byte-identical copy also in PublishKbArticleV1 (#820) |
 
 Output variable: `htmlFilePath`.
@@ -339,21 +340,21 @@ Output variable: `htmlFilePath`.
 
 Source: `Tasks/PublishKbArticle/PublishKbArticleV1/src/`. Publishes or updates a knowledge base article in ServiceNow — create, update, workflow-state transition, and image-attachment sync (content-hash-based idempotency).
 
-| File                   | Role                                                                                                                       |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `index.ts`             | Entry point — orchestrates the create/update/workflow flow                                                                 |
-| `auth.ts`              | OAuth client-credentials and Basic auth; masks secrets including derived/encoded forms                                     |
-| `servicenow-client.ts` | ServiceNow Table API client — every `sysparm_query` interpolation goes through `assertQueryValueSafe()`                    |
-| `servicenow-http.ts`   | Shared HTTP client with bounded retry (transport + 5xx only, never a received 4xx)                                         |
+| File                   | Role                                                                                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`             | Entry point — orchestrates the create/update/workflow flow                                                                                                                                                                |
+| `auth.ts`              | OAuth client-credentials and Basic auth; masks secrets including derived/encoded forms                                                                                                                                    |
+| `servicenow-client.ts` | ServiceNow Table API client — every `sysparm_query` interpolation goes through `assertQueryValueSafe()`                                                                                                                   |
+| `servicenow-http.ts`   | Shared HTTP client with bounded retry (transport + 5xx only, never a received 4xx)                                                                                                                                        |
 | `retry.ts`             | Shared bounded exponential-backoff retry (`retryAsync`) + capped 429 `Retry-After` parsing (`parseRetryAfterMs`) — byte-identical across all seven tasks in this retry family, gated by `scripts/check-shared-modules.js` |
-| `attachments.ts`       | Image-attachment upload/list/sync                                                                                          |
-| `image-rewrite.ts`     | Rewrites local `<img src>` references to uploaded attachment URLs                                                          |
-| `html-validate.ts`     | Security gate for article HTML before publish; `force` only bypasses the content-loss heuristic, never the security checks |
-| `html-sanitizer.ts`    | Shared HTML allowlist sanitizer (`sanitize-html`) — byte-identical copy also in Markdown2HtmlV1, gated by `scripts/check-shared-modules.js` |
-| `uri-scheme-guard.ts`  | Shared XSS-prevention URI/scheme allowlist — byte-identical copy also in Markdown2HtmlV1                                   |
-| `manifest.ts`          | Legacy `KB<number>.json` manifest read/write                                                                               |
-| `dry-run.ts`           | `dryRun` mode — validates without calling ServiceNow                                                                       |
-| `html-sanitizer.ts`    | Shared `sanitize-html` allowlist — the final stored-XSS defense before HTML reaches ServiceNow's `text` field; byte-identical copy also in Markdown2HtmlV1 (#820) |
+| `attachments.ts`       | Image-attachment upload/list/sync                                                                                                                                                                                         |
+| `image-rewrite.ts`     | Rewrites local `<img src>` references to uploaded attachment URLs                                                                                                                                                         |
+| `html-validate.ts`     | Security gate for article HTML before publish; `force` only bypasses the content-loss heuristic, never the security checks                                                                                                |
+| `html-sanitizer.ts`    | Shared HTML allowlist sanitizer (`sanitize-html`) — byte-identical copy also in Markdown2HtmlV1, gated by `scripts/check-shared-modules.js`                                                                               |
+| `uri-scheme-guard.ts`  | Shared XSS-prevention URI/scheme allowlist — byte-identical copy also in Markdown2HtmlV1                                                                                                                                  |
+| `manifest.ts`          | Legacy `KB<number>.json` manifest read/write                                                                                                                                                                              |
+| `dry-run.ts`           | `dryRun` mode — validates without calling ServiceNow                                                                                                                                                                      |
+| `html-sanitizer.ts`    | Shared `sanitize-html` allowlist — the final stored-XSS defense before HTML reaches ServiceNow's `text` field; byte-identical copy also in Markdown2HtmlV1 (#820)                                                         |
 
 Output variables: `kbArticleId`, `kbArticleNumber`, `kbWorkflowState`.
 
@@ -412,23 +413,23 @@ Tests are organized by command x provider: `InitTests/`, `PlanTests/`, `ApplyTes
 
 ## Key Dependencies
 
-| Package                                    | Purpose                                                                                |
-| ------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `azure-pipelines-task-lib`                 | ADO task SDK (inputs, variables, tool runners) — all 11 tasks                          |
-| `azure-pipelines-tool-lib`                 | Tool download/cache — TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller |
-| `azure-devops-node-api`                    | Azure DevOps REST API client — TerraformTaskV5                                         |
-| `azure-pipelines-tasks-artifacts-common`   | Shared artifact utilities — TerraformTaskV5                                            |
-| `azure-pipelines-tasks-securefiles-common` | Secure file download — TerraformTaskV5 (`secureVarsFile` input)                        |
-| `openpgp`                                  | GPG signature verification for installer downloads                                     |
-| `undici`                                   | HTTP/proxy client — TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller   |
-| `sanitize-html`                             | Primary allowlist HTML sanitizer (final stored-XSS defense) — Markdown2Html            |
+| Package                                    | Purpose                                                                                                                                               |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `azure-pipelines-task-lib`                 | ADO task SDK (inputs, variables, tool runners) — all 11 tasks                                                                                         |
+| `azure-pipelines-tool-lib`                 | Tool download/cache — TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller                                                                |
+| `azure-devops-node-api`                    | Azure DevOps REST API client — TerraformTaskV5                                                                                                        |
+| `azure-pipelines-tasks-artifacts-common`   | Shared artifact utilities — TerraformTaskV5                                                                                                           |
+| `azure-pipelines-tasks-securefiles-common` | Secure file download — TerraformTaskV5 (`secureVarsFile` input)                                                                                       |
+| `openpgp`                                  | GPG signature verification for installer downloads                                                                                                    |
+| `undici`                                   | HTTP/proxy client — TerraformInstaller, PolicyAgentInstaller, TerraformDocsInstaller                                                                  |
+| `sanitize-html`                            | Primary allowlist HTML sanitizer (final stored-XSS defense) — Markdown2Html                                                                           |
 | `cheerio`                                  | Markdown2Html: defense-in-depth pre-filter parsing ahead of `sanitize-html`; PublishKbArticle: independent `html-validate.ts` content-inspection gate |
-| `markdown-it`                              | Markdown parser — Markdown2Html                                                        |
-| `highlight.js`                             | Syntax highlighting — Markdown2Html                                                    |
-| `js-yaml`                                  | YAML front-matter parsing — Markdown2Html                                              |
-| `terraform-drift-contract`                 | Drift-summary contract types — TerraformDriftReport                                    |
-| `typescript`                               | Build toolchain                                                                        |
-| `mocha` + `ts-node`                        | Test framework                                                                         |
+| `markdown-it`                              | Markdown parser — Markdown2Html                                                                                                                       |
+| `highlight.js`                             | Syntax highlighting — Markdown2Html                                                                                                                   |
+| `js-yaml`                                  | YAML front-matter parsing — Markdown2Html                                                                                                             |
+| `terraform-drift-contract`                 | Drift-summary contract types — TerraformDriftReport                                                                                                   |
+| `typescript`                               | Build toolchain                                                                                                                                       |
+| `mocha` + `ts-node`                        | Test framework                                                                                                                                        |
 
 See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for the authoritative, per-task bundled-dependency breakdown.
 
@@ -445,14 +446,14 @@ The `Check Shared Module Parity` job also runs `scripts/check-enforced-disciplin
 
 Verified tooling snapshot (periodically re-verified rather than tracked to an exact date — re-check locally with `--version` if it's been a while since the table below was last touched):
 
-| Tool               | Status                 | Version                                          |
-| ------------------ | ---------------------- | ------------------------------------------------ |
-| Node.js            | Installed              | v24.14.0 (Active LTS — matches CI target)        |
-| npm                | Installed              | v11.9.0                                          |
-| TypeScript (`tsc`) | Not globally installed | Available as dev dep after `npm install`         |
+| Tool               | Status                 | Version                                                                                                  |
+| ------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| Node.js            | Installed              | v24.14.0 (Active LTS — matches CI target)                                                                |
+| npm                | Installed              | v11.9.0                                                                                                  |
+| TypeScript (`tsc`) | Not globally installed | Available as dev dep after `npm install`                                                                 |
 | `tfx-cli`          | Not globally installed | Available as dev dep after `npm install` at root (pinned `0.23.2` at the repo root — see `package.json`) |
-| GitHub CLI (`gh`)  | Installed              | v2.87.3                                          |
-| Terraform          | Installed              | v1.14.6 at `/c/dev/terraform`                    |
+| GitHub CLI (`gh`)  | Installed              | v2.87.3                                                                                                  |
+| Terraform          | Installed              | v1.14.6 at `/c/dev/terraform`                                                                            |
 
 CI and local development both target Node 24 LTS (Active LTS, EOL April 2028). Node 20 is EOL as of April 2026.
 

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CaptureOutputProtectionClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CaptureOutputProtectionClassL0.ts
@@ -49,8 +49,8 @@ class TestHandler extends BaseTerraformCommandHandler {
         return this.nextCapture;
     }
 
-    public get trackedTempFiles(): string[] { return this.tempFiles; }
-    public get trackedEmergencyOnlyTempFiles(): string[] { return this.emergencyOnlyTempFiles; }
+    public get trackedTempFiles(): readonly string[] { return this.tempFileManager.tracked; }
+    public get trackedEmergencyOnlyTempFiles(): readonly string[] { return this.tempFileManager.trackedEmergencyOnly; }
 }
 
 /** A ToolRunner is only ever created then handed to execWithStdoutCapture (overridden above) by show()/custom() -- a no-op stub is enough to avoid the real tasks.which/tasks.tool lookup. */

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/CredentialFailClosedMatrixL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/CredentialFailClosedMatrixL0.ts
@@ -12,6 +12,7 @@ import { TerraformCommandHandlerOCI } from '../src/oci-terraform-command-handler
 import { TerraformCommandHandlerHCP } from '../src/hcp-terraform-command-handler';
 import { TerraformCommandHandlerGeneric } from '../src/generic-terraform-command-handler';
 import { BaseTerraformCommandHandler } from '../src/base-terraform-command-handler';
+import { TempFileManager } from '../src/temp-file-manager';
 import { TerraformAuthorizationCommandInitializer } from '../src/terraform-commands';
 import { EnvironmentVariableHelper } from '../src/environment-variables';
 
@@ -311,8 +312,10 @@ describe('credential fail-closed matrix (handler x auth-branch x required-field)
                     new TerraformAuthorizationCommandInitializer('plan', '', fixture.serviceConnection ?? ''));
             }
         } finally {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tempFiles is protected
-            (impl as any).tempFiles = [];
+            // Drops tracking without deleting anything, as the previous `tempFiles = []`
+            // did -- these fixtures assert on credential handling, not on cleanup.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tempFileManager is protected
+            (impl as any).tempFileManager = new TempFileManager();
         }
         return impl;
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/EmergencyOnlyCleanupL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/EmergencyOnlyCleanupL0.ts
@@ -21,8 +21,8 @@ class TestHandler extends BaseTerraformCommandHandler {
     async handleBackend(): Promise<void> { /* no-op */ }
     async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> { /* no-op */ }
     async configureBackendCredentials(): Promise<void> { /* no-op */ }
-    public trackTemp(p: string): void { this.tempFiles.push(p); }
-    public trackEmergencyOnly(p: string): void { this.emergencyOnlyTempFiles.push(p); }
+    public trackTemp(p: string): void { this.tempFileManager.track(p); }
+    public trackEmergencyOnly(p: string): void { this.tempFileManager.trackEmergencyOnly(p); }
 }
 
 describe('emergency-only temp-file cleanup (#650)', function () {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -25,6 +25,7 @@ import './OutputBoundaryClassL0';
 import './ExecWithTimeoutL0';
 // Direct unit tests for the emergency-only output-file cleanup split (#650).
 import './EmergencyOnlyCleanupL0';
+import './TempFileManagerL0';
 // Direct unit tests for OCI WIF temp-dir resolution (Agent.TempDirectory).
 import './OciWifTempDirL0';
 // Direct unit test for emergency cleanup before a handler is assigned.

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciApiKeyPrivateKeyMaskingL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciApiKeyPrivateKeyMaskingL0.ts
@@ -93,7 +93,7 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
         await handler.handleProvider(makeCommand());
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tempFiles: string[] = (handler as any).tempFiles;
+        const tempFiles: readonly string[] = (handler as any).tempFileManager.tracked;
         assert.strictEqual(tempFiles.length, 1, 'exactly one tracked temp file: the private key');
         const [privateKeyPath] = tempFiles;
 
@@ -160,7 +160,7 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
         await handler.handleProvider(makeCommand());
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tempFiles: string[] = (handler as any).tempFiles;
+        const tempFiles: readonly string[] = (handler as any).tempFileManager.tracked;
         assert.strictEqual(process.env['TF_VAR_tenancy_ocid'], 'ocid1.tenancy.oc1..dummy');
         assert.strictEqual(process.env['TF_VAR_user_ocid'], 'ocid1.user.oc1..dummy');
         assert.strictEqual(process.env['TF_VAR_region'], 'us-ashburn-1');
@@ -181,7 +181,7 @@ describe('handleProvider -- OCI classic API-key private key masking (#723)', fun
         );
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        assert.strictEqual((handler as any).tempFiles.length, 0, 'no temp file is tracked when the key is missing');
+        assert.strictEqual((handler as any).tempFileManager.tracked.length, 0, 'no temp file is tracked when the key is missing');
         assert.strictEqual(setSecretCalls.length, 0, 'nothing is masked when there is no key to mask');
     });
 });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/OciWifHandleProviderL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/OciWifHandleProviderL0.ts
@@ -87,7 +87,7 @@ describe('handleProviderWIF -- OCI WIF config content, fingerprint, secret maski
         await (handler as any).handleProviderWIF(makeCommand());
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tempFiles: string[] = (handler as any).tempFiles;
+        const tempFiles: readonly string[] = (handler as any).tempFileManager.tracked;
         assert.strictEqual(tempFiles.length, 3, 'private key, UPST, and config -- exactly 3 tracked temp files');
         const [privateKeyPath, upstPath, configPath] = tempFiles;
 
@@ -132,7 +132,7 @@ describe('handleProviderWIF -- OCI WIF config content, fingerprint, secret maski
         await (handler as any).handleProviderWIF(makeCommand());
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tempFiles: string[] = (handler as any).tempFiles;
+        const tempFiles: readonly string[] = (handler as any).tempFileManager.tracked;
         const privateKeyPem = fs.readFileSync(tempFiles[0], 'utf-8');
         const nonBoundaryLines = privateKeyPem.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('-----'));
         assert.ok(nonBoundaryLines.length > 0, 'sanity: the real PEM has body lines to mask');
@@ -163,7 +163,7 @@ describe('handleProviderWIF -- OCI WIF config content, fingerprint, secret maski
         );
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tempFiles: string[] = (handler as any).tempFiles;
+        const tempFiles: readonly string[] = (handler as any).tempFileManager.tracked;
         assert.strictEqual(tempFiles.length, 2, 'the private key and UPST were tracked before the third call threw');
         for (const f of tempFiles) {
             assert.ok(fs.existsSync(f), `file written before the failure must still exist prior to cleanup: ${f}`);

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
@@ -267,7 +267,7 @@ describe('Pre-mask defect class — credential emitted before it was registered 
             // M3 in its PEM guise: normalizePem rewrites the key to a byte-different
             // on-disk form, which needs its own registration.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const tempFiles: string[] = (handler as any).tempFiles;
+            const tempFiles: readonly string[] = (handler as any).tempFileManager.tracked;
             assert.strictEqual(tempFiles.length, 1, 'exactly one tracked temp file: the OCI key');
             const onDisk = fs.readFileSync(tempFiles[0], 'utf8');
             const onDiskBody = onDisk.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('-----'));

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/SignalHandlerL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/SignalHandlerL0.ts
@@ -70,7 +70,7 @@ describe('index.ts SIGTERM/SIGINT registration -- emergency cleanup then re-rais
     async handleBackend(): Promise<void> { /* no-op: not exercised by this test */ }
     async handleProvider(_command: TerraformAuthorizationCommandInitializer): Promise<void> { /* no-op: not exercised by this test */ }
     async configureBackendCredentials(): Promise<void> { /* no-op: not exercised by this test */ }
-    public trackTemp(target: string): void { this.tempFiles.push(target); }
+    public trackTemp(target: string): void { this.tempFileManager.track(target); }
   }
 
   beforeEach(() => {

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/TempFileManagerL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/TempFileManagerL0.ts
@@ -1,0 +1,133 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import tasks = require('azure-pipelines-task-lib/task');
+import { TempFileManager } from '../src/temp-file-manager';
+
+/**
+ * Direct unit tests for the temp-file lifecycle extracted in #878 PR 1.
+ *
+ * These exist in the same PR as the extraction, not as a follow-up, because the
+ * error branches below (scrub failure, unlink failure) were the uncovered
+ * cluster inside base-terraform-command-handler.js. Measured alone in a small
+ * new file rather than averaged into a 2,300-line one, leaving them untested
+ * would have put this module under its own 60% floor.
+ */
+describe('TempFileManager (#878)', function () {
+  const origWarning = tasks.warning;
+  const origDebug = tasks.debug;
+  let warnings: string[] = [];
+  let scratch: string;
+
+  beforeEach(() => {
+    warnings = [];
+    (tasks as unknown as { warning: (m: string) => void }).warning = (m: string) => { warnings.push(m); };
+    (tasks as unknown as { debug: (m: string) => void }).debug = () => { };
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'tfm-test-'));
+  });
+
+  afterEach(() => {
+    (tasks as unknown as { warning: typeof origWarning }).warning = origWarning;
+    (tasks as unknown as { debug: typeof origDebug }).debug = origDebug;
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  const writeFile = (name: string): string => {
+    const p = path.join(scratch, name);
+    fs.writeFileSync(p, 'secret-content');
+    return p;
+  };
+
+  it('cleanup() scrubs and deletes tracked files', () => {
+    const m = new TempFileManager();
+    const a = writeFile('a.txt');
+    m.track(a);
+    m.cleanup();
+    assert.strictEqual(fs.existsSync(a), false);
+    assert.deepStrictEqual(m.tracked, []);
+  });
+
+  it('cleanup() leaves emergency-only files alone, so downstream steps can still read them', () => {
+    const m = new TempFileManager();
+    const ordinary = writeFile('ordinary.txt');
+    const retained = writeFile('retained.json');
+    m.track(ordinary);
+    m.trackEmergencyOnly(retained);
+
+    m.cleanup();
+
+    assert.strictEqual(fs.existsSync(ordinary), false);
+    assert.strictEqual(fs.existsSync(retained), true, 'the emergency-only file must survive a normal step (#650)');
+  });
+
+  it('emergencyCleanup() removes both tiers', () => {
+    const m = new TempFileManager();
+    const ordinary = writeFile('ordinary.txt');
+    const retained = writeFile('retained.json');
+    m.track(ordinary);
+    m.trackEmergencyOnly(retained);
+
+    m.emergencyCleanup();
+
+    assert.strictEqual(fs.existsSync(ordinary), false);
+    assert.strictEqual(fs.existsSync(retained), false);
+    assert.deepStrictEqual(m.trackedEmergencyOnly, []);
+  });
+
+  it('is a safe no-op when nothing was tracked, and when a tracked path never existed', () => {
+    const m = new TempFileManager();
+    assert.doesNotThrow(() => m.emergencyCleanup());
+    m.track(path.join(scratch, 'never-created.txt'));
+    assert.doesNotThrow(() => m.cleanup());
+    assert.strictEqual(warnings.length, 0, 'an absent path is not an error worth warning about');
+  });
+
+  it('warns but still unlinks when the scrub fails', () => {
+    const m = new TempFileManager();
+    const target = writeFile('scrub-fails.txt');
+    // Stub the module export rather than an fs primitive: the compiled require()
+    // is resolved at call time, so this reliably intercepts scrubFile itself
+    // regardless of which fs calls it happens to make.
+    const secureTemp = require('../src/secure-temp');
+    const origScrub = secureTemp.scrubFile;
+    secureTemp.scrubFile = () => { throw new Error('scrub boom'); };
+    try {
+      m.track(target);
+      m.cleanup();
+    } finally {
+      secureTemp.scrubFile = origScrub;
+    }
+
+    assert.strictEqual(fs.existsSync(target), false, 'a scrub failure must not skip the unlink -- the file still has to go');
+    assert.ok(warnings.some((w) => /Failed to scrub temp file/.test(w)), `expected a scrub warning; got: ${warnings.join(' | ')}`);
+  });
+
+  it('warns and continues to the next file when an unlink fails', () => {
+    const m = new TempFileManager();
+    const doomed = writeFile('doomed.txt');
+    const survivor = writeFile('survivor.txt');
+    const origUnlink = fs.unlinkSync;
+    (fs as unknown as { unlinkSync: (p: string) => void }).unlinkSync = (p: string) => {
+      if (p === doomed) throw new Error('unlink boom');
+      origUnlink(p);
+    };
+    try {
+      m.track(doomed);
+      m.track(survivor);
+      m.cleanup();
+    } finally {
+      (fs as unknown as { unlinkSync: typeof origUnlink }).unlinkSync = origUnlink;
+    }
+
+    assert.ok(warnings.some((w) => /Failed to clean up temp file/.test(w)), 'a leftover credential file must be surfaced above debug');
+    assert.strictEqual(fs.existsSync(survivor), false, 'one failure must not abort cleanup of the remaining files');
+  });
+
+  it('hands out copies, so an observer cannot register a file by mutating the view', () => {
+    const m = new TempFileManager();
+    m.track('/tmp/one');
+    (m.tracked as string[]).push('/tmp/injected');
+    assert.deepStrictEqual(m.tracked, ['/tmp/one']);
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/aws-terraform-command-handler.ts
@@ -94,7 +94,7 @@ export class TerraformCommandHandlerAWS extends BaseTerraformCommandHandler {
 
         const tokenFilePath = path.join(resolveWifTempDir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
         writeSecretFile(tokenFilePath, oidcToken);
-        this.tempFiles.push(tokenFilePath);
+        this.trackTempFile(tokenFilePath);
 
         // Clear the static keys FIRST: the SDK matches them before the
         // web-identity token file, so an inherited pair would silently discard

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -1,8 +1,9 @@
 import { TerraformToolHandler, ITerraformToolHandler, getBinaryName, resolveToolPath } from './terraform';
 import { ToolRunner, IExecOptions } from 'azure-pipelines-task-lib/toolrunner';
 import { TerraformBaseCommandInitializer, TerraformAuthorizationCommandInitializer } from './terraform-commands';
-import { getSecureVarFileArgs, SecureFileLoader } from './secure-file-loader';
-import { replaceSecretFile, scrubFile, writeSecretFile } from './secure-temp';
+import { getSecureVarFileArgs } from './secure-file-loader';
+import { replaceSecretFile, writeSecretFile } from './secure-temp';
+import { TempFileManager } from './temp-file-manager';
 import { buildPlanDigest } from './results/plan-digest';
 import { DigestBuildMeta } from './results/digest-common';
 import { buildApplyDigest, ApplyDigestOptions, parseNdjsonLines } from './results/apply-digest';
@@ -283,20 +284,8 @@ export abstract class BaseTerraformCommandHandler {
     providerName: string;
     terraformToolHandler: ITerraformToolHandler;
     backendConfig: Map<string, string>;
-    protected tempFiles: string[];
-    // Files scrubbed+deleted ONLY on a SIGTERM/cancellation (emergencyCleanupTempFiles),
-    // never on normal step completion: a retained `terraform output -json` file
-    // when cleanupOutputFile is off, which downstream steps still read via
-    // jsonOutputVariablesPath during the same job but has no legitimate reader once
-    // the job is cancelled (#650). Since #650's auto-cleanup fix, this now only holds
-    // the output file when it has NO sensitive values, or the operator explicitly
-    // opted out via cleanupOutputFileIfSensitive=false -- a sensitive-containing file
-    // is registered in `tempFiles` instead (normal-completion cleanup) by default.
-    protected emergencyOnlyTempFiles: string[] = [];
-    private secureFileId: string | null = null;
-    // Path of the downloaded secure var file, retained so it can be scrubbed
-    // (zero-overwrite) before the securefiles-common helper unlinks it (#662).
-    private secureFilePath: string | null = null;
+    // The only mutable state this class had, now owned by its own collaborator (#878).
+    protected readonly tempFileManager = new TempFileManager();
     private static readonly OUTPUT_VAR_MAX_LENGTH = 1024;
 
     abstract handleBackend(terraformToolRunner: ToolRunner): Promise<void>;
@@ -365,7 +354,6 @@ export abstract class BaseTerraformCommandHandler {
         this.providerName = "";
         this.terraformToolHandler = new TerraformToolHandler(tasks);
         this.backendConfig = new Map<string, string>();
-        this.tempFiles = [];
     }
 
     // --- Helper methods to reduce duplication ---
@@ -452,9 +440,8 @@ export abstract class BaseTerraformCommandHandler {
     protected async secureVarFileTokens(): Promise<string[]> {
         const result = await getSecureVarFileArgs();
         if (!result) return [];
-        this.secureFileId = result.secureFileId;
-        // Retained so cleanupSecureFile can scrub the file before it is unlinked (#662).
-        this.secureFilePath = result.filePath;
+        // The path is retained so the file can be scrubbed before it is unlinked (#662).
+        this.tempFileManager.setSecureFile(result.secureFileId, result.filePath);
         return [result.varFileArg];
     }
 
@@ -724,88 +711,26 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     /**
-     * Scrubs (zero-overwrites) then unlinks each tracked temp path. Shared by
-     * {@link cleanupTempFiles} (normal end-of-step) and
-     * {@link emergencyCleanupTempFiles} (SIGTERM/cancellation). Best-effort per
-     * file: a scrub or unlink failure is surfaced above debug but never aborts
-     * cleanup of the remaining files.
+     * Tracks a temp path for scrub+delete. Kept on the base class because three
+     * cloud subclasses register their own credential files through it.
      */
-    private scrubAndUnlink(files: string[]): void {
-        for (const filePath of files) {
-            try {
-                if (fs.existsSync(filePath)) {
-                    // Scrub the content (overwrite with zeros) before unlinking, uniformly
-                    // for every tracked secret temp file -- OIDC/UPST/token files, GCP/OCI
-                    // credential JSON, PEM keys, the OCI PAR backend config-<uuid>.tf, and
-                    // cleartext `terraform output -json` dumps alike -- so a crash between
-                    // the overwrite and the unlink is the only remaining exposure window
-                    // (#595). A scrub failure is surfaced but does not skip the unlink
-                    // attempt below.
-                    try {
-                        scrubFile(filePath);
-                    } catch (scrubErr) {
-                        tasks.warning(`Failed to scrub temp file ${filePath} before deletion: ${scrubErr}`);
-                    }
-                    fs.unlinkSync(filePath);
-                    tasks.debug(`Cleaned up temp file: ${filePath}`);
-                }
-            } catch (err) {
-                // A leftover credential temp file (OIDC token / GCP or OCI key)
-                // is a real exposure on a self-hosted agent -- surface it
-                // above debug.
-                tasks.warning(`Failed to clean up temp file ${filePath}: ${err}`);
-            }
-        }
+    protected trackTempFile(filePath: string): void {
+        this.tempFileManager.track(filePath);
     }
 
-    /**
-     * Scrubs+deletes the secure var file (via securefiles-common) if one was
-     * downloaded. The downloaded path is scrubbed (zero-overwrite) before the
-     * vendored helper unlinks it (#662), matching the scrub-then-unlink every
-     * other credential temp file gets -- the secure var file (.tfvars/.pkrvars)
-     * commonly carries the very secrets passed as `-var-file`.
-     */
-    private cleanupSecureFile(): void {
-        if (!this.secureFileId) return;
-        try {
-            new SecureFileLoader().deleteSecureFile(this.secureFileId, this.secureFilePath ?? undefined);
-        } catch (err) {
-            tasks.warning(`Failed to clean up secure file: ${err}`);
-        }
-        this.secureFileId = null;
-        this.secureFilePath = null;
-    }
-
-    /**
-     * End-of-step cleanup (normal completion). Scrubs+deletes every tracked temp
-     * file and the secure var file. Deliberately does NOT touch
-     * {@link emergencyOnlyTempFiles} -- those (a retained `terraform output -json`
-     * file when cleanupOutputFile is off AND it either has no sensitive values or
-     * the operator opted out via cleanupOutputFileIfSensitive=false) must survive
-     * a normal step so downstream steps can still read them via the documented
-     * output-variable contract; they are cleaned only on cancellation (#650).
-     */
+    /** End-of-step cleanup (normal completion). */
     public cleanupTempFiles(): void {
-        this.scrubAndUnlink(this.tempFiles);
-        this.tempFiles = [];
-        this.cleanupSecureFile();
+        this.tempFileManager.cleanup();
     }
 
     /**
      * Cancellation cleanup (SIGTERM/SIGINT/uncaughtException, via
-     * ParentCommandHandler.emergencyCleanup). Cleans everything
-     * {@link cleanupTempFiles} does, PLUS {@link emergencyOnlyTempFiles}: on a
-     * cancellation there is no legitimate downstream reader left for a retained
-     * (non-sensitive, or explicitly opted-out) output file, so its values are
-     * scrubbed+deleted then rather than left on a reused self-hosted agent's
-     * temp dir until job end (#650).
+     * ParentCommandHandler.emergencyCleanup). Must stay synchronous: it runs from
+     * a process-level signal handler, where a returned promise would not be
+     * awaited before the process exits.
      */
     public emergencyCleanupTempFiles(): void {
-        this.scrubAndUnlink(this.tempFiles);
-        this.tempFiles = [];
-        this.scrubAndUnlink(this.emergencyOnlyTempFiles);
-        this.emergencyOnlyTempFiles = [];
-        this.cleanupSecureFile();
+        this.tempFileManager.emergencyCleanup();
     }
 
     /**
@@ -1028,9 +953,9 @@ export abstract class BaseTerraformCommandHandler {
                 // a cancellation, where no legitimate downstream reader remains.
                 if (hasSensitive) {
                     if (tasks.getBoolInput('cleanupShowFileIfSensitive', false)) {
-                        this.tempFiles.push(showFilePath);
+                        this.tempFileManager.track(showFilePath);
                     } else {
-                        this.emergencyOnlyTempFiles.push(showFilePath);
+                        this.tempFileManager.trackEmergencyOnly(showFilePath);
                     }
                 }
             }
@@ -1115,9 +1040,9 @@ export abstract class BaseTerraformCommandHandler {
         // on a reused self-hosted agent's temp dir until job end.
         if (tasks.getBoolInput('cleanupOutputFile', false) ||
             (hasSensitiveOutputs && tasks.getBoolInput('cleanupOutputFileIfSensitive', false))) {
-            this.tempFiles.push(jsonOutputVariablesFilePath);
+            this.tempFileManager.track(jsonOutputVariablesFilePath);
         } else {
-            this.emergencyOnlyTempFiles.push(jsonOutputVariablesFilePath);
+            this.tempFileManager.trackEmergencyOnly(jsonOutputVariablesFilePath);
         }
 
         // Auto-set pipeline variables from terraform output
@@ -1481,9 +1406,9 @@ export abstract class BaseTerraformCommandHandler {
                 const hasSensitive = commandOptionsContainsJsonFlag(commandOptions) &&
                     this.warnIfSensitiveOutputs(commandOutput.stdout, customFilePath);
                 if (hasSensitive) {
-                    this.tempFiles.push(customFilePath);
+                    this.tempFileManager.track(customFilePath);
                 } else {
-                    this.emergencyOnlyTempFiles.push(customFilePath);
+                    this.tempFileManager.trackEmergencyOnly(customFilePath);
                 }
                 result = commandOutput.code;
                 if (result !== 0) {
@@ -2204,7 +2129,7 @@ export abstract class BaseTerraformCommandHandler {
                 sensitive = true;
                 if (tasks.getBoolInput('failOnSensitiveOutputs', false)) {
                     if (filePath) {
-                        this.tempFiles.push(filePath);
+                        this.tempFileManager.track(filePath);
                         throw new Error(tasks.loc('ShowSensitiveOutputsStrictFailure', filePath, sensitiveKeys.length, sensitiveKeys.join(', ')));
                     }
                     throw new Error(tasks.loc('ShowSensitiveOutputsConsoleStrictFailure', sensitiveKeys.length, sensitiveKeys.join(', ')));
@@ -2280,7 +2205,7 @@ export abstract class BaseTerraformCommandHandler {
         if (sensitiveKeys.length === 0) return false;
 
         if (tasks.getBoolInput('failOnSensitiveOutputs', false) && !tasks.getBoolInput('cleanupOutputFile', false)) {
-            this.tempFiles.push(filePath);
+            this.tempFileManager.track(filePath);
             throw new Error(tasks.loc('OutputSensitiveOutputsStrictFailure', filePath, sensitiveKeys.length, sensitiveKeys.join(', ')));
         }
         // #650: state the actual outcome accurately -- with cleanupOutputFileIfSensitive

--- a/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/gcp-terraform-command-handler.ts
@@ -101,7 +101,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
             token_uri: tokenUri
         });
         writeSecretFile(jsonKeyFilePath, jsonCredsString);
-        this.tempFiles.push(jsonKeyFilePath);
+        this.trackTempFile(jsonKeyFilePath);
 
         return jsonKeyFilePath;
     }
@@ -158,7 +158,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
 
         const tokenFilePath = path.join(resolveWifTempDir(), `${params.tokenFilePrefix}-${uuidV4()}.jwt`);
         writeSecretFile(tokenFilePath, oidcToken);
-        this.tempFiles.push(tokenFilePath);
+        this.trackTempFile(tokenFilePath);
 
         const audience = `//iam.googleapis.com/projects/${params.projectNumber}/locations/global/workloadIdentityPools/${params.poolId}/providers/${params.providerId}`;
 
@@ -173,7 +173,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
 
         const credentialsFilePath = path.join(resolveWifTempDir(), `${params.credentialsFilePrefix}-${uuidV4()}.json`);
         writeSecretFile(credentialsFilePath, JSON.stringify(credentials));
-        this.tempFiles.push(credentialsFilePath);
+        this.trackTempFile(credentialsFilePath);
 
         return credentialsFilePath;
     }

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-terraform-command-handler.ts
@@ -141,7 +141,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
         }
         const privateKeyFilePath = path.join(resolveWifTempDir(), `keyfile-${uuidV4()}.pem`);
         writeSecretFile(privateKeyFilePath, normalized);
-        this.tempFiles.push(privateKeyFilePath);
+        this.trackTempFile(privateKeyFilePath);
         return privateKeyFilePath;
     }
 
@@ -187,7 +187,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
             // (#545); the uuid filename keeps the exclusive create collision-free.
             const tfConfigFilePath = path.resolve(`${workingDirectory}/config-${uuidV4()}.tf`);
             writeSecretFile(tfConfigFilePath, config);
-            this.tempFiles.push(tfConfigFilePath);
+            this.trackTempFile(tfConfigFilePath);
             tasks.debug('Generating backend tf statefile config done.');
             this.registerOciBackendCacheForCleanup(workingDirectory);
             this.parBackendGeneratedThisInit = true;
@@ -208,7 +208,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
      */
     private registerOciBackendCacheForCleanup(workingDirectory: string): void {
         if (!tasks.getBoolInput("cleanupOCIBackendCache", false)) return;
-        this.tempFiles.push(path.resolve(`${workingDirectory}/.terraform/terraform.tfstate`));
+        this.trackTempFile(path.resolve(`${workingDirectory}/.terraform/terraform.tfstate`));
     }
 
     /**
@@ -422,11 +422,11 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
 
         const privateKeyPath = path.join(tempDir, `oci-wif-key-${sessionId}.pem`);
         writeSecretFile(privateKeyPath, privateKey);
-        this.tempFiles.push(privateKeyPath);
+        this.trackTempFile(privateKeyPath);
 
         const upstPath = path.join(tempDir, `oci-wif-upst-${sessionId}`);
         writeSecretFile(upstPath, upst);
-        this.tempFiles.push(upstPath);
+        this.trackTempFile(upstPath);
 
         const tenancyOcid = validateOciTenancyOcid(tasks.getInput("ociWifTenancyOcid", true)!);
         const region = validateOciRegion(tasks.getInput("ociWifRegion", true)!);
@@ -442,7 +442,7 @@ export class TerraformCommandHandlerOCI extends BaseTerraformCommandHandler {
 
         const configPath = path.join(tempDir, `oci-wif-config-${sessionId}`);
         writeSecretFile(configPath, configContent);
-        this.tempFiles.push(configPath);
+        this.trackTempFile(configPath);
 
         // 6. Set environment variables for the OCI Terraform provider
         neutralizeEnvironmentVariables(OCI_COMPETING_CREDENTIAL_ENV, "OCI Workload Identity Federation");

--- a/Tasks/TerraformTask/TerraformTaskV5/src/temp-file-manager.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/temp-file-manager.ts
@@ -1,0 +1,142 @@
+import fs = require('fs');
+import tasks = require('azure-pipelines-task-lib/task');
+import { SecureFileLoader } from './secure-file-loader';
+import { scrubFile } from './secure-temp';
+
+/**
+ * Owns the temp-file lifecycle for a command handler: what is tracked, what is
+ * scrubbed when, and the secure var file's identity.
+ *
+ * Extracted from BaseTerraformCommandHandler unchanged (#878 PR 1). It holds the
+ * only mutable state that class had, which is what makes the later extractions
+ * mechanical rather than questions about shared state.
+ *
+ * Two tiers, and the distinction is the point:
+ *   - {@link track}: scrubbed+deleted on normal completion AND on cancellation.
+ *   - {@link trackEmergencyOnly}: scrubbed+deleted ONLY on cancellation, because a
+ *     retained `terraform output -json` file has a legitimate downstream reader
+ *     during the job but none once the job is cancelled (#650).
+ */
+export class TempFileManager {
+  private tempFiles: string[] = [];
+  private emergencyOnlyTempFiles: string[] = [];
+  private secureFileId: string | null = null;
+  // Path of the downloaded secure var file, retained so it can be scrubbed
+  // (zero-overwrite) before the securefiles-common helper unlinks it (#662).
+  private secureFilePath: string | null = null;
+
+  /** Tracks a path for scrub+delete on normal completion and on cancellation. */
+  public track(filePath: string): void {
+    this.tempFiles.push(filePath);
+  }
+
+  /**
+   * Tracks a path scrubbed+deleted ONLY on cancellation. Since #650's
+   * auto-cleanup fix this holds the `terraform output -json` file only when it
+   * has NO sensitive values, or the operator opted out via
+   * cleanupOutputFileIfSensitive=false; a sensitive-containing file goes to
+   * {@link track} instead.
+   */
+  public trackEmergencyOnly(filePath: string): void {
+    this.emergencyOnlyTempFiles.push(filePath);
+  }
+
+  public setSecureFile(secureFileId: string, secureFilePath: string): void {
+    this.secureFileId = secureFileId;
+    this.secureFilePath = secureFilePath;
+  }
+
+  // Read-only views. Copies, so an observer cannot register a file by mutating
+  // what it was handed -- tracking goes through track()/trackEmergencyOnly().
+  public get tracked(): readonly string[] {
+    return [...this.tempFiles];
+  }
+
+  public get trackedEmergencyOnly(): readonly string[] {
+    return [...this.emergencyOnlyTempFiles];
+  }
+
+  /**
+   * Scrubs (zero-overwrites) then unlinks each tracked temp path. Shared by
+   * {@link cleanup} (normal end-of-step) and {@link emergencyCleanup}
+   * (SIGTERM/cancellation). Best-effort per file: a scrub or unlink failure is
+   * surfaced above debug but never aborts cleanup of the remaining files.
+   */
+  private scrubAndUnlink(files: string[]): void {
+    for (const filePath of files) {
+      try {
+        if (fs.existsSync(filePath)) {
+          // Scrub the content (overwrite with zeros) before unlinking, uniformly
+          // for every tracked secret temp file -- OIDC/UPST/token files, GCP/OCI
+          // credential JSON, PEM keys, the OCI PAR backend config-<uuid>.tf, and
+          // cleartext `terraform output -json` dumps alike -- so a crash between
+          // the overwrite and the unlink is the only remaining exposure window
+          // (#595). A scrub failure is surfaced but does not skip the unlink
+          // attempt below.
+          try {
+            scrubFile(filePath);
+          } catch (scrubErr) {
+            tasks.warning(`Failed to scrub temp file ${filePath} before deletion: ${scrubErr}`);
+          }
+          fs.unlinkSync(filePath);
+          tasks.debug(`Cleaned up temp file: ${filePath}`);
+        }
+      } catch (err) {
+        // A leftover credential temp file (OIDC token / GCP or OCI key)
+        // is a real exposure on a self-hosted agent -- surface it
+        // above debug.
+        tasks.warning(`Failed to clean up temp file ${filePath}: ${err}`);
+      }
+    }
+  }
+
+  /**
+   * Scrubs+deletes the secure var file (via securefiles-common) if one was
+   * downloaded. The downloaded path is scrubbed (zero-overwrite) before the
+   * vendored helper unlinks it (#662), matching the scrub-then-unlink every
+   * other credential temp file gets -- the secure var file (.tfvars/.pkrvars)
+   * commonly carries the very secrets passed as `-var-file`.
+   */
+  private cleanupSecureFile(): void {
+    if (!this.secureFileId) return;
+    try {
+      new SecureFileLoader().deleteSecureFile(this.secureFileId, this.secureFilePath ?? undefined);
+    } catch (err) {
+      tasks.warning(`Failed to clean up secure file: ${err}`);
+    }
+    this.secureFileId = null;
+    this.secureFilePath = null;
+  }
+
+  /**
+   * End-of-step cleanup (normal completion). Scrubs+deletes every tracked temp
+   * file and the secure var file. Deliberately does NOT touch the
+   * emergency-only set -- those must survive a normal step so downstream steps
+   * can still read them via the documented output-variable contract; they are
+   * cleaned only on cancellation (#650).
+   */
+  public cleanup(): void {
+    this.scrubAndUnlink(this.tempFiles);
+    this.tempFiles = [];
+    this.cleanupSecureFile();
+  }
+
+  /**
+   * Cancellation cleanup (SIGTERM/SIGINT/uncaughtException, via
+   * ParentCommandHandler.emergencyCleanup). Cleans everything {@link cleanup}
+   * does, PLUS the emergency-only set: on a cancellation there is no legitimate
+   * downstream reader left for a retained (non-sensitive, or explicitly
+   * opted-out) output file, so its values are scrubbed+deleted then rather than
+   * left on a reused self-hosted agent's temp dir until job end (#650).
+   *
+   * Synchronous by contract: it runs from a process-level signal handler, where
+   * a returned promise would not be awaited before the process exits.
+   */
+  public emergencyCleanup(): void {
+    this.scrubAndUnlink(this.tempFiles);
+    this.tempFiles = [];
+    this.scrubAndUnlink(this.emergencyOnlyTempFiles);
+    this.emergencyOnlyTempFiles = [];
+    this.cleanupSecureFile();
+  }
+}


### PR DESCRIPTION
First of the Phase 01 collaborator extractions. A pure move: same code, same call
order, new home, composed as a field. No behaviour change.

This one goes first because it takes ALL the mutable state out in a single step.
Phase 00 confirmed the class had exactly four mutable fields -- tempFiles,
emergencyOnlyTempFiles, secureFileId, secureFilePath -- and all four are
temp-file lifecycle. With them gone the class is stateless, so every later
extraction is a mechanical function move rather than a question about shared
state.

Phase 00 also measured the coupling surface before touching it: of 43
protected/public members on the base, subclasses touch only four
(applyBackendConfig, execWithTimeout, resolveAuthScheme, tempFiles). Only
tempFiles is in this PR's scope, and every subclass use is a .push() -- 10 sites
across aws/gcp/oci. They now call a protected trackTempFile() rather than
reaching into an array, which is the "thin delegating member" the plan prefers
over relocating something a subclass reads.

The public entry points keep their names and their contract:
emergencyCleanupTempFiles() still runs synchronously from the signal handler,
where a returned promise would not be awaited before the process exits.

The plan's claim that the L0 suite "asserts behaviour, not internals, so
internal restructuring cannot break them" is not accurate, and this is worth
recording for the remaining extractions. SEVEN test files reach into the moved
members:

  - 3 through typed access, which tsc caught immediately
  - 4 through (handler as any).tempFiles, which defeats the compiler and
    surfaced only as runtime TypeErrors two full suite runs later

The worst was CredentialFailClosedMatrixL0's `(impl as any).tempFiles = []`, a
WRITE. After the move it silently created a stray property and did nothing, and
the test still PASSED -- a reset that had quietly stopped resetting. It now
installs a fresh manager, which drops tracking without deleting anything, as the
assignment did.

The safety net is real but thinner than advertised: any-casts convert a compile
error into a late runtime failure, or into nothing at all.

TempFileManagerL0 is in this PR rather than a follow-up because the error
branches it covers -- scrub failure, unlink failure mid-list -- were the
uncovered cluster inside the 2,300-line file. Measured alone at 60% instead of
averaged into 91.7%, leaving them untested is what would have put the new file
under its own floor. It lands at 82.92% lines.

Gate: 781 passing, 0 failing, lint 0, all 9 repo gates exit 0, per-file floor met
for every file in the task.

Refs #878

