### PR TITLE
chore(md2html): drop two unused os imports the release build flagged

### DIFF
--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointFileList.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointFileList.ts
@@ -1,6 +1,5 @@
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import fs = require('fs');
-import os = require('os');
 import path = require('path');
 
 // #189 (sibling azure-pipelines-packer #189): this task's suite was entirely

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointMissingPrimaryFile.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointMissingPrimaryFile.ts
@@ -1,6 +1,5 @@
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import fs = require('fs');
-import os = require('os');
 import path = require('path');
 
 // #189, failure half: the REAL src/index.ts must fail closed — not throw out of


### PR DESCRIPTION
style(md2html): drop two unused `os` imports the release build flagged

The 1.14.0 release surfaced four lint annotations, two files x two platforms:

  Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointMissingPrimaryFile.ts:3
  Tasks/Markdown2Html/Markdown2HtmlV1/Tests/EntryPointFileList.ts:3
  'os' is defined but never used. Allowed unused vars must match /^_/u

Both imports are genuinely orphaned. `os` occurs on exactly two lines in each
file: the import, and a comment reading "Scratch lives under the compiled Tests
directory, not os.tmpdir()". The comment is why the name survives a grep -- the
same shape that failed lint on #920, and the same one that left an orphaned `fs`
in the handler during #878. A checker has to strip comments before it can tell.

Warnings rather than errors, so nothing was blocked; removing them keeps the
annotation list meaningful instead of a standing two-entry backlog everyone
learns to scroll past.

Gate: 9/9 repo gates exit 0, lint 0, 153 passing, per-file floor met.
