### PR TITLE
security(v5): dispatch commands through a Map, not a prototype-reachable literal

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/L0.ts
@@ -76,6 +76,9 @@ import './CaptureOutputProtectionClassL0';
 // verification-derived content -- a whole-repo site enumeration (#881/#882/#887).
 import './HardenedTempWritesClassL0';
 import './CredentialInputTypeClassL0';
+// This task's half of the prototype-chain lookup class (#884/#897): command
+// dispatch, which the signature found still keyed by a plain object literal.
+import './PrototypeSafeLookupClassL0';
 // Direct unit tests for the plan/apply digest REDACTION CORE (WP-1, the single
 // most security-critical unit): recursive redaction, digest builders, freeform
 // diagnostic scrub, and the golden-fixture regression + no-leak tripwire.

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PrototypeSafeLookupClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PrototypeSafeLookupClassL0.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'mocha';
+import assert = require('assert');
+import { BaseTerraformCommandHandler } from '../src/base-terraform-command-handler';
+import { TerraformAuthorizationCommandInitializer } from '../src/terraform-commands';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
+
+/**
+ * Class test (issues #884/#897) for THIS task's command dispatch.
+ *
+ * The sibling halves of this class live in Markdown2HtmlV1 and
+ * PublishKbArticleV1's PrototypeSafeLookupClassL0.ts. This row covers
+ * executeCommand(), which the prototype-safe-lookup signature found still
+ * indexing a plain object literal with the `command` task input after the rest
+ * of the class had been converted to Maps.
+ *
+ * Mutation-provable: restore the object literal + `commands[command]` and the
+ * `constructor` row goes red, because Object is truthy AND callable, so the
+ * not-found guard never fires and `fn()` runs Object() instead of throwing.
+ */
+
+class ProbeHandler extends BaseTerraformCommandHandler {
+  async handleBackend(_t: ToolRunner): Promise<void> { /* unreachable in these rows */ }
+  async handleProvider(_c: TerraformAuthorizationCommandInitializer): Promise<void> { /* unreachable */ }
+  async configureBackendCredentials(): Promise<void> { /* unreachable */ }
+}
+
+describe('command dispatch: prototype-chain lookup class (#884/#897)', () => {
+  // Every name Object.prototype contributes that a plain-object lookup would
+  // resolve to something truthy. `constructor` is the dangerous one: it is also
+  // callable, so a `!fn` guard passes it straight through to fn().
+  for (const magic of ['__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty']) {
+    it(`rejects '${magic}' with the invalid-command error rather than resolving an inherited member`, async () => {
+      const handler = new ProbeHandler();
+      await assert.rejects(
+        () => handler.executeCommand(magic),
+        (err: Error) => {
+          assert.match(err.message, /^Invalid command: /, `expected the not-found branch, got: ${err.message}`);
+          return true;
+        },
+      );
+    });
+  }
+
+  it('still rejects an ordinary unknown command', async () => {
+    const handler = new ProbeHandler();
+    await assert.rejects(() => handler.executeCommand('definitely-not-a-command'), /^Error: Invalid command: /);
+  });
+
+  it('lists the real commands in the error, not inherited members', async () => {
+    const handler = new ProbeHandler();
+    await assert.rejects(() => handler.executeCommand('nope'), (err: Error) => {
+      assert.ok(err.message.includes('init'), 'the valid-command list must survive the Map conversion');
+      assert.ok(!err.message.includes('hasOwnProperty'), 'no inherited member may appear in the valid-command list');
+      return true;
+    });
+  });
+});

--- a/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/base-terraform-command-handler.ts
@@ -289,27 +289,30 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async executeCommand(command: string): Promise<number> {
-        const commands: Record<string, () => Promise<number>> = {
-            init: () => this.init(),
-            validate: () => this.validate(),
-            plan: () => this.plan(),
-            apply: () => this.apply(),
-            destroy: () => this.destroy(),
-            show: () => this.show(),
-            output: () => this.output(),
-            custom: () => this.custom(),
-            workspace: () => this.workspace(),
-            state: () => this.state(),
-            fmt: () => this.fmt(),
-            test: () => this.test(),
-            get: () => this.get(),
-            import: () => this.import(),
-            forceunlock: () => this.forceUnlock(),
-            refresh: () => this.refresh(),
-        };
-        const fn = commands[command];
+        // A Map, not an object literal: `command` is a task input, and an object
+        // literal keyed by it resolves `constructor` to Object -- truthy, callable,
+        // and therefore straight past the not-found guard below (#884/#897 class).
+        const commands = new Map<string, () => Promise<number>>([
+            ['init', () => this.init()],
+            ['validate', () => this.validate()],
+            ['plan', () => this.plan()],
+            ['apply', () => this.apply()],
+            ['destroy', () => this.destroy()],
+            ['show', () => this.show()],
+            ['output', () => this.output()],
+            ['custom', () => this.custom()],
+            ['workspace', () => this.workspace()],
+            ['state', () => this.state()],
+            ['fmt', () => this.fmt()],
+            ['test', () => this.test()],
+            ['get', () => this.get()],
+            ['import', () => this.import()],
+            ['forceunlock', () => this.forceUnlock()],
+            ['refresh', () => this.refresh()],
+        ]);
+        const fn = commands.get(command);
         if (!fn) {
-            throw new Error(`Invalid command: ${command}. Valid: ${Object.keys(commands).join(', ')}`);
+            throw new Error(`Invalid command: ${command}. Valid: ${[...commands.keys()].join(', ')}`);
         }
         return fn();
     }


### PR DESCRIPTION
security(v5): dispatch commands through a Map, not a prototype-reachable literal

The prototype-safe-lookup signature written for this run's Phase 2 found one
instance of the #884/#897 class still open, in executeCommand:

    const commands: Record<string, () => Promise<number>> = { init: ..., };
    const fn = commands[command];
    if (!fn) { throw new Error(`Invalid command: ${command}. ...`); }
    return fn();

`command` is a task input. `commands['constructor']` resolves to Object, which
is truthy AND callable, so the not-found guard never fires and fn() invokes
Object() -- executeCommand resolves to {} instead of throwing the intended
"Invalid command". `__proto__`, `toString`, `valueOf` and `hasOwnProperty`
likewise reach an inherited member rather than the not-found branch.

Batch E converted four other files in this class to Map + .get() (backend-
detection BACKEND_TYPE_TO_CLOUD, converter SEP_MAP, args-builder
FORMATTER_SUBCOMMANDS, servicenow-client's two maps) and did not reach this one.
It is not in that batch's verified-already-safe list either -- it was simply
missed, and nothing re-checked the class until there was a signature for it.

Same remedy as the rest of the class: a Map, whose .get() is a real own-entry
lookup with no prototype chain to fall through to.

Tests/PrototypeSafeLookupClassL0.ts is this task's half of the class test,
matching the existing Markdown2HtmlV1 and PublishKbArticleV1 files of that name.
Five rows, one per Object.prototype member name, plus two control rows that must
stay green.

Mutation-proven, not asserted: restoring the object literal turns exactly the
five magic-key rows red and leaves both controls green (5 failing, 2 passing).
Worth recording how nearly that check lied -- the first attempt reported 7
passing against the deliberately vulnerable code, because 36 stale compiled .js
files from an earlier coverage run were shadowing the edited .ts under ts-node.
The mutation had never executed. Clearing src/**/*.js first is what made the
result real.

Gate: 9/9 repo gates exit 0, lint 0, 793 passing / 0 failing, per-file floor met.
