### PR TITLE
refactor: dedupe the truncateBody helper and single-source shared modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,6 +443,21 @@ See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for the authoritative, per-
 - `.github/workflows/release.yml` — **Release pipeline.** Triggered by semver tags (`v*.*.*`) or manual dispatch. Verifies tag is on `main`, runs full CI via `workflow_call`, builds release bundle, packages `.vsix`, generates CycloneDX SBOMs, signs with cosign (keyless), creates draft GitHub Release, publishes to VS Marketplace (requires `marketplace` environment approval), then undrafts the release.
 - `.github/workflows/codeql.yml` — **Code scanning.** CodeQL static analysis for TypeScript (GitHub Advanced Security).
 
+### Reconciling a shared module (`npm run sync:shared`)
+
+Each ADO task is an independent npm package that ships its own compiled JS in place (`include: ["src/**/*"]`, then `webpack` copies `Tasks/**` minus the `.ts`), so a shared module physically has to exist inside every task that uses it — there is no runtime import path out of a task directory. The repo's answer is byte-identical copies plus a fail-closed parity gate rather than a workspace package.
+
+To change one of those modules, edit the **canonical** copy (the first directory of its family, or the first file of its region family, in `scripts/check-shared-modules.js`) and then run:
+
+```bash
+npm run sync:shared   # node scripts/check-shared-modules.js --fix
+npm run check:shared  # verify (this is what CI runs)
+```
+
+`--fix` rewrites every non-canonical copy from its canonical source — whole files for `FAMILIES`, and only the text between the `// #region shared:<name>` markers for `REGION_FAMILIES`, so a region's host file keeps its own surrounding code. A missing canonical or a broken marker stays a hard failure even under `--fix`: there is nothing trustworthy to sync from.
+
+Syncing is deliberately **not** wired into the build. If it ran automatically before packaging, a genuine unintended divergence would be silently repaired instead of failing CI, which is exactly what the gate exists to prevent. Syncing is an authoring step; CI only ever verifies.
+
 The `Check Shared Module Parity` job also runs `scripts/check-enforced-disciplines.js` — the signature for the "documented-but-unenforced discipline" class: every task's declared execution entry point must be loaded by a test and measured by its coverage config, every declared execution handler (`Node24`, `Node20_1`) must be exercised by a CI job for that task, the Minor-bump rule must be enforced in all three layers, and the Marketplace publish must retry transient failures and keep the token off argv. No new required status check was introduced — both it and its self-test are **steps inside existing required jobs**, so branch protection needs no change.
 
 ## Local Development Environment

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts
@@ -257,9 +257,28 @@ function encodeBody(body: SnRequestOptions['body']): Buffer | undefined {
     return Buffer.from(JSON.stringify(body), 'utf8');
 }
 
-function truncate(s: string, max = 500): string {
-    return s.length > max ? `${s.slice(0, max)}… (truncated)` : s;
+// #region shared:TruncateBody
+/**
+ * Bounds a remote response body before it is interpolated into a thrown error
+ * or log line, so a large — or credential-reflecting — body cannot be dumped
+ * wholesale. The credential itself is also registered with setSecret(), so the
+ * agent masks it; this is defense-in-depth against verbose error bodies.
+ *
+ * Callers that scrub known request secrets out of a body do so BEFORE calling
+ * this, so a secret straddling the truncation boundary is still scrubbed whole.
+ *
+ * Duplicated verbatim into every transport that interpolates a remote body into
+ * an error message (#407), and byte-compared across all four copies by
+ * scripts/check-shared-modules.js — so a future hardening change here cannot
+ * land in one transport and be silently missed in the others.
+ */
+export function truncateBody(body: string, max = 500): string {
+    if (!body) {
+        return '';
+    }
+    return body.length > max ? `${body.slice(0, max)}… (truncated)` : body;
 }
+// #endregion shared:TruncateBody
 
 /** Remove known request secrets from a response body (see SnRequestOptions.scrubValues). */
 function scrubSecrets(body: string, secrets: string[] | undefined): string {
@@ -355,7 +374,7 @@ export function snRequest(
                         // withRetry can honor it (#584); other statuses carry none.
                         const retryAfterMs = status === 429 ? parseRetryAfterMs(res.headers['retry-after']) : undefined;
                         reject(new ServiceNowHttpError(
-                            `ServiceNow request ${method} ${parsed.pathname} failed with status ${status}: ${truncate(scrubSecrets(raw, options.scrubValues))}`,
+                            `ServiceNow request ${method} ${parsed.pathname} failed with status ${status}: ${truncateBody(scrubSecrets(raw, options.scrubValues))}`,
                             status,
                             retryAfterMs,
                         ));

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts
@@ -268,11 +268,20 @@ export function createHttpsClient(rejectUnauthorized = true, timeoutMs = DEFAULT
         });
 }
 
+// #region shared:TruncateBody
 /**
  * Bounds a remote response body before it is interpolated into a thrown error
  * or log line, so a large — or credential-reflecting — body cannot be dumped
  * wholesale. The credential itself is also registered with setSecret(), so the
  * agent masks it; this is defense-in-depth against verbose error bodies.
+ *
+ * Callers that scrub known request secrets out of a body do so BEFORE calling
+ * this, so a secret straddling the truncation boundary is still scrubbed whole.
+ *
+ * Duplicated verbatim into every transport that interpolates a remote body into
+ * an error message (#407), and byte-compared across all four copies by
+ * scripts/check-shared-modules.js — so a future hardening change here cannot
+ * land in one transport and be silently missed in the others.
  */
 export function truncateBody(body: string, max = 500): string {
     if (!body) {
@@ -280,3 +289,4 @@ export function truncateBody(body: string, max = 500): string {
     }
     return body.length > max ? `${body.slice(0, max)}… (truncated)` : body;
 }
+// #endregion shared:TruncateBody

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts
@@ -268,11 +268,20 @@ export function createHttpsClient(rejectUnauthorized = true, timeoutMs = DEFAULT
         });
 }
 
+// #region shared:TruncateBody
 /**
  * Bounds a remote response body before it is interpolated into a thrown error
  * or log line, so a large — or credential-reflecting — body cannot be dumped
  * wholesale. The credential itself is also registered with setSecret(), so the
  * agent masks it; this is defense-in-depth against verbose error bodies.
+ *
+ * Callers that scrub known request secrets out of a body do so BEFORE calling
+ * this, so a secret straddling the truncation boundary is still scrubbed whole.
+ *
+ * Duplicated verbatim into every transport that interpolates a remote body into
+ * an error message (#407), and byte-compared across all four copies by
+ * scripts/check-shared-modules.js — so a future hardening change here cannot
+ * land in one transport and be silently missed in the others.
  */
 export function truncateBody(body: string, max = 500): string {
     if (!body) {
@@ -280,3 +289,4 @@ export function truncateBody(body: string, max = 500): string {
     }
     return body.length > max ? `${body.slice(0, max)}… (truncated)` : body;
 }
+// #endregion shared:TruncateBody

--- a/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts
@@ -25,14 +25,28 @@ class OciTokenExchangeError extends Error {
     }
 }
 
+// #region shared:TruncateBody
 /**
- * Bound a remote response body before it is interpolated into a thrown error,
- * so a large or credential-reflecting body cannot be dumped wholesale into the
- * build log.
+ * Bounds a remote response body before it is interpolated into a thrown error
+ * or log line, so a large — or credential-reflecting — body cannot be dumped
+ * wholesale. The credential itself is also registered with setSecret(), so the
+ * agent masks it; this is defense-in-depth against verbose error bodies.
+ *
+ * Callers that scrub known request secrets out of a body do so BEFORE calling
+ * this, so a secret straddling the truncation boundary is still scrubbed whole.
+ *
+ * Duplicated verbatim into every transport that interpolates a remote body into
+ * an error message (#407), and byte-compared across all four copies by
+ * scripts/check-shared-modules.js — so a future hardening change here cannot
+ * land in one transport and be silently missed in the others.
  */
-function truncateBody(body: string, max = 500): string {
+export function truncateBody(body: string, max = 500): string {
+    if (!body) {
+        return '';
+    }
     return body.length > max ? `${body.slice(0, max)}… (truncated)` : body;
 }
+// #endregion shared:TruncateBody
 
 /**
  * Remove any occurrence of a known request secret (here the OIDC subject_token

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "deps:prune": "node scripts/for-each-task.js prune",
         "compile": "node scripts/for-each-task.js compile",
         "webpack": "webpack --config webpack.config.js --progress",
+        "check:shared": "node scripts/check-shared-modules.js",
+        "sync:shared": "node scripts/check-shared-modules.js --fix",
         "test:v5": "cd Tasks/TerraformTask/TerraformTaskV5 && npm test",
         "test:tab": "jest --config jest.config.js"
     },

--- a/scripts/check-shared-modules.js
+++ b/scripts/check-shared-modules.js
@@ -362,6 +362,30 @@ const REGION_FAMILIES = [
             'Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts',
         ],
     },
+    {
+        // truncateBody(): the last-line bound on how much of a remote response
+        // body can be interpolated into a thrown error or a log line. Every
+        // transport that surfaces a remote body in an error message carries it,
+        // and until #407 each carried its OWN copy: the two https-client.ts
+        // copies had a falsy guard, while TerraformTaskV5's oci-token-exchange.ts
+        // and PublishKbArticleV1's servicenow-http.ts had independently written
+        // variants without one (servicenow-http.ts even under a different name,
+        // truncate()). Two of the four sat outside every parity mechanism, so a
+        // tightening of the cap -- or a fix to the "does the marker itself leak
+        // length" question -- could land in one transport and be missed in the
+        // rest. All four are now byte-identical and gated here.
+        //
+        // A REGION family rather than a whole-file FAMILY because three of the
+        // four host files are not copies of each other in any other respect;
+        // this is the same reason ProxyTunnelAgent above is region-gated.
+        region: 'TruncateBody',
+        files: [
+            'Tasks/TerraformModulePublish/TerraformModulePublishV1/src/https-client.ts',
+            'Tasks/TerraformDriftReport/TerraformDriftReportV1/src/https-client.ts',
+            'Tasks/PublishKbArticle/PublishKbArticleV1/src/servicenow-http.ts',
+            'Tasks/TerraformTask/TerraformTaskV5/src/oci-token-exchange.ts',
+        ],
+    },
 ];
 
 // Normalize line endings so a CRLF checkout never reads as drift; the bytes that
@@ -406,11 +430,51 @@ function extractRegion(relPath, region) {
     if (closes[0] <= opens[0]) {
         return { ok: false, full, reason: `'${closeToken}' precedes its '${openToken}' in ${relPath}` };
     }
-    return { ok: true, full, content: lines.slice(opens[0] + 1, closes[0]).join('\n') };
+    return {
+        ok: true,
+        full,
+        content: lines.slice(opens[0] + 1, closes[0]).join('\n'),
+        // Marker positions, so --fix can splice a canonical region back in without
+        // disturbing the host file's own surrounding code.
+        lines,
+        openLine: opens[0],
+        closeLine: closes[0],
+    };
 }
 
-function main() {
+// --fix support (#300). The parity gate tells you a canonical module and its
+// copies diverged, but reconciling them was still a manual per-directory copy,
+// which is exactly the "must be made twice and kept in sync by hand" cost the
+// duplication was reported for. These two helpers make the canonical copy the
+// single source you EDIT: fix it once, run `npm run sync:shared`, and every
+// other copy is rewritten from it.
+//
+// Deliberately NOT wired into the build. If syncing ran automatically before
+// packaging, a genuine unintended divergence would be silently repaired instead
+// of failing CI, which would defeat the whole point of the gate -- the gate has
+// to stay fail-closed. Syncing is an explicit authoring step; CI only ever
+// verifies.
+function writeFamilyCopy(canonicalFull, targetFull) {
+    fs.copyFileSync(canonicalFull, targetFull);
+}
+
+function writeRegionCopy(canonicalContent, target) {
+    const spliced = [
+        ...target.lines.slice(0, target.openLine + 1),
+        ...canonicalContent.split('\n'),
+        ...target.lines.slice(target.closeLine),
+    ];
+    fs.writeFileSync(target.full, spliced.join('\n'));
+}
+
+function main(argv = process.argv.slice(2)) {
+    // `--fix` rewrites every non-canonical copy from its canonical source
+    // instead of failing on divergence (#300). A missing canonical or a broken
+    // region marker is still a hard failure even under --fix: there is nothing
+    // trustworthy to sync FROM, so repairing would be a guess.
+    const fix = argv.includes('--fix');
     let hasError = false;
+    let fixedCount = 0;
 
     for (const { dirs, modules } of FAMILIES) {
         const [canonicalDir, ...otherDirs] = dirs;
@@ -429,9 +493,16 @@ function main() {
                     continue;
                 }
                 if (other.content !== base.content) {
-                    console.error(`FAIL: ${file} diverged between ${canonicalDir} and ${dir}`);
-                    console.error(`      reconcile both copies (canonical: ${base.full})`);
-                    hasError = true;
+                    if (fix) {
+                        writeFamilyCopy(base.full, other.full);
+                        console.log(`FIXED: ${file} rewritten from canonical (${canonicalDir} -> ${dir})`);
+                        fixedCount++;
+                    } else {
+                        console.error(`FAIL: ${file} diverged between ${canonicalDir} and ${dir}`);
+                        console.error(`      reconcile both copies (canonical: ${base.full})`);
+                        console.error(`      or run: npm run sync:shared`);
+                        hasError = true;
+                    }
                 } else {
                     console.log(`OK: ${file} identical (${canonicalDir} == ${dir})`);
                 }
@@ -455,9 +526,16 @@ function main() {
                 continue;
             }
             if (other.content !== base.content) {
-                console.error(`FAIL: shared region '${region}' diverged between ${canonicalFile} and ${file}`);
-                console.error(`      reconcile both copies (canonical: ${base.full})`);
-                hasError = true;
+                if (fix) {
+                    writeRegionCopy(base.content, other);
+                    console.log(`FIXED: region '${region}' rewritten from canonical (${canonicalFile} -> ${file})`);
+                    fixedCount++;
+                } else {
+                    console.error(`FAIL: shared region '${region}' diverged between ${canonicalFile} and ${file}`);
+                    console.error(`      reconcile both copies (canonical: ${base.full})`);
+                    console.error(`      or run: npm run sync:shared`);
+                    hasError = true;
+                }
             } else {
                 console.log(`OK: region '${region}' identical (${canonicalFile} == ${file})`);
             }
@@ -466,6 +544,12 @@ function main() {
 
     if (hasError) {
         process.exit(1);
+    }
+    if (fix) {
+        console.log(fixedCount === 0
+            ? 'Nothing to sync: every copy already matches its canonical source.'
+            : `Synced ${fixedCount} cop${fixedCount === 1 ? 'y' : 'ies'} from canonical. Review the diff before committing.`);
+        return;
     }
     console.log('All shared-module parity checks passed.');
 }

--- a/scripts/test-check-shared-modules.js
+++ b/scripts/test-check-shared-modules.js
@@ -43,6 +43,26 @@ function runCheck(cwd) {
     return spawnSync(process.execPath, [scriptPath], { cwd, encoding: 'utf8' });
 }
 
+// `--fix` mode (#300): rewrites every non-canonical copy from its canonical
+// source. Cases 7 and 8 below prove it actually repairs both family kinds and
+// that it leaves a region host file's surrounding code untouched.
+function runFix(cwd) {
+    return spawnSync(process.execPath, [scriptPath, '--fix'], { cwd, encoding: 'utf8' });
+}
+
+// Read the text strictly between a region's markers, mirroring
+// check-shared-modules.js's own extractRegion() closely enough to assert on
+// exact region content after a --fix run.
+function readRegion(file, region) {
+    const lines = fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n').split('\n');
+    const open = lines.findIndex(l => l.trimStart().startsWith(`// #region shared:${region}`));
+    const close = lines.findIndex(l => l.trimStart().startsWith(`// #endregion shared:${region}`));
+    if (open === -1 || close === -1 || close <= open) {
+        return null;
+    }
+    return lines.slice(open + 1, close).join('\n');
+}
+
 // Escape a literal string for safe interpolation into a RegExp.
 function escapeRegExp(s) {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -144,6 +164,93 @@ try {
         failed = true;
     } else {
         console.log('OK: check-shared-modules.js fails closed when a shared-region marker is deleted.');
+    }
+
+    // Case 6: the truncateBody() region (#407). oci-token-exchange.ts carried a
+    // variant of this helper that sat outside EVERY parity mechanism before
+    // #407, so this case specifically diverges THAT copy: it is the one whose
+    // drift previously could not be detected at all. Asserting on the exact
+    // region name proves the failure comes from the TruncateBody comparison and
+    // not from some unrelated family tripping first.
+    fs.cpSync(path.join(repoRoot, 'Tasks'), path.join(scratchDir, 'Tasks'), { recursive: true });
+    fs.cpSync(path.join(repoRoot, 'src'), path.join(scratchDir, 'src'), { recursive: true });
+    const truncateTargetFile = path.join('Tasks', 'TerraformTask', 'TerraformTaskV5', 'src', 'oci-token-exchange.ts');
+    const truncateScratchTarget = path.join(scratchDir, truncateTargetFile);
+    const truncateEndMarker = '// #endregion shared:TruncateBody';
+    const truncateOriginal = fs.readFileSync(truncateScratchTarget, 'utf8');
+    // Weaken the bound the way a careless edit would: raise the cap only here.
+    fs.writeFileSync(
+        truncateScratchTarget,
+        truncateOriginal.replace('max = 500', 'max = 50000'),
+    );
+
+    const truncateDivergedResult = runCheck(scratchDir);
+    const truncateDivergedOutput = `${truncateDivergedResult.stdout}${truncateDivergedResult.stderr}`;
+    if (truncateDivergedResult.status === 0 || !truncateDivergedOutput.includes("shared region 'TruncateBody' diverged")) {
+        console.error('FAIL: check-shared-modules.js did not flag a diverged shared TruncateBody region.');
+        console.error(truncateDivergedResult.stdout, truncateDivergedResult.stderr);
+        failed = true;
+    } else {
+        console.log("OK: check-shared-modules.js exits non-zero when the truncateBody bound diverges in one transport.");
+    }
+
+    // Case 7 (--fix, #300): with BOTH a whole-file family copy and a region copy
+    // deliberately diverged, `--fix` must rewrite each from its canonical source
+    // so a subsequent plain check passes. Asserts on exact post-fix content, not
+    // merely on a zero exit, so a --fix that "succeeded" by doing nothing (or by
+    // rewriting the wrong direction) still fails this case.
+    fs.cpSync(path.join(repoRoot, 'Tasks'), path.join(scratchDir, 'Tasks'), { recursive: true });
+    fs.cpSync(path.join(repoRoot, 'src'), path.join(scratchDir, 'src'), { recursive: true });
+    const fixFamilyTarget = path.join(scratchDir, targetFile);
+    const fixFamilyCanonical = path.join(scratchDir, 'Tasks', 'TerraformInstaller', 'TerraformInstallerV1', 'src', 'http-client.ts');
+    const canonicalFamilyContent = fs.readFileSync(fixFamilyCanonical, 'utf8');
+    fs.appendFileSync(fixFamilyTarget, '\n// check-shared-modules --fix self-test divergence marker\n');
+
+    const fixRegionTarget = path.join(scratchDir, truncateTargetFile);
+    const fixRegionCanonicalFile = path.join(scratchDir, 'Tasks', 'TerraformModulePublish', 'TerraformModulePublishV1', 'src', 'https-client.ts');
+    const canonicalRegionContent = readRegion(fixRegionCanonicalFile, 'TruncateBody');
+    fs.writeFileSync(fixRegionTarget, fs.readFileSync(fixRegionTarget, 'utf8').replace('max = 500', 'max = 50000'));
+
+    // Sanity: the tree really is broken before --fix runs, so a green result
+    // below cannot come from having diverged nothing at all.
+    if (runCheck(scratchDir).status === 0) {
+        console.error('FAIL: self-test setup error — the tree was still clean before --fix ran.');
+        failed = true;
+    }
+
+    const fixResult = runFix(scratchDir);
+    const postFixCheck = runCheck(scratchDir);
+    const repairedFamily = fs.readFileSync(fixFamilyTarget, 'utf8');
+    const repairedRegion = readRegion(fixRegionTarget, 'TruncateBody');
+
+    if (fixResult.status !== 0) {
+        console.error('FAIL: check-shared-modules.js --fix exited non-zero.');
+        console.error(fixResult.stdout, fixResult.stderr);
+        failed = true;
+    } else if (repairedFamily !== canonicalFamilyContent) {
+        console.error('FAIL: --fix did not restore the whole-file family copy to the canonical bytes.');
+        failed = true;
+    } else if (repairedRegion !== canonicalRegionContent) {
+        console.error('FAIL: --fix did not restore the shared region to the canonical bytes.');
+        failed = true;
+    } else if (postFixCheck.status !== 0) {
+        console.error('FAIL: the parity gate still fails after --fix repaired every copy.');
+        console.error(postFixCheck.stdout, postFixCheck.stderr);
+        failed = true;
+    } else {
+        console.log('OK: --fix rewrites both a whole-file copy and a shared region from canonical.');
+    }
+
+    // Case 8 (--fix must not clobber a region host file): splicing a region back
+    // into servicenow-http.ts/oci-token-exchange.ts must replace ONLY the text
+    // between the markers. A --fix implemented as a whole-file copy would pass
+    // case 7's region assertion while destroying the host file, so assert the
+    // surrounding code — the file's own class, unique to it — survived.
+    if (!fs.readFileSync(fixRegionTarget, 'utf8').includes('class OciTokenExchangeError')) {
+        console.error('FAIL: --fix clobbered the region host file\'s surrounding code.');
+        failed = true;
+    } else {
+        console.log('OK: --fix leaves a region host file\'s surrounding code intact.');
     }
 } finally {
     fs.rmSync(scratchDir, { recursive: true, force: true });


### PR DESCRIPTION
## What

Deduplicates the copy-pasted helpers reported in #300 and #407, using the parity mechanism this repo already has rather than inventing a new one.

## Verified counts (both issues were wrong)

**#407 — claimed "reimplemented independently 4 times".** There are indeed **4 definitions**, but only **3 are independent**: the `TerraformDriftReport`/`TerraformModulePublish` pair is one file duplicated and already whole-file parity-gated, so those two cannot drift apart. The issue body also says "three of the four sit entirely outside any parity mechanism" — that is **two**, not three, and it contradicts the same paragraph's acknowledgement that the pair is gated. Both line references are stale: `servicenow-http.ts` is at **line 260** (not 49–51) and `https-client.ts` at **line 277** (not 101).

**#300 — claimed "three byte-identical source files ... between TerraformInstallerV1 and PolicyAgentInstallerV1".** The three files are right, but the duplication spans **three tasks, not two**: `http-client.ts` (485 lines) has a third byte-identical copy in `TerraformDocsInstallerV1`. So it is **7 files, not 6**. The issue also understates the estate — the parity gate already covered **18 distinct modules across 15 whole-file families (54 gated file copies)** plus 2 marked-region families (3 after this PR), with `retry.ts` at **8 copies**.

## Not silently harmonised

The four `truncate` copies were **not** behaviourally identical. The two `https-client.ts` copies guard a falsy body and return `''`; `oci-token-exchange.ts` and `servicenow-http.ts` did not, and would throw a `TypeError` on a null/undefined body. The guarded form is adopted everywhere — the fail-safe direction. It is **unreachable through the current call sites** (all four pass an already-materialised string), so no shipped behaviour changes; it only removes a latent crash. Called out here rather than buried in the refactor.

## Why no workspace package for #300

Each ADO task is an independent npm package that compiles `include: ["src/**/*"]` and ships its own compiled JS in place (`webpack` copies `Tasks/**` minus the `.ts`). There is no runtime import path out of a task directory, so a `Tasks/_shared` package would not remove a single copy from the shipped layout — it would only add a fourth. What was genuinely still manual was **reconciliation**, and that is what `npm run sync:shared` (`--fix`) fixes: edit the canonical copy, sync, done.

`--fix` is deliberately **not** wired into the build — syncing automatically before packaging would silently repair a real unintended divergence instead of failing CI, defeating the gate. Syncing is an authoring step; CI only ever verifies.

## Mutation table

Every guard was broken and watched to fail; each source mutation was also typechecked, since a build failure is not a test result. Restored from `cp` backups.

| # | Mutation | Guard | Result | Typecheck |
|---|---|---|---|---|
| M1 | `max = 500` → `50000` in `oci-token-exchange.ts` only | parity gate | **exit 1**, `shared region 'TruncateBody' diverged` ×1 | `0` |
| M2 | drop the falsy guard from `servicenow-http.ts` only | parity gate | **exit 1**, same sentinel ×1 | `0` |
| M3 | delete `#endregion shared:TruncateBody` from the drift copy | fail-closed marker check | **exit 1**, `expected exactly one` ×1 | `0` |
| M4 | remove the `TruncateBody` entry from the gate config, then re-apply M1's real drift | gate config is load-bearing | gate **exit 0** — drift becomes invisible, confirming the entry does the work | n/a |
| M4b | same removal, run the self-test | self-test case 6 | **exit 1**, `did not flag a diverged shared TruncateBody region` | n/a |
| M5 | reimplement `--fix` as a whole-file overwrite (markers kept) | self-test case 8 | **exit 1**, `--fix clobbered the region host file's surrounding code`, while case 7 still passed — isolating the assertion | n/a |

## Behaviour preservation

Baseline established before any change and re-run after — identical counts, no test added to paper over a change:

| Task | Before | After |
|---|---|---|
| TerraformDriftReportV1 | 76 | 76 |
| TerraformModulePublishV1 | 76 | 76 |
| TerraformTaskV5 | 793 | 793 |
| PublishKbArticleV1 | 267 | 267 |

The three installer tasks (419 / 264 / 245) are untouched by this PR. All 9 repo check scripts and all 5 script self-tests pass; lint clean on all four changed tasks.

## Task version bumps

**None, deliberately.** Per-task `task.json` Minor bumps are auto-applied on the release-please Release PR by `release-pr-minor-bumps.yml`, and `CLAUDE.md` says never to hand-edit them (double-increment risk). The `Release PR Minor Bumps` required check skips any branch that is not `release-please--*`. The four tasks whose `src/` changed here will be bumped automatically when the next Release PR is prepared.

## Deliberately left undone

`TerraformPolicyCheckV1` has **5 open-coded truncation sites** with no helper at all — `opa-engine.ts:50,57` (`.slice(0, 500)`) and `sentinel-engine.ts:66,78,108` (`.slice(0, 2000)`). Neither issue mentions them. They are **not** the same behaviour: they truncate silently, with no `… (truncated)` marker, and Sentinel uses a different bound. Folding them in would change operator-visible error text, so it belongs in its own change rather than inside a behaviour-preserving refactor.

Closes #300, closes #407

