### PR TITLE
ci: check out all 14 SIGNATURE_SCOPE repos in signature-replay

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -58,7 +58,7 @@ jobs:
       # rather than pretending otherwise — so these checkouts are load-bearing,
       # not convenience.
       #
-      # All eight are PUBLIC, so none takes a `token:`: actions/checkout falls
+      # All of them are PUBLIC, so none takes a `token:`: actions/checkout falls
       # back to this job's own GITHUB_TOKEN, which reads public repositories
       # anywhere.
       #
@@ -125,6 +125,41 @@ jobs:
           persist-credentials: false
           repository: sethbacon/azure-pipelines-terraform
           path: suite/azure-pipelines-terraform
+
+      # The GitHub-Actions family, added to SIGNATURE_SCOPE in 2026-08: two
+      # composite actions whose whole implementation is shell in action.yml, two
+      # node actions that ship TypeScript plus a committed dist/, and the drift
+      # payload contract this extension's TerraformDriftReport task shares with
+      # them — scope.json records it as a `consumes` of this repo. Same rule as
+      # every checkout above — in scope.json and absent here is exit 2 for the
+      # whole job, not a quieter run. Note the OWNER: drift-contract is in the
+      # 4cloudguru org, not sethbacon. Both orgs' repos are public, so this job's
+      # own GITHUB_TOKEN still reads them, but the slug is not interchangeable.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/setup-terraform-hardened
+          path: suite/setup-terraform-hardened
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-provider-mirror
+          path: suite/terraform-provider-mirror
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-drift-report
+          path: suite/terraform-drift-report
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-module-publish
+          path: suite/terraform-module-publish
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: 4cloudguru/terraform-drift-contract
+          path: suite/terraform-drift-contract
 
       # Overwrite this repo's sibling copy with the commit under test, so the
       # replay reads the PR's code and not origin/main's. Guarded because


### PR DESCRIPTION
## What broke

`security-orchestration` commit `9d3d645` added five repos to `remediation/replay/scope.json`: `setup-action`, `mirror-action`, `drift-report-action`, `module-publish-action` and `drift-contract`. `SIGNATURE_SCOPE` is now **14** repos.

The replay refuses to run when a scoped repo is not checked out — it exits **2**, "could not run", which is deliberately never read as clean: a signature that cannot run against a repo establishes nothing about it. This repo's copy of `.github/workflows/signature-replay.yml` still checked out **9** of the 14, so the next PR, push or `06:17` cron run on `main` would have failed the `replay` job outright. Nothing had surfaced yet only because the last run predated the scope change.

## What this changes

The five missing checkouts, and nothing else:

| repository | path |
| --- | --- |
| `sethbacon/setup-terraform-hardened` | `suite/setup-terraform-hardened` |
| `sethbacon/terraform-provider-mirror` | `suite/terraform-provider-mirror` |
| `sethbacon/terraform-drift-report` | `suite/terraform-drift-report` |
| `sethbacon/terraform-module-publish` | `suite/terraform-module-publish` |
| `4cloudguru/terraform-drift-contract` | `suite/terraform-drift-contract` |

Note the **owner** on the last one: `terraform-drift-contract` is in the `4cloudguru` org, not `sethbacon`. Both orgs' repos are public, so the job's own `GITHUB_TOKEN` reads them and none of the new steps takes a `token:`; all five carry `persist-credentials: false` like every checkout above them.

No job renames, no permission changes, no `actions/checkout` SHA bumps — the new steps use this file's existing pin and existing block style. The only non-checkout edit is the comment that used to say "All eight are PUBLIC ... put it in eight more places", which my own change would have made false; it no longer names a number.

## How the checkout set was verified

Not by eye. A script parses this workflow as YAML, walks `jobs.replay.steps`, collects `(repository, path)` from every `actions/checkout` step, and compares that set to `{(gh, "suite/" + dir)}` built from `scope.json`'s `suite` + `sharedModules` on `security-orchestration@main`. It fails on a missing entry, an extra entry, a wrong owner, a wrong `path` basename, or a duplicate. `security-orchestration` itself is excluded — it is the private ledger checkout, not a scope entry, and its path is not under `suite/`.

```
scope.json entries  : 14
suite/ checkouts    : 14
RESULT              : EQUAL - checkout set == scope.json
```

Same script run against this file before the change reported the five above as `MISSING`, and run against the four already-corrected copies (`setup-terraform-hardened` #25, `terraform-provider-mirror` #21, `terraform-drift-report` #34, `terraform-module-publish` #35) reports `EQUAL` — so this repo now agrees with them.

`actionlint` is clean on the edited workflow.

## Note on the `replay` job itself

The four newly-scoped repos do not yet carry repo-scoped `SUITE_READ_APP_ID` / `SUITE_READ_APP_KEY`. That gap is in *those* repos and does not affect this one, whose own credentials are unchanged by this PR.
