### PR TITLE
ci(replay): check out the GitHub-Actions family and drift-contract

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -112,6 +112,36 @@ jobs:
           persist-credentials: false
           repository: 4cloudguru/pipeline-task-core
           path: suite/pipeline-task-core
+      # The GitHub-Actions family plus the drift payload contract they share with
+      # the ADO TerraformDriftReport task. In SIGNATURE_SCOPE and absent here is
+      # exit 2 for the whole job, not a quieter run. Note drift-contract is owned
+      # by 4cloudguru, not sethbacon; each path basename must equal that repo's
+      # `dir` in scope.json, which is what `--repos-root suite` resolves against.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/setup-terraform-hardened
+          path: suite/setup-terraform-hardened
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-provider-mirror
+          path: suite/terraform-provider-mirror
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-drift-report
+          path: suite/terraform-drift-report
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-module-publish
+          path: suite/terraform-module-publish
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          repository: 4cloudguru/terraform-drift-contract
+          path: suite/terraform-drift-contract
       # The two ADO extensions are siblings that COPY modules between each other
       # rather than sharing a versioned one, so a class found in either is
       # presumed in the other and every signature runs in both.


### PR DESCRIPTION
`security-orchestration#36` widened `SIGNATURE_SCOPE` with four recorded signatures for the GitHub-Actions family, plus the drift payload contract they share with the ADO TerraformDriftReport task. Repos in scope that are not checked out make the gate **exit 2** — a signature that cannot run is never read as a pass — so `replay` fails on every PR here until these five checkouts exist.

Adds:

| repo | path |
| --- | --- |
| `sethbacon/setup-terraform-hardened` | `suite/setup-terraform-hardened` |
| `sethbacon/terraform-provider-mirror` | `suite/terraform-provider-mirror` |
| `sethbacon/terraform-drift-report` | `suite/terraform-drift-report` |
| `sethbacon/terraform-module-publish` | `suite/terraform-module-publish` |
| `4cloudguru/terraform-drift-contract` | `suite/terraform-drift-contract` |

`drift-contract` is in the **4cloudguru** org, not `sethbacon` — the slug is not interchangeable. Both are public, so the job own `GITHUB_TOKEN` still reads them. Each `path` basename equals that repo `dir` in `scope.json`, which is what `--repos-root suite` resolves against.

### Consistency

Matches the canonical `remediation/replay/workflows/signature-replay.yml` in security-orchestration, and the shape already merged in `azure-pipelines-packer` and `terraform-state-manager-frontend`. Reuses this repo existing pinned `actions/checkout` rather than importing the template unpinned `@v5`.

### Verified

- checkout set compared against the canonical template: **15 repos, 0 difference** in either direction
- workflow parses as valid YAML
- additive only — no existing step modified
