### PR TITLE
ci: comment the remaining action pins with their exact tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Install root dependencies
         run: npm ci --ignore-scripts
       - name: Download build artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build
           path: build/
@@ -294,7 +294,7 @@ jobs:
         # already installed the full dev tree, so no reinstall is needed here.
         run: npx --no-install cyclonedx-npm --output-file sbom-tab.cdx.json
       - name: Download vsix artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
       - name: Install cosign
@@ -394,11 +394,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Download vsix artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
       - name: Download SBOM and signature artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom-and-signatures
       - name: Install cosign
@@ -453,7 +453,7 @@ jobs:
       - name: Install root dependencies
         run: npm ci --ignore-scripts
       - name: Download vsix artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
       # The signing job (sbom-and-sign) produced a cosign keyless sign-blob
@@ -462,7 +462,7 @@ jobs:
       # that are about to be published, not merely that "some valid signature
       # exists" somewhere.
       - name: Download SBOM and signature artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom-and-signatures
       - name: Install cosign


### PR DESCRIPTION
A bare `# v7` / `# v9` comment names a **moving** tag. It is true only until the upstream cuts a release and GitHub advances that tag past the pinned SHA — at which point zizmor's `ref-version-mismatch` fails **every PR in the repo**, with no change on our side.

That is not hypothetical. It is exactly how the `codeql-action` pins broke earlier today: `v4.37.7` shipped, the `v4` tag moved off our pinned `v4.37.6`, and green PRs went red on their own across several repos.

### What this does

Replaces each bare-major comment with the precise tag its pinned SHA **already resolves to**, so the comment cannot expire.

**No SHA changes.** No action upgrades ride along — bumping a pin stays Dependabot's job, and keeping the two separate means a lint fix never quietly ships a new action version.

### How the tags were chosen

Each pinned SHA was resolved against the upstream tag list, and the precise `vX.Y.Z` tag pointing at that exact commit was used. Any pin whose SHA could not be matched to a precise tag would have been left untouched and reported rather than guessed — there were none.

### Scope

Part of a suite-wide sweep: **53 pins across 8 repos**. `terraform-state-manager-frontend` and `pipeline-task-core` were already clean and needed no change.

Verification is zizmor itself — it runs this audit online on this PR. Note that a *local* zizmor run without a token silently skips it and reports a false clean, so the CI result here is the meaningful one.
