### PR TITLE
ci: drop duplicated replay checkouts

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -112,36 +112,6 @@ jobs:
           persist-credentials: false
           repository: 4cloudguru/pipeline-task-core
           path: suite/pipeline-task-core
-      # The GitHub-Actions family plus the drift payload contract they share with
-      # the ADO TerraformDriftReport task. In SIGNATURE_SCOPE and absent here is
-      # exit 2 for the whole job, not a quieter run. Note drift-contract is owned
-      # by 4cloudguru, not sethbacon; each path basename must equal that repo's
-      # `dir` in scope.json, which is what `--repos-root suite` resolves against.
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          repository: sethbacon/setup-terraform-hardened
-          path: suite/setup-terraform-hardened
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          repository: sethbacon/terraform-provider-mirror
-          path: suite/terraform-provider-mirror
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          repository: sethbacon/terraform-drift-report
-          path: suite/terraform-drift-report
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          repository: sethbacon/terraform-module-publish
-          path: suite/terraform-module-publish
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          repository: 4cloudguru/terraform-drift-contract
-          path: suite/terraform-drift-contract
       # The two ADO extensions are siblings that COPY modules between each other
       # rather than sharing a versioned one, so a class found in either is
       # presumed in the other and every signature runs in both.


### PR DESCRIPTION
`signature-replay.yml` checked out five repos twice. The GitHub-Actions family (`setup-terraform-hardened`, `terraform-provider-mirror`, `terraform-drift-report`, `terraform-module-publish`) plus `terraform-drift-contract` each appeared in two adjacent blocks, so the job cloned **19** trees to cover the **14** entries `SIGNATURE_SCOPE` lists.

The second clone of each was wasted work rather than a second opinion: the replay resolves a repo by its `dir` under `--repos-root`, so the later checkout landed on the path the earlier one had already populated. `azure-pipelines-packer` never carried the duplicate — the two sibling copies had diverged, and packer is the reference shape here.

This removes the **earlier** of the two blocks. What remains is identical in content and order to packer's copy, and keeps the comment that records why `drift-contract` is in scope for *this* repo specifically (`scope.json` lists it as a `consumes` of `terraform-ext`).

## Verified programmatically, not by reading

A checker parses `scope.json` into a set over `suite[] + sharedModules[]`, parses this workflow with a real YAML parser into a set over every `actions/checkout` whose `path` starts with `suite/`, and asserts five things independently.

| | before | after | packer (reference) |
|---|---|---|---|
| `scope.json` dirs | 14 | 14 | 14 |
| `suite/` checkouts | **19** | **14** | 14 |
| unique | 14 | 14 | 14 |
| duplicated dirs | **5** | 0 | 0 |

Before: `FAIL A3 duplicates: {setup-terraform-hardened: 2, terraform-drift-contract: 2, terraform-drift-report: 2, terraform-module-publish: 2, terraform-provider-mirror: 2}`
After: `PASS A1 no missing / A2 no extra / A3 no duplicates / A4 persist-credentials:false everywhere / A5 exactly one token, on the private repo`

Two exclusions, both of which had previously produced false readings:

- the templated self-checkout `suite/${{ github.event.repository.name }}` re-checks-out a repo already listed, so counting it reports a phantom entry — excluded from the set comparison, but **not** from the `persist-credentials` assertion;
- the "exactly one token-bearing checkout, and it is the one private repo" assertion is scoped to the **checkout job**. Both extension copies happen to have a single `replay` job, but `security-orchestration`'s own central copy mints its token in a separate job, and a file-wide count cannot tell those two shapes apart.

## Falsification

A green checker on a clean file proves nothing — `exit 0` would do the same. Each assertion was broken in turn against packer's known-clean copy, and each reddened only its own line:

| injected defect | fired | wanted |
|---|---|---|
| drop a scoped repo (`suite-identity`) | A1 | A1 |
| check out an out-of-scope repo | A2 | A2 |
| duplicate a checkout block | A3 | A3 |
| remove one `persist-credentials` | A4 | A4 |
| add a token to a **public** checkout | A5 | A5 |

Control: the unmutated file round-tripped through the same YAML dump path still passes, so a red mutant is the defect and not the dumping.

`actionlint` clean. No behaviour change to the replay itself — same 14 trees, cloned once each.

Closes #945