### PR TITLE
deps: bump pipeline-task-core to ^0.5.0

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
         "openpgp": "^6.0.1",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",
     "openpgp": "^6.0.1",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/package-lock.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "cheerio": "^1.2.0",
         "sanitize-html": "^2.17.6"
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/package.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "3.232.1",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "cheerio": "^1.2.0",
     "sanitize-html": "^2.17.6"

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
         "undici": "^6.28.0"
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",
     "undici": "^6.28.0"

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/package-lock.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "@4cloudguru/terraform-drift-contract": "^1.1.0",
         "azure-pipelines-task-lib": "^5.2.10"
       },
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "@4cloudguru/terraform-drift-contract": "^1.1.0",
     "azure-pipelines-task-lib": "^5.2.10"
   },

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
         "openpgp": "^6.0.1",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",
     "openpgp": "^6.0.1",

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/package-lock.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10"
       },
       "devDependencies": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
+++ b/Tasks/TerraformModulePublish/TerraformModulePublishV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10"
   },
   "overrides": {

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package-lock.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10"
       },
       "devDependencies": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package.json
+++ b/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10"
   },
   "overrides": {

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package-lock.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10"
       },
       "devDependencies": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package.json
+++ b/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10"
   },
   "overrides": {

--- a/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1",
+        "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-devops-node-api": "^12.0.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-artifacts-common": "^2.225.0",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.5.0.tgz",
+      "integrity": "sha512-bv9TS7F5X+kK9NFZrOJdUZ0qBk9haMKgP/+wggayZZXAM75cIJwC6b3CI6l5zNYgGGvQhzakgHm7zbvNywnFIQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -19,7 +19,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@4cloudguru/pipeline-task-core": "^0.3.1",
+    "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-devops-node-api": "^12.0.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-artifacts-common": "^2.225.0",


### PR DESCRIPTION
All **nine** tasks that pin `@4cloudguru/pipeline-task-core` move from `^0.3.1` to `^0.5.0`. Only `package.json` and `package-lock.json` change — `npm install` reported *"changed 1 package"* in every task, so there is no incidental transitive churn.

`0.5.0` is the first release published with **SLSA provenance**, so the pin now resolves to an artifact whose build is attested:

```
$ npm view @4cloudguru/pipeline-task-core@0.5.0 dist.attestations
{ url: '…/attestations/@4cloudguru%2fpipeline-task-core@0.5.0',
  provenance: { predicateType: 'https://slsa.dev/provenance/v1' } }
```

## What this repo does and does not take

**`resolveEnvProxy` (new in 0.5.0) is deliberately not wired in.** These tasks resolve the proxy from the agent's own configuration (`Agent.ProxyUrl` / `Agent.ProxyUsername` / `Agent.ProxyPassword`) via `proxy-config.ts`, which is the correct source on an ADO agent. Reading it from the environment instead would be a regression here.

**0.5.0's `fetchJson` message fix does not reach this repo** — and the pin is not what is stopping it. The three installer tasks each carry their own hand-copy of `http-client.ts` with their own `fetchJson`, and it is those copies, not the package, that the install-path call sites resolve to; only `retryAsync` is imported from the package there. The sibling `azure-pipelines-packer` *does* inherit the fix, because it consumes `createHttpClient()`.

I did not fix that here. Consolidating a security primitive across a released extension is a change to sequence deliberately, not to slip into a dependency bump. Filed as #947 with the full drift analysis, including a semantic divergence that would break the OPA and terraform-docs checksum fetches if the migration were done naively.

## Tests

Full suites re-run in every affected task, installed via `npm ci` from the updated lockfiles (what CI does), before and after:

| task | before (0.3.1) | after (0.5.0) | failing |
|---|---|---|---|
| TerraformTaskV5 | 793 | 793 | 0 |
| TerraformInstallerV1 | 431 | 431 | 0 |
| PublishKbArticleV1 | 267 | 267 | 0 |
| PolicyAgentInstallerV1 | 264 | 264 | 0 |
| TerraformDocsInstallerV1 | 246 | 246 | 0 |
| TerraformPolicyCheckV1 | 99 | 99 | 0 |
| TerraformDriftReportV1 | 77 | 77 | 0 |
| TerraformModulePublishV1 | 76 | 76 | 0 |
| TerraformProviderMirrorV1 | 58 | 58 | 0 |
| **total** | **2311** | **2311** | **0** |

**No assertion was adjusted, weakened or otherwise touched.** No message text these tasks assert on changed — and the reason is worth stating rather than assuming: the tasks that assert on HTTP error text assert against their own hand-copies, which this bump does not affect. That is the same divergence #947 describes, observed from the test side.

## Not touched

No `task.json` `Minor` bumps — those are applied automatically on the Release PR and must never be hand-edited.