### PR TITLE
refactor: consume the GPG verification from pipeline-task-core

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/gpg-verifier.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/gpg-verifier.ts
@@ -3,8 +3,19 @@
 // the copies stay byte-identical, failing the build on any divergence, so a fix or
 // key rotation here MUST be applied to BOTH copies. This duplication is deliberate
 // (each task bundles independently) — not drift to be flagged.
+//
+// The CRYPTOGRAPHIC decision now comes from @4cloudguru/pipeline-task-core/gpg
+// (verifyDetached), so the openpgp API surface lives in one place instead of two
+// copies. What stays here is what the package deliberately refuses to own:
+//   - the trust root (HASHICORP_GPG_PUBLIC_KEY), because vendoring a signing key
+//     through a package means a compromise of that package silently replaces it;
+//   - the 404-vs-transient distinction, because only the caller knows a missing
+//     signature MAY be downgraded on operator opt-out while a 5xx never may;
+//   - the VerificationFailure typing, which is what lets the cache-hit
+//     re-verification path fail closed on a bad signature but degrade on an outage.
 import tasks = require('azure-pipelines-task-lib/task');
-import * as openpgp from 'openpgp';
+
+import { verifyDetached } from '@4cloudguru/pipeline-task-core/gpg';
 
 import { fetchBufferAllow404 } from './http-client';
 import { HASHICORP_GPG_PUBLIC_KEY } from './hashicorp-gpg-key';
@@ -38,28 +49,22 @@ export async function verifyGpgSignature(sha256SumsContent: string, signatureUrl
 
     tasks.debug(`Verifying GPG signature from ${signatureUrl}`);
 
-    const publicKey = await openpgp.readKey({ armoredKey: HASHICORP_GPG_PUBLIC_KEY });
-    const signature = await openpgp.readSignature({ binarySignature: signatureBytes });
-    const message = await openpgp.createMessage({ text: sha256SumsContent });
-
-    const result = await openpgp.verify({
-        message,
-        signature,
-        verificationKeys: publicKey,
+    const result = await verifyDetached({
+        message: new TextEncoder().encode(sha256SumsContent),
+        signature: signatureBytes,
+        armoredPublicKeys: [HASHICORP_GPG_PUBLIC_KEY],
     });
 
     // From here on the signature material was OBTAINED but does not verify —
     // throw the typed VerificationFailure so the cache-hit re-verification path
     // fails closed instead of degrading to "material unavailable".
-    if (!result.signatures || result.signatures.length === 0) {
-        throw new VerificationFailure(`GPG signature verification failed: no signatures found in ${signatureUrl}`);
-    }
-    const { verified } = result.signatures[0];
-    try {
-        await verified;
-    } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        throw new VerificationFailure(`GPG signature verification failed for SHA256SUMS: ${errorMessage}`);
+    if (!result.verified) {
+        // The reasons are how an operator tells a key-rotation miss from a tampered
+        // file; without them this failure reads the same either way. The URL is kept
+        // because the deleted "no signatures found in <url>" branch was the only place
+        // a zero-signature .sig named which file was empty.
+        const detail = result.reasons?.join('; ') || 'no signature verified';
+        throw new VerificationFailure(`GPG signature verification failed for SHA256SUMS (${signatureUrl}): ${detail}`);
     }
 
     tasks.debug('GPG signature verification passed');

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/gpg-verifier.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/gpg-verifier.ts
@@ -3,8 +3,19 @@
 // the copies stay byte-identical, failing the build on any divergence, so a fix or
 // key rotation here MUST be applied to BOTH copies. This duplication is deliberate
 // (each task bundles independently) — not drift to be flagged.
+//
+// The CRYPTOGRAPHIC decision now comes from @4cloudguru/pipeline-task-core/gpg
+// (verifyDetached), so the openpgp API surface lives in one place instead of two
+// copies. What stays here is what the package deliberately refuses to own:
+//   - the trust root (HASHICORP_GPG_PUBLIC_KEY), because vendoring a signing key
+//     through a package means a compromise of that package silently replaces it;
+//   - the 404-vs-transient distinction, because only the caller knows a missing
+//     signature MAY be downgraded on operator opt-out while a 5xx never may;
+//   - the VerificationFailure typing, which is what lets the cache-hit
+//     re-verification path fail closed on a bad signature but degrade on an outage.
 import tasks = require('azure-pipelines-task-lib/task');
-import * as openpgp from 'openpgp';
+
+import { verifyDetached } from '@4cloudguru/pipeline-task-core/gpg';
 
 import { fetchBufferAllow404 } from './http-client';
 import { HASHICORP_GPG_PUBLIC_KEY } from './hashicorp-gpg-key';
@@ -38,28 +49,22 @@ export async function verifyGpgSignature(sha256SumsContent: string, signatureUrl
 
     tasks.debug(`Verifying GPG signature from ${signatureUrl}`);
 
-    const publicKey = await openpgp.readKey({ armoredKey: HASHICORP_GPG_PUBLIC_KEY });
-    const signature = await openpgp.readSignature({ binarySignature: signatureBytes });
-    const message = await openpgp.createMessage({ text: sha256SumsContent });
-
-    const result = await openpgp.verify({
-        message,
-        signature,
-        verificationKeys: publicKey,
+    const result = await verifyDetached({
+        message: new TextEncoder().encode(sha256SumsContent),
+        signature: signatureBytes,
+        armoredPublicKeys: [HASHICORP_GPG_PUBLIC_KEY],
     });
 
     // From here on the signature material was OBTAINED but does not verify —
     // throw the typed VerificationFailure so the cache-hit re-verification path
     // fails closed instead of degrading to "material unavailable".
-    if (!result.signatures || result.signatures.length === 0) {
-        throw new VerificationFailure(`GPG signature verification failed: no signatures found in ${signatureUrl}`);
-    }
-    const { verified } = result.signatures[0];
-    try {
-        await verified;
-    } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        throw new VerificationFailure(`GPG signature verification failed for SHA256SUMS: ${errorMessage}`);
+    if (!result.verified) {
+        // The reasons are how an operator tells a key-rotation miss from a tampered
+        // file; without them this failure reads the same either way. The URL is kept
+        // because the deleted "no signatures found in <url>" branch was the only place
+        // a zero-signature .sig named which file was empty.
+        const detail = result.reasons?.join('; ') || 'no signature verified';
+        throw new VerificationFailure(`GPG signature verification failed for SHA256SUMS (${signatureUrl}): ${detail}`);
     }
 
     tasks.debug('GPG signature verification passed');


### PR DESCRIPTION
Delegates the cryptographic decision in both byte-identical `gpg-verifier.ts`
copies (`TerraformInstallerV1`, `PolicyAgentInstallerV1`) to `verifyDetached`
from `@4cloudguru/pipeline-task-core/gpg`.

This is the last of the shared-module migrations, after retry (#940), egress +
path-segment (#942), verification + artifact-discard (#943), URL redaction
(#944) and the HTTP client (#949). It backports
sethbacon/azure-pipelines-packer#247, whose `@shared-module-status` header
recorded this backport as pending.

## What moves, and what deliberately stays

Only the openpgp API surface and the multi-signature handling move, so they
live in one place instead of two copies. Three things stay here on purpose,
because the package refuses to own them:

| Stays | Why |
| --- | --- |
| the trust root (`HASHICORP_GPG_PUBLIC_KEY`) | vendoring a signing key *through* a package means a compromise of that package silently replaces it |
| the 404-vs-transient distinction | only the caller knows a missing signature MAY be downgraded on operator opt-out, while a 5xx never may |
| the `VerificationFailure` typing | it is what lets the cache-hit re-verification path fail closed on a bad signature but degrade on a transport outage |

`result.reasons` replaces the old "no signatures found" branch, so a
key-rotation miss still reads differently from a tampered file, and the
signature URL is kept in the message rather than lost with that branch.

`openpgp` stays a dependency of both tasks — the `GpgVerifierL0` suites
generate real signatures and parse the embedded trust root directly — matching
the sibling repo.

## Verification

- TerraformInstallerV1 **431 passing**, PolicyAgentInstallerV1 **264 passing**,
  both unchanged from baseline, re-run after rebasing onto the post-#949 main
  so the delegated `fetchBufferAllow404` import is exercised against the new
  adapter.
- Both copies byte-identical; `check-shared-modules.js` green; full
  `scripts/check-*.js` sweep green.
- Coverage **improved** in both tasks (removing the openpgp error branches
  removed uncovered code), and both per-file floor checks pass:
  TerraformInstallerV1 95.08 / 84.36 / 92.68 / 96.30 (was 94.46 / 82.62 /
  90.51 / 96.09); PolicyAgentInstallerV1 93.69 / 82.05 / 93.50 / 94.35 (was
  92.48 / 78.94 / 91.50 / 93.51).
- Mutation-verified: replacing the `if (!result.verified)` rejection with
  `if (false)` fails `GpgVerifierL0` (exit 1, 1 failing), so the delegated
  verdict is genuinely gated rather than merely returned. The mutation was
  applied **and recompiled** — mutating the `.ts` alone silently no-ops,
  because Node resolves the previously-compiled sibling `src/gpg-verifier.js`
  ahead of ts-node's `.ts`.

## Follow-up (separate, not in this PR)

azure-pipelines-packer's copy still carries `@shared-module-status: DIVERGED —
… Backport to azure-pipelines-terraform is pending`. Once this lands the two
copies are reconciled, so that header should be updated in that repo.
