### PR TITLE
fix: forward the drift contract's completeness markers

### DIFF
--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCompletenessMarkers.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/DriftReportCompletenessMarkers.ts
@@ -1,0 +1,114 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+import fs = require('fs');
+import { resolveRejectUnauthorized, resolveFailOnCallbackError, truncateBody } from '../src/callback';
+
+// Drives the real src/index.js -- and therefore the real, resolved
+// @4cloudguru/terraform-drift-contract -- over one of several plan documents,
+// and CAPTURES THE BYTES THE TASK WOULD POST.
+//
+// #950: the callback body was assembled by naming the contract's fields one at a
+// time into a `Record<string, unknown>`, so the five completeness markers the
+// contract computes (`unparseable`, `unmasked`, `truncated`, `omitted_entries`,
+// `omitted_attrs`) were dropped with nothing red -- `tsc` cannot report a field
+// that a pick list never mentions, and the destination type accepted anything.
+//
+// The case is chosen by TDR_MARKER_CASE, and the captured body is written to
+// TDR_MARKER_POSTED. mock-test's runner spawns this file with the parent's
+// environment and only strips INPUT_/SECRET_/VSTS_TASKVARIABLE_, so both survive
+// the hop. One fixture over a table of documents rather than six near-identical
+// files: the defect is a CLASS, and every case has to be asserted in BOTH
+// directions -- a body that hardcoded `unparseable: false` passes any test that
+// only ever feeds it a readable plan.
+
+const CASES: Record<string, unknown> = {
+    // Parses as JSON but is not a plan: no `resource_changes` at all. A
+    // truncated `terraform show -json`, a wrong file, an empty document. This
+    // summarizes to 0/0/0 + drifted:false -- byte-identical to `clean` below on
+    // every other field, which is the whole reason the marker exists.
+    unreadable: {},
+    clean: { resource_changes: [] },
+    unmasked: {
+        resource_changes: [
+            { address: 'aws_instance.x', change: { actions: ['update'], before: { size: 1 }, after: { size: 2 } } },
+        ],
+    },
+    masked: {
+        resource_changes: [
+            {
+                address: 'aws_instance.x',
+                change: {
+                    actions: ['update'],
+                    before: { size: 1 },
+                    after: { size: 2 },
+                    before_sensitive: {},
+                    after_sensitive: {},
+                },
+            },
+        ],
+    },
+    // Three past the contract's 500-entry cap: 503 creates, 500 summary rows.
+    // The COUNTS are not capped, so the discrepancy is only legible because
+    // omitted_entries travels alongside them.
+    cappedEntries: {
+        resource_changes: Array.from({ length: 503 }, (_unused, i) => ({
+            address: `aws_s3_bucket.b${i}`,
+            change: { actions: ['create'], before: null, after: {} },
+        })),
+    },
+    // Four past the contract's 50-attrs-per-entry cap.
+    cappedAttrs: {
+        resource_changes: [
+            {
+                address: 'aws_instance.w',
+                change: {
+                    actions: ['update'],
+                    before: Object.fromEntries(Array.from({ length: 54 }, (_unused, i) => [`k${i}`, i])),
+                    after: Object.fromEntries(Array.from({ length: 54 }, (_unused, i) => [`k${i}`, 1000 + i])),
+                    before_sensitive: {},
+                    after_sensitive: {},
+                },
+            },
+        ],
+    },
+};
+
+const caseName = process.env['TDR_MARKER_CASE'] ?? 'unreadable';
+const plan = CASES[caseName];
+if (plan === undefined) {
+    throw new Error(`unknown TDR_MARKER_CASE: ${caseName}`);
+}
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdr-markers-'));
+const planFile = path.join(dir, 'plan.json');
+fs.writeFileSync(planFile, JSON.stringify(plan));
+
+const postedFile = process.env['TDR_MARKER_POSTED'] ?? path.join(dir, 'posted.json');
+
+const tp = path.join(__dirname, '..', 'src', 'index.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(tp);
+
+tr.setInput('planJsonFile', planFile);
+tr.setInput('includeModuleProvenance', 'false');
+tr.setInput('failOnDrift', 'false');
+tr.setInput('callbackUrl', 'https://tsm.example.com/drift');
+tr.setInput('callbackToken', 'super-secret-callback-token');
+tr.setInput('rejectUnauthorized', 'true');
+
+// Stubs the transport only. The body handed to it is the real one the task
+// assembled, written out verbatim so L0 asserts against the bytes that would
+// leave the agent rather than against the summary artifact alone -- a refactor
+// that assembled the POST separately would keep one right and send the other.
+tr.registerMock('./callback', {
+    postJson: async () => ({ status: 200, body: '{}' }),
+    postJsonWithRetry: async (_url: string, _headers: unknown, body: string) => {
+        fs.writeFileSync(postedFile, body);
+        return { status: 200, body: '{}' };
+    },
+    truncateBody,
+    resolveRejectUnauthorized,
+    resolveFailOnCallbackError,
+});
+
+tr.run();

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/L0.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 import * as net from 'net';
 import * as https from 'https';
 import tasks = require('azure-pipelines-task-lib/task');
+import { summarize } from '@4cloudguru/terraform-drift-contract';
 import { postJson, postJsonWithRetry, truncateBody } from '../src/callback';
 import { createHttpsClient } from '../src/https-client';
 import { TLS_CERT, TLS_KEY } from './loopback-tls';
@@ -797,5 +798,156 @@ describe('TerraformDriftReport Test Suite', function () {
                 'should warn that TLS verification is off',
             );
         }, tr);
+    });
+});
+
+// #950 — the completeness markers: what the check did NOT do.
+//
+// The callback body was assembled by naming the contract's fields one at a time
+// into a `Record<string, unknown>`. Contract 1.2.0 added five markers and every
+// one was dropped, invisibly: a pick list cannot report a field it never
+// mentions, and the destination type accepted anything, so `tsc` had nothing to
+// say either. The result was that a plan this task could not read left the agent
+// as `drifted: false` with zero counts -- byte-identical to a verified-clean run
+// -- and TSM auto-resolved the live drift record on it.
+//
+// Every case asserts BOTH directions. A body that hardcoded `unparseable: false`
+// passes any test that only ever feeds it a readable plan, and one that
+// hardcoded `true` passes any test that only feeds it a broken one; only the
+// pair distinguishes a forwarded value from a constant.
+describe('TerraformDriftReport completeness markers (#950)', function () {
+    this.timeout(30000);
+
+    const MARKERS = ['unparseable', 'unmasked', 'truncated', 'omitted_entries', 'omitted_attrs'] as const;
+
+    interface Posted extends Record<string, unknown> {
+        added: number;
+        changed: number;
+        destroyed: number;
+        drifted: boolean;
+        summary: unknown[];
+    }
+
+    // Runs the shared fixture for one case and returns BOTH the bytes it would
+    // have POSTed and the summary artifact it wrote. The two are the same object
+    // in src/index.ts, and #950 dropped the markers from both; asserting only one
+    // would pass on a refactor that split them.
+    async function runCase(name: string): Promise<{ posted: Posted; artifact: Posted; tr: ttm.MockTestRunner }> {
+        const postedFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'tdr-posted-')), 'posted.json');
+        process.env['TDR_MARKER_CASE'] = name;
+        process.env['TDR_MARKER_POSTED'] = postedFile;
+        try {
+            const tr = new ttm.MockTestRunner(path.join(__dirname, 'DriftReportCompletenessMarkers.js'));
+            await tr.runAsync();
+            assert(tr.succeeded, `task should have succeeded for case ${name}: ${tr.stdout}\n${tr.stderr}`);
+            assert(fs.existsSync(postedFile), `no callback body was captured for case ${name}: ${tr.stdout}`);
+            const posted = JSON.parse(fs.readFileSync(postedFile, 'utf-8')) as Posted;
+
+            const line = tr.stdout.split('\n').find(l => l.includes('##vso[task.setvariable variable=summaryFilePath;'));
+            assert(line, `summaryFilePath output variable not found: ${tr.stdout}`);
+            const artifactPath = line!.slice(line!.indexOf(']') + 1).trim();
+            const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf-8')) as Posted;
+            return { posted, artifact, tr };
+        } finally {
+            delete process.env['TDR_MARKER_CASE'];
+            delete process.env['TDR_MARKER_POSTED'];
+        }
+    }
+
+    // The load-bearing one. This body is 0/0/0 + drifted:false -- identical to
+    // the clean case below on every other field. `unparseable` is the only thing
+    // separating "we checked and it was clean" from "we never finished
+    // checking", and the receiver resolved the record on both until it arrived.
+    it('an unreadable document is POSTed as unparseable, not as clean', async () => {
+        const { posted, artifact } = await runCase('unreadable');
+        assert.strictEqual(posted.unparseable, true, 'unparseable must travel');
+        assert.deepStrictEqual(
+            [posted.added, posted.changed, posted.destroyed, posted.drifted],
+            [0, 0, 0, false],
+            'an unreadable document is otherwise indistinguishable from a clean one',
+        );
+        assert.strictEqual(artifact.unparseable, true, 'the on-agent summary artifact must carry it too');
+    });
+
+    // Positive control. A hardcoded `unparseable: true` satisfies the assertion
+    // above; only a run where the value is genuinely false proves the marker is
+    // forwarded rather than pinned.
+    it('a genuinely clean plan is POSTed as parseable (positive control)', async () => {
+        const { posted, artifact } = await runCase('clean');
+        assert.strictEqual(posted.unparseable, false);
+        assert.strictEqual(artifact.unparseable, false);
+        assert.deepStrictEqual([posted.added, posted.changed, posted.destroyed, posted.drifted], [0, 0, 0, false]);
+    });
+
+    it('a change carrying no sensitivity metadata sets unmasked', async () => {
+        const { posted } = await runCase('unmasked');
+        assert.strictEqual(posted.unmasked, true);
+    });
+
+    it('a change carrying sensitivity mirrors does not (positive control)', async () => {
+        const { posted } = await runCase('masked');
+        assert.strictEqual(posted.unmasked, false);
+    });
+
+    it('a capped summary POSTs truncated and how many rows were dropped', async () => {
+        const { posted } = await runCase('cappedEntries');
+        assert.strictEqual(posted.truncated, true);
+        assert.strictEqual(posted.omitted_entries, 3);
+        // The counts are NOT capped, so `drifted` stays truthful while the list
+        // is partial. That discrepancy is only legible because the marker rides
+        // along with it.
+        assert.strictEqual(posted.added, 503, 'counts must not be capped');
+        assert.strictEqual(posted.summary.length, 500, 'the summary is capped at the contract bound');
+    });
+
+    it('a capped attribute list POSTs how many attrs were dropped', async () => {
+        const { posted } = await runCase('cappedAttrs');
+        assert.strictEqual(posted.truncated, true);
+        assert.strictEqual(posted.omitted_attrs, 4);
+    });
+
+    it('an uncapped report says so rather than staying silent (positive control)', async () => {
+        const { posted } = await runCase('unmasked');
+        assert.strictEqual(posted.truncated, false);
+        assert.strictEqual(posted.omitted_entries, 0);
+        assert.strictEqual(posted.omitted_attrs, 0);
+    });
+
+    // The class guard, and the reason the body is a spread rather than a pick
+    // list: this fails on the NEXT field the contract adds, not just on the five
+    // dropped this time. It re-derives the expectation from the resolved package,
+    // so a contract bump that widens Result reddens here -- in the producer that
+    // emits the payload -- instead of arriving at TSM as a silent omission.
+    it('every field the contract computes is forwarded, with the contract-computed value', async () => {
+        const { posted } = await runCase('cappedEntries');
+        const computed = summarize({
+            resource_changes: Array.from({ length: 503 }, (_unused, i) => ({
+                address: `aws_s3_bucket.b${i}`,
+                change: { actions: ['create'], before: null, after: {} },
+            })),
+        }) as unknown as Record<string, unknown>;
+
+        const dropped = Object.keys(computed).filter(k => !(k in posted));
+        assert.deepStrictEqual(dropped, [], `the callback body drops contract fields: ${dropped.join(', ')}`);
+        for (const marker of MARKERS) {
+            assert.deepStrictEqual(
+                posted[marker],
+                computed[marker],
+                `${marker} is not the contract-computed value (a constant would pass a one-sided test)`,
+            );
+        }
+    });
+
+    // The names are not this task's to choose. TSM decodes them as the json tags
+    // of `completeness` in internal/api/drift_records.go, and its own generated
+    // jq templates already post exactly these keys. Because that callback
+    // deliberately does not use DisallowUnknownFields -- its token is one-shot,
+    // so a rejected body would strand the run -- a renamed marker is dropped in
+    // silence rather than reported.
+    it('uses the snake_case wire names the receiver decodes', async () => {
+        const { posted } = await runCase('unmasked');
+        for (const marker of MARKERS) {
+            assert(marker in posted, `the callback body must carry ${marker}; got ${Object.keys(posted).join(', ')}`);
+        }
     });
 });

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/SecureTempL0.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/Tests/SecureTempL0.ts
@@ -219,7 +219,21 @@ describe('replaceSecretFile (TerraformDriftReport copy) — user-named SARIF out
  * temp directory.
  */
 describe('writeSarif (TerraformDriftReport) — auto-generated path prefers the caller-supplied tempDir (#882)', function () {
-    const emptyResult: Result = { added: 0, changed: 0, destroyed: 0, drifted: false, summary: [] };
+    // Spelled out rather than cast: `Result` gained the five completeness
+    // markers in contract 1.2.0, and a literal that names every field is what
+    // makes the NEXT such addition a compile error here too.
+    const emptyResult: Result = {
+        added: 0,
+        changed: 0,
+        destroyed: 0,
+        drifted: false,
+        summary: [],
+        unparseable: false,
+        unmasked: false,
+        truncated: false,
+        omitted_entries: 0,
+        omitted_attrs: 0,
+    };
     let scratchDir: string;
 
     beforeEach(() => {

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/package-lock.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@4cloudguru/pipeline-task-core": "^0.5.0",
-        "@4cloudguru/terraform-drift-contract": "^1.1.0",
+        "@4cloudguru/terraform-drift-contract": "^1.2.0",
         "azure-pipelines-task-lib": "^5.2.10"
       },
       "devDependencies": {
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@4cloudguru/terraform-drift-contract": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/terraform-drift-contract/-/terraform-drift-contract-1.1.0.tgz",
-      "integrity": "sha512-ZOx8xw7b1Ehn929Kvawj/3jbjFHW9Mt/7mIdRv1A1hRulUu2HQlxe32raFucNlVl0IH3zLCn0oTcJe6xF9TDbQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/terraform-drift-contract/-/terraform-drift-contract-1.2.0.tgz",
+      "integrity": "sha512-6nMLtYZJdPh3p4ijUOZuoTH2syVzFI94FrkHu94TLe5sVZ/gAnEKsjcNTm1E2+60prABvt8nBfQfH3H6zpWTPg==",
       "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/package.json
@@ -20,7 +20,7 @@
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
     "@4cloudguru/pipeline-task-core": "^0.5.0",
-    "@4cloudguru/terraform-drift-contract": "^1.1.0",
+    "@4cloudguru/terraform-drift-contract": "^1.2.0",
     "azure-pipelines-task-lib": "^5.2.10"
   },
   "overrides": {

--- a/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
+++ b/Tasks/TerraformDriftReport/TerraformDriftReportV1/src/index.ts
@@ -3,7 +3,7 @@ import path = require('path');
 import fs = require('fs');
 import os = require('os');
 import { randomUUID } from 'crypto';
-import { summarize, moduleCallsPlan, Plan } from '@4cloudguru/terraform-drift-contract';
+import { summarize, moduleCallsPlan, Plan, Result } from '@4cloudguru/terraform-drift-contract';
 import { postJsonWithRetry, truncateBody, resolveRejectUnauthorized, resolveFailOnCallbackError } from './callback';
 import { writeSarif } from './sarif';
 import { writeSecretFile, scrubFile } from './secure-temp';
@@ -17,6 +17,46 @@ import { writeSecretFile, scrubFile } from './secure-temp';
  * legitimately tens of MB, but a runaway can't exhaust the agent.
  */
 export const MAX_PLAN_JSON_BYTES = 100 * 1024 * 1024; // 100 MB
+
+/**
+ * The wire contract with TSM: what this task POSTs to the drift callback, and
+ * byte-for-byte what it writes as the on-agent summary artifact.
+ *
+ * It used to be a bare `Record<string, unknown>` assembled by naming the
+ * contract's fields one at a time (#950). Both halves of that were the bug. The
+ * pick list could only ever describe the contract as of the day it was written,
+ * and `Record<string, unknown>` accepts anything, so `tsc` could not report that
+ * `summarize()` had begun returning fields the body did not carry. The omission
+ * was invisible to the entire toolchain.
+ *
+ * Contract 1.2.0 is where that bill came due: it added five markers describing
+ * what a check did NOT do -- `unparseable`, `unmasked`, `truncated`,
+ * `omitted_entries`, `omitted_attrs` -- and this task forwarded none of them.
+ * `unparseable` is the one that changed an answer. A truncated `terraform show
+ * -json`, a wrong file and an empty `{}` all summarize to `added: 0, changed: 0,
+ * destroyed: 0, drifted: false`, byte-identical to a verified-clean plan, and
+ * TSM auto-resolved the live drift record on receiving one.
+ *
+ * So `extends Result` rather than a copy of its members, and the body below is a
+ * SPREAD of the summarize() result: the contract's own type is the field list,
+ * every field of it is required here, a field the contract adds next is
+ * forwarded by construction, and dropping one is a compile error rather than a
+ * silent omission.
+ *
+ * The wire names are the contract's field names unchanged -- which is what the
+ * backend decodes (`completeness`, internal/api/drift_records.go) and what its
+ * generated jq templates already post. That callback deliberately does NOT use
+ * DisallowUnknownFields, because its token is one-shot and a rejected body would
+ * strand the run permanently; the cost of that leniency is that a renamed or
+ * missing key is dropped in silence, which is exactly how this went unnoticed.
+ */
+export interface CallbackBody extends Result {
+    status: string;
+    detail: string;
+    /** Module provenance; present only with includeModuleProvenance. */
+    plan?: unknown;
+    module_locks?: unknown;
+}
 
 // Reads `.terraform/modules/modules.json` verbatim for the callback's
 // module_locks field; null when absent/unreadable/oversized (the backend then
@@ -133,13 +173,12 @@ async function run(): Promise<void> {
         const detail = tasks.getInput('detail', false) || '';
         const includeProvenance = tasks.getBoolInput('includeModuleProvenance', false);
 
-        const body: Record<string, unknown> = {
+        // Spread, not a pick list. Everything the contract computed goes on the
+        // wire, including the markers that say what this check did NOT do; only
+        // the two fields the contract does not own are added here.
+        const body: CallbackBody = {
+            ...result,
             status: 'completed',
-            added: result.added,
-            changed: result.changed,
-            destroyed: result.destroyed,
-            drifted: result.drifted,
-            summary: result.summary,
             detail,
         };
         if (includeProvenance) {

--- a/docs/yaml-examples.md
+++ b/docs/yaml-examples.md
@@ -1015,6 +1015,25 @@ surface drift in SARIF-aware tooling.
 > (GitHub code scanning, a SIEM). The JUnit results the policy-check task also emits render
 > natively in the **Tests** tab, so JUnit is the zero-setup path.
 
+**Completeness markers.** The report and the callback body carry five fields
+describing what the run did **not** do, straight from the drift contract:
+
+| Field | Meaning |
+| --- | --- |
+| `unparseable` | the document did not have the shape of a plan — nothing was actually checked |
+| `unmasked` | a change carried no sensitivity metadata, so nothing was redacted for it |
+| `truncated` | a bound was reached and the summary is not the whole story |
+| `omitted_entries` | summary rows dropped by the entry cap (**the counts still include them**) |
+| `omitted_attrs` | changed attributes dropped by the per-row cap, across all rows |
+
+`unparseable` is the one that changes an answer. Without it a truncated
+`terraform show -json`, a wrong file, an empty `{}` and a genuinely clean plan
+all leave the agent as `added: 0, changed: 0, destroyed: 0, drifted: false` —
+byte-identical bodies — so "we checked and it was clean" and "we never finished
+checking" were the same report, and TSM auto-resolved the live drift record on
+either. Gate on `driftDetected` by all means, but treat `unparseable` as a
+failure of the check rather than as a clean result.
+
 Module provenance: `includeModuleProvenance` (default `true`) adds the
 configuration's module calls and locked module versions — read from
 `moduleManifest` (default `.terraform/modules/modules.json`) — to the report and


### PR DESCRIPTION
## What

`TerraformDriftReportV1` assembled its callback body as a
`Record<string, unknown>` by naming the contract's fields one at a time. Both
halves of that were the bug: a pick list can only describe the contract as of the
day it was written, and the destination type accepts anything, so `tsc` could not
report that `summarize()` had begun returning fields the body did not carry. The
omission was invisible to the entire toolchain.

`@4cloudguru/terraform-drift-contract` **1.2.0** added five markers describing
what a check did **not** do, and this task forwarded none of them — neither in
the POST nor in the `writeSecretFile`'d summary artifact, which is the same
object.

| Field | Meaning |
| --- | --- |
| `unparseable` | the document did not have the shape of a plan — nothing was actually checked |
| `unmasked` | a change carried no sensitivity metadata, so nothing was redacted for it |
| `truncated` | a bound was reached and the summary is not the whole story |
| `omitted_entries` | summary rows dropped by the entry cap (the counts still include them) |
| `omitted_attrs` | changed attributes dropped by the per-row cap, across all rows |

## Why it matters

`unparseable` is the one that changes an answer. A truncated `terraform show
-json`, a wrong file and an empty `{}` all summarize to `added: 0, changed: 0,
destroyed: 0, drifted: false` — **byte-identical** to a verified-clean plan. TSM
received those bodies and **auto-resolved the live drift record** on them, so a
plan this task could not read closed a real finding.

The server half of that fail-open was closed in
`terraform-state-manager-backend#382`. This is the producer half.

## How

Fixed as the class, not as five keys.

- `CallbackBody extends Result` replaces `Record<string, unknown>` — the
  contract's own type **is** the field list, and every field of it is required.
- The body is a **spread** of the `summarize()` result rather than a pick list.

A field the contract adds next is forwarded by construction, and dropping one is
a compile error rather than a silent omission.

## The wire names are not this task's to choose

They are the contract's field names unchanged, which is exactly what the backend
decodes — `completeness` in `internal/api/drift_records.go`, embedded in both
`driftRunResultPayload` and `driftIngestPayload`:

```go
type completeness struct {
	Truncated      bool `json:"truncated"`
	OmittedEntries int  `json:"omitted_entries"`
	OmittedAttrs   int  `json:"omitted_attrs"`
	Unparseable    bool `json:"unparseable"`
	Unmasked       bool `json:"unmasked"`
}
```

TSM's own generated jq templates already post the same five keys
(`drift_workflows.go:179` and `:335`), and
`TestDriftCallbackPayload_EveryGeneratedKeyIsDecoded` asserts the generated keys
against that DTO. So there was an existing on-the-wire contract to conform to,
not one to invent.

The callback deliberately does **not** use `DisallowUnknownFields` — its token is
one-shot, so a rejected body would strand the run permanently. The price of that
leniency is that a wrong or missing name is dropped in silence rather than
reported, which is exactly how this went unnoticed. A test therefore asserts the
names rather than assuming them.

> Note for anyone reading the issue: #950's "check the receiver" caveat is now
> **stale**. The backend persists all five on `drift_records` (migration
> `000029`), answers `422` for a raw plan it cannot parse, and returns `200` with
> `status: "unverified"` for a sender-reported `unparseable`. Verified against
> `main`, not assumed.

## Dependency

`^1.1.0` already resolved 1.2.0, so **only the lockfile strictly needed
refreshing**. The range moves to `^1.2.0` because the code now *requires* those
fields and a range still admitting 1.1.1 misstates that. #950 also notes 1.2.0
was unpublished — it is on npm now (`dist-tags.latest = 1.2.0`, SLSA
provenance), so the blocker is gone.

The bump widened `Result`, which is why `SecureTempL0`'s `emptyResult` literal
gains the five fields — spelled out rather than cast, so the next such addition
is a compile error there too.

No `task.json` edit: per-task Minor bumps are auto-applied on the Release PR.

## Mutation proofs (run, not asserted)

Each inversion was applied to a pristine tree and the suite re-run. The total
stayed at **86** in every runtime case, so no unrelated row reddened.

| Inversion | Compile | Result |
| --- | --- | --- |
| the defect verbatim: `Record<string, unknown>` + pick list | **clean**, exactly as it shipped | all **9** marker rows red |
| the pick list against the declared `CallbackBody` | **TS2739**, names all five missing properties | no build at all |
| `unparseable` pinned to `false` (the live fail-open, re-armed) | clean | exactly **1** row red |
| `unparseable` pinned to `true` | clean | **2** red — caught *only* by the positive-control rows |
| one marker deleted after the spread | clean | **4** red — the class guard fires |

The fourth row is the point of the **positive control**: a test asserting "the
marker is forwarded" passes while the value is hardcoded. Every marker is
asserted in **both** directions — a broken document *and* a clean one — so a
constant satisfies one direction and the pair refuses it.

## Tests

`Tests/DriftReportCompletenessMarkers.ts` drives the real `src/index.js` over a
table of six plan documents (selected by `TDR_MARKER_CASE`) and **captures the
bytes the task would POST**, so assertions run against the wire body and the
on-agent artifact rather than one standing in for the other. One of its nine L0
cases re-derives the expectation from the resolved contract package, so a future
`Result` widening reddens here — in the producer — instead of arriving at TSM as
a silent omission.

## Verification

- `npm run compile:all`, `npx eslint src/ Tests/` clean
- `npm run test:coverage` — **86 passing** (was 77); per-file coverage floor met
- `check-versions`, `check-shared-modules`, `check-enforced-disciplines`,
  `check-docs-claims`, `check-task-list`, `check-near-duplicate-modules`,
  `check-egress-authorization`, `check-proxy-parity`, `check-artifact-trust` —
  all pass

## Related

Same defect class, fixed independently in the GitHub Action sibling:
`sethbacon/terraform-drift-report#56`. Separate PR, separate base — not stacked.

Closes #950
