### PR TITLE
refactor: consume the ADO HTTP client from pipeline-task-ado

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@4cloudguru/pipeline-task-ado": "^0.2.0",
         "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
@@ -28,6 +29,44 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@4cloudguru/pipeline-task-ado": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.2.0.tgz",
+      "integrity": "sha512-0kzKRxrfLyW/QT9k2woJ1Ly4NMv/dkPjm2fDXACCEPz/7js/yA/7PHLGdH6mGYw6bSAjPKrYwRM88yZLesIGKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@4cloudguru/pipeline-task-core": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "azure-pipelines-task-lib": ">=4",
+        "undici": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@4cloudguru/pipeline-task-ado/node_modules/@4cloudguru/pipeline-task-core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
+      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "openpgp": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "openpgp": {
+          "optional": true
+        }
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
@@ -19,6 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
+    "@4cloudguru/pipeline-task-ado": "^0.2.0",
     "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts
@@ -4,19 +4,18 @@
 // byte-identical, so a change here MUST be applied to ALL THREE copies. Each
 // task bundles independently, so the duplication is deliberate — not drift.
 //
-// The client itself now comes from @4cloudguru/pipeline-task-core, which took
-// the UNION of this file and azure-pipelines-packer's copy: this side
-// contributed the response-size cap, 429/Retry-After handling and the GitHub
-// asset-redirect exception, packer's contributed the retry-safe download
-// attempt. What remains here is only what the package refuses to own — it
-// imports neither azure-pipelines-task-lib nor undici, so proxy dispatch,
-// secret masking, localized message text and the redirect policy are injected
-// from the task.
+// The transport comes from @4cloudguru/pipeline-task-core and the Azure DevOps
+// wiring around it — proxy dispatch, secret registration, the debug channel —
+// from @4cloudguru/pipeline-task-ado. What remains here is only what neither
+// package can know: this task's localized message text and its redirect policy.
+//
+// This file stays a module rather than folding into its callers because it is
+// also the TEST SEAM: the L0 suites mock './http-client' to stub the network
+// while the real egress/verification guards keep resolving from -core and stay
+// live. Mocking a package specifier instead would blank those guards too.
 import tasks = require('azure-pipelines-task-lib/task');
-import { ProxyAgent } from 'undici';
+import { createAdoHttpClient } from '@4cloudguru/pipeline-task-ado';
 import {
-    createHttpClient,
-    resolveProxy,
     anyRedirectPolicy,
     sameHostOnly,
     githubAssetRedirects,
@@ -31,34 +30,15 @@ export const METADATA_TIMEOUT_MS = CORE_METADATA_TIMEOUT_MS;
 export const DOWNLOAD_TIMEOUT_MS = CORE_DOWNLOAD_TIMEOUT_MS;
 export const parseRetryAfterMs = coreParseRetryAfterMs;
 
-function buildFetchOptions(): RequestInit {
-    const resolved = resolveProxy(tasks.getHttpProxyConfiguration());
-    if (!resolved) return {};
-
-    // Every spelling of the credential the resolver found, including the
-    // percent-encoded form the dispatcher URL actually embeds and any userinfo
-    // already inside Agent.ProxyUrl: the agent's masker matches registered
-    // literals, never derivations of them.
-    for (const secret of resolved.secrets) {
-        tasks.setSecret(secret);
-    }
-
-    return {
-        // @ts-expect-error Node.js fetch accepts undici dispatcher
-        dispatcher: new ProxyAgent(resolved.proxyUrl)
-    };
-}
-
-const injected = {
-    // Re-evaluated per attempt, so a proxy change between retries is picked up.
-    fetchOptions: buildFetchOptions,
-    debug: (message: string) => tasks.debug(message),
-    // These installers download release assets from github.com (OpenTofu, OPA,
-    // terraform-docs), which 302 onto GitHub's own *.githubusercontent.com CDN.
-    // The package makes that exception opt-in; this repo has always applied it
-    // to every caller, so it stays enabled here to preserve behaviour exactly.
-    redirectPolicy: anyRedirectPolicy(sameHostOnly, githubAssetRedirects),
-};
+// These installers download release assets from github.com (OpenTofu, OPA,
+// terraform-docs), which 302 onto GitHub's own *.githubusercontent.com CDN.
+// The package makes that exception opt-in; passing it preserves behaviour.
+//
+// Narrowing it to only the GitHub-bound callers is NOT a matter of dropping it
+// from one site: the policy is per-client, and this same client also serves
+// releases.hashicorp.com, so narrowing means splitting the GitHub downloads
+// onto a client of their own. Deliberately left as separate work.
+const redirectPolicy = anyRedirectPolicy(sameHostOnly, githubAssetRedirects);
 
 const insecureUrl = (url: string) => tasks.loc("InsecureUrlRejected", url);
 
@@ -66,8 +46,8 @@ const insecureUrl = (url: string) => tasks.loc("InsecureUrlRejected", url);
 // construction it is reporting; two bare module-level calls are indistinguishable
 // to it, and an unnamed site is the one thing that gate exists to avoid.
 function createDefaultClient() {
-    return createHttpClient({
-        ...injected,
+    return createAdoHttpClient({
+        redirectPolicy,
         messages: { insecureUrl, requestFailed: (url, status) => `Failed to fetch ${url}: HTTP ${status}` },
     });
 }
@@ -75,8 +55,8 @@ function createDefaultClient() {
 // Registry metadata keeps its own localized message: "Registry request failed"
 // is wrong on a releases.hashicorp.com SHA256SUMS fetch, which is not one.
 function createRegistryClient() {
-    return createHttpClient({
-        ...injected,
+    return createAdoHttpClient({
+        redirectPolicy,
         messages: { insecureUrl, requestFailed: (url, status) => tasks.loc("RegistryRequestFailed", url, status) },
     });
 }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@4cloudguru/pipeline-task-ado": "^0.2.0",
         "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
@@ -26,6 +27,44 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@4cloudguru/pipeline-task-ado": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.2.0.tgz",
+      "integrity": "sha512-0kzKRxrfLyW/QT9k2woJ1Ly4NMv/dkPjm2fDXACCEPz/7js/yA/7PHLGdH6mGYw6bSAjPKrYwRM88yZLesIGKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@4cloudguru/pipeline-task-core": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "azure-pipelines-task-lib": ">=4",
+        "undici": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@4cloudguru/pipeline-task-ado/node_modules/@4cloudguru/pipeline-task-core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
+      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "openpgp": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "openpgp": {
+          "optional": true
+        }
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
@@ -19,6 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
+    "@4cloudguru/pipeline-task-ado": "^0.2.0",
     "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts
@@ -4,19 +4,18 @@
 // byte-identical, so a change here MUST be applied to ALL THREE copies. Each
 // task bundles independently, so the duplication is deliberate — not drift.
 //
-// The client itself now comes from @4cloudguru/pipeline-task-core, which took
-// the UNION of this file and azure-pipelines-packer's copy: this side
-// contributed the response-size cap, 429/Retry-After handling and the GitHub
-// asset-redirect exception, packer's contributed the retry-safe download
-// attempt. What remains here is only what the package refuses to own — it
-// imports neither azure-pipelines-task-lib nor undici, so proxy dispatch,
-// secret masking, localized message text and the redirect policy are injected
-// from the task.
+// The transport comes from @4cloudguru/pipeline-task-core and the Azure DevOps
+// wiring around it — proxy dispatch, secret registration, the debug channel —
+// from @4cloudguru/pipeline-task-ado. What remains here is only what neither
+// package can know: this task's localized message text and its redirect policy.
+//
+// This file stays a module rather than folding into its callers because it is
+// also the TEST SEAM: the L0 suites mock './http-client' to stub the network
+// while the real egress/verification guards keep resolving from -core and stay
+// live. Mocking a package specifier instead would blank those guards too.
 import tasks = require('azure-pipelines-task-lib/task');
-import { ProxyAgent } from 'undici';
+import { createAdoHttpClient } from '@4cloudguru/pipeline-task-ado';
 import {
-    createHttpClient,
-    resolveProxy,
     anyRedirectPolicy,
     sameHostOnly,
     githubAssetRedirects,
@@ -31,34 +30,15 @@ export const METADATA_TIMEOUT_MS = CORE_METADATA_TIMEOUT_MS;
 export const DOWNLOAD_TIMEOUT_MS = CORE_DOWNLOAD_TIMEOUT_MS;
 export const parseRetryAfterMs = coreParseRetryAfterMs;
 
-function buildFetchOptions(): RequestInit {
-    const resolved = resolveProxy(tasks.getHttpProxyConfiguration());
-    if (!resolved) return {};
-
-    // Every spelling of the credential the resolver found, including the
-    // percent-encoded form the dispatcher URL actually embeds and any userinfo
-    // already inside Agent.ProxyUrl: the agent's masker matches registered
-    // literals, never derivations of them.
-    for (const secret of resolved.secrets) {
-        tasks.setSecret(secret);
-    }
-
-    return {
-        // @ts-expect-error Node.js fetch accepts undici dispatcher
-        dispatcher: new ProxyAgent(resolved.proxyUrl)
-    };
-}
-
-const injected = {
-    // Re-evaluated per attempt, so a proxy change between retries is picked up.
-    fetchOptions: buildFetchOptions,
-    debug: (message: string) => tasks.debug(message),
-    // These installers download release assets from github.com (OpenTofu, OPA,
-    // terraform-docs), which 302 onto GitHub's own *.githubusercontent.com CDN.
-    // The package makes that exception opt-in; this repo has always applied it
-    // to every caller, so it stays enabled here to preserve behaviour exactly.
-    redirectPolicy: anyRedirectPolicy(sameHostOnly, githubAssetRedirects),
-};
+// These installers download release assets from github.com (OpenTofu, OPA,
+// terraform-docs), which 302 onto GitHub's own *.githubusercontent.com CDN.
+// The package makes that exception opt-in; passing it preserves behaviour.
+//
+// Narrowing it to only the GitHub-bound callers is NOT a matter of dropping it
+// from one site: the policy is per-client, and this same client also serves
+// releases.hashicorp.com, so narrowing means splitting the GitHub downloads
+// onto a client of their own. Deliberately left as separate work.
+const redirectPolicy = anyRedirectPolicy(sameHostOnly, githubAssetRedirects);
 
 const insecureUrl = (url: string) => tasks.loc("InsecureUrlRejected", url);
 
@@ -66,8 +46,8 @@ const insecureUrl = (url: string) => tasks.loc("InsecureUrlRejected", url);
 // construction it is reporting; two bare module-level calls are indistinguishable
 // to it, and an unnamed site is the one thing that gate exists to avoid.
 function createDefaultClient() {
-    return createHttpClient({
-        ...injected,
+    return createAdoHttpClient({
+        redirectPolicy,
         messages: { insecureUrl, requestFailed: (url, status) => `Failed to fetch ${url}: HTTP ${status}` },
     });
 }
@@ -75,8 +55,8 @@ function createDefaultClient() {
 // Registry metadata keeps its own localized message: "Registry request failed"
 // is wrong on a releases.hashicorp.com SHA256SUMS fetch, which is not one.
 function createRegistryClient() {
-    return createHttpClient({
-        ...injected,
+    return createAdoHttpClient({
+        redirectPolicy,
         messages: { insecureUrl, requestFailed: (url, status) => tasks.loc("RegistryRequestFailed", url, status) },
     });
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@4cloudguru/pipeline-task-ado": "^0.2.0",
         "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
@@ -28,6 +29,44 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@4cloudguru/pipeline-task-ado": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.2.0.tgz",
+      "integrity": "sha512-0kzKRxrfLyW/QT9k2woJ1Ly4NMv/dkPjm2fDXACCEPz/7js/yA/7PHLGdH6mGYw6bSAjPKrYwRM88yZLesIGKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@4cloudguru/pipeline-task-core": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "azure-pipelines-task-lib": ">=4",
+        "undici": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@4cloudguru/pipeline-task-ado/node_modules/@4cloudguru/pipeline-task-core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
+      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "openpgp": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "openpgp": {
+          "optional": true
+        }
       }
     },
     "node_modules/@4cloudguru/pipeline-task-core": {

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -19,6 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
+    "@4cloudguru/pipeline-task-ado": "^0.2.0",
     "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts
@@ -4,19 +4,18 @@
 // byte-identical, so a change here MUST be applied to ALL THREE copies. Each
 // task bundles independently, so the duplication is deliberate — not drift.
 //
-// The client itself now comes from @4cloudguru/pipeline-task-core, which took
-// the UNION of this file and azure-pipelines-packer's copy: this side
-// contributed the response-size cap, 429/Retry-After handling and the GitHub
-// asset-redirect exception, packer's contributed the retry-safe download
-// attempt. What remains here is only what the package refuses to own — it
-// imports neither azure-pipelines-task-lib nor undici, so proxy dispatch,
-// secret masking, localized message text and the redirect policy are injected
-// from the task.
+// The transport comes from @4cloudguru/pipeline-task-core and the Azure DevOps
+// wiring around it — proxy dispatch, secret registration, the debug channel —
+// from @4cloudguru/pipeline-task-ado. What remains here is only what neither
+// package can know: this task's localized message text and its redirect policy.
+//
+// This file stays a module rather than folding into its callers because it is
+// also the TEST SEAM: the L0 suites mock './http-client' to stub the network
+// while the real egress/verification guards keep resolving from -core and stay
+// live. Mocking a package specifier instead would blank those guards too.
 import tasks = require('azure-pipelines-task-lib/task');
-import { ProxyAgent } from 'undici';
+import { createAdoHttpClient } from '@4cloudguru/pipeline-task-ado';
 import {
-    createHttpClient,
-    resolveProxy,
     anyRedirectPolicy,
     sameHostOnly,
     githubAssetRedirects,
@@ -31,34 +30,15 @@ export const METADATA_TIMEOUT_MS = CORE_METADATA_TIMEOUT_MS;
 export const DOWNLOAD_TIMEOUT_MS = CORE_DOWNLOAD_TIMEOUT_MS;
 export const parseRetryAfterMs = coreParseRetryAfterMs;
 
-function buildFetchOptions(): RequestInit {
-    const resolved = resolveProxy(tasks.getHttpProxyConfiguration());
-    if (!resolved) return {};
-
-    // Every spelling of the credential the resolver found, including the
-    // percent-encoded form the dispatcher URL actually embeds and any userinfo
-    // already inside Agent.ProxyUrl: the agent's masker matches registered
-    // literals, never derivations of them.
-    for (const secret of resolved.secrets) {
-        tasks.setSecret(secret);
-    }
-
-    return {
-        // @ts-expect-error Node.js fetch accepts undici dispatcher
-        dispatcher: new ProxyAgent(resolved.proxyUrl)
-    };
-}
-
-const injected = {
-    // Re-evaluated per attempt, so a proxy change between retries is picked up.
-    fetchOptions: buildFetchOptions,
-    debug: (message: string) => tasks.debug(message),
-    // These installers download release assets from github.com (OpenTofu, OPA,
-    // terraform-docs), which 302 onto GitHub's own *.githubusercontent.com CDN.
-    // The package makes that exception opt-in; this repo has always applied it
-    // to every caller, so it stays enabled here to preserve behaviour exactly.
-    redirectPolicy: anyRedirectPolicy(sameHostOnly, githubAssetRedirects),
-};
+// These installers download release assets from github.com (OpenTofu, OPA,
+// terraform-docs), which 302 onto GitHub's own *.githubusercontent.com CDN.
+// The package makes that exception opt-in; passing it preserves behaviour.
+//
+// Narrowing it to only the GitHub-bound callers is NOT a matter of dropping it
+// from one site: the policy is per-client, and this same client also serves
+// releases.hashicorp.com, so narrowing means splitting the GitHub downloads
+// onto a client of their own. Deliberately left as separate work.
+const redirectPolicy = anyRedirectPolicy(sameHostOnly, githubAssetRedirects);
 
 const insecureUrl = (url: string) => tasks.loc("InsecureUrlRejected", url);
 
@@ -66,8 +46,8 @@ const insecureUrl = (url: string) => tasks.loc("InsecureUrlRejected", url);
 // construction it is reporting; two bare module-level calls are indistinguishable
 // to it, and an unnamed site is the one thing that gate exists to avoid.
 function createDefaultClient() {
-    return createHttpClient({
-        ...injected,
+    return createAdoHttpClient({
+        redirectPolicy,
         messages: { insecureUrl, requestFailed: (url, status) => `Failed to fetch ${url}: HTTP ${status}` },
     });
 }
@@ -75,8 +55,8 @@ function createDefaultClient() {
 // Registry metadata keeps its own localized message: "Registry request failed"
 // is wrong on a releases.hashicorp.com SHA256SUMS fetch, which is not one.
 function createRegistryClient() {
-    return createHttpClient({
-        ...injected,
+    return createAdoHttpClient({
+        redirectPolicy,
         messages: { insecureUrl, requestFailed: (url, status) => tasks.loc("RegistryRequestFailed", url, status) },
     });
 }

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
@@ -58,19 +58,21 @@ interface SourceSite {
  * M3: the WHATWG URL setter percent-encodes the password, so the string the
  * dispatcher URL embeds is byte-different from the raw proxyPassword — the
  * agent's masker matches registered literals, never derivations of them.
- * Assembling that URL now happens in pipeline-task-core's resolveProxy(), which
- * cannot call setSecret itself (the package does not import the task lib), so
- * it returns every spelling it produced and registering them stays the caller's
- * obligation. That makes this row MORE load-bearing than when the encoding was
- * inline: the guard is the only thing tying the returned secrets to a setSecret
- * call before the URL reaches ProxyAgent. All three http-client.ts copies are
- * byte-identical (gated by scripts/check-shared-modules.js), so all three carry
- * the same row.
+ *
+ * This class NO LONGER HAS A SOURCE ROW IN THIS REPO. Assembling the proxy URL,
+ * registering every spelling it produced, and building the dispatcher all moved
+ * into @4cloudguru/pipeline-task-ado's buildAdoFetchOptions, so the regexes that
+ * used to pin the ordering here now match nothing — and a source assertion that
+ * cannot fail is worse than no assertion, because it reads as coverage.
+ *
+ * What is still checkable from here is PROVENANCE: that each installer depends
+ * on a version of the package known to contain the wiring AND the test that
+ * asserts its ordering (both events share one log there, and the assertion is
+ * that no dispatcher is constructed before the last setSecret). The floor below
+ * is that check. See ADO_PACKAGE_FLOOR.
  */
-const PROXY_ENCODED_GUARD = /for \(const secret of resolved\.secrets\) \{\s*\n\s*tasks\.setSecret\(secret\);\s*\n\s*\}[\s\S]{0,400}?new ProxyAgent\(resolved\.proxyUrl\)/;
-// Tempered so it can only match when NO registration intervenes: in the correct
-// shape the setSecret loop sits between the two, and the match cannot span it.
-const PROXY_ENCODED_DEFECT = /resolveProxy\((?:(?!tasks\.setSecret)[\s\S]){0,800}?new ProxyAgent\(/;
+const ADO_PACKAGE = '@4cloudguru/pipeline-task-ado';
+const ADO_PACKAGE_FLOOR = '0.2.0';
 
 /**
  * M5: the registry-supplied pre-signed download_url carries a live signing token
@@ -81,27 +83,6 @@ const PRESIGNED_GUARD = /const urlTokenSecrets = extractUrlTokenSecrets\(data\.d
 const PRESIGNED_DEFECT = /tasks\.loc\("InsecureUrlRejected", data\.download_url\)/;
 
 const SOURCE_SITES: SourceSite[] = [
-    {
-        mechanism: 'M3',
-        site: 'TerraformInstallerV1/src/http-client.ts:buildFetchOptions',
-        file: path.join(TF_INSTALLER, 'http-client.ts'),
-        guard: PROXY_ENCODED_GUARD,
-        defect: PROXY_ENCODED_DEFECT,
-    },
-    {
-        mechanism: 'M3',
-        site: 'PolicyAgentInstallerV1/src/http-client.ts:buildFetchOptions',
-        file: path.join(POLICY_INSTALLER, 'http-client.ts'),
-        guard: PROXY_ENCODED_GUARD,
-        defect: PROXY_ENCODED_DEFECT,
-    },
-    {
-        mechanism: 'M3',
-        site: 'TerraformDocsInstallerV1/src/http-client.ts:buildFetchOptions',
-        file: path.join(DOCS_INSTALLER, 'http-client.ts'),
-        guard: PROXY_ENCODED_GUARD,
-        defect: PROXY_ENCODED_DEFECT,
-    },
     {
         mechanism: 'M5',
         site: 'TerraformInstallerV1/src/terraform-installer.ts:downloadZipFromRegistry (pre-signed download_url)',
@@ -163,6 +144,38 @@ describe('Pre-mask defect class — credential emitted before it was registered 
                     !row.defect.test(source),
                     `pre-fix defect shape is back at ${row.site}: ${row.defect}`,
                 );
+            });
+        }
+    });
+
+    // M3's source rows are gone: the proxy URL assembly and the secret
+    // registration that must precede it now live in pipeline-task-ado. Deleting
+    // them without this would quietly retire the class from this repo, so what
+    // replaces them is the one thing still checkable here — that every installer
+    // consuming that wiring pins a version known to contain it, and the test
+    // that asserts its ordering.
+    describe('M3 — delegated to pipeline-task-ado, checked by version floor', () => {
+        const installers: ReadonlyArray<readonly [string, string]> = [
+            ['TerraformInstallerV1', path.join(TF_INSTALLER, '..', 'package.json')],
+            ['PolicyAgentInstallerV1', path.join(POLICY_INSTALLER, '..', 'package.json')],
+            ['TerraformDocsInstallerV1', path.join(DOCS_INSTALLER, '..', 'package.json')],
+        ];
+
+        for (const [name, manifest] of installers) {
+            it(`${name} pins ${ADO_PACKAGE} >= ${ADO_PACKAGE_FLOOR}`, () => {
+                const json = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+                const range: string | undefined = (json.dependencies || {})[ADO_PACKAGE];
+                assert.ok(range, `${name} does not depend on ${ADO_PACKAGE}, so the proxy masking wiring has no declared source`);
+
+                // Only a caret or exact range pins a floor that can be reasoned
+                // about; `*` or a git URL cannot be shown to include the fix.
+                const parsed = /^\^?(\d+)\.(\d+)\.(\d+)/.exec(range.trim());
+                assert.ok(parsed, `${name} pins ${ADO_PACKAGE} as ${range}, which cannot be shown to include the masking fix`);
+
+                const actual = parsed.slice(1, 4).map(Number);
+                const floor = ADO_PACKAGE_FLOOR.split('.').map(Number);
+                const ordered = actual[0] - floor[0] || actual[1] - floor[1] || actual[2] - floor[2];
+                assert.ok(ordered >= 0, `${name} pins ${ADO_PACKAGE}@${range}, below the ${ADO_PACKAGE_FLOOR} floor that carries the pre-mask ordering`);
             });
         }
     });

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/ProxyParityL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/ProxyParityL0.ts
@@ -95,32 +95,32 @@ const SITE_ROWS: SiteRow[] = [
     },
     {
         file: 'Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts',
-        fn: 'createDefaultClient', sink: 'createHttpClient', verdict: 'PROXIED',
-        why: 'installer transport, now delegated to pipeline-task-core: the package cannot read the agent proxy itself, so this must inject fetchOptions from buildFetchOptions()',
+        fn: 'createDefaultClient', sink: 'createAdoHttpClient', verdict: 'PROXIED-BY-PACKAGE',
+        why: 'installer transport; the proxy decision itself now lives in pipeline-task-ado, so there is no fetchOptions here to inspect and the site is held to a version floor instead',
     },
     {
         file: 'Tasks/TerraformInstaller/TerraformInstallerV1/src/http-client.ts',
-        fn: 'createRegistryClient', sink: 'createHttpClient', verdict: 'PROXIED',
-        why: 'the same transport with the registry-specific failure message; a second construction is a second place the injection could be dropped',
+        fn: 'createRegistryClient', sink: 'createAdoHttpClient', verdict: 'PROXIED-BY-PACKAGE',
+        why: 'the same transport with the registry-specific failure message; a second construction is a second site the floor has to cover',
     },
     {
         file: 'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts',
-        fn: 'createDefaultClient', sink: 'createHttpClient', verdict: 'PROXIED',
+        fn: 'createDefaultClient', sink: 'createAdoHttpClient', verdict: 'PROXIED-BY-PACKAGE',
         why: 'byte-identical copy of the installer transport',
     },
     {
         file: 'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/http-client.ts',
-        fn: 'createRegistryClient', sink: 'createHttpClient', verdict: 'PROXIED',
+        fn: 'createRegistryClient', sink: 'createAdoHttpClient', verdict: 'PROXIED-BY-PACKAGE',
         why: 'byte-identical copy of the installer transport',
     },
     {
         file: 'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts',
-        fn: 'createDefaultClient', sink: 'createHttpClient', verdict: 'PROXIED',
+        fn: 'createDefaultClient', sink: 'createAdoHttpClient', verdict: 'PROXIED-BY-PACKAGE',
         why: 'byte-identical copy of the installer transport',
     },
     {
         file: 'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/http-client.ts',
-        fn: 'createRegistryClient', sink: 'createHttpClient', verdict: 'PROXIED',
+        fn: 'createRegistryClient', sink: 'createAdoHttpClient', verdict: 'PROXIED-BY-PACKAGE',
         why: 'byte-identical copy of the installer transport',
     },
     // --- node:https, proxied via the CONNECT-tunnelling ProxyTunnelAgent ---

--- a/scripts/check-proxy-parity.js
+++ b/scripts/check-proxy-parity.js
@@ -73,8 +73,66 @@ const NODE_HTTP_SINKS = ['https.request', 'https.get', 'http.request', 'http.get
  */
 const DELEGATED_FETCH_SINKS = ['createHttpClient'];
 
+/**
+ * Factories where the proxy DECISION itself has left this repo, not just the
+ * fetch() call: @4cloudguru/pipeline-task-ado reads the agent proxy, registers
+ * every spelling of the credential and builds the dispatcher internally, so
+ * there is no fetchOptions here to inspect and the shape check above cannot
+ * apply.
+ *
+ * A site that cannot be shape-checked must still be checked, or it silently
+ * leaves the inventory and the gate passes by seeing nothing — the exact
+ * failure this file exists to prevent, and one this repo has now hit twice
+ * (#949, and again on the move to the ado package). What is verifiable here is
+ * PROVENANCE: that the task depends on a version of the package known to carry
+ * the wiring and the tests that assert its ordering. So the assertion becomes a
+ * version floor, and the site stays in the report either way.
+ */
+const PACKAGE_DELEGATED_SINKS = {
+    createAdoHttpClient: { pkg: '@4cloudguru/pipeline-task-ado', min: '0.2.0' },
+};
+
 /** Proxy-aware by construction inside azure-pipelines-tool-lib (see header). */
 const TOOL_LIB_SINKS = ['downloadTool'];
+
+/** The package.json of the task that owns `file`, or null above the task roots. */
+function declaredDependency(file, pkg) {
+    let dir = path.dirname(path.resolve(file));
+    const stop = path.resolve(__dirname, '..');
+    while (dir.startsWith(stop)) {
+        const manifest = path.join(dir, 'package.json');
+        if (fs.existsSync(manifest)) {
+            try {
+                const json = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+                const range = (json.dependencies || {})[pkg];
+                if (range) return range;
+            } catch {
+                return null;
+            }
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+    return null;
+}
+
+/**
+ * Deliberately narrow: only a caret or exact range pins a floor this gate can
+ * reason about. `*`, `latest` or a git URL cannot be shown to include the fix,
+ * so they are treated as NOT satisfying it rather than waved through.
+ */
+function satisfiesFloor(range, min) {
+    const parsed = /^\^?(\d+)\.(\d+)\.(\d+)/.exec(String(range).trim());
+    if (!parsed) return false;
+    const floor = min.split('.').map(Number);
+    const actual = parsed.slice(1).map(Number);
+    for (let i = 0; i < 3; i += 1) {
+        if (actual[i] > floor[i]) return true;
+        if (actual[i] < floor[i]) return false;
+    }
+    return true;
+}
 
 function walk(dir, out = []) {
     let entries;
@@ -312,6 +370,19 @@ for (const file of files) {
         }
     }
 
+    for (const [sink, { pkg, min }] of Object.entries(PACKAGE_DELEGATED_SINKS)) {
+        const re = new RegExp(`(?<![.\\w$])${sink}\\s*\\(`, 'g');
+        let m;
+        while ((m = re.exec(masked)) !== null) {
+            const declared = declaredDependency(file, pkg);
+            const ok = declared !== null && satisfiesFloor(declared, min);
+            record(m.index, sink, ok ? 'PROXIED-BY-PACKAGE' : 'UNPROXIED',
+                ok
+                    ? `proxy dispatch and secret registration come from ${pkg}@${declared} (floor ${min})`
+                    : `delegates the proxy decision to ${pkg}, but the owning task declares ${declared ?? 'no dependency on it'} (floor ${min})`);
+        }
+    }
+
     for (const sink of NODE_HTTP_SINKS) {
         const re = new RegExp(`(?<![\\w$])${sink.replace('.', '\\.')}\\s*\\(`, 'g');
         let m;
@@ -350,7 +421,7 @@ if (JSON_OUTPUT) {
     process.exit(failures ? 1 : 0);
 }
 
-const order = ['UNPROXIED', 'PROXIED', 'EXEMPT-TOOL-LIB', 'EXEMPT-PROXY-TRANSPORT', 'EXEMPT-BROWSER'];
+const order = ['UNPROXIED', 'PROXIED', 'PROXIED-BY-PACKAGE', 'EXEMPT-TOOL-LIB', 'EXEMPT-PROXY-TRANSPORT', 'EXEMPT-BROWSER'];
 for (const verdict of order) {
     const group = sites.filter((s) => s.verdict === verdict);
     if (!group.length) continue;


### PR DESCRIPTION
refactor: consume the ADO HTTP client from pipeline-task-ado

Moves the proxy dispatch and secret registration out of the three
byte-identical http-client.ts copies and into
@4cloudguru/pipeline-task-ado's createAdoHttpClient. buildFetchOptions,
the undici ProxyAgent import and resolveProxy are gone from this repo:
the wiring now has one source, shared with azure-pipelines-packer.

What stays here is what neither package can know -- this task's
localized message text and its redirect policy -- and the file stays a
module rather than folding into its callers because it is also the TEST
SEAM: 112 L0 scenarios mock './http-client' to stub the network while
the real egress and verification guards keep resolving from -core and
stay live. Mocking a package specifier instead would blank those guards
too, turning the SSRF and redaction tests green without checking
anything.

The GitHub release-asset redirect exception is passed explicitly, so
behaviour is unchanged. Narrowing it is NOT available as a parameter
change: the policy is per-client and the same client serves both
github.com and releases.hashicorp.com, so narrowing means splitting the
GitHub downloads onto a client of their own. Recorded at the call site
rather than done by omission.

TWO GATES CHANGED KIND, because the thing they checked has left the repo.

check-proxy-parity went blind the moment the code moved -- 20 sites down
to 14, exit 0, asserting nothing. That is the third time this has
happened in this migration (#949, the ado move, and here), and it is why
the rule could not simply gain another sink name: createAdoHttpClient
takes no fetchOptions, because the proxy DECISION now lives in the
package, not just the fetch() call. So the check became provenance
rather than shape. PROXIED-BY-PACKAGE requires the owning task to
declare the package at >= 0.2.0 -- the version carrying both the wiring
and the test that asserts its ordering. Only a caret or exact range
satisfies it; `*` or a git URL cannot be shown to contain the fix and
fails. Mutation-verified twice: below the floor and dependency removed
both exit 1 naming the affected sites.

PreMaskingClassL0's M3 rows regexed source that no longer exists. They
were not deleted: a source assertion that can never fail is worse than
none, because it reads as coverage. They are replaced by the same
version floor, with the class's ordering property now asserted in the
package's own tests, where both events share one log.

Verified: TerraformTaskV5 796, TerraformInstallerV1 431,
PolicyAgentInstallerV1 264, TerraformDocsInstallerV1 246 -- all
unchanged from baseline. Full scripts/check-*.js sweep green. Per-file
coverage floors met in all three installers, with http-client.js at
100%.
