### PR TITLE
fix: pin pipeline-task-ado 0.3.0 and gate the transitive core version

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-ado": "^0.2.0",
+        "@4cloudguru/pipeline-task-ado": "^0.3.0",
         "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
@@ -32,12 +32,12 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-ado": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.2.0.tgz",
-      "integrity": "sha512-0kzKRxrfLyW/QT9k2woJ1Ly4NMv/dkPjm2fDXACCEPz/7js/yA/7PHLGdH6mGYw6bSAjPKrYwRM88yZLesIGKQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.3.0.tgz",
+      "integrity": "sha512-MCTtlYD6HcVheN70oXCF/eToTKtSOPyOtWEw0QlluilwXRVsfRUaRqAXnsasZuZ6nJ7GR5QVRy7hse2/ybl+NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1"
+        "@4cloudguru/pipeline-task-core": "^0.5.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -48,23 +48,6 @@
       },
       "peerDependenciesMeta": {
         "undici": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@4cloudguru/pipeline-task-ado/node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "openpgp": "^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "openpgp": {
           "optional": true
         }
       }

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-ado": "^0.2.0",
+    "@4cloudguru/pipeline-task-ado": "^0.3.0",
     "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-ado": "^0.2.0",
+        "@4cloudguru/pipeline-task-ado": "^0.3.0",
         "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
@@ -30,12 +30,12 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-ado": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.2.0.tgz",
-      "integrity": "sha512-0kzKRxrfLyW/QT9k2woJ1Ly4NMv/dkPjm2fDXACCEPz/7js/yA/7PHLGdH6mGYw6bSAjPKrYwRM88yZLesIGKQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.3.0.tgz",
+      "integrity": "sha512-MCTtlYD6HcVheN70oXCF/eToTKtSOPyOtWEw0QlluilwXRVsfRUaRqAXnsasZuZ6nJ7GR5QVRy7hse2/ybl+NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1"
+        "@4cloudguru/pipeline-task-core": "^0.5.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -46,23 +46,6 @@
       },
       "peerDependenciesMeta": {
         "undici": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@4cloudguru/pipeline-task-ado/node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "openpgp": "^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "openpgp": {
           "optional": true
         }
       }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-ado": "^0.2.0",
+    "@4cloudguru/pipeline-task-ado": "^0.3.0",
     "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@4cloudguru/pipeline-task-ado": "^0.2.0",
+        "@4cloudguru/pipeline-task-ado": "^0.3.0",
         "@4cloudguru/pipeline-task-core": "^0.5.0",
         "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tool-lib": "^2.0.12",
@@ -32,12 +32,12 @@
       }
     },
     "node_modules/@4cloudguru/pipeline-task-ado": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.2.0.tgz",
-      "integrity": "sha512-0kzKRxrfLyW/QT9k2woJ1Ly4NMv/dkPjm2fDXACCEPz/7js/yA/7PHLGdH6mGYw6bSAjPKrYwRM88yZLesIGKQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-ado/-/pipeline-task-ado-0.3.0.tgz",
+      "integrity": "sha512-MCTtlYD6HcVheN70oXCF/eToTKtSOPyOtWEw0QlluilwXRVsfRUaRqAXnsasZuZ6nJ7GR5QVRy7hse2/ybl+NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@4cloudguru/pipeline-task-core": "^0.3.1"
+        "@4cloudguru/pipeline-task-core": "^0.5.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -48,23 +48,6 @@
       },
       "peerDependenciesMeta": {
         "undici": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@4cloudguru/pipeline-task-ado/node_modules/@4cloudguru/pipeline-task-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/pipeline-task-core/-/pipeline-task-core-0.3.1.tgz",
-      "integrity": "sha512-r1Akg26OQKzQ+/pv3uHfBYdOsztesPYH9sHQZE1j9aIKNkLGL3aYULvjDShyfpx30XQ+Aw5xK/KOpnKbhcY2dw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "openpgp": "^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "openpgp": {
           "optional": true
         }
       }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/package.json
@@ -19,7 +19,7 @@
   },
   "minimumAgentVersion": "2.144.0",
   "dependencies": {
-    "@4cloudguru/pipeline-task-ado": "^0.2.0",
+    "@4cloudguru/pipeline-task-ado": "^0.3.0",
     "@4cloudguru/pipeline-task-core": "^0.5.0",
     "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tool-lib": "^2.0.12",

--- a/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
+++ b/Tasks/TerraformTask/TerraformTaskV5/Tests/PreMaskingClassL0.ts
@@ -72,7 +72,7 @@ interface SourceSite {
  * is that check. See ADO_PACKAGE_FLOOR.
  */
 const ADO_PACKAGE = '@4cloudguru/pipeline-task-ado';
-const ADO_PACKAGE_FLOOR = '0.2.0';
+const ADO_PACKAGE_FLOOR = '0.3.0';
 
 /**
  * M5: the registry-supplied pre-signed download_url carries a live signing token

--- a/scripts/check-proxy-parity.js
+++ b/scripts/check-proxy-parity.js
@@ -89,7 +89,17 @@ const DELEGATED_FETCH_SINKS = ['createHttpClient'];
  * version floor, and the site stays in the report either way.
  */
 const PACKAGE_DELEGATED_SINKS = {
-    createAdoHttpClient: { pkg: '@4cloudguru/pipeline-task-ado', min: '0.2.0' },
+    createAdoHttpClient: {
+        pkg: '@4cloudguru/pipeline-task-ado',
+        min: '0.3.0',
+        // The package delegates onward to core, so the direct floor above only
+        // vouches for the wiring - not for which implementation it wires up.
+        // ado@0.2.0 declared core ^0.3.1 while the tasks declared ^0.5.0, and
+        // caret on a 0.x version is patch-only, so the ranges were disjoint,
+        // npm nested a second copy, and the delegated client ran the older one.
+        // Both floors passed throughout. Hence the resolved check below.
+        carries: { pkg: '@4cloudguru/pipeline-task-core', min: '0.5.0' },
+    },
 };
 
 /** Proxy-aware by construction inside azure-pipelines-tool-lib (see header). */
@@ -132,6 +142,70 @@ function satisfiesFloor(range, min) {
         if (actual[i] < floor[i]) return false;
     }
     return true;
+}
+
+/** The lockfile of the task that owns `file` — what `npm ci` actually installs. */
+function lockfileFor(file) {
+    let dir = path.dirname(path.resolve(file));
+    const stop = path.resolve(__dirname, '..');
+    while (dir.startsWith(stop)) {
+        const lock = path.join(dir, 'package-lock.json');
+        if (fs.existsSync(lock)) return lock;
+        const parent = path.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+    return null;
+}
+
+/**
+ * Every copy of `dep` the owning task installs, top-level or nested. Read from
+ * the lockfile rather than the manifests because two compatible-LOOKING ranges
+ * can still resolve to two different copies, and only the lockfile shows it.
+ * Returns null when there is nothing to read, which the caller fails closed on.
+ */
+function installedCopies(file, dep) {
+    const lock = lockfileFor(file);
+    if (!lock) return null;
+    let json;
+    try {
+        json = JSON.parse(fs.readFileSync(lock, 'utf8'));
+    } catch {
+        return null;
+    }
+    const suffix = `node_modules/${dep}`;
+    return Object.entries(json.packages || {})
+        .filter(([key]) => key === suffix || key.endsWith(`/${suffix}`))
+        .map(([key, value]) => ({ path: key, version: value && value.version }));
+}
+
+/**
+ * Resolves the delegated sink's verdict: the owning task must declare the
+ * delegating package at or above its floor AND, when that package delegates
+ * onward, the onward dependency must resolve to exactly one copy at or above
+ * its own floor.
+ */
+function packageDelegationVerdict(file, { pkg, min, carries }) {
+    const declared = declaredDependency(file, pkg);
+    if (declared === null || !satisfiesFloor(declared, min)) {
+        return { ok: false, why: `delegates the proxy decision to ${pkg}, but the owning task declares ${declared ?? 'no dependency on it'} (floor ${min})` };
+    }
+    if (!carries) {
+        return { ok: true, why: `proxy dispatch and secret registration come from ${pkg}@${declared} (floor ${min})` };
+    }
+
+    const copies = installedCopies(file, carries.pkg);
+    if (copies === null) {
+        return { ok: false, why: `${pkg}@${declared} delegates onward to ${carries.pkg}, but no lockfile was readable to show which copy is installed` };
+    }
+    if (copies.length !== 1) {
+        const seen = copies.map((c) => `${c.version} at ${c.path}`).join(', ') || 'none';
+        return { ok: false, why: `${pkg}@${declared} delegates onward to ${carries.pkg}, which resolves to ${copies.length} copies (${seen}) — the delegated call runs whichever one is nested, not the one this task imports` };
+    }
+    if (!satisfiesFloor(copies[0].version, carries.min)) {
+        return { ok: false, why: `${pkg}@${declared} delegates onward to ${carries.pkg}@${copies[0].version}, below the ${carries.min} floor` };
+    }
+    return { ok: true, why: `proxy dispatch and secret registration come from ${pkg}@${declared} (floor ${min}), resolving a single ${carries.pkg}@${copies[0].version} (floor ${carries.min})` };
 }
 
 function walk(dir, out = []) {
@@ -370,16 +444,12 @@ for (const file of files) {
         }
     }
 
-    for (const [sink, { pkg, min }] of Object.entries(PACKAGE_DELEGATED_SINKS)) {
+    for (const [sink, spec] of Object.entries(PACKAGE_DELEGATED_SINKS)) {
         const re = new RegExp(`(?<![.\\w$])${sink}\\s*\\(`, 'g');
         let m;
         while ((m = re.exec(masked)) !== null) {
-            const declared = declaredDependency(file, pkg);
-            const ok = declared !== null && satisfiesFloor(declared, min);
-            record(m.index, sink, ok ? 'PROXIED-BY-PACKAGE' : 'UNPROXIED',
-                ok
-                    ? `proxy dispatch and secret registration come from ${pkg}@${declared} (floor ${min})`
-                    : `delegates the proxy decision to ${pkg}, but the owning task declares ${declared ?? 'no dependency on it'} (floor ${min})`);
+            const { ok, why } = packageDelegationVerdict(file, spec);
+            record(m.index, sink, ok ? 'PROXIED-BY-PACKAGE' : 'UNPROXIED', why);
         }
     }
 


### PR DESCRIPTION
> [!WARNING]
> **Do not merge release PR #952 until this lands.** As `main` stands, a 1.14.3 release would ship a stale, nested copy of `pipeline-task-core`.

## The defect

`@4cloudguru/pipeline-task-ado@0.2.0` — the version #955 pinned — declares `@4cloudguru/pipeline-task-core: ^0.3.1`. On a `0.x` version caret is **patch-only**, so that is `>=0.3.1 <0.4.0`, disjoint from the `^0.5.0` the installers declare for core directly. npm cannot dedupe disjoint ranges, so it nests. All three installer lockfiles on `main` today carry **two copies**:

```
node_modules/@4cloudguru/pipeline-task-core                                    => 0.5.0
node_modules/@4cloudguru/pipeline-task-ado/node_modules/.../pipeline-task-core => 0.3.1
```

`createAdoHttpClient` runs the nested **0.3.1** while the task code imports **0.5.0**. Concretely, `createDefaultClient()` and `createRegistryClient()` build `anyRedirectPolicy(sameHostOnly, githubAssetRedirects)` from core 0.5.0 and hand it to core 0.3.1's `createHttpClient` — so the bounded response bodies, 429/`Retry-After` handling and per-hop redirect re-authorization added in core 0.4.0/0.5.0 are **not** in the shipped HTTP path. Reviewed, tested and audited code is not the code that executes.

`ado@0.3.0` (4cloudguru/pipeline-task-ado#9) raises its range to `^0.5.0`. Pinning it here collapses each tree to a single `core@0.5.0`.

## The more important half: the gate did not catch it

The `PROXIED-BY-PACKAGE` verdict added in #955 checks the **direct** `ado` version and reported green the entire time — a floor on the delegating package says nothing about which implementation that package delegates to *in turn*. That is the **fourth** time in this migration a check has passed by not looking at the thing that moved.

So `PACKAGE_DELEGATED_SINKS` entries now carry an optional `carries` floor, and the verdict additionally reads the owning task's **`package-lock.json`**, requiring the onward dependency to resolve to **exactly one copy** at or above its own floor:

```js
createAdoHttpClient: {
    pkg: '@4cloudguru/pipeline-task-ado',
    min: '0.3.0',
    carries: { pkg: '@4cloudguru/pipeline-task-core', min: '0.5.0' },
},
```

The lockfile is the correct source, not the manifests: two compatible-*looking* ranges can still resolve to two different copies, and only the lockfile shows it. A missing or unreadable lockfile fails closed.

## Verification

| Check | Result |
| --- | --- |
| TerraformTaskV5 | **796 passing** (baseline) |
| TerraformInstallerV1 | **431 passing** (baseline) |
| PolicyAgentInstallerV1 | **264 passing** (baseline) |
| TerraformDocsInstallerV1 | **246 passing** (baseline) |
| Parity | 20/20 OK; all 6 delegated sites report `resolving a single @4cloudguru/pipeline-task-core@0.5.0` |

**Mutation-proven against the real defect, not a synthetic one.** Setting a range back to `^0.2.0` and reinstalling reproduces the nested `core@0.3.1` exactly; the gate then exits `1` with `UNPROXIED`, naming both copies and their install paths. Restoring returns it to `0`.

## Unrelated pre-existing failures

`check-minor-bumps` and `check-per-file-coverage` fail **identically on clean `main`** with this branch stashed, so they are not from this change:

- `check-per-file-coverage` — no root `coverage/coverage-summary.json` outside a full coverage run (environmental).
- `check-minor-bumps` — 4 tasks changed `src/` since v1.14.2 without a `Minor` bump (PolicyAgentInstaller, TerraformDocsInstaller, TerraformDriftReport, TerraformInstaller). That is the auto-bump layer's job on the Release PR, but **#952 appears not to have been refreshed since #955 merged** — worth confirming before merging it.
