### PR TITLE
docs(wif): correct the audience the AWS/GCP/OCI guides tell operators to trust

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -35,6 +35,8 @@ jobs:
         run: node scripts/check-versions.js
       - name: Validate task list consistency
         run: node scripts/check-task-list.js
+      - name: Validate WIF audience parity across the setup guides
+        run: node scripts/check-wif-audience-parity.js
       - name: Self-test check-versions.js
         run: node scripts/test-check-versions.js
       - name: Self-test check-minor-bumps.js

--- a/docs/setup/aws-wif-setup.md
+++ b/docs/setup/aws-wif-setup.md
@@ -31,7 +31,7 @@ The service connection type this task uses (`PTTAWSServiceEndpoint`) is a placeh
    - Replace `<your-azure-devops-organization-id>` with your org's GUID (not the org name)
    - Example: `https://vstoken.dev.azure.com/a1b2c3d4-e5f6-7890-abcd-ef1234567890`
 5. Click **Get thumbprint** to automatically populate the certificate thumbprint
-6. Set **Audience** to: `api://AzureADTokenV2`
+6. Set **Audience** to: `api://AzureADTokenExchange`
 7. Click **Add provider**
 
 ## Step 2: Create an IAM Role for Terraform
@@ -39,7 +39,7 @@ The service connection type this task uses (`PTTAWSServiceEndpoint`) is a placeh
 1. Navigate to **IAM** → **Roles** → **Create role**
 2. Select **Web identity** as the trusted entity type
 3. Select the identity provider you just created
-4. Set audience to `api://AzureADTokenV2`
+4. Set audience to `api://AzureADTokenExchange`
 5. Click **Next** and attach a policy scoped to what your Terraform configuration actually manages. For example, a role that only provisions EC2 instances behind a naming convention:
 
    ```json
@@ -102,7 +102,7 @@ Update the trust policy condition:
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "vstoken.dev.azure.com/<ORG_ID>:aud": "api://AzureADTokenV2",
+          "vstoken.dev.azure.com/<ORG_ID>:aud": "api://AzureADTokenExchange",
           "vstoken.dev.azure.com/<ORG_ID>:sub": "sc://<ORG_NAME>/<PROJECT_NAME>/<SERVICE_CONNECTION_NAME>"
         }
       }
@@ -135,7 +135,7 @@ To keep an `sts:RoleSessionName` condition while still getting per-run attributi
 ```json
 "Condition": {
   "StringEquals": {
-    "vstoken.dev.azure.com/<ORG_ID>:aud": "api://AzureADTokenV2",
+    "vstoken.dev.azure.com/<ORG_ID>:aud": "api://AzureADTokenExchange",
     "vstoken.dev.azure.com/<ORG_ID>:sub": "sc://<ORG_NAME>/<PROJECT_NAME>/<SERVICE_CONNECTION_NAME>"
   },
   "StringLike": {
@@ -180,14 +180,14 @@ At runtime, the task:
 
 The temporary credentials have a maximum lifetime of 1 hour, which is sufficient for any Terraform operation.
 
-> **Audience scoping:** the task mints the same Azure DevOps OIDC token (ADO's default `api://AzureADTokenV2` audience) for every cloud — it does not set a per-cloud custom audience or TTL, and cannot: the Azure DevOps OIDC request API does not expose per-exchange audience selection. The IAM role's trust-policy `:aud` and `:sub` conditions (Step 2) are therefore the security boundary: they **must** pin the audience and the exact service-connection `sub` so that only this org/project/service connection can assume the role. This is an operator responsibility, not something the task enforces on your behalf.
+> **Audience scoping:** the task mints the same Azure DevOps OIDC token (ADO's default `api://AzureADTokenExchange` audience) for every cloud — it does not set a per-cloud custom audience or TTL, and cannot: the Azure DevOps OIDC request API does not expose per-exchange audience selection. The IAM role's trust-policy `:aud` and `:sub` conditions (Step 2) are therefore the security boundary: they **must** pin the audience and the exact service-connection `sub` so that only this org/project/service connection can assume the role. This is an operator responsibility, not something the task enforces on your behalf.
 
 ## Troubleshooting
 
 ### "WebIdentityErr: failed to retrieve credentials"
 
 - Verify the role ARN is correct
-- Verify the trust policy audience matches `api://AzureADTokenV2`
+- Verify the trust policy audience matches `api://AzureADTokenExchange`
 - Verify the `sub` condition (if set) matches the service connection path exactly
 
 ### "InvalidIdentityToken: No OpenIDConnect provider found"

--- a/docs/setup/gcp-wif-setup.md
+++ b/docs/setup/gcp-wif-setup.md
@@ -61,7 +61,7 @@ gcloud iam workload-identity-pools providers create-oidc "azure-devops-provider"
     --workload-identity-pool="azure-devops-pool" \
     --display-name="Azure DevOps OIDC" \
     --issuer-uri="https://vstoken.dev.azure.com/<YOUR_ORG_ID>" \
-    --allowed-audiences="api://AzureADTokenV2" \
+    --allowed-audiences="api://AzureADTokenExchange" \
     --attribute-mapping="google.subject=assertion.sub,attribute.service_connection=assertion.sub"
 ```
 
@@ -163,7 +163,7 @@ At runtime, the task:
 
 The access token is valid for 1 hour, which is sufficient for any Terraform operation.
 
-> **Audience scoping:** the task mints the same Azure DevOps OIDC token (ADO's default `api://AzureADTokenV2` audience) for every cloud — it does not set a per-cloud custom audience or TTL, and cannot: the Azure DevOps OIDC request API does not expose per-exchange audience selection. The provider's `--allowed-audiences` and the `sub` attribute condition (Step 3) are therefore the security boundary: they **must** pin the audience and the exact service-connection `sub` so that only this org/project/service connection can impersonate the service account. This is an operator responsibility, not something the task enforces on your behalf.
+> **Audience scoping:** the task mints the same Azure DevOps OIDC token (ADO's default `api://AzureADTokenExchange` audience) for every cloud — it does not set a per-cloud custom audience or TTL, and cannot: the Azure DevOps OIDC request API does not expose per-exchange audience selection. The provider's `--allowed-audiences` and the `sub` attribute condition (Step 3) are therefore the security boundary: they **must** pin the audience and the exact service-connection `sub` so that only this org/project/service connection can impersonate the service account. This is an operator responsibility, not something the task enforces on your behalf.
 
 ## Troubleshooting
 

--- a/docs/setup/oci-wif-setup.md
+++ b/docs/setup/oci-wif-setup.md
@@ -75,7 +75,7 @@ curl -X POST "https://<identity-domain-admin-url>/admin/v1/IdentityPropagationTr
       { "rule": "sub eq *", "value": "<service-user-id-from-step-2>" }
     ],
     "clientClaimName": "aud",
-    "clientClaimValues": ["api://AzureADTokenV2"]
+    "clientClaimValues": ["api://AzureADTokenExchange"]
   }'
 ```
 
@@ -113,7 +113,7 @@ Prefer resource-type-specific verbs/compartments over `manage all-resources` at 
 
 At runtime (`oci-terraform-command-handler.ts` / `oci-token-exchange.ts`), the task:
 
-1. Requests an OIDC token from Azure DevOps for the service connection (signed by `vstoken.dev.azure.com`, default `api://AzureADTokenV2` audience — the same token-issuance path used for AWS/GCP/AzureRM WIF)
+1. Requests an OIDC token from Azure DevOps for the service connection (signed by `vstoken.dev.azure.com`, default `api://AzureADTokenExchange` audience — the same token-issuance path used for AWS/GCP/AzureRM WIF)
 2. Generates an ephemeral RSA-2048 key pair in memory, unique to this task run
 3. POSTs the OIDC JWT, the `ociWifClientId`, and the ephemeral public key to `{ociWifIdentityDomainUrl}/oauth2/v1/token` (RFC 8693 token exchange). The destination host is validated against OCI's known Identity Domains realms (`*.identity.oraclecloud.com`, `*.identity.oraclegovcloud.com`, `*.identity.oraclegovcloud.uk`, `*.identity.oraclecloud.eu`) before the JWT is ever sent, and the request refuses to follow any redirect
 4. OCI validates the JWT against the Identity Propagation Trust from Step 3, checks the `clientClaimName`/`clientClaimValues` condition, maps it to the service user, and returns a UPST bound (proof-of-possession) to the ephemeral public key
@@ -123,7 +123,7 @@ At runtime (`oci-terraform-command-handler.ts` / `oci-token-exchange.ts`), the t
 
 The UPST and the tenancy's normal session-token lifetime apply — there is no static long-lived credential to rotate or leak.
 
-> **Audience scoping:** the OIDC token minted for OCI carries the same default `api://AzureADTokenV2` audience used for every cloud in this extension — the task does not set a per-cloud custom audience or TTL, and cannot: the Azure DevOps OIDC request API does not expose per-exchange audience selection. It is the Identity Propagation Trust's `issuer`, `clientClaimName`/`clientClaimValues`, and `subjectClaimName` conditions (Step 3) that form the actual security boundary. Scope `clientClaimValues` to your audience and, where possible, add a `sub`-based condition restricting the trust to this specific service connection's `sc://<org>/<project>/<service-connection>` subject, mirroring the AWS/GCP guides' `sub` trust-policy condition — otherwise any service connection in the organization that can request an OIDC token could exchange it through this trust. This is an operator responsibility, not something the task enforces on your behalf.
+> **Audience scoping:** the OIDC token minted for OCI carries the same default `api://AzureADTokenExchange` audience used for every cloud in this extension — the task does not set a per-cloud custom audience or TTL, and cannot: the Azure DevOps OIDC request API does not expose per-exchange audience selection. It is the Identity Propagation Trust's `issuer`, `clientClaimName`/`clientClaimValues`, and `subjectClaimName` conditions (Step 3) that form the actual security boundary. Scope `clientClaimValues` to your audience and, where possible, add a `sub`-based condition restricting the trust to this specific service connection's `sc://<org>/<project>/<service-connection>` subject, mirroring the AWS/GCP guides' `sub` trust-policy condition — otherwise any service connection in the organization that can request an OIDC token could exchange it through this trust. This is an operator responsibility, not something the task enforces on your behalf.
 
 ## Troubleshooting
 

--- a/scripts/check-wif-audience-parity.js
+++ b/scripts/check-wif-audience-parity.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * check-wif-audience-parity.js -- one token, one audience, four guides.
+ *
+ * CLASS: a value that MUST be identical across several documents because a
+ * single code path produces it, but which is maintained by hand in each one.
+ *
+ * Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts requests the
+ * federated token with only the service-connection id and sets NO custom
+ * audience, so Azure DevOps issues its default-audience OIDC JWT -- and that
+ * one requester is reused for Azure, AWS, GCP and OCI by design. The four
+ * relying parties are therefore configured to expect the SAME audience. Any
+ * guide naming a different one instructs the operator to build a trust that
+ * rejects the only token this extension can mint.
+ *
+ * That is not hypothetical: #965 was filed because aws/gcp/oci-wif-setup.md
+ * all said `api://AzureADTokenV2` while azure-wif-setup.md said
+ * `api://AzureADTokenExchange`. Azure DevOps mints the latter, so following
+ * the three non-Azure guides as written produced a hard auth failure on
+ * first use. Nothing compared the four documents, so the divergence survived.
+ *
+ * This gate does not assert WHICH audience is correct -- the value lives in
+ * Azure DevOps, not in this repo, and hard-coding it here would be a second
+ * unverified declaration. It asserts that the guides AGREE, which is the
+ * property the shared requester actually guarantees, and that each guide
+ * names one at all.
+ *
+ *   node scripts/check-wif-audience-parity.js [repoRoot]
+ *
+ * Exit 0 = every guide names exactly one audience and all agree.
+ * Exit 1 = a divergence, a guide naming none, or no guides found.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = process.argv[2] || process.cwd();
+const dir = path.join(root, 'docs', 'setup');
+const AUDIENCE = /api:\/\/[A-Za-z0-9._-]+/g;
+
+const errors = [];
+let guides = [];
+try {
+    guides = fs.readdirSync(dir).filter((f) => /-wif-setup\.md$/.test(f)).sort();
+} catch (e) {
+    console.error(`check-wif-audience-parity: cannot read ${dir}: ${e.message}`);
+    process.exit(1);
+}
+
+// An empty universe is a red flag, not a pass: if the guides move or are
+// renamed, this gate must say it examined nothing rather than report clean.
+if (guides.length === 0) {
+    console.error(`check-wif-audience-parity: no *-wif-setup.md under ${dir} -- the gate enumerated NOTHING, which is not the same as agreement.`);
+    process.exit(1);
+}
+
+const seen = new Map(); // audience -> [guides]
+for (const g of guides) {
+    const text = fs.readFileSync(path.join(dir, g), 'utf8');
+    const found = [...new Set(text.match(AUDIENCE) || [])];
+    if (found.length === 0) {
+        errors.push(`${g}: names no api:// audience at all. An operator following it cannot configure the relying party's expected audience.`);
+        continue;
+    }
+    if (found.length > 1) {
+        errors.push(`${g}: names ${found.length} different audiences (${found.join(', ')}). One requester mints one token; a guide cannot need two.`);
+    }
+    for (const a of found) {
+        if (!seen.has(a)) seen.set(a, []);
+        seen.get(a).push(g);
+    }
+}
+
+if (seen.size > 1) {
+    const lines = [...seen.entries()].map(([a, gs]) => `    ${a}  <-- ${gs.join(', ')}`).join('\n');
+    errors.push(
+        `the guides disagree about the audience, but one code path mints the token for all of them:\n${lines}\n` +
+        `    id-token-generator.ts sets no custom audience, so every cloud receives the SAME token. At most one of these values can work.`
+    );
+}
+
+console.log(`enumerated: ${guides.length} WIF setup guide(s) (${guides.join(', ')}), ${seen.size} distinct audience(s).`);
+if (errors.length) {
+    console.error('check-wif-audience-parity FAILED:');
+    for (const e of errors) console.error(`  ${e}`);
+    process.exit(1);
+}
+console.log(`OK: all ${guides.length} guides name the same audience (${[...seen.keys()][0]}).`);


### PR DESCRIPTION
The AWS, GCP and OCI WIF guides instruct operators to configure the relying party to expect **`api://AzureADTokenV2`**. Azure DevOps mints **`api://AzureADTokenExchange`**. Following any of them as written produces a hard authentication failure on first use — #965 reproduced it with a real `gcloud` invocation.

## The decisive evidence is internal to this repo

`Tasks/TerraformTask/TerraformTaskV5/src/id-token-generator.ts` requests the federated token with only the service-connection id and sets **no custom audience**:

> `// The federated token is requested with only the service-connection id; no`
> `// custom audience/aud is set, so ADO issues its default-audience OIDC JWT.`
> `// This single requester is reused for Azure/AWS/GCP/OCI by design`

One token, one audience, four relying parties. `azure-wif-setup.md` already said `AzureADTokenExchange` — and the Azure path works. So the four guides could not all be right, and the three disagreeing with the working one were the wrong three. That argument holds without reference to the external reproduction.

## What changed

11 occurrences across `aws-`, `gcp-` and `oci-wif-setup.md` — including the IAM trust-policy conditions, the `--allowed-audiences` flag and the `clientClaimValues` array that operators copy verbatim.

## Why a gate, and why this one

The divergence survived because **nothing compared the four documents**. `scripts/check-wif-audience-parity.js` runs in the existing `unit-test.yml` job alongside `check-task-list.js` — no new required context.

It deliberately does **not** assert which audience is correct. That value lives in Azure DevOps, not here; hard-coding it would be a second declaration nothing verifies, and it would go stale the day Microsoft changes it. It asserts the property the shared requester actually guarantees: **the guides agree**. It also fails on a guide naming no audience, and on an empty guide set — enumerating nothing is not the same as agreement.

## Mutation evidence

| mutation | result |
|---|---|
| reintroduce #965 exactly (gcp → `AzureADTokenV2`) | **exit 1**, naming both values and which guides hold each |
| a guide naming no `api://` audience | **exit 1**, naming the guide |
| empty guide set | **exit 1** — *"the gate enumerated NOTHING, which is not the same as agreement"* |
| clean tree | exit 0, `4 guide(s), 1 distinct audience` |

## Related, not fixed here

**#959** — all three non-Azure paths are built on the `vstoken.dev.azure.com` issuer, deprecated 1 July 2026 and retired 1 July 2027. This PR corrects what the guides say about the audience; it does not migrate the issuer. When that migration lands, this gate keeps the four guides honest about whatever the new audience turns out to be.