### PR TITLE
chore(ci): label the shared-workflow pins with the release they are

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,13 @@
 # that drifts, and repos on different pins is HARDER to see than divergent
 # files -- every repo looks like it is using "the shared one".
 #
+# The trailing `# v1.0.0` NAMES the release that SHA is; it does not select it.
+# Do not "simplify" the ref to @v1.0.0 -- a tag is mutable, so the reviewed
+# workflow and the executed workflow would stop being the same thing. The label
+# exists because an unlabelled 40-hex SHA cannot be reviewed or updated
+# deliberately, which azure-pipelines-release-docs' workflow-hardening guard
+# rejects outright and the other twelve repos accepted without noticing.
+#
 # `vars` resolves against THIS repository, so RELEASE_DISPATCH_APP_ID is
 # unchanged and nothing about the App installation moves. The workflow keeps the
 # name "Release Please" so anything keyed on it still matches.
@@ -28,7 +35,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@2279e55c6318846f60f0c8ffcbadbeb9317e5fb5
+    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@2279e55c6318846f60f0c8ffcbadbeb9317e5fb5 # v1.0.0
     # Exactly one secret, named. NOT `secrets: inherit` -- that forwards EVERY
     # secret in this repository to a workflow in another owner's repository,
     # which zizmor flags (secrets-inherit) and which would be an over-grant


### PR DESCRIPTION
Labels every `4cloudguru/shared-workflows` pin with the release that SHA is, and moves `workflow-security.yml` onto the tagged commit.

## Why

`azure-pipelines-release-docs` runs `check-workflow-hardening.js`, which rejects a pinned SHA with no trailing version comment — *"an unlabelled 40-hex ref cannot be reviewed or updated deliberately."* It failed that repo's conversion PR.

The guard is right. It also accepts **any** non-empty comment, so the cheap fix was to write `# v1.0.0` and move on — a decorative label naming a version that did not exist, which is the exact failure the guard is there to prevent.

So `4cloudguru/shared-workflows` is now tagged [**v1.0.0**](https://github.com/4cloudguru/shared-workflows/releases/tag/v1.0.0) at `2279e55c`, and the label is true.

## The ref is still a SHA

`@2279e55c… # v1.0.0` — the tag is **named**, not selected. A tag is mutable; the reviewed workflow and the executed workflow must be the same thing. The added comment says so, because a label like this invites someone to "simplify" it to `@v1.0.0` later.

## workflow-security moved too

It was pinned at `a48c17cb`, which predates the tag — labelling *that* `# v1.0.0` would have been false. The file is **byte-identical** between `a48c17cb` and `2279e55c`, so this is a zero-behaviour-change move that lets both pins carry a truthful label.

## Worth noting

This guard exists in **one of the thirteen** repos. The other twelve took the same unlabelled pin without complaint — the same one-repo-has-it pattern that put `harden-runner` in four repos and not the other nine.