### PR TITLE
ci: count breaking-change declarations across the commits being squashed

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -97,6 +97,138 @@ jobs:
         if: ${{ startsWith(github.event.pull_request.head.ref, 'release-please--') }}
         run: node scripts/check-minor-bumps.js
 
+  # ── Breaking-change declarations survive the squash ────────────────────
+  # This repository squash-merges with
+  # `squash_merge_commit_message=COMMIT_MESSAGES` (verified on the live
+  # repository, not assumed), so every commit body in a pull request is
+  # concatenated into ONE merge commit. release-please then keeps only the
+  # FIRST `BREAKING CHANGE:` footer of that commit, and reads a `!` marker only
+  # from its header. A second declaration anywhere in the PR is dropped in
+  # silence: the change ships with no changelog entry, no upgrade note, and
+  # nothing failing to say so.
+  #
+  # This is not hypothetical. terraform-registry-backend v4.0.0 published with
+  # two undocumented breaking changes this way -- one of them 403s any CI job
+  # calling `/auth/refresh` with an API key -- and
+  # terraform-state-manager-backend lost three from a PR that declared four,
+  # caught only by reading the release notes line by line before the cut.
+  #
+  # It costs more here than in a service repository. This extension publishes to
+  # the VS Marketplace, where a pipeline author's only signal that a task
+  # changed incompatibly is the release notes release-please generates from
+  # these footers; and ADO agents cache tasks by Major.Minor, so the change
+  # reaches a running agent on its own schedule with nothing to read.
+  #
+  # Splitting the footers across separate commits does not help; the squash
+  # concatenates them back. One merged commit can announce exactly one breaking
+  # change. Either open one PR per breaking change, or combine them into a
+  # single footer and write each one up in the upgrade guide.
+  #
+  # This is the CROSS-COMMIT half of the release-parsing pair. Its sibling
+  # below, `release-please can read the merged commit`, builds the ONE message
+  # this PR would squash into main and asks whether release-please's parser can
+  # read it at all; this job counts declarations ACROSS the commits being
+  # concatenated. Neither subsumes the other: a perfectly parseable squash can
+  # still swallow a second footer, and a single-footer PR can still be
+  # unparseable.
+  #
+  # PROVENANCE. Ported (#966) from `azure-pipelines-release-docs`, which took it
+  # from `terraform-registry-backend` -- carried there together with
+  # terraform-registry-frontend, terraform-state-manager-{backend,frontend} and
+  # terraform-suite-identity -- and added the self-test named below.
+  #
+  # It is mutation-proved: scripts/test-breaking-change-footers.js EXTRACTS the
+  # script below out of this file, rather than copying it (a copy drifts from
+  # the thing it claims to prove, which is the same defect one level up), and
+  # runs it against fixture commit histories with `gh` stubbed. That runs in the
+  # already-required `Lint GitHub Actions` job, beside the other workflow-shaped
+  # gates.
+  #
+  # A NEW required context has to be added to main's branch protection by hand:
+  # "Breaking-change footers survive the squash". Until that is done this job
+  # reports on every pull request without blocking one -- which is also the
+  # state of `release-please can read the merged commit` below, the other half
+  # of the pair, and both should be promoted together.
+  breaking-change-footers:
+    name: Breaking-change footers survive the squash
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Count breaking-change declarations across this PR's commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '.[] | {sha: .sha[0:7], msg: .commit.message}' > commits.ndjson
+
+          total=0
+          report=""
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            sha=$(jq -r '.sha' <<<"$line")
+            msg=$(jq -r '.msg' <<<"$line")
+            subject=$(head -n1 <<<"$msg")
+
+            # Spec allows both spellings of the footer token.
+            footers=$(grep -cE '^BREAKING[ -]CHANGE:' <<<"$msg" || true)
+            if [ "$footers" -gt 0 ]; then
+              # A footer wins over the header's `!`, so they are not additive.
+              n="$footers"
+            elif printf '%s' "$subject" | grep -qE '^[a-zA-Z]+(\([^)]*\))?!:'; then
+              n=1
+            else
+              n=0
+            fi
+
+            if [ "$n" -gt 0 ]; then
+              report="${report}  ${sha}  ${n} declaration(s)  ${subject}"$'\n'
+            fi
+            total=$((total + n))
+          done < commits.ndjson
+
+          echo "Breaking-change declarations in this PR: $total"
+          if [ -n "$report" ]; then
+            printf 'Where they are:\n%s' "$report"
+          fi
+
+          if [ "$total" -le 1 ]; then
+            echo "OK: at most one declaration, so the squash loses nothing."
+            exit 0
+          fi
+
+          {
+            echo "### Breaking-change declarations do not survive the squash"
+            echo
+            echo "This PR declares **$total** breaking changes. The squash-merge"
+            echo "concatenates every commit body into one commit, and release-please"
+            echo "keeps only the **first** \`BREAKING CHANGE:\` footer of a commit."
+            echo "The other $((total - 1)) would ship with no changelog entry and no notice."
+            echo
+            echo '```'
+            printf '%s' "$report"
+            echo '```'
+            echo
+            echo "Two ways out:"
+            echo
+            echo "1. **One PR per breaking change.** Preferred when they are independent."
+            echo "2. **One footer.** Combine the declarations into a single"
+            echo "   \`BREAKING CHANGE:\` footer and write each one up in the upgrade"
+            echo "   guide, which is where a pipeline author preparing an upgrade looks."
+            echo
+            echo "Moving the footers into separate commits within this PR does **not**"
+            echo "work -- the squash concatenates them back into one commit body."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::This PR declares $total breaking changes; the squash keeps only the first. See the job summary."
+          exit 1
+
   # ── The merged commit has to be readable by release-please ─────────────
   # release-please chooses what to release by parsing the commits on main
   # with a strict reading of the Conventional Commits grammar. A message it

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -805,6 +805,20 @@ jobs:
       - name: Run actionlint
         run: ./actionlint -color
 
+      # ── The one guard that is a shell script inside YAML ───────────────────
+      # pr-checks.yml's "Breaking-change footers survive the squash" job is a
+      # bash script embedded in a workflow: actionlint above checks its syntax,
+      # zizmor below checks the workflow around it, and nothing runs it. In the
+      # five estate repos it was ported from it has never had a test, so a regex
+      # edit, a lost `set -euo pipefail` or a silently renamed job would leave a
+      # green required context asserting nothing (#966). This EXTRACTS the
+      # script out of the workflow and runs it against fixture commit histories
+      # with `gh` stubbed — here, in the workflow-shaped job, because that is
+      # what it is a statement about, and because this context is already
+      # required so the proof blocks a merge from the day it lands.
+      - name: Self-test the breaking-change footer guard
+        run: node scripts/test-breaking-change-footers.js
+
   zizmor:
     name: Scan Workflows (zizmor)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,20 @@ feat: add registry download strategy to terraform installer
 Closes #12
 ```
 
+**One merged commit announces exactly ONE breaking change.** This repo squashes
+with `squash_merge_commit_message=COMMIT_MESSAGES`, so every commit body in a PR
+is concatenated into one merge commit — and release-please keeps only the
+**first** `BREAKING CHANGE:` footer, reading a `!` marker only from the header.
+A second declaration anywhere in the PR ships with no changelog entry and no
+notice (terraform-registry-backend v4.0.0 shipped two that way). Moving the
+footers into separate commits does not help; the squash concatenates them back.
+Open one PR per breaking change, or combine them into a single footer and write
+each one up in the upgrade guide. A footer plus a `!` header in the *same*
+commit is one declaration, not two. The `Breaking-change footers survive the
+squash` job in `.github/workflows/pr-checks.yml` counts them across the PR;
+`scripts/test-breaking-change-footers.js` extracts that script from the workflow
+and proves it still rejects, in the required `Lint GitHub Actions` job.
+
 ## Workflow Per Change
 
 1. Create branch from `main`: `git checkout -b feature/<description> main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,13 +95,38 @@ directories and their per-task test commands.
    - `Build and Test Markdown2Html V1`
    - `Build and Test Publish KB Article V1`
    - `Build and Test Tab` — type-checks and builds the Terraform results tab.
-   - `Lint GitHub Actions` — actionlint.
+   - `Lint GitHub Actions` — actionlint, plus the self-test that proves the
+     breaking-change footer guard in `.github/workflows/pr-checks.yml` still
+     rejects what it claims to (`scripts/test-breaking-change-footers.js`).
    - `Scan Workflows (zizmor)` — workflow-security scan.
    <!-- ci-jobs:end -->
 
    This list is checked against `.github/workflows/unit-test.yml` by
    `scripts/check-docs-claims.js`, in both directions, so it cannot drift as jobs
    are added or renamed. Adding a task means adding its job here too.
+
+   `.github/workflows/pr-checks.yml` gates the PR as well, with the conventional
+   title check, dependency review, the Release-PR Minor-bump backstop, and the
+   two release-parsing guards: `release-please can read the merged commit` builds
+   the single message this PR would squash into `main` and parses it, while
+   `Breaking-change footers survive the squash` counts breaking-change
+   declarations across the commits being concatenated.
+
+## One breaking change per merged commit
+
+This repository squash-merges with `squash_merge_commit_message=COMMIT_MESSAGES`,
+so every commit body in a PR is concatenated into one merge commit — and
+release-please keeps only the **first** `BREAKING CHANGE:` footer of a commit,
+reading a `!` marker only from its header. A second declaration anywhere in the
+PR is dropped in silence: no changelog entry, no upgrade note, and nothing
+failing to say so. terraform-registry-backend v4.0.0 shipped two undocumented
+breaking changes exactly this way.
+
+Splitting the footers across separate commits does not help; the squash
+concatenates them back. Either open one PR per breaking change, or combine them
+into a single `BREAKING CHANGE:` footer and write each one up in the upgrade
+guide. A footer and a `!` header in the same commit are one declaration, not
+two, and are fine.
 
 6. Squash-merge when CI passes and the PR is approved; the branch is deleted automatically.
 

--- a/scripts/test-breaking-change-footers.js
+++ b/scripts/test-breaking-change-footers.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// Mutation self-test for the "Breaking-change footers survive the squash" job
+// in .github/workflows/pr-checks.yml (#966).
+//
+// Same contract as every other self-test in scripts/, and the reason this one
+// exists at all: that guard is a shell script embedded in YAML. actionlint
+// checks its syntax, zizmor checks the workflow around it, and nothing runs
+// it. It was ported from terraform-registry-backend by way of
+// azure-pipelines-release-docs, and in the five estate repos that carry it, it
+// has never had a test — so a regex edit, a lost `set -euo pipefail`, or a
+// silently renamed job would leave a green required context asserting nothing.
+// That is this estate's most expensive failure mode and it is what this file
+// refuses.
+//
+// HOW. The `run:` block is EXTRACTED from the workflow file rather than copied
+// here: a copy would drift from the thing it claims to prove, which is the same
+// defect one level up. `gh` is stubbed with a script that prints a fixture
+// commit history, so no network and no repository are involved.
+//
+// Cases, and the property each one pins:
+//   clean-single / clean-none    an ordinary PR is not obstructed
+//   two-footers                  THE case — release-please keeps the first
+//                                and drops the rest (registry-backend v4.0.0)
+//   two-bang-headers             the `!` marker counted the same way
+//   footer-plus-bang-one-commit  a footer and a `!` in ONE commit is ONE
+//                                declaration, not two — the footer wins
+//   hyphen-spelling              `BREAKING-CHANGE:` is the same token
+//   prose-mention                a mid-line mention is prose, not a footer
+//   summary-names-the-commits    the failure says WHICH commits, in the job
+//                                summary a reviewer actually reads
+//   gh-unavailable               it FAILS CLOSED when it cannot read the
+//                                commit list — an unreadable history counted
+//                                as zero declarations is a green context
+//                                asserting nothing, and it is what a lost
+//                                `set -euo pipefail` degrades to
+//   job-present                  the vacuity contract: if the job or its
+//                                script cannot be found, this test fails
+//                                rather than passing over nothing
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const WORKFLOW = path.join(__dirname, '..', '.github', 'workflows', 'pr-checks.yml');
+const JOB_KEY = 'breaking-change-footers';
+
+const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'breaking-change-footers-selftest-'));
+
+let failures = 0;
+const report = (ok, message) => {
+    if (ok) {
+        console.log(`  OK   ${message}`);
+    } else {
+        console.error(`  FAIL ${message}`);
+        failures += 1;
+    }
+};
+
+/* ------------------------------------------------------------------ *
+ * Extract the guard from the workflow.
+ * ------------------------------------------------------------------ */
+
+/** The dedented body of the `run: |` block inside job `key`. */
+function extractRunBlock(yaml, key) {
+    const lines = yaml.split(/\r?\n/);
+    const start = lines.findIndex((line) => new RegExp(`^  ${key}:\\s*$`).test(line));
+    if (start === -1) return { error: `no job \`${key}:\` in ${path.relative(process.cwd(), WORKFLOW)}` };
+
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+        if (/^  [A-Za-z0-9_.-]+:\s*$/.test(lines[i])) {
+            end = i;
+            break;
+        }
+    }
+
+    const body = lines.slice(start, end);
+    const runAt = body.findIndex((line) => /^\s+run:\s*\|\s*$/.test(line));
+    if (runAt === -1) return { error: `job \`${key}\` has no \`run: |\` block` };
+
+    const indent = /^(\s+)/.exec(body[runAt + 1] || '');
+    if (!indent) return { error: `job \`${key}\`'s \`run: |\` block is empty` };
+
+    const script = [];
+    for (let i = runAt + 1; i < body.length; i++) {
+        const line = body[i];
+        if (line.trim() === '') {
+            script.push('');
+            continue;
+        }
+        if (!line.startsWith(indent[1])) break;
+        script.push(line.slice(indent[1].length));
+    }
+    return { script: script.join('\n') };
+}
+
+const extracted = extractRunBlock(fs.readFileSync(WORKFLOW, 'utf8'), JOB_KEY);
+if (extracted.error) {
+    console.error(`  FAIL vacuity: ${extracted.error}`);
+    console.error('\ntest-breaking-change-footers: the guard this file exists to prove could not be found, which is a failure and not a pass.');
+    process.exit(1);
+}
+report(true, `extracted the guard from ${JOB_KEY} (${extracted.script.split('\n').length} lines)`);
+// The extraction has to be of the REAL script, not of an empty match that then
+// "passes" every case below.
+report(/BREAKING\[ -\]CHANGE:/.test(extracted.script), 'the extracted script contains the footer-matching expression');
+
+const scriptPath = path.join(workRoot, 'guard.sh');
+fs.writeFileSync(scriptPath, extracted.script);
+
+/* ------------------------------------------------------------------ *
+ * A `gh` that prints a fixture history instead of calling GitHub.
+ * ------------------------------------------------------------------ */
+
+const binDir = path.join(workRoot, 'bin');
+fs.mkdirSync(binDir);
+fs.writeFileSync(path.join(binDir, 'gh'), '#!/bin/sh\ncat "$FIXTURE_COMMITS"\n', { mode: 0o755 });
+
+// The other `gh`: one that fails the way the real one does on an API error, a
+// revoked token or a rate limit. The guard must not read that as "no breaking
+// changes here".
+const failingBinDir = path.join(workRoot, 'bin-failing');
+fs.mkdirSync(failingBinDir);
+fs.writeFileSync(
+    path.join(failingBinDir, 'gh'),
+    '#!/bin/sh\necho "gh: HTTP 403: Resource not accessible by integration" >&2\nexit 1\n',
+    { mode: 0o755 },
+);
+
+let fixtureSeq = 0;
+function runGuard(commits, stubDir = binDir) {
+    const dir = path.join(workRoot, `case-${(fixtureSeq += 1)}`);
+    fs.mkdirSync(dir);
+    const fixture = path.join(dir, 'commits.json');
+    fs.writeFileSync(fixture, `${commits.map((c, i) => JSON.stringify({ sha: `abc00${i}`, msg: c })).join('\n')}\n`);
+    const summary = path.join(dir, 'summary.md');
+    fs.writeFileSync(summary, '');
+
+    const result = spawnSync('bash', [scriptPath], {
+        cwd: dir,
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            PATH: `${stubDir}${path.delimiter}${process.env.PATH}`,
+            FIXTURE_COMMITS: fixture,
+            GH_TOKEN: 'stub',
+            PR_NUMBER: '123',
+            REPO: 'sethbacon/azure-pipelines-terraform',
+            GITHUB_STEP_SUMMARY: summary,
+        },
+    });
+    return {
+        status: result.status,
+        output: `${result.stdout || ''}${result.stderr || ''}`,
+        summary: fs.readFileSync(summary, 'utf8'),
+    };
+}
+
+function expectPass(label, commits, mustSay = []) {
+    const { status, output } = runGuard(commits);
+    if (status !== 0) {
+        report(false, `${label}: exited ${status} on a PR it should accept\n${output}`);
+        return;
+    }
+    const missing = mustSay.filter((w) => !output.includes(w));
+    if (missing.length > 0) {
+        report(false, `${label}: passed but never said ${missing.map((m) => JSON.stringify(m)).join(', ')}\n${output}`);
+        return;
+    }
+    report(true, `${label}: exits 0${mustSay.length ? ` saying ${mustSay.map((w) => JSON.stringify(w)).join(' + ')}` : ''}`);
+}
+
+function expectRejection(label, commits, mustSay, mustSummarise = []) {
+    const { status, output, summary } = runGuard(commits);
+    if (status === 0) {
+        report(false, `${label}: exited 0 on a PR that would lose a breaking change\n${output}`);
+        return;
+    }
+    const wanted = Array.isArray(mustSay) ? mustSay : [mustSay];
+    const missing = wanted.filter((w) => !output.includes(w));
+    if (missing.length > 0) {
+        report(false, `${label}: failed but never mentioned ${missing.map((m) => JSON.stringify(m)).join(', ')}\n${output}`);
+        return;
+    }
+    const unsummarised = mustSummarise.filter((w) => !summary.includes(w));
+    if (unsummarised.length > 0) {
+        report(false, `${label}: failed without putting ${unsummarised.map((m) => JSON.stringify(m)).join(', ')} in the job summary\n${summary}`);
+        return;
+    }
+    report(true, `${label}: exits ${status} naming ${wanted.map((w) => JSON.stringify(w)).join(' + ')}`);
+}
+
+const FOOTER = 'BREAKING CHANGE: the provider-mirror input is no longer optional';
+
+try {
+    console.log('\npull requests this guard must not obstruct:');
+    expectPass('clean-none', ['fix: correct the registry allowlist check'], ['declarations in this PR: 0', 'at most one declaration']);
+    expectPass('clean-single', [`feat: rework the mirror download path\n\n${FOOTER}`], ['declarations in this PR: 1']);
+    expectPass('clean-many-commits', ['ci: pin an action', 'docs: fix a link', 'test: cover the parser'], ['declarations in this PR: 0']);
+    // The shape called out as the false positive to avoid: a `!` header and a
+    // footer in the SAME commit describe ONE breaking change, because
+    // release-please reads the footer and the header is the marker for it.
+    expectPass('footer-plus-bang-one-commit', [`feat!: rework the mirror download path\n\n${FOOTER}`], ['declarations in this PR: 1']);
+    // A mention inside a paragraph is prose. Only a line that STARTS with the
+    // token is a footer, and a guard that fired on prose would be routed around.
+    expectPass('prose-mention', ['docs: explain that a BREAKING CHANGE: footer is kept only once'], ['declarations in this PR: 0']);
+
+    console.log('\nmutations — the squash losing a declaration (#966):');
+    // THE case: registry-backend v4.0.0 published two breaking changes and
+    // documented one.
+    expectRejection(
+        'two-footers',
+        [`feat: drop the V4 task\n\n${FOOTER}`, 'feat: require a service connection\n\nBREAKING CHANGE: the PAT input is gone'],
+        ['declares 2 breaking changes', 'the squash keeps only the first'],
+        ['**2** breaking changes', 'abc000', 'abc001'],
+    );
+    expectRejection(
+        'two-bang-headers',
+        ['feat!: drop the V4 task', 'fix(auth)!: require a service connection'],
+        ['declares 2 breaking changes'],
+        ['drop the V4 task', 'require a service connection'],
+    );
+    // Both spellings of the token are the spec's. A guard blind to the hyphen
+    // would be routed around by the first person who writes it that way.
+    expectRejection(
+        'hyphen-spelling',
+        [`feat: drop the V4 task\n\n${FOOTER}`, 'feat: require a service connection\n\nBREAKING-CHANGE: the PAT input is gone'],
+        ['declares 2 breaking changes'],
+    );
+    // Three, which is the registry-backend PR that started this rule.
+    expectRejection(
+        'three-footers',
+        [`feat: a\n\n${FOOTER}`, 'feat: b\n\nBREAKING CHANGE: b changed', 'feat: c\n\nBREAKING CHANGE: c changed'],
+        ['declares 3 breaking changes'],
+        ['The other 2 would ship with no changelog entry'],
+    );
+    console.log('\nthe guard has to fail closed, not quiet:');
+    // `set -euo pipefail` is the whole of this property. Without it the failed
+    // `gh api` leaves an empty commits.ndjson behind, the loop counts nothing,
+    // and the job reports "declarations in this PR: 0" and goes green — a
+    // required context that has stopped looking, which is indistinguishable
+    // from a clean tree. This is the one mutation the ported test could not see.
+    {
+        const { status, output } = runGuard(['feat: anything at all'], failingBinDir);
+        report(
+            status !== 0 && !output.includes('declarations in this PR: 0'),
+            status !== 0 && !output.includes('declarations in this PR: 0')
+                ? `gh-unavailable: exits ${status} rather than counting an unreadable history as zero`
+                : `gh-unavailable: exited ${status} when \`gh\` failed, so an unreadable commit list passes as clean\n${output}`,
+        );
+    }
+} finally {
+    fs.rmSync(workRoot, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+    console.error(`\ntest-breaking-change-footers: ${failures} case(s) failed.`);
+    process.exit(1);
+}
+console.log('\ntest-breaking-change-footers: the guard counts every declaration the squash would drop, and passes the shapes it must not obstruct.');


### PR DESCRIPTION
## What this adds

A merge gate that counts breaking-change declarations **across the commits GitHub will
concatenate into one squash commit**, and a self-test that proves the gate still rejects.

- `.github/workflows/pr-checks.yml` — new job `breaking-change-footers`, context name
  **`Breaking-change footers survive the squash`**.
- `scripts/test-breaking-change-footers.js` — new; **extracts** the guard's `run:` block out of
  the committed workflow and runs it against fixture commit histories with `gh` stubbed.
- `.github/workflows/unit-test.yml` — one step added to the existing, already-required
  `Lint GitHub Actions` job to run that self-test. No job renamed, split, or added there.
- `CONTRIBUTING.md`, `CLAUDE.md` — the rule, written down where a contributor and an agent
  each look.

No `task.json` was touched.

## Why

This repo squash-merges with `squash_merge_commit_message=COMMIT_MESSAGES` (re-verified on the
live repo, not assumed), so every commit body in a PR is concatenated into one merge commit.
release-please keeps only the **first** `BREAKING CHANGE:` footer of that commit, and reads a `!`
marker only from its header. A second declaration anywhere in the PR is dropped in silence.

`terraform-registry-backend` v4.0.0 shipped **two** undocumented breaking changes exactly this
way. It costs more here than in a service repo: this extension publishes to the VS Marketplace,
where release notes are a pipeline author's only signal that a task changed incompatibly, and ADO
agents cache tasks by `Major.Minor`, so the change reaches a running agent on its own schedule
with nothing to read.

Five other suite repos carry this guard. The two ADO extensions did not.

## Relationship to `.github/commit-message-check/verify.mjs`

Complementary, not overlapping, and the port neither duplicates nor contradicts it:

| | reads | asks |
|---|---|---|
| `release-please can read the merged commit` (`verify.mjs`) | the **one** message this PR would squash | can release-please's parser read it **at all**? |
| `Breaking-change footers survive the squash` (new) | **every commit** in the PR | how many breaking-change declarations does the squash **drop**? |

`verify.mjs` never counts declarations — its only `BREAKING` matches are prose in its own failure
text. Neither subsumes the other: a perfectly parseable squash can still swallow a second footer,
and a single-footer PR can still be unparseable. The two jobs sit next to each other in
`pr-checks.yml` as the two halves of one pair.

## Provenance

Ported from `sethbacon/azure-pipelines-release-docs`, which took it from
`terraform-registry-backend` and added the extraction-based self-test. The extraction is
load-bearing: in the five repos carrying this guard it is bash embedded in YAML that nothing ever
executes, so it can rot silently — and a *copied* test drifts from the thing it claims to prove,
which is the same defect one level up.

Style follows **this** repo, not the source: no `harden-runner` (this repo uses none in
`pr-checks.yml`), `timeout-minutes: 30` to match its neighbours, and no `actions/checkout` at all —
the guard reads the commit list through `gh api`, so this repo's `v6.0.3` pin is not involved and
`ref-version-mismatch` has nothing to fire on. `actionlint` and `zizmor 1.29.0` both run clean over
the whole workflow directory.

## Mutation evidence

The self-test asserts every rejection **by name**, not by exit code.

Must **not** obstruct — all pass:

| case | result |
|---|---|
| `clean-none` | exits 0, `declarations in this PR: 0` + `at most one declaration` |
| `clean-single` | exits 0, `declarations in this PR: 1` |
| `clean-many-commits` | exits 0, `declarations in this PR: 0` |
| `footer-plus-bang-one-commit` | exits 0, `declarations in this PR: 1` — a footer and a `!` header in **one** commit is **one** declaration |
| `prose-mention` | exits 0 — a mid-line mention is prose, not a footer |

Must reject — all named:

| case | result |
|---|---|
| `two-footers` | exits 1, `declares 2 breaking changes` + `the squash keeps only the first`; summary carries `**2** breaking changes` and both shas |
| `two-bang-headers` | exits 1, `declares 2 breaking changes`; summary names both subjects |
| `hyphen-spelling` (`BREAKING-CHANGE:`) | exits 1, `declares 2 breaking changes` |
| `three-footers` | exits 1, `declares 3 breaking changes`; summary says `The other 2 would ship with no changelog entry` |

And the guard itself was broken five ways against the committed workflow; each was **seen** failing
the test:

| mutation | caught by |
|---|---|
| `^BREAKING[ -]CHANGE:` → `^BREAKING CHANGE:` | `hyphen-spelling` + the extraction assertion |
| `n="$footers"` → `n=$((footers + 1))` | `clean-single`, `footer-plus-bang-one-commit`, and 3 rejection cases losing their names |
| `-le 1` → `-le 2` | `two-footers`, `two-bang-headers`, `hyphen-spelling` |
| job renamed | the vacuity contract: `FAIL vacuity: no job \`breaking-change-footers:\`` |
| `set -euo pipefail` → `set +e` | `gh-unavailable` |

### One improvement over the source implementation

The source's own comment claims a lost `set -euo pipefail` would be caught. It would not have been:
without it a failed `gh api` leaves an empty commit list behind, the loop counts nothing, and the
job reports `declarations in this PR: 0` and goes **green** — a required context that has stopped
looking is indistinguishable from a clean tree. This port adds a `gh-unavailable` case that stubs a
failing `gh` and requires the guard to fail closed. It is the mutation table row above, and it is
worth back-porting to `azure-pipelines-release-docs` and the five originating repos.

## Branch protection — action needed after merge

This adds **one new context**. Nothing existing was renamed or split.

> **`Breaking-change footers survive the squash`**

Add it to `main`'s required status checks by hand. Until then the job reports on every PR without
blocking one — which is also the current state of `release-please can read the merged commit`, the
other half of the pair; both should be promoted together.

Closes #966
