### PR TITLE
chore(ci): converge every shared-workflow pin on v1.6.1

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -181,6 +181,21 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      # This job runs only shell, so before this step it reached no action at
+      # all -- and a job that never runs an action never runs harden-runner
+      # either. The gate reports that as an egress finding rather than treating
+      # "no actions" as "nothing to protect": the shell here still talks to the
+      # GitHub API with a token.
+      #
+      # hardening-exception: egress-audit — this job calls the GitHub API to count
+      #   breaking-change declarations across the PR's commits and runs no other
+      #   network operation; harden-runner has never run in this repository, so no
+      #   endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Count breaking-change declarations across this PR's commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-hardening.yml
+++ b/.github/workflows/workflow-hardening.yml
@@ -39,6 +39,6 @@ concurrency:
 
 jobs:
   workflow-hardening:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@27f846580ccd323f515a3e94120e54702a903c5a # v1.3.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@8b7215beac6420881d20d52f9b096edff4238ec9 # v1.6.1
     with:
-      script-ref: 27f846580ccd323f515a3e94120e54702a903c5a
+      script-ref: 8b7215beac6420881d20d52f9b096edff4238ec9


### PR DESCRIPTION
Points every `4cloudguru/shared-workflows` pin at **one** commit — [`v1.6.1`](https://github.com/4cloudguru/shared-workflows/releases/tag/v1.6.1) — with a label that is **true**.

## Why the pins diverged

The shared definitions moved six times today, each release fixing something a caller had exposed:

| release | what it fixed |
| --- | --- |
| v1.1.0 | `go-install` retry — a module-proxy read had failed a required check |
| v1.2.0 | the hardening gate, made portable (ADO per-task check no longer universal) |
| v1.3.0 | matcher fitted to one repo's formatting reported a **false failure** |
| v1.4.0 | actionlint was installed by **curl piped into bash, unverified** |
| v1.5.0 | per-task install found by declaration site, not by one filename |
| v1.6.0 | npm matched **inside quoted strings** — remediation advice read as an install |
| v1.6.1 | checker ran as `.cjs` so it works in `"type": "module"` callers |

Repos adopted mid-stream, so callers ended up spread across four pins. **Pin parity requires every caller of a workflow to agree** — the signature that enforces it reports disagreement, not staleness, because a repo deliberately held back is a decision while N repos disagreeing is drift.

## A mislabel this fixes — one I introduced

Three repos carried `# v1.2.0` on a **v1.5.0** SHA. The generator that wrote the gate block hardcoded the label in its template while the SHA came from a variable, so the two drifted apart the moment the shared repo moved.

That is exactly the defect this programme has been correcting in other repos — `dependency-review-action@a1d282b3` labelled `# v4` when it is v5.0.0 — committed by the tooling doing the correcting.

The label and the SHA now come from **the same pair**, and the script verifies after writing that every `uses:` pin, every `script-ref`, and every label agree. The generator no longer accepts a SHA without being told which release it is.
