### PR TITLE
docs(security): record the shared-workflow trust relationship, and fix what it invalidated

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -146,3 +146,15 @@ This project has a single maintainer (`@sethbacon`), who is also the sole GitHub
 ## Preferred Languages
 
 English preferred.
+
+## Shared CI workflows
+
+Part of this repository's CI is **defined in another repository** — [`4cloudguru/shared-workflows`](https://github.com/4cloudguru/shared-workflows) — and called from `.github/workflows/`. That is a real supply-chain relationship, and it is recorded here so an audit of this repository does not stop at this repository's own tree.
+
+**What runs, and where it is pinned.** Each caller in `.github/workflows/` names the shared workflow on its `uses:` line, pinned to a full 40-hex commit SHA with a trailing comment naming the release that SHA is. The tag is a label; the SHA is what runs. An unlabelled SHA is rejected by the workflow-hardening gate, because a bare 40-hex ref cannot be reviewed or updated deliberately.
+
+**Why the pins have to agree across repositories.** A shared definition drifts differently from a duplicated file: every repository looks like it is using "the shared one" while sitting on different commits, which is *harder* to see than divergent files, not easier. A signature in `security-orchestration` (`shared-workflow-pin-parity`) reports **disagreement** between callers of the same shared workflow — it reports disagreement rather than staleness, because a repository deliberately held back is a decision while N repositories disagreeing without anyone deciding is drift.
+
+**What the shared repository is itself protected by.** Its `main` requires its own zizmor and actionlint checks with `enforce_admins` enabled, restricts which third-party actions may run to an explicit allowlist, issues a read-only default `GITHUB_TOKEN`, and runs the workflow-hardening gate against itself.
+
+**What this repository still controls.** Triggers, concurrency, and the secrets it passes. Secrets are passed **by name** — never `secrets: inherit`, which would forward every secret in this repository to a workflow owned by someone else. Any `vars.*` a shared workflow reads resolve against **this** repository, so credentials and their installation scope do not move.


### PR DESCRIPTION
Records a trust relationship this repository acquired and did not document, and corrects claims that stopped being true when it did.

## The relationship

Part of this repository's CI is now **defined in another repository** — [`4cloudguru/shared-workflows`](https://github.com/4cloudguru/shared-workflows) — and called from `.github/workflows/`. Workflows owned by someone else run in this repository's CI, with secrets this repository passes them.

That belongs in `SECURITY.md`, because an audit that stops at this repository's own tree no longer sees what actually runs.

The new section states what is pinned and where, why the pins must agree across callers (and which signature enforces that), what the shared repository is itself protected by, and what this repository still controls — triggers, concurrency, and secrets passed **by name**, never `secrets: inherit`.

## Claims that were no longer true

**`All GitHub Actions are pinned to full commit SHAs (see .github/workflows/)`** — 5 repos.

Still true that they're pinned; no longer true that `.github/workflows/` is where you check. The actions that actually run are pinned in the shared repository. An auditor following that instruction would have verified a caller and concluded the claim held. It now names both places and says plainly that checking one no longer verifies it.

**`Releases are cut by a GitHub App via actions/create-github-app-token in release-please.yml`** — `cloud-suite-ui`.

That file is now a caller and contains no token step. Following the link would find nothing and the reader would be left to guess whether the control still exists. It now says the token is minted inside the shared workflow the caller points at.

**`signature-replay / replay … Not a required check yet`** — `terraform-suite-identity`.

Wrong on both counts. The context is `replay / replay` — a reusable workflow reports as `<caller-job-id> / <called-job-name>` — and it **is** required on `main`.

## Verification

Each repository's own docs-claims guard still passes where one exists.
