### PR TITLE
chore(ci): pick up the footer guard's empty-remainder fix

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -237,7 +237,7 @@ jobs:
       # as "Breaking-change footers survive the squash", so no branch protection
       # moves.
       - name: Count breaking-change declarations across this PR's commits
-        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@8a1e77427abbc21ac693c0b04b7a4b16a46f555f # v1.10.0
+        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@f38de4ea7ae1f75a35ad07604a6b7ce79625206b # v1.10.1
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
v1.10.0 → **v1.10.1**, converging this repository's pin with the other eight.

The guard counted **every** hyphenated breaking-change token. release-please does not — its body scan requires a **non-empty capture**, so a token with nothing after it is not a declaration there. The guard was **blocking two shapes release-please accepts**: a sentence ending in the bare token, and a real footer followed by one.

**This matters more today than yesterday**, because the check is now **required on main**. Until today its failure was advisory in eight of the nine repos carrying it — a guard that cannot block what it exists to stop. A *required* guard that rejects what the tool it models accepts is the opposite failure: one people route around, then delete.

**The exclusion is narrow.** The body scan's whitespace class crosses **newlines**, so a token whose description sits on a later line still counts, and so does one whose "description" is merely the next footer. Only a token followed by nothing but whitespace to the **end of the body** is dropped.

**Unchanged:** two declarations on two lines still count 2 where release-please counts 1 — it keeps only the first, and detecting that loss is the point.

## Note on this pull request

Its first commit message quoted the hyphenated token **verbatim** while describing the regex, and the guard rejected all eight PRs — **correctly**.

release-please would have read that prose as a real declaration and proposed a **major** bump whose changelog entry was the remainder of the sentence. That is precisely the defect this fix addresses, and precisely how it reached production the first time: the commit that *added* the guard to `azure-pipelines-terraform` tripped it the same way.

The token is now described rather than spelled — which is what the guard's own error message tells you to do.
