### PR TITLE
fix(ci): stop a self-test filename counting as an unguarded publish

### DIFF
--- a/scripts/check-enforced-disciplines.js
+++ b/scripts/check-enforced-disciplines.js
@@ -145,8 +145,23 @@ if (tasks.length === 0) {
     process.exit(1);
 }
 
-const unitTestYml = readIfExists('.github/workflows/unit-test.yml') || '';
-const ciJobs = parseJobs(unitTestYml);
+// The workflows that RUN the per-task tests: unit-test.yml in the sibling
+// extensions, ci.yml here. release.yml is deliberately not read -- it sets Node
+// up to BUILD, and a build is not an exercise of the test suite.
+const ciJobs = new Map();
+for (const wf of ['unit-test.yml', 'ci.yml']) {
+    const text = readIfExists(`.github/workflows/${wf}`);
+    if (!text) continue;
+    for (const [id, body] of parseJobs(text)) ciJobs.set(`${wf}:${id}`, body);
+}
+
+// A repo may name one job per task, or fan every task out through a single
+// runner. Under the second shape no job mentions any task directory, so matching
+// only on the path would report a fully-tested repo as untested.
+const fanOutScripts = Object.entries((readJsonIfExists('package.json') || {}).scripts || {})
+    .filter(([, cmd]) => /for-each-task(?:\.js)?\s+(?:test|smoke)\b/.test(cmd))
+    .map(([name]) => name);
+const runsEveryTask = (text) => fanOutScripts.some((s) => text.includes(`npm run ${s}`));
 
 for (const task of tasks) {
     const manifest = readJsonIfExists(`${task}/task.json`);
@@ -197,7 +212,7 @@ for (const task of tasks) {
     // Shipping a Node20_1 fallback that CI never runs means the agents least
     // able to recover (older/air-gapped, no Node 24 runner) are the ones that
     // discover a Node-20-incompatible dependency first.
-    const jobsForTask = [...ciJobs.entries()].filter(([, text]) => text.includes(task));
+    const jobsForTask = [...ciJobs.entries()].filter(([, text]) => text.includes(task) || runsEveryTask(text));
     const exercised = new Set();
     for (const [, text] of jobsForTask) {
         for (const major of nodeMajorsIn(text)) exercised.add(major);
@@ -215,8 +230,8 @@ for (const task of tasks) {
             `${task} -> ${handler}`,
             ok,
             ok
-                ? `unit-test.yml runs Node ${major} in ${jobsForTask.map(([id]) => id).join(', ')}`
-                : `task.json declares the ${handler} handler but no unit-test.yml job for ${task} sets up Node ${major} (jobs seen: ${jobsForTask.map(([id]) => id).join(', ') || 'none'})`,
+                ? `Node ${major} runs in ${jobsForTask.map(([id]) => id).join(', ')}`
+                : `task.json declares the ${handler} handler but no test-workflow job for ${task} sets up Node ${major} (jobs seen: ${jobsForTask.map(([id]) => id).join(', ') || 'none'})`,
         );
     }
 }
@@ -264,8 +279,12 @@ for (const task of tasks) {
 // off argv. Both are release-pipeline rules that were previously only comments.
 {
     const releaseYml = readIfExists('.github/workflows/release.yml') || '';
+    // Matched against the same path the wrapper check below looks for: a bare
+    // `publish-marketplace.js` substring also matches test-publish-marketplace.js,
+    // which made a job that merely runs the wrapper's own unit test look like an
+    // unguarded publish.
     const publishJobs = [...parseJobs(releaseYml).entries()].filter(
-        ([, text]) => /tfx\s+extension\s+publish|publish-marketplace\.js/.test(text),
+        ([, text]) => /tfx\s+extension\s+publish/.test(text) || text.includes('scripts/publish-marketplace.js'),
     );
     if (publishJobs.length === 0) {
         record('marketplace-publish-retry', 'release.yml -> publish job', false, 'no job in release.yml publishes the extension; the signature cannot verify the publish disciplines');

--- a/scripts/test-check-enforced-disciplines.js
+++ b/scripts/test-check-enforced-disciplines.js
@@ -158,7 +158,9 @@ const CASES = [
             const p = path.join(root, '.github/workflows/unit-test.yml');
             fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace('          node-version: "20"\n      - run: node src/index.js\n', ''));
         },
-        expect: 'declares the Node20_1 handler but no unit-test.yml job',
+        // "test-workflow" rather than "unit-test.yml": the gate reads whichever
+        // of unit-test.yml / ci.yml a repo keeps its task tests in.
+        expect: 'declares the Node20_1 handler but no test-workflow job',
     },
     {
         name: 'minor-bump-enforced/script',


### PR DESCRIPTION
Two defects in the enforced-disciplines gate, found while running it against a third extension and fixed there first (sethbacon/azure-pipelines-release-docs#81). Both are present here.

## 1. A self-test filename counted as an unguarded publish

The publish-job filter matched a bare substring:

```js
([, text]) => /tfx\s+extension\s+publish|publish-marketplace\.js/.test(text)
```

`test-publish-marketplace.js` contains `publish-marketplace.js`. So a job that merely runs the wrapper's **own unit test** was classified as a publish job, then failed the wrapper check because it does not invoke `scripts/publish-marketplace.js`. It is now matched against the same path that check looks for.

This repository escapes the false positive by luck: it mentions that filename only in a comment inside the job that genuinely publishes. Move the self-test into `release.yml` — as release-docs did — and it fires here too.

## 2. The handler discipline assumed one repository's layout

It read `.github/workflows/unit-test.yml` alone, and correlated jobs to tasks by directory path. Both are true here and neither is a property of the discipline. An extension that runs its task tests from `ci.yml` through a single fan-out runner has no job naming any task, so the gate reported a fully-tested repository as untested — four false FAILs.

It now reads whichever of `unit-test.yml` or `ci.yml` is present, and understands a runner that fans out over every task. `release.yml` is still deliberately not read: setting Node up to **build** is not exercising the tests.

## Why the self-test is in the same commit

Fix 2 renames the message the discipline emits, and `test-check-enforced-disciplines.js` asserts that string verbatim:

```js
expect: 'declares the Node20_1 handler but no unit-test.yml job',
```

Split them and this repository goes red on arrival. That assertion is also how the problem surfaced — release-docs carries the self-test but has never wired it into a workflow, so it had been failing there, unnoticed, since #81. Both siblings run it in CI, which is why it had to be got right before this landed.

## Verified

Run against this repository before and after the change: **the same disciplines, the same verdicts** — the only difference is the job label inside the message (`unit-test.yml runs Node 24 in <job>` → `Node 24 runs in unit-test.yml:<job>`). Gate exits 0, self-test exits 0.
