### PR TITLE
refactor(ci): take release-docs' task-dirs, the one every other gate sits on

### DIFF
--- a/scripts/lib/task-dirs.js
+++ b/scripts/lib/task-dirs.js
@@ -1,43 +1,238 @@
-// Single source of truth for "what are the task directories?".
-//
-// The repo used to hand-maintain the 11-task list in several places
-// (check-versions.js, check-minor-bumps.js, package.json script families) and
-// rely on check-task-list.js to catch drift after the fact. Those consumers now
-// DERIVE the list from disk via this module instead, so a new task is picked up
-// automatically and cannot be forgotten (issue #502). The remaining
-// hand-maintained surfaces that carry per-task metadata which cannot be derived
-// (azure-devops-extension.json contributions, release.yml SBOM steps,
-// dependabot.yml entries) are still cross-checked against this same scan by
-// check-task-list.js.
-//
-// Ground truth: every immediate subdirectory of Tasks/<Family>/ that contains a
-// task.json, returned as sorted repo-relative 'Tasks/<Family>/<Version>' paths.
+#!/usr/bin/env node
+'use strict'
 
-const fs = require('fs');
-const path = require('path');
+// Single source of truth for "what is a task directory?".
+//
+// Three scripts used to answer that question independently — check-versions.js
+// and for-each-task.js each walked exactly two directory levels looking for a
+// task.json, while copy-build.js walked Tasks/ recursively and packaged whatever
+// it found. Only the gates were restrictive, so a task.json one level deeper was
+// validated by nobody and shipped anyway (issue #37). The fix is not a better
+// filter in copy-build.js; it is that composition and enumeration stop being two
+// functions with two definitions.
+//
+// Canonical layout, matching the sibling extensions:
+//
+//   Tasks/<Family>/<TaskDirVn>/task.json
+//
+// exactly two directory levels below Tasks/. Anything else under Tasks/ is a
+// layout error, not a thing to be quietly copied or quietly skipped.
 
-// `root` is the repo root to scan (the directory that contains Tasks/). Callers
-// pass process.cwd() when they operate relative to the invocation directory
-// (check-versions.js, check-minor-bumps.js — mirroring their git/fs calls) or
-// their own resolved repo root (check-task-list.js).
-function discoverTaskDirs(root) {
-    const dirs = [];
-    const familyRoot = path.join(root, 'Tasks');
-    if (!fs.existsSync(familyRoot)) {
-        return dirs;
-    }
-    for (const family of fs.readdirSync(familyRoot, { withFileTypes: true })) {
-        if (!family.isDirectory()) continue;
-        const familyPath = path.join(familyRoot, family.name);
-        for (const version of fs.readdirSync(familyPath, { withFileTypes: true })) {
-            if (!version.isDirectory()) continue;
-            const taskJson = path.join(familyPath, version.name, 'task.json');
-            if (fs.existsSync(taskJson)) {
-                dirs.push(`Tasks/${family.name}/${version.name}`);
-            }
-        }
-    }
-    return dirs.sort();
+const fs = require('node:fs')
+const path = require('node:path')
+
+// Directory levels below Tasks/ at which a task.json is canonical.
+// Tasks/<Family>/<TaskDir>/task.json === 2.
+const TASK_DIR_DEPTH = 2
+
+function toPosix(p) {
+  return p.split(path.sep).join('/')
 }
 
-module.exports = { discoverTaskDirs };
+/**
+ * Every immediate subdirectory of Tasks/<Family>/ that contains a task.json,
+ * as sorted repo-relative POSIX paths ('Tasks/<Family>/<TaskDir>').
+ *
+ * This is the enumeration every gate and the packager agree on.
+ */
+function discoverTaskDirs(root) {
+  const tasksRoot = path.join(root, 'Tasks')
+  if (!fs.existsSync(tasksRoot)) return []
+
+  const dirs = []
+  for (const family of fs.readdirSync(tasksRoot, { withFileTypes: true })) {
+    if (!family.isDirectory()) continue
+    const familyPath = path.join(tasksRoot, family.name)
+    for (const taskDir of fs.readdirSync(familyPath, { withFileTypes: true })) {
+      if (!taskDir.isDirectory()) continue
+      if (fs.existsSync(path.join(familyPath, taskDir.name, 'task.json'))) {
+        dirs.push(`Tasks/${family.name}/${taskDir.name}`)
+      }
+    }
+  }
+  return dirs.sort()
+}
+
+/**
+ * Every entry under `dir`, recursively, WITHOUT following symlinks.
+ *
+ * `fs.readdirSync(.., { withFileTypes: true })` reports a symlink dirent as
+ * isSymbolicLink() — isFile() and isDirectory() are both false for it. That is
+ * the exact property copy-build.js used to get wrong: its `if (isDirectory)`
+ * / `else` fell through to `copyFileSync`, which FOLLOWS the link and copies
+ * the target's bytes (issue #40). Here a symlink is reported as a symlink and
+ * never descended into, so callers decide what to do about it rather than
+ * silently dereferencing it.
+ *
+ * Returns entries as { rel, kind } where rel is repo-relative POSIX and kind is
+ * one of 'file' | 'dir' | 'symlink' | 'other'.
+ */
+function walkTree(root, relDir, shouldDescend = () => true) {
+  const out = []
+  const absDir = path.join(root, relDir)
+  if (!fs.existsSync(absDir)) return out
+
+  const stack = [relDir]
+  while (stack.length > 0) {
+    const current = stack.pop()
+    for (const entry of fs.readdirSync(path.join(root, current), { withFileTypes: true })) {
+      const rel = toPosix(path.join(current, entry.name))
+      if (entry.isSymbolicLink()) {
+        out.push({ rel, kind: 'symlink' })
+      } else if (entry.isDirectory()) {
+        out.push({ rel, kind: 'dir' })
+        if (shouldDescend(rel)) stack.push(rel)
+      } else if (entry.isFile()) {
+        out.push({ rel, kind: 'file' })
+      } else {
+        out.push({ rel, kind: 'other' })
+      }
+    }
+  }
+  return out.sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0))
+}
+
+/** True when `rel` is inside one of `taskDirs` (or is one of them). */
+function insideTaskDir(rel, taskDirs) {
+  return taskDirs.some((dir) => rel === dir || rel.startsWith(`${dir}/`))
+}
+
+/** True when `rel` is an ancestor directory of one of `taskDirs`. */
+function ancestorOfTaskDir(rel, taskDirs) {
+  return taskDirs.some((dir) => dir.startsWith(`${rel}/`))
+}
+
+
+// ── The DECLARED universe ────────────────────────────────────────────────────
+//
+// `discoverTaskDirs` answers "what is here". It cannot answer the question a
+// green gate actually rests on: "is what is here what was supposed to be here?"
+// Today Tasks/ holds zero tracked files, and a gate that walks it exits 0 having
+// read nothing — a result textually identical to one that read three tasks and
+// found them sound. That is the estate's recurring defect, and it is the reason
+// this file also owns a DECLARATION.
+//
+// The declaration lives in task-universe.json at the repo root, in the shape the
+// estate already uses for the blind-audit code-universe gate
+// (security-orchestration `PROFILES[].codeUniverse[]`: `{ path, expect, minFiles,
+// why }`, Phase 0b, which aborts a run rather than grade a tree nobody opened).
+// It is data rather than a constant in this module so that a scratch tree — the
+// mutation self-tests, a fixture, a future split of this repo — carries its own
+// and is measured against it, instead of being measured against this repo's.
+//
+// The three outcomes are deliberately different things:
+//
+//   declared absent, none found  -> PASS, with a SCAFFOLD banner saying in words
+//                                   that nothing was validated. Honest, because
+//                                   the emptiness was declared in advance and is
+//                                   re-checked on every run.
+//   declared absent, some found  -> FAIL. The declaration has outlived its scope;
+//                                   the gates would otherwise start reporting on
+//                                   real task code under a floor of zero.
+//   declared present, too few    -> FAIL. The floor issue #39 asked for: once N
+//                                   tasks must exist, enumerating fewer is a
+//                                   broken checkout or a broken walk, not a pass.
+//
+// What makes this honest rather than a loophole is the second row. "Examined
+// nothing because there is nothing yet" is a claim that must be written down,
+// justified, and falsified automatically the moment it stops being true. An
+// undeclared zero is "examined nothing and called it clean"; there is no way to
+// stay in the first state by accident.
+
+const UNIVERSE_FILE = 'task-universe.json'
+
+/** A `why` shorter than this is not a justification, it is a placeholder. */
+const MIN_WHY_LENGTH = 40
+
+const SCAFFOLD_BANNER =
+  'SCAFFOLD: 0 tasks enumerated under Tasks/ — this gate proved nothing about task code. ' +
+  `Declared in ${UNIVERSE_FILE} as expect:"absent"; it fails the moment a task lands.`
+
+/**
+ * Read and validate task-universe.json. A missing or malformed declaration is an
+ * error in itself: without one, zero tasks is unfalsifiable.
+ */
+function readTaskUniverse(root) {
+  const file = path.join(root, UNIVERSE_FILE)
+  const errors = []
+  if (!fs.existsSync(file)) {
+    errors.push(
+      `${UNIVERSE_FILE}: missing — the gates walk Tasks/ and cannot tell "nothing here yet" from ` +
+        '"found nothing" without a declaration of what should be here',
+    )
+    return { declaration: null, errors }
+  }
+
+  let declaration
+  try {
+    declaration = JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch (err) {
+    errors.push(`${UNIVERSE_FILE}: not valid JSON — ${err.message}`)
+    return { declaration: null, errors }
+  }
+
+  if (declaration.expect !== 'absent' && declaration.expect !== 'present') {
+    errors.push(`${UNIVERSE_FILE}: expect must be "absent" or "present", got ${JSON.stringify(declaration.expect)}`)
+  }
+  if (typeof declaration.why !== 'string' || declaration.why.trim().length < MIN_WHY_LENGTH) {
+    errors.push(
+      `${UNIVERSE_FILE}: why must be at least ${MIN_WHY_LENGTH} characters explaining what this declaration ` +
+        'asserts and when it stops being true — a declaration nobody justified is one nobody will revisit',
+    )
+  }
+  if (declaration.expect === 'absent') {
+    if (declaration.minTasks !== undefined && declaration.minTasks !== 0) {
+      errors.push(`${UNIVERSE_FILE}: expect:"absent" cannot carry minTasks ${JSON.stringify(declaration.minTasks)}`)
+    }
+  } else if (declaration.expect === 'present') {
+    if (!Number.isInteger(declaration.minTasks) || declaration.minTasks < 1) {
+      errors.push(
+        `${UNIVERSE_FILE}: expect:"present" needs an integer minTasks >= 1 (the floor a run must clear), got ` +
+          JSON.stringify(declaration.minTasks),
+      )
+    }
+  }
+
+  return { declaration, errors }
+}
+
+/**
+ * Measure Tasks/ against the declaration.
+ *
+ * Returns { dirs, count, declaration, errors, banner, proved }. `errors` is
+ * empty only when the tree matches what was declared; `banner` is a non-null
+ * string exactly when the run enumerated nothing, and every caller must print
+ * it instead of an unqualified success line.
+ */
+function checkTaskUniverse(root) {
+  const dirs = discoverTaskDirs(root)
+  const { declaration, errors } = readTaskUniverse(root)
+
+  if (declaration && errors.length === 0) {
+    if (declaration.expect === 'absent' && dirs.length > 0) {
+      errors.push(
+        `${UNIVERSE_FILE}: declares Tasks/ absent, but ${dirs.length} task(s) are present (${dirs.join(', ')}). ` +
+          'The declaration has outlived its scope: set expect:"present" and minTasks to the count that must exist, ' +
+          'so the floor moves with reality instead of staying at zero while real task code is judged against it',
+      )
+    }
+    if (declaration.expect === 'present' && dirs.length < declaration.minTasks) {
+      errors.push(
+        `${UNIVERSE_FILE}: declares at least ${declaration.minTasks} task(s), but ${dirs.length} were enumerated ` +
+          `(${dirs.length === 0 ? 'none' : dirs.join(', ')}). Either the checkout is incomplete or the walk is broken; ` +
+          'a gate that examined fewer tasks than exist has not run',
+      )
+    }
+  }
+
+  return {
+    dirs,
+    count: dirs.length,
+    declaration,
+    errors,
+    banner: dirs.length === 0 && errors.length === 0 ? SCAFFOLD_BANNER : null,
+    proved: dirs.length > 0,
+  }
+}
+
+module.exports = { TASK_DIR_DEPTH, UNIVERSE_FILE, SCAFFOLD_BANNER, readTaskUniverse, checkTaskUniverse, discoverTaskDirs, walkTree, insideTaskDir, ancestorOfTaskDir, toPosix }


### PR DESCRIPTION
`scripts/lib/task-dirs.js` is three-way divergent — **44 lines in APT, 40 in packer, 239 in release-docs** — and every other gate imports it, so its shape has to settle before any of them can be reconciled. Group C of 4cloudguru/shared-workflows#20.

## Why this is safe to adopt wholesale

`discoverTaskDirs` is **behaviourally identical** in all three. Same walk of `Tasks/<family>/<version>`, same `task.json` filter, same sorted `Tasks/family/version` strings, same early return when `Tasks/` is absent. Only formatting and comments differ:

```js
// this repo                                    // release-docs
for (const version of fs.readdirSync(…)) {      for (const taskDir of fs.readdirSync(…)) {
  if (!version.isDirectory()) continue;           if (!taskDir.isDirectory()) continue
  const taskJson = path.join(…, 'task.json');     if (fs.existsSync(path.join(…, 'task.json')))
  if (fs.existsSync(taskJson)) …                    dirs.push(`Tasks/${family.name}/${taskDir.name}`)
}                                               }
return dirs.sort();                             return dirs.sort()
```

So the callers that exist here cannot notice.

## What it adds, and why nothing changes yet

The larger file exports `walkTree` (a recursive walk that does **not** follow symlinks — `readdirSync(.., {withFileTypes:true})` reports a symlink as neither file nor directory), `insideTaskDir`/`ancestorOfTaskDir`, and `readTaskUniverse`/`checkTaskUniverse`.

That last pair is the interesting one: it enforces a declared task count from `task-universe.json`, so **"zero tasks" becomes a falsified state rather than a silent pass** — a gate that enumerates nothing looks exactly like a clean repository otherwise.

**Nothing here calls it, and no `task-universe.json` is added.** The capability arrives inert. Wiring it up is a real behaviour change and belongs in its own PR — I'd rather this one be provably a no-op.

## Verified

Every gate in this repository that imports `task-dirs.js`, run before and after the swap:

- **APT: 6/6 identical exit codes**
- **packer: 3/3 identical exit codes**

## Sequencing

This unblocks the rest of the reconciliation — `check-versions.js`, `check-minor-bumps.js`, `check-enforced-disciplines.js` and the others all resolve their task list through this file, so reconciling them against a moving `discoverTaskDirs` would have meant redoing the work.
