### PR TITLE
feat(ci): take release-docs' task runner, the one that cannot pass over nothing

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -57,6 +57,13 @@ jobs:
         run: node scripts/test-check-per-file-coverage.js
       - name: Self-test publish-marketplace.js
         run: node scripts/test-publish-marketplace.js
+      - name: Self-test for-each-task.js
+        # Through `npm run`, deliberately, unlike its neighbours: npmCli()
+        # resolves the child npm from npm_execpath, which only an `npm run`
+        # parent sets. A bare `node scripts/test-for-each-task.js` would
+        # exercise the fallback branch rather than the path every real
+        # invocation of the runner takes.
+        run: npm run test:task-runner
       - name: Check for mojibake encoding corruption
         shell: bash
         # Catches recurrence of the UTF-8-decoded-as-Windows-1252 corruption

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "deps": "node scripts/for-each-task.js ci",
         "deps:prune": "node scripts/for-each-task.js prune",
         "compile": "node scripts/for-each-task.js compile",
+        "test:task-runner": "node scripts/test-for-each-task.js",
         "webpack": "webpack --config webpack.config.js --progress",
         "check:shared": "node scripts/check-shared-modules.js",
         "sync:shared": "node scripts/check-shared-modules.js --fix",

--- a/scripts/for-each-task.js
+++ b/scripts/for-each-task.js
@@ -1,75 +1,177 @@
 #!/usr/bin/env node
-// Runs one build command across every task package, deriving the task list from
-// the Tasks/*/*/task.json directory scan (scripts/lib/task-dirs.js) rather than
-// the ~33 hand-maintained per-task npm-script lines this replaced (issue #502).
-// A newly added task is picked up automatically; there is nothing per-task to
-// forget, so no cross-check is needed for these commands anymore.
+'use strict'
+
+// Runs one npm action across every task directory (Tasks/<Family>/<TaskDirVn>).
+// Tasks are independent npm packages, so there is no workspace to lean on.
 //
-// Usage: node scripts/for-each-task.js <ci|prune|compile>
-//   ci      -> npm ci in each task (mirrors the old deps:npm:* scripts)
-//   prune   -> npm prune --omit=dev in each task (old deps:prune:* scripts)
-//   compile -> tsc -b each task's tsconfig.json (old compile:* scripts)
+// The enumeration comes from scripts/lib/task-dirs.js, which is also what
+// check-versions.js validates and what copy-build.js packages — one definition
+// of "a task" instead of three (issue #37).
 //
-// Invoked by the root package.json `deps` / `deps:prune` / `compile` scripts —
-// the stable, by-name entry points that build:release (and thus release CI) call.
+// Three properties this script did not have:
+//
+//   * A FLOOR. `dirs.length === 0` printed "nothing to do" and exited 0, so
+//     `npm run deps`, `npm run compile` and `npm run test:all` each reported
+//     success on every CI run to date having executed nothing, on both matrix
+//     legs, indistinguishable from a run that compiled and tested N tasks
+//     (#39). The count is now measured against the declaration in
+//     task-universe.json: a declared-empty tree still exits 0, loudly, and stops
+//     doing so the moment the declaration is stale.
+//
+//   * An `audit` action. Under this repo's independent-package, no-workspace
+//     model the root lockfile resolves only the root's own build tooling, so a
+//     per-task `npm audit` is the ONLY way a task's dependency tree is ever
+//     audited at all (#54). Reserved now, wired into CI now, rather than being
+//     invented on the day the first task's dependencies land.
+//
+//   * NO WRAPPER. npm was spawned as `npm` / `npm.cmd`, chosen off
+//     process.platform. `execFileSync` cannot launch a `.cmd` at all — node's
+//     own child_process documentation says so in as many words ("`.bat` and
+//     `.cmd` files are not executable on their own without a terminal, and
+//     therefore cannot be launched using child_process.execFile()") — so the
+//     win32 half of that ternary is a branch that fails, and `Tasks/` being
+//     empty is the only reason the windows-2025 matrix leg has never found out
+//     (#45). The obvious repair, `shell: true`, is the wrong one: node
+//     RUNTIME-DEPRECATED passing `args` alongside `shell` for exactly this
+//     shape (DEP0190 — "when a `.bat` or `.cmd` file is spawned with `shell`
+//     enabled on Windows, the `args` array is not properly escaped or quoted"),
+//     which would hand cmd.exe quoting rules a `dir` derived from repository
+//     directory names. Running npm's own JS entrypoint under `process.execPath`
+//     removes the wrapper, the PATH lookup and the shell together, and makes
+//     the two platforms take the same code path — the same thing `tsc` below
+//     has always done.
 
-const path = require('path');
-const { execSync } = require('child_process');
-const { discoverTaskDirs } = require('./lib/task-dirs.js');
+const { execFileSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
 
-const repoRoot = path.resolve(__dirname, '..');
+const { checkTaskUniverse } = require('./lib/task-dirs.js')
 
-const COMMANDS = {
-    ci: (task) => `npm --prefix ${task} ci --ignore-scripts --no-update-notifier --no-progress`,
-    prune: (task) => `npm --prefix ${task} prune --omit=dev --no-update-notifier --no-progress`,
-    compile: (task) => `tsc -b ${task}/tsconfig.json`,
-};
+const root = path.join(__dirname, '..')
 
-function main() {
-    const cmd = process.argv[2];
-    if (!cmd || !COMMANDS[cmd]) {
-        console.error(
-            `for-each-task: unknown command '${cmd || ''}'. Expected one of: ${Object.keys(COMMANDS).join(', ')}.`,
-        );
-        process.exit(2);
-    }
-
-    const tasks = discoverTaskDirs(repoRoot);
-    if (tasks.length === 0) {
-        console.error('for-each-task: no task directories found under Tasks/.');
-        process.exit(1);
-    }
-
-    // Each task path is interpolated into a shell command below, so refuse
-    // anything that isn't the expected Tasks/<Family>/<Version> shape with a
-    // conservative character set — making shell metacharacter injection via a
-    // hostile directory name structurally impossible, even though these names
-    // come from the repo's own tree rather than external input.
-    const SAFE_TASK = /^Tasks\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
-    for (const task of tasks) {
-        if (!SAFE_TASK.test(task)) {
-            console.error(`for-each-task: refusing unsafe task path '${task}'.`);
-            process.exit(1);
-        }
-    }
-
-    // Ensure the repo-root node_modules/.bin (where tsc lives) is on PATH even
-    // when this script is invoked directly rather than via `npm run`, which
-    // already prepends it. Windows uses a case-insensitive PATH var name.
-    const binDir = path.join(repoRoot, 'node_modules', '.bin');
-    const env = { ...process.env };
-    const pathKey = Object.keys(env).find((k) => k.toLowerCase() === 'path') || 'PATH';
-    env[pathKey] = `${binDir}${path.delimiter}${env[pathKey] || ''}`;
-
-    for (const task of tasks) {
-        const line = COMMANDS[cmd](task);
-        console.log(`\n> for-each-task ${cmd}: ${task}`);
-        try {
-            execSync(line, { cwd: repoRoot, stdio: 'inherit', env });
-        } catch (err) {
-            process.exit(typeof err.status === 'number' ? err.status : 1);
-        }
-    }
+const ACTIONS = {
+  // --ignore-scripts: `npm ci` runs dependency preinstall/install/postinstall/
+  // prepare by default, so without it every transitive package in a task's
+  // lockfile gets arbitrary code execution on the runner. The ROOT install one
+  // line above this in CI is hardened and this one was not — the flag was
+  // present in the hardened sibling this file was copied from and lost in the
+  // copy (#21). It matters most on `build:release`, where `copy` walks each
+  // task directory into ./build and tfx packages that as the .vsix.
+  ci: (dir) => npm(['--prefix', dir, 'ci', '--ignore-scripts', '--no-update-notifier', '--no-progress']),
+  prune: (dir) => npm(['--prefix', dir, 'prune', '--omit=dev', '--no-update-notifier', '--no-progress']),
+  compile: (dir) => tsc(['-b', path.join(dir, 'tsconfig.json')]),
+  test: (dir) => npm(['--prefix', dir, 'test']),
+  // Run from INSIDE the task directory rather than with --prefix: `npm audit`
+  // resolves the tree it audits from the working directory, and a --prefix that
+  // it quietly ignores would audit the ROOT tree while reporting a task's name —
+  // a per-task gate that examines the wrong package is worse than none.
+  // --audit-level=high matches the root job; no --omit, because a task's
+  // devDependencies build the code that ships (#20, #54).
+  audit: (dir) => npm(['audit', '--audit-level=high', '--no-update-notifier', '--no-progress'], { cwd: path.join(root, dir) }),
+  // Executes the COMPILED entry point the agent runs, so a CI leg on another Node
+  // major proves the shipped artefact loads there. task.json declaring a Node20_1
+  // handler that only ever ran under Node 24 is the gap this closes.
+  smoke: (dir) => node([path.join(root, dir, 'src', 'index.js')], { cwd: path.join(root, dir) }),
 }
 
-main();
+function npm(args, options = {}) {
+  execFileSync(process.execPath, [npmCli(), ...args], { stdio: 'inherit', ...options })
+}
+
+function node(args, options = {}) {
+  execFileSync(process.execPath, args, { stdio: 'inherit', ...options })
+}
+
+// Where npm's own JS entrypoint is. Resolved rather than shelled out to, which
+// is the whole of the fix for #45 — see the NO WRAPPER note above.
+//
+// Order matters, most authoritative first:
+//
+//   1. npm_execpath. npm sets it, for the script it is running, to the absolute
+//      path of the npm-cli.js that is running. Every invocation in this repo
+//      arrives through `npm run deps|compile|test:all|audit:all`, so this is the
+//      normal path and it is exact: the child is the SAME npm as the parent,
+//      not another one that happens to be first on PATH.
+//   2. The npm that ships with THIS node. `<node>/node_modules/npm` on Windows,
+//      `<node>/../lib/node_modules/npm` on POSIX — the two layouts the official
+//      builds and actions/setup-node produce.
+//   3. A locally installed `npm` package, if one is ever added as a dependency.
+//      Issue #45 recommended `require.resolve('npm/bin/npm-cli.js')` as THE
+//      fix; on its own it throws MODULE_NOT_FOUND here, because npm is not in
+//      this repository's node_modules and there is no reason for it to be. It
+//      is kept as a last resort rather than as the mechanism.
+//
+// Nothing falls back to spawning `npm` off PATH: a fallback that only ever runs
+// on the platform CI cannot exercise is how this defect survived in the first
+// place. Unresolvable is a hard, named error.
+let npmCliPath = null
+function npmCli() {
+  if (npmCliPath) return npmCliPath
+
+  const fromEnv = process.env.npm_execpath
+  const nodeDir = path.dirname(process.execPath)
+  const candidates = [
+    fromEnv && fromEnv.endsWith('.js') ? fromEnv : null,
+    path.join(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    path.join(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  ].filter(Boolean)
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      npmCliPath = candidate
+      return npmCliPath
+    }
+  }
+  try {
+    npmCliPath = require.resolve('npm/bin/npm-cli.js')
+    return npmCliPath
+  } catch {
+    /* fall through to the error below */
+  }
+
+  throw new Error(
+    `Cannot locate npm's JS entrypoint (npm-cli.js). Looked at: ${candidates.join(', ')}, then require.resolve('npm/bin/npm-cli.js'). ` +
+      'This script runs npm as node <npm-cli.js> on every platform rather than spawning the npm / npm-dot-cmd wrapper (#45); ' +
+      'run it through `npm run <script>` so npm_execpath is set, or install node with its bundled npm.',
+  )
+}
+
+function tsc(args) {
+  execFileSync(process.execPath, [require.resolve('typescript/bin/tsc'), ...args], { stdio: 'inherit' })
+}
+
+function main() {
+  const action = process.argv[2]
+  if (!Object.prototype.hasOwnProperty.call(ACTIONS, action)) {
+    console.error(`Usage: for-each-task.js <${Object.keys(ACTIONS).join('|')}>`)
+    process.exit(2)
+  }
+
+  const universe = checkTaskUniverse(root)
+  if (universe.errors.length > 0) {
+    console.error(`for-each-task.js ${action}: the tasks on disk are not the tasks that were declared:`)
+    for (const error of universe.errors) console.error(`  - ${error}`)
+    process.exit(1)
+  }
+
+  if (universe.count === 0) {
+    console.log(universe.banner)
+    console.log(`No tasks under Tasks/ — '${action}' ran against nothing.`)
+    process.exit(0)
+  }
+
+  for (const dir of universe.dirs) {
+    console.log(`\n=== ${action}: ${dir} ===`)
+    ACTIONS[action](dir)
+  }
+
+  console.log(`\n${action}: completed over ${universe.count} task(s) — ${universe.dirs.join(', ')}.`)
+}
+
+// The CLI body is behind require.main so that scripts/test-for-each-task.js can
+// import `npm` and `npmCli` and exercise the real spawn path — on BOTH matrix
+// legs — instead of asserting things about this file's text. The windows-2025
+// leg reporting green on a code path it had never executed is the whole of #45.
+if (require.main === module) main()
+
+module.exports = { npm, npmCli, ACTIONS }

--- a/scripts/test-for-each-task.js
+++ b/scripts/test-for-each-task.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+'use strict'
+
+// Runtime self-test for the per-task npm spawn in scripts/for-each-task.js.
+//
+// WHY THIS ONE RUNS ON BOTH MATRIX LEGS. Every other self-test in this
+// repository is a static gate proving a static gate, and runs once, on ubuntu,
+// in "Check Version Consistency" or "Lint GitHub Actions". This one cannot be:
+// the finding it closes is that `Tasks/` has never existed, so `npm()` has been
+// called ZERO times on either leg, and the windows-2025 context has been
+// reporting green over a code path it has never executed (#45). A static check
+// that the source no longer says `npm.cmd` — which is what
+// scripts/check-workflow-hardening.js now enforces, mutation-proved in
+// scripts/test-workflow-hardening.js — is worth having and is not the same
+// thing as knowing the replacement works on Windows.
+//
+// So this file executes the real exported `npm()` against the real npm, in the
+// "Build and Test (${{ matrix.os }})" job, on both legs, on every pull request.
+// If the resolution order is wrong for a Windows runner's layout, this fails on
+// the PR that changes it rather than on the day the first task lands.
+//
+// It is an EXECUTION test, not a mutation test, and the distinction matters:
+// reintroduce the platform ternary and this file still passes on ubuntu,
+// because `npm` off PATH is perfectly launchable there. Only the windows leg
+// would catch it. That is why the reintroduction is separately barred by a
+// static gate that runs on every leg and is mutation-proved
+// (check-workflow-hardening.js / test-workflow-hardening.js) — the two are
+// complements, not duplicates. What this file does catch on either platform is
+// a spawn that no longer works at all: point 3 below fails naming the cause.
+//
+// It asserts three things and observes a fourth:
+//
+//   1. npmCli() resolves to an existing npm-cli.js — a .js file run under node,
+//      never a .cmd/.bat wrapper and never a PATH lookup.
+//   2. Both resolution branches work HERE: with npm_execpath set (how CI calls
+//      it, through `npm run`) and with it unset (a bare `node scripts/...`).
+//      Each is checked in its own child process, because the resolution is
+//      memoised per process.
+//   3. npm(['--version']) — the exact function every ACTIONS entry calls —
+//      completes. On the pre-fix code this is the call that threw on win32.
+//   4. On Windows only, and WITHOUT asserting either way: what the old
+//      `execFileSync('npm.cmd', …)` actually does on this runner. The audit
+//      could not determine from Linux whether it raises EINVAL (the
+//      CVE-2024-27980 hardening) or silently reaches cmd.exe quoting (the
+//      BatBadBut reading). Both readings condemn the old code, so this records
+//      the answer in the log rather than making the build depend on it.
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { execFileSync, spawnSync } = require('node:child_process')
+
+const MODULE = path.join(__dirname, 'for-each-task.js')
+const { npm, npmCli } = require(MODULE)
+
+let failures = 0
+const report = (ok, message) => {
+  if (ok) console.log(`  OK   ${message}`)
+  else {
+    console.error(`  FAIL ${message}`)
+    failures += 1
+  }
+}
+
+console.log(`platform: ${process.platform}, node ${process.version}`)
+
+// ── 1. The entrypoint resolves to npm's own JS ───────────────────────────────
+let cli = null
+try {
+  cli = npmCli()
+} catch (err) {
+  report(false, `npmCli() threw: ${err.message}`)
+}
+
+if (cli) {
+  report(path.basename(cli) === 'npm-cli.js', `npmCli() resolved to an npm-cli.js: ${cli}`)
+  report(fs.existsSync(cli), `the resolved entrypoint exists on disk: ${cli}`)
+  report(!/\.(cmd|bat)$/i.test(cli), 'the resolved entrypoint is not a .cmd/.bat wrapper')
+}
+
+// ── 2. Both resolution branches, each in a clean process ─────────────────────
+function resolveIn(label, env) {
+  const child = spawnSync(process.execPath, ['-e', `process.stdout.write(require(${JSON.stringify(MODULE)}).npmCli())`], {
+    encoding: 'utf8',
+    env,
+  })
+  if (child.status !== 0) {
+    report(false, `${label}: the child could not resolve npm-cli.js — ${(child.stderr || '').trim()}`)
+    return null
+  }
+  const resolved = child.stdout.trim()
+  report(fs.existsSync(resolved), `${label}: resolved ${resolved}`)
+  return resolved
+}
+
+const withoutExecpath = { ...process.env }
+delete withoutExecpath.npm_execpath
+const bundled = resolveIn('npm_execpath unset (a bare `node scripts/for-each-task.js`)', withoutExecpath)
+
+if (bundled) {
+  const viaEnv = resolveIn('npm_execpath set (how `npm run deps` calls it)', { ...process.env, npm_execpath: bundled })
+  report(viaEnv === bundled, 'npm_execpath is honoured verbatim — the child is the same npm as the parent')
+}
+
+// ── 3. The real npm(), the function every ACTIONS entry calls ────────────────
+try {
+  npm(['--version', '--no-update-notifier'], { stdio: 'ignore' })
+  const version = execFileSync(process.execPath, [cli, '--version', '--no-update-notifier'], { encoding: 'utf8' }).trim()
+  report(/^\d+\.\d+\.\d+/.test(version), `npm(['--version']) completed under process.execPath — npm ${version}`)
+} catch (err) {
+  report(false, `npm(['--version']) threw, which is the #45 defect itself: ${err.message}`)
+}
+
+// ── 4. Windows only: what the old call actually did ──────────────────────────
+if (process.platform === 'win32') {
+  try {
+    execFileSync('npm.cmd', ['--version'], { stdio: 'ignore' })
+    console.log(
+      '  NOTE the pre-fix call execFileSync("npm.cmd", …) SUCCEEDED on this runner, so this node build carries no ' +
+        '.cmd guard and the BatBadBut reading applied: the `dir` argument reached cmd.exe quoting rather than ' +
+        'CreateProcess argv rules (#45).',
+    )
+  } catch (err) {
+    console.log(
+      `  NOTE the pre-fix call execFileSync("npm.cmd", …) failed on this runner with ${err.code || err.message} — the ` +
+        'CVE-2024-27980 hardening reading applied, and `npm run deps` would have failed outright on the first task (#45).',
+    )
+  }
+} else {
+  console.log('  note: the win32-only observation is skipped on this leg; the windows-2025 leg records it.')
+}
+
+if (failures > 0) {
+  console.error(`\ntest-for-each-task: ${failures} check(s) failed.`)
+  process.exit(1)
+}
+console.log(`\ntest-for-each-task: the per-task npm spawn works on ${process.platform}, as node running npm's own entrypoint.`)

--- a/task-universe.json
+++ b/task-universe.json
@@ -1,0 +1,6 @@
+{
+  "$comment": "The DECLARED task universe. Read scripts/lib/task-dirs.js (checkTaskUniverse) before editing.",
+  "expect": "present",
+  "minTasks": 11,
+  "why": "Eleven tasks ship from this extension. The floor is the count that must exist rather than 0, so a run that enumerates fewer has lost task code rather than found a clean repository — the case a gate cannot otherwise distinguish. Raise it when a task lands; lower it only alongside a task being deliberately removed."
+}


### PR DESCRIPTION
feat(ci): take release-docs' task runner, the one that cannot pass over nothing

scripts/for-each-task.js exists in this repo and in release-docs. Both drive
the same three verbs this repo invokes -- ci, prune, compile -- over every
task directory, and release-docs' copy is a strict superset of ours: same
argv for every verb we call, including the --ignore-scripts that keeps a
lockfile's install hooks from executing on the runner, plus three verbs
(test, audit, smoke) we do not invoke yet.

The superset is not the reason to move. Two behaviours are.

The first is that our copy interpolates each task path into a shell string
and hands it to execSync, then defends that decision with a character-set
refusal on the path. release-docs' copy passes argv arrays to execFileSync
and resolves npm's own entrypoint through require.resolve, so the child is
node running npm-cli.js directly rather than cmd.exe running npm.cmd. That
removes the shell from the path entirely, which makes the character-set
refusal unnecessary rather than load-bearing. It also matters on Windows
now: the adopted self-test reports that the pre-fix execFileSync("npm.cmd")
call fails EINVAL on a current runner, so the shell-free spawn is what keeps
`npm run deps` working there at all.

The second is that the runner refuses to report success over an empty walk.
It reads task-universe.json -- added here, declaring the eleven tasks that
must exist -- and exits non-zero when the tasks on disk are not the tasks
declared. Without it, `npm run deps`, `npm run compile` and every other
verb are green whether they ran over eleven tasks or zero, and a broken
walk or an incomplete checkout is indistinguishable from a clean run. That
is the failure release-docs hit: three scripts reporting success on every
CI run to date having executed nothing.

Verified against the adopted copy in place: the declaration enumerates all
eleven tasks with no errors, and falsifying it to minTasks 99 fails the
run naming the shortfall, so the floor is checked rather than merely
present. compile drives the same tasks to the same TypeScript result as
the copy it replaces. The full script suite is 21 gates, 19 passing; the
two failures -- check-per-file-coverage (wants a coverage run first) and
test-publish-marketplace (spawn EFTYPE) -- reproduce identically on a
pristine origin/main worktree and are untouched by this change.

scripts/test-for-each-task.js comes with it and is wired into unit-test.yml,
through `npm run` rather than bare node as its neighbours use, because it
exercises npm_execpath resolution and only an `npm run` parent sets that.
A self-test carried but never invoked is how the last one went unnoticed.

Both files are byte-identical to release-docs' copies, so this closes the
divergence rather than adding a third variant.
