### PR TITLE
refactor(ci): make the publish script one file again, not three headers

### DIFF
--- a/scripts/publish-marketplace.js
+++ b/scripts/publish-marketplace.js
@@ -1,20 +1,34 @@
 #!/usr/bin/env node
-// Publishes the packaged .vsix to the VS Marketplace via tfx-cli, with the two
-// release-pipeline disciplines that were previously only comments in
-// release.yml enforced by construction:
+// Publishes the packaged .vsix to the VS Marketplace via tfx-cli.
+//
+// BYTE-IDENTICAL across sethbacon/azure-pipelines-terraform,
+// sethbacon/azure-pipelines-packer and sethbacon/azure-pipelines-release-docs.
+// All three publish the same kind of artefact the same way, with a token minted
+// from the same service principal, so a fix here belongs in all three: edit one
+// copy and propagate the same bytes rather than repairing only the one that
+// failed. This estate already acquired three hand-copies of one HTTP client and
+// an egress fix that reached only some of them, and both disciplines below were
+// each learned from a real failure in one extension. Issue references are fully
+// qualified for the same reason — a bare `#109` resolves to a different issue
+// in each repository.
+//
+// Two release-pipeline disciplines that were previously only comments in
+// release.yml, enforced here by construction:
 //
 //   1. THE TOKEN NEVER TOUCHES argv. tfx is spawned with --auth-type pat and NO
 //      --token, so it prompts for the token on stdin; the minted Entra access
 //      token is written to that stdin pipe. `::add-mask::` only redacts log
 //      output -- a token on argv is readable in /proc/<pid>/cmdline by anything
-//      else running in the job for the lifetime of the process (CWE-214, #109).
+//      else running in the job for the lifetime of the process (CWE-214,
+//      sethbacon/azure-pipelines-packer#109).
 //
-//   2. A TRANSIENT UPSTREAM FAILURE DOES NOT BURN THE RELEASE. v1.2.7's publish
-//      died on a single HTTP 503 from the Marketplace; with no retry the release
-//      job failed and left an orphaned draft GitHub Release behind. Retries are
-//      bounded and classify the failure: only transport/5xx/429 output is
-//      retried, never a deterministic rejection (bad manifest, auth failure,
-//      duplicate version), so a genuine error still fails fast.
+//   2. A TRANSIENT UPSTREAM FAILURE DOES NOT BURN THE RELEASE. The packer
+//      extension's v1.2.7 publish died on a single HTTP 503 from the
+//      Marketplace; with no retry the release job failed and left an orphaned
+//      draft GitHub Release behind. Retries are bounded and classify the
+//      failure: only transport/5xx/429 output is retried, never a deterministic
+//      rejection (bad manifest, auth failure, duplicate version), so a genuine
+//      error still fails fast.
 //
 //      Retrying a publish is only safe because of the "already published"
 //      handling below: if attempt N actually reached the Marketplace but the
@@ -22,6 +36,13 @@
 //      successfully rather than failing the release a second time. That check is
 //      deliberately gated on attempt >= 2, so publishing a version that really
 //      was already published still fails on a first attempt.
+//
+// The bounded retry is also why the token is minted in the SAME workflow step
+// that runs this script. The publishing service principal carries a Microsoft
+// Graph tokenLifetimePolicy pinning AccessTokenLifetime to 00:10:00, the
+// platform minimum, so the whole retry budget has to fit inside ten minutes:
+// PUBLISH_MAX_ATTEMPTS=4 with a 5s base and exponential backoff spends at most
+// 35s waiting.
 //
 // This runs INSIDE the `marketplace` environment job; it does not change, skip
 // or weaken that environment's required-reviewer approval or its deployment

--- a/scripts/test-publish-marketplace.js
+++ b/scripts/test-publish-marketplace.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 // Table-driven self-test for scripts/publish-marketplace.js.
 //
+// BYTE-IDENTICAL across sethbacon/azure-pipelines-terraform,
+// sethbacon/azure-pipelines-packer and sethbacon/azure-pipelines-release-docs,
+// alongside the script it tests.
+//
 // A retry wrapper nobody has watched fail is not a guard, so every row below
 // drives the REAL script against a fake `tfx` that records how it was invoked
 // and can be scripted to fail transiently, fail permanently, or succeed. The


### PR DESCRIPTION
refactor(ci): make the publish script one file again, not three headers

scripts/publish-marketplace.js and its self-test differ across the three
extensions in their COMMENT HEADER and nothing else: the 213 executable lines
of the script and the 243 of the test hash identically in all three today.

The divergence had a real cause. release-docs' copy carries a provenance
header explaining that it was ported, and fully qualifies its issue references
because a bare `#109` resolves to a different issue in each repository. Both
points are correct. Neither needs the file to differ.

So the header now says the thing that is true everywhere -- the file is
byte-identical across the three, all of which publish the same kind of artefact
the same way, minting a token from the same service principal in the same
workflow step -- and every issue reference is fully qualified, which is what
made the copies differ in the first place. The richer of the two headers is
kept: it also explains why retrying a publish is safe (the "already published"
handling is gated on attempt >= 2) and why the retry budget must fit inside ten
minutes (the publishing principal's tokenLifetimePolicy pins AccessTokenLifetime
to the 00:10:00 platform minimum).

Nothing executable changes. Verified: the body below the header is byte-for-byte
unchanged from origin/main in all three repositories, all three files parse, and
the self-test exits exactly as it did before.

That self-test has a pre-existing Windows-only failure this does NOT address:
publish-marketplace.js defaults --tfx to ./node_modules/.bin/tfx, the
extensionless POSIX shim, which a current Node cannot exec on win32
(spawn EFTYPE). It reproduces on origin/main in all three repositories and is
invisible in CI because every job that runs the self-test is ubuntu-latest. It
is a behavioural fix to a release-critical script and belongs in its own change,
not in a header reconciliation.
