### PR TITLE
feat(ci): take the shared workflow-security definition, and scan the whole repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     groups:
@@ -19,6 +21,8 @@ updates:
     directory: "/Tasks/TerraformTask/TerraformTaskV5"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -41,6 +45,8 @@ updates:
     directory: "/Tasks/TerraformInstaller/TerraformInstallerV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -57,6 +63,8 @@ updates:
     directory: "/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -73,6 +81,8 @@ updates:
     directory: "/Tasks/TerraformModulePublish/TerraformModulePublishV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -89,6 +99,8 @@ updates:
     directory: "/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -105,6 +117,8 @@ updates:
     directory: "/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -121,6 +135,8 @@ updates:
     directory: "/Tasks/TerraformDriftReport/TerraformDriftReportV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -137,6 +153,8 @@ updates:
     directory: "/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -153,6 +171,8 @@ updates:
     directory: "/Tasks/TerraformDocs/TerraformDocsV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -169,6 +189,8 @@ updates:
     directory: "/Tasks/Markdown2Html/Markdown2HtmlV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -185,6 +207,8 @@ updates:
     directory: "/Tasks/PublishKbArticle/PublishKbArticleV1"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -201,6 +225,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 5
@@ -228,6 +254,8 @@ updates:
     directory: /.github/commit-message-check
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
       day: monday
       time: "09:00"
       timezone: UTC

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -948,6 +948,7 @@ jobs:
   # dependabot-cooldown audit never saw dependabot.yml and reported nothing --
   # not because there was nothing to report. The shared job scans the repository.
   workflow-security:
+    name: Workflow Security
     uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@d370b2c876b1c9653bce4424b1b6b9a06898d7ae # v1.12.0
     with:
       # release.yml calls this workflow at the commit it is about to publish;

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -943,81 +943,14 @@ jobs:
         if: needs.build-and-test-tab.result != 'success'
         run: exit 1
 
-  actionlint:
-    name: Lint GitHub Actions
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      # hardening-exception: egress-audit — this job clones this repository;
-      #   harden-runner has never run in this repository, so no endpoint baseline
-      #   exists and a block policy written without one fails closed on its first run;
-      #   audit is what produces that list
-      - name: Harden the runner
-        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-          persist-credentials: false
-      - name: Install actionlint
-        shell: bash
-        # Downloads the release asset directly and verifies it against
-        # actionlint's own published SHA256 checksum before extracting,
-        # rather than the convenience install script (pinned to a commit SHA
-        # below only for its own historical reference) — that script pipes
-        # curl straight into tar with no integrity check at all. Matches this
-        # repo's verify-before-extract convention used everywhere else
-        # (TerraformInstaller/PolicyAgentInstaller GPG+SHA256SUMS, OpenTofu
-        # cosign). Checksum from
-        # https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_checksums.txt
-        # (linux_amd64, matching this job's ubuntu-latest runner).
-        run: |
-          set -euo pipefail
-          curl -sSfLO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
-          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum -c -
-          tar xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
-      - name: Run actionlint
-        run: ./actionlint -color
-  zizmor:
-    name: Scan Workflows (zizmor)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    steps:
-      # hardening-exception: egress-audit — this job calls the GitHub API and clones
-      #   this repository; harden-runner has never run in this repository, so no
-      #   endpoint baseline exists and a block policy written without one fails closed
-      #   on its first run; audit is what produces that list
-      - name: Harden the runner
-        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-          persist-credentials: false
-      - name: Download and verify zizmor
-        shell: bash
-        # Downloads the zizmor wheel directly from PyPI and verifies it
-        # against PyPI's own published SHA256 digest before use, rather than
-        # `pipx run --spec zizmor==1.26.1` (a version-string pin only, with no
-        # integrity check). Matches this repo's verify-before-use convention
-        # used everywhere else (see the actionlint step above). zizmor ships
-        # no runtime Python dependencies (requires_dist is empty per the PyPI
-        # JSON API), so verifying the single wheel it resolves to is
-        # sufficient. Checksum from
-        # https://pypi.org/pypi/zizmor/1.29.0/json (manylinux_2_28_x86_64
-        # wheel, matching this job's ubuntu-latest x86_64 runner).
-        run: |
-          set -euo pipefail
-          curl -sSfLO https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl
-          echo "587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20  zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl" | sha256sum -c -
-      # Online audits (ref-version-mismatch, impostor-commit, known-vulnerable
-      # actions) use GITHUB_TOKEN; the rest (unpinned-uses, template-injection,
-      # excessive-permissions) run regardless. Pinned for a deterministic gate.
-      - name: Run zizmor
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pipx run --spec ./zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl zizmor .github/workflows/
+  # Both linters come from the shared definition rather than being maintained
+  # here. The local pair scanned `.github/workflows/` only, so zizmor's
+  # dependabot-cooldown audit never saw dependabot.yml and reported nothing --
+  # not because there was nothing to report. The shared job scans the repository.
+  workflow-security:
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@d370b2c876b1c9653bce4424b1b6b9a06898d7ae # v1.12.0
+    with:
+      # release.yml calls this workflow at the commit it is about to publish;
+      # the linters have to read that commit, not the run's default.
+      ref: ${{ inputs.ref || github.sha }}
+

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -539,72 +539,6 @@ jobs:
             })().catch(function (err) { console.error("terraform-docs sha256-only canary FAILED: " + (err && err.message ? err.message : err)); process.exit(1); });
           '
 
-  # ── Tooling version drift canary ───────────────────────
-  # actionlint and zizmor are both hand-pinned inline (curl + sha256) in
-  # unit-test.yml's actionlint/zizmor jobs rather than tracked by any package
-  # manager Dependabot understands (#824) -- dependabot.yml has no ecosystem
-  # entry for either, so a new release only gets adopted if a human remembers
-  # to bump the version string by hand. Mirrors the HashiCorp GPG / OpenTofu
-  # cosign trust-root canaries above: compares the pinned version against the
-  # tool's latest published release and fails (opening an issue via
-  # notify-on-failure below) when they diverge, rather than drifting forever.
-  tooling-version-drift-canary:
-    name: Tooling version drift canary (actionlint, zizmor)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    steps:
-      # hardening-exception: egress-audit — this job clones this repository;
-      #   harden-runner has never run in this repository, so no endpoint baseline
-      #   exists and a block policy written without one fails closed on its first run;
-      #   audit is what produces that list
-      - name: Harden the runner
-        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: Check actionlint version drift
-        run: |
-          set -euo pipefail
-          pinned=$(grep -E 'curl .*actionlint/releases/download/v[0-9]' .github/workflows/unit-test.yml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-          if [ -z "$pinned" ]; then
-            echo "::error::Could not resolve the actionlint version pinned in unit-test.yml."
-            exit 1
-          fi
-          latest=$(curl -fsSL https://api.github.com/repos/rhysd/actionlint/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-          if [ -z "$latest" ] || [ "$latest" = "null" ]; then
-            echo "::error::Could not resolve the latest actionlint release version."
-            exit 1
-          fi
-          echo "Pinned actionlint version: $pinned; latest release: $latest"
-          if [ "$pinned" != "$latest" ]; then
-            echo "::error::actionlint is pinned to $pinned in unit-test.yml but the latest release is $latest. Bump the pinned version, tarball URL, and sha256 checksum (issue #824)."
-            exit 1
-          fi
-          echo "OK: actionlint pin ($pinned) matches the latest release."
-      - name: Check zizmor version drift
-        run: |
-          set -euo pipefail
-          pinned=$(grep -oE 'zizmor-[0-9]+\.[0-9]+\.[0-9]+-py3-none-manylinux' .github/workflows/unit-test.yml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          if [ -z "$pinned" ]; then
-            echo "::error::Could not resolve the zizmor version pinned in unit-test.yml."
-            exit 1
-          fi
-          latest=$(curl -fsSL https://pypi.org/pypi/zizmor/json | jq -r '.info.version')
-          if [ -z "$latest" ] || [ "$latest" = "null" ]; then
-            echo "::error::Could not resolve the latest zizmor release version from PyPI."
-            exit 1
-          fi
-          echo "Pinned zizmor version: $pinned; latest release: $latest"
-          if [ "$pinned" != "$latest" ]; then
-            echo "::error::zizmor is pinned to $pinned in unit-test.yml but the latest release is $latest. Bump the pinned version, wheel URL, and sha256 checksum (issue #824)."
-            exit 1
-          fi
-          echo "OK: zizmor pin ($pinned) matches the latest release."
-
   # ── Notify on failure ─────────────────────────────────
   notify-on-failure:
     name: Create issue on failure
@@ -619,7 +553,6 @@ jobs:
         opentofu-cosign-canary,
         hashicorp-gpg-canary,
         sha256-only-installer-drift-canary,
-        tooling-version-drift-canary,
       ]
     if: failure() && github.event_name == 'schedule'
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,9 @@ directories and their per-task test commands.
    - `Build and Test Markdown2Html V1`
    - `Build and Test Publish KB Article V1`
    - `Build and Test Tab` — type-checks and builds the Terraform results tab.
-   - `Lint GitHub Actions` — actionlint, plus the self-test that proves the
-     breaking-change footer guard in `.github/workflows/pr-checks.yml` still
-     rejects what it claims to (`4cloudguru/shared-workflows' tests/test-breaking-change-footers.js`).
-   - `Scan Workflows (zizmor)` — workflow-security scan.
+   - `Workflow Security` — actionlint checks the workflow schema and zizmor scans
+     for workflow-security anti-patterns, both from `4cloudguru/shared-workflows`'
+     `workflow-security.yml` rather than maintained here.
    <!-- ci-jobs:end -->
 
    This list is checked against `.github/workflows/unit-test.yml` by


### PR DESCRIPTION
feat(ci): take the shared workflow-security definition, and scan the whole repository

The local actionlint and zizmor jobs are replaced by
4cloudguru/shared-workflows' workflow-security.yml. This is convergence, but it
is not only tidiness: the local zizmor invocation was
`zizmor .github/workflows/`, and that path argument is why this repository has
never reported a finding.

zizmor's dependabot-cooldown audit only fires on a Dependabot config. Passing it
a workflows directory means it never saw .github/dependabot.yml, so fourteen
update entries with no `cooldown` were not a clean result -- they were an
unasked question. The shared job scans the repository, so the audit reaches
them.

They are answered here rather than left to arrive as fourteen findings on the
migration: every entry now sets `default-days: 7`. Dependabot's implicit default
is 3, which is what the audit reports as insufficient -- a compromised release is
usually yanked within days, and an update that lands the hour it is published
adopts it before anyone has looked. This delays VERSION updates only; GitHub
documents cooldown as not applying to SECURITY updates, so a patched advisory
still arrives immediately.

Nothing is given up by migrating. The local job verified the zizmor wheel
against PyPI's published SHA256, which looked like a control the shared
definition lacked. It is not: zizmorcore/zizmor-action does not fetch a binary
at runtime, it resolves an image BY DIGEST from a table shipped inside the
action and frozen by the action's own SHA pin, and an unrecognised version fails
closed rather than falling back to a tag. Same property, different route. The
shared file additionally names `version: "1.29.0"` explicitly, which this
repository's invocation also did -- so the scanner version stays a reviewable
line rather than moving with an action bump.

The online audits are preserved too: the action defaults its `token` input to
`github.token`, so ref-version-mismatch and impostor-commit still run rather
than silently skipping, which is what they do when no token is present.

The shared workflow is passed `ref: ${{ inputs.ref || github.sha }}`. release.yml
calls this workflow at the commit it is about to publish, and the linters have
to read that commit; the input for it was added upstream in v1.12.0 rather than
letting the migration quietly swap it for the run's default.

weekly-security.yml's tooling-version-drift canary goes with them. It worked by
grepping unit-test.yml for the pinned actionlint and zizmor versions, and both
pins now live in the shared definition -- it would have failed with "Could not
resolve the actionlint version pinned in unit-test.yml" on its next scheduled
run. Detecting that the shared pins have fallen behind is real work, and it
belongs where the pins are; raised as 4cloudguru/shared-workflows#23 rather than
left as a broken job here.

Branch protection moves in the same change: `Scan Workflows (zizmor)` and
`Lint GitHub Actions` are replaced by the contexts the called workflow reports.
A required check whose context no longer exists is not enforced and does not say
so.
