### PR TITLE
chore(ci): move the hardening gate to the version its self-test proves

### DIFF
--- a/.github/workflows/workflow-hardening.yml
+++ b/.github/workflows/workflow-hardening.yml
@@ -39,6 +39,6 @@ concurrency:
 
 jobs:
   workflow-hardening:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@8b7215beac6420881d20d52f9b096edff4238ec9 # v1.6.1
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
     with:
-      script-ref: 8b7215beac6420881d20d52f9b096edff4238ec9
+      script-ref: 9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b


### PR DESCRIPTION
chore(ci): move the hardening gate to the version its self-test proves

Pinned at v1.6.1 since the gate was shared. azure-pipelines-release-docs now
pins v1.13.0, which would have left three extensions running two versions of
one gate -- the drift sharing it was meant to end.

v1.13.0 is also the first version the gate is tested at. Until it, the only
mutation proof of check-workflow-hardening.cjs anywhere was release-docs' test
of its own older 462-line local copy: not the file any repository actually
runs. That test now lives beside the checker and runs on every change to it.

Verified against this tree before bumping rather than after: the v1.13.0
checker passes here, enumerating what it read.
