### PR TITLE
chore(ci): move workflow-security to the version that self-tests its linter

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -949,7 +949,7 @@ jobs:
   # not because there was nothing to report. The shared job scans the repository.
   workflow-security:
     name: Workflow Security
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@d370b2c876b1c9653bce4424b1b6b9a06898d7ae # v1.12.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
     with:
       # release.yml calls this workflow at the commit it is about to publish;
       # the linters have to read that commit, not the run's default.


### PR DESCRIPTION
chore(ci): move workflow-security to the version that self-tests its linter

Pinned at v1.12.0, which predates the actionlint fixture. v1.13.0 adds a
workflow with an unknown runner label, built outside the checkout so the real
run never sees it, and fails if actionlint accepts it.

That control existed in azure-pipelines-release-docs and nowhere else. It went
upstream when that repository migrated onto the shared definition, so taking
this version is how it arrives here rather than staying one repository's habit.

A linter reporting no findings and a linter that has stopped looking produce
the same green, which is the distinction this whole gate exists to make.
