### PR TITLE
chore(deps): withhold major version updates, and repair a schedule this split

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     groups:
@@ -23,6 +28,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -47,6 +57,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -65,6 +80,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -83,6 +103,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -101,6 +126,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -119,6 +149,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -137,6 +172,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -155,6 +195,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -173,6 +218,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -191,6 +241,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -209,6 +264,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -227,6 +287,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 5
@@ -254,11 +319,16 @@ updates:
     directory: /.github/commit-message-check
     schedule:
       interval: weekly
-    cooldown:
-      default-days: 7
       day: monday
       time: "09:00"
       timezone: UTC
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
       - github-actions


### PR DESCRIPTION
chore(deps): withhold major version updates, and repair a schedule this split

Two changes to .github/dependabot.yml, one of them a fix for a defect this
repository shipped a day ago.

WITHHOLDING MAJORS

A grouped Dependabot pull request in azure-pipelines-release-docs bundled
markdown-it 14 -> 15, eslint 9 -> 10 and @types/node 24 -> 26 together with five
patch bumps, and arrived red. markdown-it is the renderer feeding the HTML that
html-sanitizer.ts and uri-scheme-guard.ts exist to sanitise, so a major there
changes what those guards receive -- not something to review as one line of an
eight-update PR.

Every entry now allows only minor and patch version updates.

The mechanism is `allow`, deliberately, and NOT `ignore`. They are not
interchangeable and the difference is a security property:

  ignore  applies to version updates AND security updates. GitHub: "configure
          Dependabot to ignore those dependencies when it opens pull requests
          for version updates and security updates."
  allow   `update-types` affects version updates ONLY. GitHub: "Security updates
          will always be created regardless of the update-types setting."

So an `ignore` on semver-major -- the obvious way to write this, and the way the
existing typescript hold is written -- would also suppress a security fix whose
only available patch is a new major. `allow` withholds the routine majors and
leaves the advisory path open.

A major is now adopted by editing the manifest deliberately, which is the right
amount of friction for a change that can alter behaviour.

THE SCHEDULE THIS REPOSITORY SPLIT

The cooldown blocks added yesterday were inserted directly after `interval:`, on
the assumption that it ends a schedule block. It does not when `day`, `time` or
`timezone` are also set, and for the .github/commit-message-check entry those
three keys ended up nested under `cooldown:` instead:

    schedule:
      interval: weekly
    cooldown:
      default-days: 7
      day: monday          # belongs to schedule

That is valid YAML, which is why nothing caught it -- the schedule silently lost
its day and time, and cooldown gained three keys it does not define. One entry
here, one in azure-pipelines-packer, none in release-docs. Both restored.

It was found by parsing the file rather than reading the diff: adding the allow
block below `default-days` made the same mistake produce INVALID YAML, and the
parser said so.
