### PR TITLE
feat(tasks): warn on every run that Markdown2Html and PublishKbArticle are moving

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,6 +342,7 @@ Source: `Tasks/Markdown2Html/Markdown2HtmlV1/src/`. Converts Markdown files to H
 | `highlight-theme.ts`  | Syntax-highlighting theme wiring for `highlight.js`                                                                                                                  |
 | `document.ts`         | Document model / metadata                                                                                                                                            |
 | `render.ts`           | HTML rendering + sanitization (uses `uri-scheme-guard.ts`)                                                                                                           |
+| `deprecation-notice.ts` | The migration notice this task warns with on every run (#55) — byte-identical copy also in PublishKbArticleV1 |
 | `html-sanitizer.ts`   | Shared HTML allowlist sanitizer (`sanitize-html`) — byte-identical copy also in PublishKbArticleV1, gated by `scripts/check-shared-modules.js`                       |
 | `uri-scheme-guard.ts` | Shared XSS-prevention URI/scheme allowlist — byte-identical copy also in PublishKbArticleV1                                                                          |
 | `html-sanitizer.ts`   | Shared `sanitize-html` allowlist — the final stored-XSS defense before HTML reaches ServiceNow's `text` field; byte-identical copy also in PublishKbArticleV1 (#820) |
@@ -365,6 +366,7 @@ Source: `Tasks/PublishKbArticle/PublishKbArticleV1/src/`. Publishes or updates a
 | `uri-scheme-guard.ts`  | Shared XSS-prevention URI/scheme allowlist — byte-identical copy also in Markdown2HtmlV1                                                                          |
 | `manifest.ts`          | Legacy `KB<number>.json` manifest read/write                                                                                                                      |
 | `dry-run.ts`           | `dryRun` mode — validates without calling ServiceNow                                                                                                              |
+| `deprecation-notice.ts` | The migration notice this task warns with on every run (#55) — byte-identical copy also in Markdown2HtmlV1 |
 | `html-sanitizer.ts`    | Shared `sanitize-html` allowlist — the final stored-XSS defense before HTML reaches ServiceNow's `text` field; byte-identical copy also in Markdown2HtmlV1 (#820) |
 
 Output variables: `kbArticleId`, `kbArticleNumber`, `kbWorkflowState`.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Generates documentation for a Terraform module using terraform-docs. Requires te
 
 ### `Markdown2Html@1` — Markdown to HTML Converter
 
+> **Moving to another extension.** This task is being republished as `PipelineMarkdown2Html` in [Pipeline Tasks for Release & Documentation](https://github.com/sethbacon/azure-pipelines-release-docs). A task GUID cannot be reused across two separately-published extensions, so the replacement arrives under a new name and a new id: `Markdown2Html@1` keeps resolving here until you edit your YAML, and both extensions can be installed side by side while you move. Every run of this task now logs a non-fatal warning saying so. No cutover date has been set — see the link for status.
+
 Converts Markdown files to a single styled HTML document (via markdown-it with highlight.js syntax highlighting) — typically the module docs produced by `PipelineTerraformDocs@1` — ready to publish as a ServiceNow knowledge base article. Pure local processing; no network access.
 
 | Input         | Default                   | Description                                                                                                                 |
@@ -419,6 +421,8 @@ Converts Markdown files to a single styled HTML document (via markdown-it with h
 | `htmlFilePath` | Absolute path to the generated HTML file. |
 
 ### `PublishKbArticle@1` — Publish KB Article to ServiceNow
+
+> **Moving to another extension.** This task is being republished as `PipelinePublishKbArticle` in [Pipeline Tasks for Release & Documentation](https://github.com/sethbacon/azure-pipelines-release-docs), for the same reasons and on the same terms as `Markdown2Html@1` above: new name, new id, `PublishKbArticle@1` keeps resolving here until you edit your YAML, and every run now logs a non-fatal warning. No cutover date has been set.
 
 Creates or updates a ServiceNow knowledge base article from an HTML file. Idempotent: a stable `sourceKey` (or a `kb-key:` front-matter field) correlates re-runs to the same article. Optionally auto-creates categories/subcategories and uploads relative `<img>` images as attachments. Authenticates via a `ServiceNowKb` service connection (OAuth client credentials or basic) or inline credentials. See the [ServiceNow Setup Guide](docs/setup/servicenow-setup.md) for the minimal ServiceNow roles/ACLs this integration needs.
 

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/Tests/L0.ts
@@ -23,6 +23,7 @@ import {
 } from '../src/render';
 import { generateHtmlDocument } from '../src/document';
 import { parseFileList, processFileList, processFrontMatterDriven } from '../src/converter';
+import { migrationNotice, MIGRATION_URL } from '../src/deprecation-notice';
 
 // Per-scenario security suites, split into self-titled files (#565) matching
 // the sibling tasks' Tests/ convention so the abuse-case inventory is visible
@@ -56,6 +57,31 @@ function writeTmpDir(files: Record<string, string>): string {
     }
     return dir;
 }
+
+// ---------------------------------------------------------------------------
+// migrationNotice (deprecation-notice.ts)
+// ---------------------------------------------------------------------------
+
+describe('migrationNotice', () => {
+    const notice = migrationNotice('Markdown2Html', 'PipelineMarkdown2Html');
+
+    it('names this task and its replacement', () => {
+        assert.ok(notice.includes('Markdown2Html'));
+        assert.ok(notice.includes('PipelineMarkdown2Html'));
+    });
+
+    it('points at the documented migration URL', () => {
+        assert.ok(notice.includes(MIGRATION_URL));
+    });
+
+    it('stays on one line so the ##vso logissue command is not split', () => {
+        assert.ok(!/[\r\n]/.test(notice));
+    });
+
+    it('says the current build is unaffected, since the warning must not read as a failure', () => {
+        assert.ok(/unaffected/i.test(notice));
+    });
+});
 
 // ---------------------------------------------------------------------------
 // parseFrontMatter

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/deprecation-notice.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/deprecation-notice.ts
@@ -1,0 +1,36 @@
+/**
+ * The migration notice that Markdown2Html and PublishKbArticle emit on every
+ * run while they move out of this extension into their own
+ * (azure-pipelines-release-docs).
+ *
+ * WHY A RUNTIME WARNING AND NOT JUST A README LINE. A task GUID cannot be
+ * reused across two separately-published extensions, so the replacements
+ * arrive under a new name AND a new id. That makes this a rename, not an
+ * in-place move: an existing `Markdown2Html@1` reference keeps resolving to
+ * THIS task indefinitely, and nothing in the product tells the pipeline author
+ * that a successor exists. Absent a signal on the run itself, the migration
+ * completes only for people who happen to read a repository README.
+ *
+ * Kept byte-identical across both tasks' `src/` directories and guarded by
+ * scripts/check-shared-modules.js: the destination extension, the replacement
+ * names and the URL are one answer to one question, and a correction to any of
+ * them must not be applied to one task and silently missed in the other.
+ */
+
+/** Where the replacement extension and the migration's status are documented. */
+export const MIGRATION_URL = 'https://github.com/sethbacon/azure-pipelines-release-docs';
+
+/**
+ * Returned rather than logged so it is testable without an agent, and single
+ * line by construction: `tasks.warning` writes a line-based
+ * `##vso[task.logissue]` command that an embedded newline would split in two.
+ */
+export function migrationNotice(currentTaskName: string, replacementTaskName: string): string {
+    return (
+        `DEPRECATION: ${currentTaskName} is moving out of this extension and will be republished as ` +
+        `${replacementTaskName} in the "Pipeline Tasks for Release & Documentation" extension. ` +
+        'This build is unaffected: a task reference is never redirected automatically, so this ' +
+        `pipeline keeps using ${currentTaskName} until its YAML is changed. ` +
+        `Migration status, availability and the cutover window: ${MIGRATION_URL}`
+    );
+}

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/src/index.ts
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/src/index.ts
@@ -1,9 +1,13 @@
 import tasks = require('azure-pipelines-task-lib/task');
 import path = require('path');
 import { processFrontMatterDriven, processFileList, parseFileList } from './converter';
+import { migrationNotice } from './deprecation-notice';
 
 async function run(): Promise<void> {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
+    // Outside the try: a notice the catch could swallow would go quiet on
+    // exactly the runs most likely to be someone's last with this task.
+    tasks.warning(migrationNotice('Markdown2Html', 'PipelineMarkdown2Html'));
     try {
         const mode = tasks.getInput('mode', true)!;
         const outputFile = tasks.getInput('outputFile', true)!;

--- a/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
+++ b/Tasks/Markdown2Html/Markdown2HtmlV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "11",
+        "Minor": "12",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/Tests/L0.ts
@@ -22,6 +22,7 @@ import { extractLocalImageRefs, rewriteImageSrcs } from '../src/image-rewrite';
 import { processArticleImages, syncImageAttachment, contentTypeFor, fileSha256, listArticleAttachments, uploadAttachment, deleteAttachment, MAX_ATTACHMENT_BYTES } from '../src/attachments';
 import * as manifest from '../src/manifest';
 import { snRequest, withRetry } from '../src/servicenow-http';
+import { migrationNotice, MIGRATION_URL } from '../src/deprecation-notice';
 // Direct unit tests for the shared retry.ts module (retryAsync + parseRetryAfterMs).
 import './RetryL0';
 // Direct unit tests for the shared html-sanitizer.ts allowlist policy and
@@ -40,6 +41,31 @@ const HEADERS = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
 };
+
+// ---------------------------------------------------------------------------
+// migrationNotice (deprecation-notice.ts)
+// ---------------------------------------------------------------------------
+
+describe('migrationNotice', () => {
+    const notice = migrationNotice('PublishKbArticle', 'PipelinePublishKbArticle');
+
+    it('names this task and its replacement', () => {
+        assert.ok(notice.includes('PublishKbArticle'));
+        assert.ok(notice.includes('PipelinePublishKbArticle'));
+    });
+
+    it('points at the documented migration URL', () => {
+        assert.ok(notice.includes(MIGRATION_URL));
+    });
+
+    it('stays on one line so the ##vso logissue command is not split', () => {
+        assert.ok(!/[\r\n]/.test(notice));
+    });
+
+    it('says the current build is unaffected, since the warning must not read as a failure', () => {
+        assert.ok(/unaffected/i.test(notice));
+    });
+});
 
 // ---------------------------------------------------------------------------
 // Spy helpers for tasks.setSecret / tasks.warning

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/deprecation-notice.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/deprecation-notice.ts
@@ -1,0 +1,36 @@
+/**
+ * The migration notice that Markdown2Html and PublishKbArticle emit on every
+ * run while they move out of this extension into their own
+ * (azure-pipelines-release-docs).
+ *
+ * WHY A RUNTIME WARNING AND NOT JUST A README LINE. A task GUID cannot be
+ * reused across two separately-published extensions, so the replacements
+ * arrive under a new name AND a new id. That makes this a rename, not an
+ * in-place move: an existing `Markdown2Html@1` reference keeps resolving to
+ * THIS task indefinitely, and nothing in the product tells the pipeline author
+ * that a successor exists. Absent a signal on the run itself, the migration
+ * completes only for people who happen to read a repository README.
+ *
+ * Kept byte-identical across both tasks' `src/` directories and guarded by
+ * scripts/check-shared-modules.js: the destination extension, the replacement
+ * names and the URL are one answer to one question, and a correction to any of
+ * them must not be applied to one task and silently missed in the other.
+ */
+
+/** Where the replacement extension and the migration's status are documented. */
+export const MIGRATION_URL = 'https://github.com/sethbacon/azure-pipelines-release-docs';
+
+/**
+ * Returned rather than logged so it is testable without an agent, and single
+ * line by construction: `tasks.warning` writes a line-based
+ * `##vso[task.logissue]` command that an embedded newline would split in two.
+ */
+export function migrationNotice(currentTaskName: string, replacementTaskName: string): string {
+    return (
+        `DEPRECATION: ${currentTaskName} is moving out of this extension and will be republished as ` +
+        `${replacementTaskName} in the "Pipeline Tasks for Release & Documentation" extension. ` +
+        'This build is unaffected: a task reference is never redirected automatically, so this ' +
+        `pipeline keeps using ${currentTaskName} until its YAML is changed. ` +
+        `Migration status, availability and the cutover window: ${MIGRATION_URL}`
+    );
+}

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/src/index.ts
@@ -15,6 +15,7 @@ import { DryRunPlan, PlannedAction, formatDryRunReport } from './dry-run';
 import { processArticleImages } from './attachments';
 import { updateArticleBody } from './servicenow-client';
 import { ServiceNowHttpError } from './servicenow-http';
+import { migrationNotice } from './deprecation-notice';
 
 interface ResolvedAuth {
     instance: string;
@@ -250,6 +251,9 @@ async function executeCreateOrUpdate(
 
 async function run() {
     tasks.setResourcePath(path.join(__dirname, '..', 'task.json'));
+    // Outside the try: a notice the catch could swallow would go quiet on
+    // exactly the runs most likely to be someone's last with this task.
+    tasks.warning(migrationNotice('PublishKbArticle', 'PipelinePublishKbArticle'));
     try {
         const { instance, headers } = await resolveAuth();
 

--- a/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
+++ b/Tasks/PublishKbArticle/PublishKbArticleV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "18",
+        "Minor": "19",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/scripts/lib/shared-modules.js
+++ b/scripts/lib/shared-modules.js
@@ -141,6 +141,23 @@ const FAMILIES = [
         ],
     },
     {
+        // The migration notice both KB-publishing tasks emit on every run while
+        // they move to azure-pipelines-release-docs. Shared for the same reason
+        // the sanitizers above are: it states WHERE these tasks are going and
+        // WHAT they will be called, and two tasks migrating to one destination
+        // must not answer that in two ways. A corrected URL, a changed
+        // replacement name or a revised cutover story applied to one task and
+        // missed in the other is precisely how a consumer ends up following a
+        // stale instruction (#55).
+        dirs: [
+            'Tasks/Markdown2Html/Markdown2HtmlV1/src',
+            'Tasks/PublishKbArticle/PublishKbArticleV1/src',
+        ],
+        modules: [
+            'deprecation-notice.ts',
+        ],
+    },
+    {
         // Frozen plan/apply digest CONTRACT shared between the task that PRODUCES
         // the redacted digest (src/results/) and the build-results tab that
         // CONSUMES it (src/tab/). digest-schema.ts is the versioned TypeScript


### PR DESCRIPTION
feat(tasks): warn on every run that Markdown2Html and PublishKbArticle are moving

Both tasks are migrating to azure-pipelines-release-docs. Nothing on a run
said so, and the shape of this migration means nothing ever would have.

A task GUID cannot be reused across two separately-published extensions, so
the replacements arrive under a NEW name and a NEW id: PipelineMarkdown2Html
and PipelinePublishKbArticle. That makes this a rename, not an in-place move.
An existing `Markdown2Html@1` reference keeps resolving to THIS task
indefinitely, no matter what the other extension publishes, and Azure DevOps
never tells the pipeline author a successor exists. Left alone, the migration
would complete only for the subset of consumers who happened to read a README
they had no reason to open.

So each task now emits, on every run, one warning naming itself, its
replacement, the destination extension and where the cutover is tracked. It is
`tasks.warning`, which surfaces in the build summary without failing anything
-- loud, not blocking. It also says the current build is unaffected, because a
deprecation notice that reads like an error gets triaged as one.

The wording lives in a single shared module (src/deprecation-notice.ts),
byte-identical in both tasks and registered in FAMILIES. Two tasks migrating
to one destination must not answer "where am I going" in two ways, and this is
exactly the class of file where a corrected URL gets applied to one copy and
missed in the other -- the same failure that produced #446 and #820 in the
sanitizers this family sits beside.

The notice is built by a pure function returning a string rather than logging
directly, so it is asserted without an agent: both suites check it names the
task and its replacement, carries the documented URL, and stays on ONE line --
`tasks.warning` writes a line-based `##vso[task.logissue]` command that an
embedded newline would split in two. 100% covered in both tasks.

DELIBERATELY NOT DONE: `"deprecated": true` in task.json. That is the other
non-blocking signal available, and it belongs at cutover, not now -- it
deprioritises the task in the picker, and the replacement extension has not
published anything yet. Pushing people off this task before there is something
to move to is worse than the silence being fixed here.

The notice makes no claim with an expiry date for the same reason: it does not
say "not yet published" or name a date, so it stays true on both sides of that
event and nobody has to remember to come back and edit it.

Minors bumped on both tasks so agents re-fetch the changed handler.

Refs #55.
