### PR TITLE
fix(installers): share the artifact-hashing primitives the three installers copied

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -3,8 +3,6 @@ import tools = require('azure-pipelines-tool-lib/tool');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import crypto = require('crypto');
-import { pipeline } from 'stream/promises';
 
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchText, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
@@ -12,6 +10,10 @@ import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 import { retryAsync, parseAllowedHosts, assertEgressHostAllowed, EgressHostMessages, validateUrlPathSegment, VerificationFailure, isVerificationFailure, discardArtifactOnFailure, extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from '@4cloudguru/pipeline-task-core';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
+import { getPlatformString, hashFile, verifySha256 } from './tool-integrity';
+// Re-exported so this module's public surface is unchanged by the move to the
+// shared copy: existing importers and tests keep resolving them here (#996).
+export { getPlatformString, verifySha256 } from './tool-integrity';
 
 // The package does not import the ADO task lib, so the discard's log line is wired here.
 const discardLog = { debug: (message: string) => tasks.debug(message) };
@@ -545,31 +547,6 @@ export function parseFirstSha256(content: string, fileName: string): string {
     return parseSha256(content, fileName);
 }
 
-export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
-    const actualHash = await computeSha256Streaming(filePath);
-    if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
-        throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
-    }
-    tasks.debug(`SHA256 verification passed: ${actualHash}`);
-}
-
-/**
- * Computes a file's SHA256 via a streaming read (fs.createReadStream piped into
- * the hash) instead of buffering the whole file into memory at once (#728).
- * A compromised/malicious registry or mirror serving an oversized artifact
- * would otherwise drive the agent toward memory exhaustion at this step; the
- * streaming approach keeps memory usage constant regardless of file size.
- */
-async function computeSha256Streaming(filePath: string): Promise<string> {
-    const hash = crypto.createHash('sha256');
-    await pipeline(fs.createReadStream(filePath), hash);
-    return hash.digest('hex');
-}
-
-async function hashFile(filePath: string): Promise<string> {
-    return computeSha256Streaming(filePath);
-}
-
 /**
  * Writes a local integrity marker recording the SHA256 of the just-verified,
  * just-cached executable, so a later job's cache hit for the same tool/version can
@@ -717,15 +694,6 @@ async function reverifyUnmarkedCacheEntry(agent: string, downloadSource: string,
     }
     await writeCacheIntegrityMarker(toolDir, cachedExePath);
     console.log(tasks.loc("CachedToolReverified", toolLabel));
-}
-
-export function getPlatformString(): string {
-    switch (os.type()) {
-        case "Darwin": return "darwin";
-        case "Linux": return "linux";
-        case "Windows_NT": return "windows";
-        default: throw new Error(tasks.loc("OperatingSystemNotSupported", os.type()));
-    }
 }
 
 export function getArchString(): string {

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/tool-integrity.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/tool-integrity.ts
@@ -1,0 +1,64 @@
+/**
+ * The hashing and platform primitives shared by the three installer tasks
+ * (TerraformInstallerV1, PolicyAgentInstallerV1, TerraformDocsInstallerV1):
+ * computing an artifact's SHA256 and comparing it to a published checksum.
+ *
+ * Kept byte-identical across all three tasks' `src/` directories and guarded by
+ * scripts/check-shared-modules.js. Each of these bodies was previously
+ * hand-duplicated in every installer with identical content (#996) -- the same
+ * drift risk #681 named for the version resolver, on the download-verification
+ * path, where a correction landing in one installer and missed in the other two
+ * is a security difference rather than a cosmetic one.
+ *
+ * Neither parity gate could see that duplication while it lived inline:
+ * check-shared-modules.js only compares files named in FAMILIES, and
+ * check-near-duplicate-modules.js groups candidates by BASENAME, so bodies
+ * sitting in terraform-installer.ts, policy-agent-installer.ts and
+ * terraform-docs-installer.ts were never compared to one another. Extracting
+ * them into one same-named module is what brings them into reach of both.
+ *
+ * DELIBERATELY NOT HERE: writeCacheIntegrityMarker and verifyCachedTool, which
+ * are byte-identical in all three installers too and by rights belong beside
+ * these. They cannot move yet. scripts/check-artifact-trust.js classifies a
+ * CACHE-ADMIT site by resolving the call graph WITHIN A SINGLE FILE -- its
+ * `recordReaders` set is built from that file's own top-level functions, and the
+ * 64-hex marker validator it looks for must be a module-scope const in that same
+ * file. Moving the pair out makes all four cache-admission sites report
+ * TRUSTS-CACHE-BLINDLY even though the re-verification still happens: that is,
+ * de-duplicating them would blind the signature that guards them. Teaching that
+ * gate to follow same-directory imports is its own change, tracked separately.
+ */
+
+import tasks = require('azure-pipelines-task-lib/task');
+import os = require('os');
+import fs = require('fs');
+import crypto = require('crypto');
+import { pipeline } from 'stream/promises';
+import { VerificationFailure } from '@4cloudguru/pipeline-task-core';
+
+export function getPlatformString(): string {
+    switch (os.type()) {
+        case "Darwin": return "darwin";
+        case "Linux": return "linux";
+        case "Windows_NT": return "windows";
+        default: throw new Error(tasks.loc("OperatingSystemNotSupported", os.type()));
+    }
+}
+
+export async function computeSha256Streaming(filePath: string): Promise<string> {
+    const hash = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(filePath), hash);
+    return hash.digest('hex');
+}
+
+export async function hashFile(filePath: string): Promise<string> {
+    return computeSha256Streaming(filePath);
+}
+
+export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
+    const actualHash = await computeSha256Streaming(filePath);
+    if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
+        throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
+    }
+    tasks.debug(`SHA256 verification passed: ${actualHash}`);
+}

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "21",
+        "Minor": "25",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -3,14 +3,16 @@ import tools = require('azure-pipelines-tool-lib/tool');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import crypto = require('crypto');
-import { pipeline } from 'stream/promises';
 
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
 import { getBoolInputDefaultTrue } from './bool-input';
 import { retryAsync, parseAllowedHosts, assertEgressHostAllowed, EgressHostMessages, validateUrlPathSegment, VerificationFailure, isVerificationFailure, discardArtifactOnFailure, extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from '@4cloudguru/pipeline-task-core';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
+import { getPlatformString, hashFile, verifySha256 } from './tool-integrity';
+// Re-exported so this module's public surface is unchanged by the move to the
+// shared copy: existing importers and tests keep resolving them here (#996).
+export { getPlatformString, verifySha256 } from './tool-integrity';
 
 // The package does not import the ADO task lib, so the discard's log line is wired here.
 const discardLog = { debug: (message: string) => tasks.debug(message) };
@@ -413,31 +415,6 @@ export function parseSha256(sha256SumsContent: string, fileName: string): string
     throw new VerificationFailure(`SHA256 checksum not found for ${fileName}`);
 }
 
-export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
-    const actualHash = await computeSha256Streaming(filePath);
-    if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
-        throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
-    }
-    tasks.debug(`SHA256 verification passed: ${actualHash}`);
-}
-
-/**
- * Computes a file's SHA256 via a streaming read (fs.createReadStream piped into
- * the hash) instead of buffering the whole file into memory at once (#728).
- * A compromised/malicious registry or mirror serving an oversized artifact
- * would otherwise drive the agent toward memory exhaustion at this step; the
- * streaming approach keeps memory usage constant regardless of file size.
- */
-async function computeSha256Streaming(filePath: string): Promise<string> {
-    const hash = crypto.createHash('sha256');
-    await pipeline(fs.createReadStream(filePath), hash);
-    return hash.digest('hex');
-}
-
-async function hashFile(filePath: string): Promise<string> {
-    return computeSha256Streaming(filePath);
-}
-
 /**
  * Writes a local integrity marker recording the SHA256 of the just-verified,
  * just-cached executable, so a later job's cache hit for the same tool/version can
@@ -578,15 +555,6 @@ async function reverifyUnmarkedCacheEntry(downloadSource: string, version: strin
     }
     await writeCacheIntegrityMarker(toolDir, cachedExePath);
     console.log(tasks.loc("CachedToolReverified", toolLabel));
-}
-
-export function getPlatformString(): string {
-    switch (os.type()) {
-        case "Darwin": return "darwin";
-        case "Linux": return "linux";
-        case "Windows_NT": return "windows";
-        default: throw new Error(tasks.loc("OperatingSystemNotSupported", os.type()));
-    }
 }
 
 /** terraform-docs publishes amd64, arm64 and arm builds only (no 386). */

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/tool-integrity.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/tool-integrity.ts
@@ -1,0 +1,64 @@
+/**
+ * The hashing and platform primitives shared by the three installer tasks
+ * (TerraformInstallerV1, PolicyAgentInstallerV1, TerraformDocsInstallerV1):
+ * computing an artifact's SHA256 and comparing it to a published checksum.
+ *
+ * Kept byte-identical across all three tasks' `src/` directories and guarded by
+ * scripts/check-shared-modules.js. Each of these bodies was previously
+ * hand-duplicated in every installer with identical content (#996) -- the same
+ * drift risk #681 named for the version resolver, on the download-verification
+ * path, where a correction landing in one installer and missed in the other two
+ * is a security difference rather than a cosmetic one.
+ *
+ * Neither parity gate could see that duplication while it lived inline:
+ * check-shared-modules.js only compares files named in FAMILIES, and
+ * check-near-duplicate-modules.js groups candidates by BASENAME, so bodies
+ * sitting in terraform-installer.ts, policy-agent-installer.ts and
+ * terraform-docs-installer.ts were never compared to one another. Extracting
+ * them into one same-named module is what brings them into reach of both.
+ *
+ * DELIBERATELY NOT HERE: writeCacheIntegrityMarker and verifyCachedTool, which
+ * are byte-identical in all three installers too and by rights belong beside
+ * these. They cannot move yet. scripts/check-artifact-trust.js classifies a
+ * CACHE-ADMIT site by resolving the call graph WITHIN A SINGLE FILE -- its
+ * `recordReaders` set is built from that file's own top-level functions, and the
+ * 64-hex marker validator it looks for must be a module-scope const in that same
+ * file. Moving the pair out makes all four cache-admission sites report
+ * TRUSTS-CACHE-BLINDLY even though the re-verification still happens: that is,
+ * de-duplicating them would blind the signature that guards them. Teaching that
+ * gate to follow same-directory imports is its own change, tracked separately.
+ */
+
+import tasks = require('azure-pipelines-task-lib/task');
+import os = require('os');
+import fs = require('fs');
+import crypto = require('crypto');
+import { pipeline } from 'stream/promises';
+import { VerificationFailure } from '@4cloudguru/pipeline-task-core';
+
+export function getPlatformString(): string {
+    switch (os.type()) {
+        case "Darwin": return "darwin";
+        case "Linux": return "linux";
+        case "Windows_NT": return "windows";
+        default: throw new Error(tasks.loc("OperatingSystemNotSupported", os.type()));
+    }
+}
+
+export async function computeSha256Streaming(filePath: string): Promise<string> {
+    const hash = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(filePath), hash);
+    return hash.digest('hex');
+}
+
+export async function hashFile(filePath: string): Promise<string> {
+    return computeSha256Streaming(filePath);
+}
+
+export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
+    const actualHash = await computeSha256Streaming(filePath);
+    if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
+        throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
+    }
+    tasks.debug(`SHA256 verification passed: ${actualHash}`);
+}

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/task.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "1",
-    "Minor": "17",
+    "Minor": "21",
     "Patch": "0"
   },
   "minimumAgentVersion": "4.265.1",

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -3,8 +3,6 @@ import tools = require('azure-pipelines-tool-lib/tool');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import crypto = require('crypto');
-import { pipeline } from 'stream/promises';
 
 import { randomUUID as uuidV4 } from 'crypto';
 import { fetchJson, fetchText, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } from './http-client';
@@ -13,6 +11,10 @@ import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';
 import { retryAsync, parseAllowedHosts, assertEgressHostAllowed, EgressHostMessages, validateUrlPathSegment, VerificationFailure, isVerificationFailure, discardArtifactOnFailure, extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from '@4cloudguru/pipeline-task-core';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
+import { getPlatformString, hashFile, verifySha256 } from './tool-integrity';
+// Re-exported so this module's public surface is unchanged by the move to the
+// shared copy: existing importers and tests keep resolving them here (#996).
+export { getPlatformString, verifySha256 } from './tool-integrity';
 
 // The package does not import the ADO task lib, so the discard's log line is wired here.
 const discardLog = { debug: (message: string) => tasks.debug(message) };
@@ -444,31 +446,6 @@ export function parseSha256(sha256SumsContent: string, zipFileName: string): str
     throw new VerificationFailure(`SHA256 checksum not found for ${zipFileName}`);
 }
 
-export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
-    const actualHash = await computeSha256Streaming(filePath);
-    if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
-        throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
-    }
-    tasks.debug(`SHA256 verification passed: ${actualHash}`);
-}
-
-/**
- * Computes a file's SHA256 via a streaming read (fs.createReadStream piped into
- * the hash) instead of buffering the whole file into memory at once (#728).
- * A compromised/malicious registry or mirror serving an oversized artifact
- * would otherwise drive the agent toward memory exhaustion at this step; the
- * streaming approach keeps memory usage constant regardless of file size.
- */
-async function computeSha256Streaming(filePath: string): Promise<string> {
-    const hash = crypto.createHash('sha256');
-    await pipeline(fs.createReadStream(filePath), hash);
-    return hash.digest('hex');
-}
-
-async function hashFile(filePath: string): Promise<string> {
-    return computeSha256Streaming(filePath);
-}
-
 /**
  * Writes a local integrity marker recording the SHA256 of the just-verified,
  * just-cached executable, so a later job's cache hit for the same tool/version can
@@ -631,15 +608,6 @@ async function downloadVerifiedZipForReverify(downloadSource: string, version: s
         }
         default: // "hashicorp"
             return downloadZipFromHashiCorp(version);
-    }
-}
-
-export function getPlatformString(): string {
-    switch (os.type()) {
-        case "Darwin": return "darwin";
-        case "Linux": return "linux";
-        case "Windows_NT": return "windows";
-        default: throw new Error(tasks.loc("OperatingSystemNotSupported", os.type()));
     }
 }
 

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/tool-integrity.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/tool-integrity.ts
@@ -1,0 +1,64 @@
+/**
+ * The hashing and platform primitives shared by the three installer tasks
+ * (TerraformInstallerV1, PolicyAgentInstallerV1, TerraformDocsInstallerV1):
+ * computing an artifact's SHA256 and comparing it to a published checksum.
+ *
+ * Kept byte-identical across all three tasks' `src/` directories and guarded by
+ * scripts/check-shared-modules.js. Each of these bodies was previously
+ * hand-duplicated in every installer with identical content (#996) -- the same
+ * drift risk #681 named for the version resolver, on the download-verification
+ * path, where a correction landing in one installer and missed in the other two
+ * is a security difference rather than a cosmetic one.
+ *
+ * Neither parity gate could see that duplication while it lived inline:
+ * check-shared-modules.js only compares files named in FAMILIES, and
+ * check-near-duplicate-modules.js groups candidates by BASENAME, so bodies
+ * sitting in terraform-installer.ts, policy-agent-installer.ts and
+ * terraform-docs-installer.ts were never compared to one another. Extracting
+ * them into one same-named module is what brings them into reach of both.
+ *
+ * DELIBERATELY NOT HERE: writeCacheIntegrityMarker and verifyCachedTool, which
+ * are byte-identical in all three installers too and by rights belong beside
+ * these. They cannot move yet. scripts/check-artifact-trust.js classifies a
+ * CACHE-ADMIT site by resolving the call graph WITHIN A SINGLE FILE -- its
+ * `recordReaders` set is built from that file's own top-level functions, and the
+ * 64-hex marker validator it looks for must be a module-scope const in that same
+ * file. Moving the pair out makes all four cache-admission sites report
+ * TRUSTS-CACHE-BLINDLY even though the re-verification still happens: that is,
+ * de-duplicating them would blind the signature that guards them. Teaching that
+ * gate to follow same-directory imports is its own change, tracked separately.
+ */
+
+import tasks = require('azure-pipelines-task-lib/task');
+import os = require('os');
+import fs = require('fs');
+import crypto = require('crypto');
+import { pipeline } from 'stream/promises';
+import { VerificationFailure } from '@4cloudguru/pipeline-task-core';
+
+export function getPlatformString(): string {
+    switch (os.type()) {
+        case "Darwin": return "darwin";
+        case "Linux": return "linux";
+        case "Windows_NT": return "windows";
+        default: throw new Error(tasks.loc("OperatingSystemNotSupported", os.type()));
+    }
+}
+
+export async function computeSha256Streaming(filePath: string): Promise<string> {
+    const hash = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(filePath), hash);
+    return hash.digest('hex');
+}
+
+export async function hashFile(filePath: string): Promise<string> {
+    return computeSha256Streaming(filePath);
+}
+
+export async function verifySha256(filePath: string, expectedHash: string): Promise<void> {
+    const actualHash = await computeSha256Streaming(filePath);
+    if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
+        throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
+    }
+    tasks.debug(`SHA256 verification passed: ${actualHash}`);
+}

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "1",
-        "Minor": "245",
+        "Minor": "249",
         "Patch": "0"
     },
     "minimumAgentVersion": "4.265.1",

--- a/scripts/lib/shared-modules.js
+++ b/scripts/lib/shared-modules.js
@@ -93,6 +93,33 @@ const FAMILIES = [
         ],
     },
     {
+        // Artifact hashing and platform detection shared by the same three
+        // installer tasks: computing a downloaded artifact's SHA256 and comparing
+        // it to a published checksum. Previously hand-duplicated inline in each
+        // installer with identical bodies (#996).
+        //
+        // This duplication was invisible to BOTH gates while it lived inline:
+        // this script only compares files named in FAMILIES, and
+        // check-near-duplicate-modules.js groups by basename, so bodies sitting in
+        // terraform-installer.ts, policy-agent-installer.ts and
+        // terraform-docs-installer.ts were never compared to each other.
+        // Extracting them into one same-named module is what puts them in reach.
+        //
+        // writeCacheIntegrityMarker/verifyCachedTool are byte-identical across the
+        // three too, and are NOT here: check-artifact-trust.js resolves a
+        // CACHE-ADMIT verdict within a single file, so moving them out reports the
+        // cache-admission sites as TRUSTS-CACHE-BLINDLY. See the note in
+        // tool-integrity.ts.
+        dirs: [
+            'Tasks/TerraformInstaller/TerraformInstallerV1/src',
+            'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src',
+            'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src',
+        ],
+        modules: [
+            'tool-integrity.ts',
+        ],
+    },
+    {
         // Fail-closed boolean-input helper: requireGpgSignature / requireChecksum /
         // requireCosignVerification default to TRUE even on agents that do not
         // materialize task.json defaultValues. A drift here could silently flip a


### PR DESCRIPTION
fix(installers): share the artifact-hashing primitives the three installers copied

#996, split out of #681. That issue moved the registry version resolver into a
shared module; this is the set left behind, on a higher-consequence path.

getPlatformString, computeSha256Streaming, hashFile and verifySha256 were
declared separately in terraform-installer.ts, policy-agent-installer.ts and
terraform-docs-installer.ts with byte-identical bodies. They now live in one
tool-integrity.ts, byte-identical across the three src/ directories and
registered in FAMILIES, so check-shared-modules.js fails on any divergence.

Each installer re-exports what it exported before, so no caller and none of the
46 importing test files had to change.

WHY NOTHING REPORTED THIS

Both parity gates were structurally unable to see it. check-shared-modules.js
only compares files named in FAMILIES. check-near-duplicate-modules.js groups
candidates by BASENAME and compares within a group -- these bodies sat in three
differently-named files, so they were never compared to each other, then or now.

That is the general shape worth remembering: the parity machinery can only see
duplication that has ALREADY been extracted into a same-named module. Extracting
is what brings a thing into scope; it is not merely tidying afterwards.

WHAT DELIBERATELY DID NOT MOVE, AND WHY

writeCacheIntegrityMarker and verifyCachedTool are byte-identical across the
three as well, and by rights belong beside these. Moving them broke the build in
a way worth recording rather than working around:

  FAIL: 4 residual instance(s) of the artifact-trust class.
    downloadTerraform()      [CACHE-ADMIT] TRUSTS-CACHE-BLINDLY
    downloadTofu()           [CACHE-ADMIT] TRUSTS-CACHE-BLINDLY
    downloadPolicyAgent()    [CACHE-ADMIT] TRUSTS-CACHE-BLINDLY
    downloadTerraformDocs()  [CACHE-ADMIT] TRUSTS-CACHE-BLINDLY

Nothing had stopped re-verifying. scripts/check-artifact-trust.js resolves a
CACHE-ADMIT verdict WITHIN A SINGLE FILE: its `recordReaders` set is built from
that file's own top-level functions, and the 64-hex marker validator it looks
for must be a module-scope const in the same file. Move the pair out and the
gate can no longer see the re-verification it is there to confirm.

So de-duplicating those two would have blinded the signature that guards them.
They stay put, with the reason recorded at both the module and the FAMILIES
entry rather than left for the next person to rediscover. Teaching that gate to
follow same-directory imports is a change to a security gate and wants its own
commit and its own mutation test; it is filed separately.

Verified: 431 + 264 + 246 tests pass across the three installers;
check-artifact-trust.js still reports "every path by which an artifact becomes
trusted verifies it, discards it on failure, and degrades legibly"; the shared
parity gate now covers 12 families and 20 file comparisons; lint and tsc clean.

Minors bumped on all three so agents re-fetch the changed handlers.

Closes #996.
