### PR TITLE
docs: give the migrating tasks a cutover rule instead of "not set"

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Generates documentation for a Terraform module using terraform-docs. Requires te
 
 ### `Markdown2Html@1` — Markdown to HTML Converter
 
-> **Moving to another extension.** This task is being republished as `PipelineMarkdown2Html` in [Pipeline Tasks for Release & Documentation](https://github.com/sethbacon/azure-pipelines-release-docs). A task GUID cannot be reused across two separately-published extensions, so the replacement arrives under a new name and a new id: `Markdown2Html@1` keeps resolving here until you edit your YAML, and both extensions can be installed side by side while you move. Every run of this task now logs a non-fatal warning saying so. No cutover date has been set — see the link for status.
+> **Moving to another extension.** This task is being republished as `PipelineMarkdown2Html` in [Pipeline Tasks for Release & Documentation](https://github.com/sethbacon/azure-pipelines-release-docs). A task GUID cannot be reused across two separately-published extensions, so the replacement arrives under a new name and a new id: `Markdown2Html@1` keeps resolving here until you edit your YAML, and both extensions can be installed side by side while you move. Every run of this task now logs a non-fatal warning saying so. **Cutover:** this task stays here until both extensions have published five minor releases with it available in both, counting from that extension's first published release; it is removed here only after that.
 
 Converts Markdown files to a single styled HTML document (via markdown-it with highlight.js syntax highlighting) — typically the module docs produced by `PipelineTerraformDocs@1` — ready to publish as a ServiceNow knowledge base article. Pure local processing; no network access.
 
@@ -422,7 +422,7 @@ Converts Markdown files to a single styled HTML document (via markdown-it with h
 
 ### `PublishKbArticle@1` — Publish KB Article to ServiceNow
 
-> **Moving to another extension.** This task is being republished as `PipelinePublishKbArticle` in [Pipeline Tasks for Release & Documentation](https://github.com/sethbacon/azure-pipelines-release-docs), for the same reasons and on the same terms as `Markdown2Html@1` above: new name, new id, `PublishKbArticle@1` keeps resolving here until you edit your YAML, and every run now logs a non-fatal warning. No cutover date has been set.
+> **Moving to another extension.** This task is being republished as `PipelinePublishKbArticle` in [Pipeline Tasks for Release & Documentation](https://github.com/sethbacon/azure-pipelines-release-docs), for the same reasons and on the same terms as `Markdown2Html@1` above: new name, new id, `PublishKbArticle@1` keeps resolving here until you edit your YAML, every run now logs a non-fatal warning, and the same five-minor-releases-in-both cutover applies.
 
 Creates or updates a ServiceNow knowledge base article from an HTML file. Idempotent: a stable `sourceKey` (or a `kb-key:` front-matter field) correlates re-runs to the same article. Optionally auto-creates categories/subcategories and uploads relative `<img>` images as attachments. Authenticates via a `ServiceNowKb` service connection (OAuth client credentials or basic) or inline credentials. See the [ServiceNow Setup Guide](docs/setup/servicenow-setup.md) for the minimal ServiceNow roles/ACLs this integration needs.
 


### PR DESCRIPTION
docs: give the migrating tasks a cutover rule instead of "not set"

Both task sections said "No cutover date has been set". #55 has now decided
one, so state it where a consumer reading about the task will find it:
Markdown2Html and PublishKbArticle stay in this extension until both it and
azure-pipelines-release-docs have published five minor releases with the tasks
available in both, counted from that extension's first published release.

A version count rather than a date, and counted from the replacement's first
real release rather than from today: side-by-side only begins when there is
something to install alongside, and release-docs has not published yet.

No code change. The per-run warning added in #995 deliberately carries no
expiring claim and no date — it names the replacement and links to where the
window is documented, so the wording holds on both sides of this decision and
of the first release.

Refs #55.
