### PR TITLE
fix: teach check-artifact-trust.js to resolve names across a same-directory import

### DIFF
--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts
@@ -10,10 +10,10 @@ import { getBoolInputDefaultTrue } from './bool-input';
 import { verifyGpgSignature } from './gpg-verifier';
 import { retryAsync, parseAllowedHosts, assertEgressHostAllowed, EgressHostMessages, validateUrlPathSegment, VerificationFailure, isVerificationFailure, discardArtifactOnFailure, extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from '@4cloudguru/pipeline-task-core';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
-import { getPlatformString, hashFile, verifySha256 } from './tool-integrity';
+import { getPlatformString, hashFile, verifySha256, writeCacheIntegrityMarker, verifyCachedTool } from './tool-integrity';
 // Re-exported so this module's public surface is unchanged by the move to the
 // shared copy: existing importers and tests keep resolving them here (#996).
-export { getPlatformString, verifySha256 } from './tool-integrity';
+export { getPlatformString, verifySha256, writeCacheIntegrityMarker, verifyCachedTool } from './tool-integrity';
 
 // The package does not import the ADO task lib, so the discard's log line is wired here.
 const discardLog = { debug: (message: string) => tasks.debug(message) };
@@ -37,15 +37,6 @@ const MIRROR_EGRESS_MESSAGES: EgressHostMessages = {
 
 
 const isWindows = os.type().match(/^Win/);
-
-// File name of the local, per-cached-tool-directory integrity marker written after
-// a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
-const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
-
-// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
-// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
-// was tampered with; see verifyCachedTool (#198).
-const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 /**
  * Bounded retry for the binary download itself (#78): tools.downloadTool performs a
@@ -545,80 +536,6 @@ export function parseFirstSha256(content: string, fileName: string): string {
         }
     }
     return parseSha256(content, fileName);
-}
-
-/**
- * Writes a local integrity marker recording the SHA256 of the just-verified,
- * just-cached executable, so a later job's cache hit for the same tool/version can
- * re-verify it (see verifyCachedTool) without re-downloading anything. Best-effort:
- * a write failure must never fail an install that has already been verified — it
- * only means a future cache hit for this tool degrades to the pre-existing
- * trust-the-cache behavior.
- */
-async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
-    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
-    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
-    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
-    // a container kill -- leaves a marker that exists and is readable but is empty or
-    // truncated, and every later install of that version then compares the real digest
-    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
-    // permanently bricking the version on that agent (#198). Renaming into place means
-    // a reader only ever sees a complete digest or no marker at all.
-    const tempPath = `${markerPath}.${uuidV4()}.tmp`;
-    try {
-        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
-        fs.renameSync(tempPath, markerPath);
-    } catch (err) {
-        tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
-        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
-    }
-}
-
-/**
- * On a tool-cache hit, re-verifies the cached executable against the local
- * integrity marker written when it was originally downloaded and verified. This is
- * a purely local, offline comparison (no network call), so it can never break
- * offline/air-gapped cache usage.
- *
- * - No marker (cached before this check existed, or cached by a run where checksum
- *   verification was disabled): returns false — the caller escalates to a remote
- *   re-verification against a freshly downloaded release (see
- *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
- * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
- *   an interrupted write (#198): returns false, exactly like a missing marker. An
- *   unverifiable record is not evidence of tampering; feeding the fragment to the
- *   comparison would fail every subsequent install of that version with a
- *   tampering-shaped error and send an operator down a security-incident path for
- *   what is a torn file. The marker is NOT healed here — healing happens only after
- *   the escalated re-verification actually proves the cached executable.
- * - Marker present and it matches the cached executable's current hash: passes
- *   silently, returns true.
- * - Marker present, well-formed, and it does not match: the cached executable changed
- *   since it was verified (tampering or corruption on a shared agent) — fail closed.
- *
- * Trust-boundary note: the marker lives next to the executable it protects, so an
- * attacker who can rewrite the cached binary under the agent account can rewrite
- * the marker to match. This check is defense-in-depth against corruption and
- * cross-job verification-policy mixing, not against an attacker who already has
- * write access to the agent's tool cache (who effectively owns the agent).
- */
-async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
-    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
-    if (!fs.existsSync(markerPath)) {
-        tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
-        return false;
-    }
-    const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
-    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
-        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
-        return false;
-    }
-    const actualHash = (await hashFile(exePath)).toLowerCase();
-    if (actualHash !== storedHash) {
-        throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
-    }
-    tasks.debug(`Cache hit for ${toolLabel}: integrity marker verified (${actualHash}).`);
-    return true;
 }
 
 /**

--- a/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/tool-integrity.ts
+++ b/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/tool-integrity.ts
@@ -1,7 +1,7 @@
 /**
- * The hashing and platform primitives shared by the three installer tasks
- * (TerraformInstallerV1, PolicyAgentInstallerV1, TerraformDocsInstallerV1):
- * computing an artifact's SHA256 and comparing it to a published checksum.
+ * The hashing, platform and cache-integrity primitives shared by the three
+ * installer tasks (TerraformInstallerV1, PolicyAgentInstallerV1,
+ * TerraformDocsInstallerV1).
  *
  * Kept byte-identical across all three tasks' `src/` directories and guarded by
  * scripts/check-shared-modules.js. Each of these bodies was previously
@@ -17,24 +17,31 @@
  * terraform-docs-installer.ts were never compared to one another. Extracting
  * them into one same-named module is what brings them into reach of both.
  *
- * DELIBERATELY NOT HERE: writeCacheIntegrityMarker and verifyCachedTool, which
- * are byte-identical in all three installers too and by rights belong beside
- * these. They cannot move yet. scripts/check-artifact-trust.js classifies a
- * CACHE-ADMIT site by resolving the call graph WITHIN A SINGLE FILE -- its
- * `recordReaders` set is built from that file's own top-level functions, and the
- * 64-hex marker validator it looks for must be a module-scope const in that same
- * file. Moving the pair out makes all four cache-admission sites report
- * TRUSTS-CACHE-BLINDLY even though the re-verification still happens: that is,
- * de-duplicating them would blind the signature that guards them. Teaching that
- * gate to follow same-directory imports is its own change, tracked separately.
+ * writeCacheIntegrityMarker and verifyCachedTool moved in last (#998):
+ * scripts/check-artifact-trust.js used to classify a CACHE-ADMIT site by
+ * resolving the call graph within a single file, so moving this pair out on its
+ * own would have made every cache-admission site in the three callers report
+ * TRUSTS-CACHE-BLINDLY even though the re-verification still happens. That gate
+ * now follows same-directory `import`s (see its own header comment), so the pair
+ * can live here with the primitives it is built on.
  */
 
 import tasks = require('azure-pipelines-task-lib/task');
 import os = require('os');
 import fs = require('fs');
+import path = require('path');
 import crypto = require('crypto');
 import { pipeline } from 'stream/promises';
 import { VerificationFailure } from '@4cloudguru/pipeline-task-core';
+
+// File name of the local, per-cached-tool-directory integrity marker written after
+// a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
+const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
+
+// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
+// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
+// was tampered with; see verifyCachedTool (#198).
+const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 export function getPlatformString(): string {
     switch (os.type()) {
@@ -61,4 +68,78 @@ export async function verifySha256(filePath: string, expectedHash: string): Prom
         throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
     }
     tasks.debug(`SHA256 verification passed: ${actualHash}`);
+}
+
+/**
+ * Writes a local integrity marker recording the SHA256 of the just-verified,
+ * just-cached executable, so a later job's cache hit for the same tool/version can
+ * re-verify it (see verifyCachedTool) without re-downloading anything. Best-effort:
+ * a write failure must never fail an install that has already been verified — it
+ * only means a future cache hit for this tool degrades to the pre-existing
+ * trust-the-cache behavior.
+ */
+export async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
+    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
+    // a container kill -- leaves a marker that exists and is readable but is empty or
+    // truncated, and every later install of that version then compares the real digest
+    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
+    // permanently bricking the version on that agent (#198). Renaming into place means
+    // a reader only ever sees a complete digest or no marker at all.
+    const tempPath = `${markerPath}.${crypto.randomUUID()}.tmp`;
+    try {
+        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
+        fs.renameSync(tempPath, markerPath);
+    } catch (err) {
+        tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
+        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
+    }
+}
+
+/**
+ * On a tool-cache hit, re-verifies the cached executable against the local
+ * integrity marker written when it was originally downloaded and verified. This is
+ * a purely local, offline comparison (no network call), so it can never break
+ * offline/air-gapped cache usage.
+ *
+ * - No marker (cached before this check existed, or cached by a run where checksum
+ *   verification was disabled): returns false — the caller escalates to a remote
+ *   re-verification against a freshly downloaded release (see
+ *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
+ * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
+ *   an interrupted write (#198): returns false, exactly like a missing marker. An
+ *   unverifiable record is not evidence of tampering; feeding the fragment to the
+ *   comparison would fail every subsequent install of that version with a
+ *   tampering-shaped error and send an operator down a security-incident path for
+ *   what is a torn file. The marker is NOT healed here — healing happens only after
+ *   the escalated re-verification actually proves the cached executable.
+ * - Marker present and it matches the cached executable's current hash: passes
+ *   silently, returns true.
+ * - Marker present, well-formed, and it does not match: the cached executable changed
+ *   since it was verified (tampering or corruption on a shared agent) — fail closed.
+ *
+ * Trust-boundary note: the marker lives next to the executable it protects, so an
+ * attacker who can rewrite the cached binary under the agent account can rewrite
+ * the marker to match. This check is defense-in-depth against corruption and
+ * cross-job verification-policy mixing, not against an attacker who already has
+ * write access to the agent's tool cache (who effectively owns the agent).
+ */
+export async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    if (!fs.existsSync(markerPath)) {
+        tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
+        return false;
+    }
+    const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
+    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
+        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
+        return false;
+    }
+    const actualHash = (await hashFile(exePath)).toLowerCase();
+    if (actualHash !== storedHash) {
+        throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
+    }
+    tasks.debug(`Cache hit for ${toolLabel}: integrity marker verified (${actualHash}).`);
+    return true;
 }

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts
@@ -9,10 +9,10 @@ import { fetchJson, fetchTextAllow404, downloadToFile, DOWNLOAD_TIMEOUT_MS } fro
 import { getBoolInputDefaultTrue } from './bool-input';
 import { retryAsync, parseAllowedHosts, assertEgressHostAllowed, EgressHostMessages, validateUrlPathSegment, VerificationFailure, isVerificationFailure, discardArtifactOnFailure, extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from '@4cloudguru/pipeline-task-core';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
-import { getPlatformString, hashFile, verifySha256 } from './tool-integrity';
+import { getPlatformString, hashFile, verifySha256, writeCacheIntegrityMarker, verifyCachedTool } from './tool-integrity';
 // Re-exported so this module's public surface is unchanged by the move to the
 // shared copy: existing importers and tests keep resolving them here (#996).
-export { getPlatformString, verifySha256 } from './tool-integrity';
+export { getPlatformString, verifySha256, writeCacheIntegrityMarker, verifyCachedTool } from './tool-integrity';
 
 // The package does not import the ADO task lib, so the discard's log line is wired here.
 const discardLog = { debug: (message: string) => tasks.debug(message) };
@@ -37,15 +37,6 @@ const MIRROR_EGRESS_MESSAGES: EgressHostMessages = {
 
 const toolName = "terraform-docs";
 const isWindows = os.type().match(/^Win/);
-
-// File name of the local, per-cached-tool-directory integrity marker written after
-// a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
-const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
-
-// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
-// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
-// was tampered with; see verifyCachedTool (#198).
-const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 /**
  * Bounded retry for the binary download itself (#78): tools.downloadTool performs a
@@ -413,80 +404,6 @@ export function parseSha256(sha256SumsContent: string, fileName: string): string
     // typed as a verification failure so the cache-hit re-verification path
     // fails closed instead of degrading to "material unavailable".
     throw new VerificationFailure(`SHA256 checksum not found for ${fileName}`);
-}
-
-/**
- * Writes a local integrity marker recording the SHA256 of the just-verified,
- * just-cached executable, so a later job's cache hit for the same tool/version can
- * re-verify it (see verifyCachedTool) without re-downloading anything. Best-effort:
- * a write failure must never fail an install that has already been verified — it
- * only means a future cache hit for this tool degrades to the pre-existing
- * trust-the-cache behavior.
- */
-async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
-    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
-    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
-    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
-    // a container kill -- leaves a marker that exists and is readable but is empty or
-    // truncated, and every later install of that version then compares the real digest
-    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
-    // permanently bricking the version on that agent (#198). Renaming into place means
-    // a reader only ever sees a complete digest or no marker at all.
-    const tempPath = `${markerPath}.${uuidV4()}.tmp`;
-    try {
-        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
-        fs.renameSync(tempPath, markerPath);
-    } catch (err) {
-        tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
-        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
-    }
-}
-
-/**
- * On a tool-cache hit, re-verifies the cached executable against the local
- * integrity marker written when it was originally downloaded and verified. This is
- * a purely local, offline comparison (no network call), so it can never break
- * offline/air-gapped cache usage.
- *
- * - No marker (cached before this check existed, or cached by a run where checksum
- *   verification was disabled): returns false — the caller escalates to a remote
- *   re-verification against a freshly downloaded release (see
- *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
- * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
- *   an interrupted write (#198): returns false, exactly like a missing marker. An
- *   unverifiable record is not evidence of tampering; feeding the fragment to the
- *   comparison would fail every subsequent install of that version with a
- *   tampering-shaped error and send an operator down a security-incident path for
- *   what is a torn file. The marker is NOT healed here — healing happens only after
- *   the escalated re-verification actually proves the cached executable.
- * - Marker present and it matches the cached executable's current hash: passes
- *   silently, returns true.
- * - Marker present, well-formed, and it does not match: the cached executable changed
- *   since it was verified (tampering or corruption on a shared agent) — fail closed.
- *
- * Trust-boundary note: the marker lives next to the executable it protects, so an
- * attacker who can rewrite the cached binary under the agent account can rewrite
- * the marker to match. This check is defense-in-depth against corruption and
- * cross-job verification-policy mixing, not against an attacker who already has
- * write access to the agent's tool cache (who effectively owns the agent).
- */
-async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
-    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
-    if (!fs.existsSync(markerPath)) {
-        tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
-        return false;
-    }
-    const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
-    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
-        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
-        return false;
-    }
-    const actualHash = (await hashFile(exePath)).toLowerCase();
-    if (actualHash !== storedHash) {
-        throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
-    }
-    tasks.debug(`Cache hit for ${toolLabel}: integrity marker verified (${actualHash}).`);
-    return true;
 }
 
 /**

--- a/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/tool-integrity.ts
+++ b/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/tool-integrity.ts
@@ -1,7 +1,7 @@
 /**
- * The hashing and platform primitives shared by the three installer tasks
- * (TerraformInstallerV1, PolicyAgentInstallerV1, TerraformDocsInstallerV1):
- * computing an artifact's SHA256 and comparing it to a published checksum.
+ * The hashing, platform and cache-integrity primitives shared by the three
+ * installer tasks (TerraformInstallerV1, PolicyAgentInstallerV1,
+ * TerraformDocsInstallerV1).
  *
  * Kept byte-identical across all three tasks' `src/` directories and guarded by
  * scripts/check-shared-modules.js. Each of these bodies was previously
@@ -17,24 +17,31 @@
  * terraform-docs-installer.ts were never compared to one another. Extracting
  * them into one same-named module is what brings them into reach of both.
  *
- * DELIBERATELY NOT HERE: writeCacheIntegrityMarker and verifyCachedTool, which
- * are byte-identical in all three installers too and by rights belong beside
- * these. They cannot move yet. scripts/check-artifact-trust.js classifies a
- * CACHE-ADMIT site by resolving the call graph WITHIN A SINGLE FILE -- its
- * `recordReaders` set is built from that file's own top-level functions, and the
- * 64-hex marker validator it looks for must be a module-scope const in that same
- * file. Moving the pair out makes all four cache-admission sites report
- * TRUSTS-CACHE-BLINDLY even though the re-verification still happens: that is,
- * de-duplicating them would blind the signature that guards them. Teaching that
- * gate to follow same-directory imports is its own change, tracked separately.
+ * writeCacheIntegrityMarker and verifyCachedTool moved in last (#998):
+ * scripts/check-artifact-trust.js used to classify a CACHE-ADMIT site by
+ * resolving the call graph within a single file, so moving this pair out on its
+ * own would have made every cache-admission site in the three callers report
+ * TRUSTS-CACHE-BLINDLY even though the re-verification still happens. That gate
+ * now follows same-directory `import`s (see its own header comment), so the pair
+ * can live here with the primitives it is built on.
  */
 
 import tasks = require('azure-pipelines-task-lib/task');
 import os = require('os');
 import fs = require('fs');
+import path = require('path');
 import crypto = require('crypto');
 import { pipeline } from 'stream/promises';
 import { VerificationFailure } from '@4cloudguru/pipeline-task-core';
+
+// File name of the local, per-cached-tool-directory integrity marker written after
+// a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
+const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
+
+// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
+// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
+// was tampered with; see verifyCachedTool (#198).
+const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 export function getPlatformString(): string {
     switch (os.type()) {
@@ -61,4 +68,78 @@ export async function verifySha256(filePath: string, expectedHash: string): Prom
         throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
     }
     tasks.debug(`SHA256 verification passed: ${actualHash}`);
+}
+
+/**
+ * Writes a local integrity marker recording the SHA256 of the just-verified,
+ * just-cached executable, so a later job's cache hit for the same tool/version can
+ * re-verify it (see verifyCachedTool) without re-downloading anything. Best-effort:
+ * a write failure must never fail an install that has already been verified — it
+ * only means a future cache hit for this tool degrades to the pre-existing
+ * trust-the-cache behavior.
+ */
+export async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
+    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
+    // a container kill -- leaves a marker that exists and is readable but is empty or
+    // truncated, and every later install of that version then compares the real digest
+    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
+    // permanently bricking the version on that agent (#198). Renaming into place means
+    // a reader only ever sees a complete digest or no marker at all.
+    const tempPath = `${markerPath}.${crypto.randomUUID()}.tmp`;
+    try {
+        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
+        fs.renameSync(tempPath, markerPath);
+    } catch (err) {
+        tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
+        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
+    }
+}
+
+/**
+ * On a tool-cache hit, re-verifies the cached executable against the local
+ * integrity marker written when it was originally downloaded and verified. This is
+ * a purely local, offline comparison (no network call), so it can never break
+ * offline/air-gapped cache usage.
+ *
+ * - No marker (cached before this check existed, or cached by a run where checksum
+ *   verification was disabled): returns false — the caller escalates to a remote
+ *   re-verification against a freshly downloaded release (see
+ *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
+ * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
+ *   an interrupted write (#198): returns false, exactly like a missing marker. An
+ *   unverifiable record is not evidence of tampering; feeding the fragment to the
+ *   comparison would fail every subsequent install of that version with a
+ *   tampering-shaped error and send an operator down a security-incident path for
+ *   what is a torn file. The marker is NOT healed here — healing happens only after
+ *   the escalated re-verification actually proves the cached executable.
+ * - Marker present and it matches the cached executable's current hash: passes
+ *   silently, returns true.
+ * - Marker present, well-formed, and it does not match: the cached executable changed
+ *   since it was verified (tampering or corruption on a shared agent) — fail closed.
+ *
+ * Trust-boundary note: the marker lives next to the executable it protects, so an
+ * attacker who can rewrite the cached binary under the agent account can rewrite
+ * the marker to match. This check is defense-in-depth against corruption and
+ * cross-job verification-policy mixing, not against an attacker who already has
+ * write access to the agent's tool cache (who effectively owns the agent).
+ */
+export async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    if (!fs.existsSync(markerPath)) {
+        tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
+        return false;
+    }
+    const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
+    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
+        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
+        return false;
+    }
+    const actualHash = (await hashFile(exePath)).toLowerCase();
+    if (actualHash !== storedHash) {
+        throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
+    }
+    tasks.debug(`Cache hit for ${toolLabel}: integrity marker verified (${actualHash}).`);
+    return true;
 }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/ArtifactTrustL0.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/Tests/ArtifactTrustL0.ts
@@ -37,6 +37,12 @@ const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const TF = 'Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts';
 const PA = 'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/policy-agent-installer.ts';
 const TD = 'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/terraform-docs-installer.ts';
+// writeCacheIntegrityMarker/verifyCachedTool live in the shared tool-integrity.ts
+// beside the hashing primitives they are built on (#998), one per task's own
+// src/ directory (kept byte-identical, guarded by check-shared-modules.js).
+const TF_TI = 'Tasks/TerraformInstaller/TerraformInstallerV1/src/tool-integrity.ts';
+const PA_TI = 'Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1/src/tool-integrity.ts';
+const TD_TI = 'Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1/src/tool-integrity.ts';
 
 type SiteRow = { file: string; fn: string; kind: string; verdict: string };
 
@@ -78,8 +84,8 @@ const SITE_ROWS: SiteRow[] = [
     { file: TF, fn: 'downloadZipFromMirror', kind: 'SUMS-ABSENT', verdict: 'HONORS-SIGNATURE-TOGGLE' },
     { file: TF, fn: 'downloadZipFromMirror', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
     { file: TF, fn: 'downloadZipFromMirror', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
-    { file: TF, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
-    { file: TF, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
+    { file: TF_TI, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
+    { file: TF_TI, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
     { file: TF, fn: 'downloadTofu', kind: 'CACHE-ADMIT', verdict: 'REVERIFIES-AND-GATES' },
     { file: TF, fn: 'resolveVersionFromOpenTofu', kind: 'LATEST', verdict: 'FAILS-CLOSED' },
     { file: TF, fn: 'downloadZipFromOpenTofu', kind: 'ACQUIRE', verdict: 'VERIFIED' },
@@ -109,8 +115,8 @@ const SITE_ROWS: SiteRow[] = [
     { file: PA, fn: 'verifyMirrorChecksum', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
     { file: PA, fn: 'downloadTo', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
     { file: PA, fn: 'downloadFromMirrorUrl', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
-    { file: PA, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
-    { file: PA, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
+    { file: PA_TI, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
+    { file: PA_TI, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
 
     // ---------------- TerraformDocsInstallerV1: sha256 only, no signature ----------
     { file: TD, fn: 'downloadTerraformDocs', kind: 'CACHE-ADMIT', verdict: 'REVERIFIES-AND-GATES' },
@@ -124,8 +130,8 @@ const SITE_ROWS: SiteRow[] = [
     { file: TD, fn: 'verifyChecksumOrSkip', kind: 'VERIFY', verdict: 'DISCARDS-ON-FAILURE' },
     { file: TD, fn: 'downloadTo', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
     { file: TD, fn: 'downloadFromMirrorUrl', kind: 'ACQUIRE', verdict: 'EXEMPT-DELEGATES-TO-CALLER' },
-    { file: TD, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
-    { file: TD, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
+    { file: TD_TI, fn: 'writeCacheIntegrityMarker', kind: 'RECORD-WRITE', verdict: 'ATOMIC-WRITE' },
+    { file: TD_TI, fn: 'verifyCachedTool', kind: 'RECORD-READ', verdict: 'VALIDATES-RECORD' },
 ];
 
 // --- Table B: the cache-integrity marker's edge states ----------------------
@@ -403,5 +409,98 @@ describe('artifact trust (class test #65/#78/#136/#198/#204)', function () {
                 }
             });
         }
+    });
+
+    describe('D. cross-file CACHE-ADMIT resolution is not over-widened (#998)', () => {
+        // Proves scripts/check-artifact-trust.js resolving names imported from a
+        // sibling module (so writeCacheIntegrityMarker/verifyCachedTool could move
+        // into tool-integrity.ts without blinding the gate) did not also make it
+        // stop catching a GENUINELY blind cache admission. Two synthetic files a
+        // real installer's shape, minus everything not needed for the classification:
+        // one whose CACHE-ADMIT function calls a reader imported from a sibling (the
+        // capability this issue added) and re-verifies, one whose CACHE-ADMIT
+        // function calls nothing at all (still blind, must still fail). A third
+        // sibling carries the 64-hex validator pattern the reader imports rather than
+        // declares itself, proving hexConsts resolves across the same import too.
+        let dir: string;
+
+        beforeEach(() => {
+            dir = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-trust-crossfile-'));
+            fs.mkdirSync(path.join(dir, 'src'));
+            fs.writeFileSync(path.join(dir, 'src', 'hex-pattern.ts'),
+                `export const MARKER_HEX_PATTERN = /^[a-fA-F0-9]{64}$/;\n`);
+            fs.writeFileSync(path.join(dir, 'src', 'reader.ts'), [
+                `import * as fs from 'fs';`,
+                `import { MARKER_HEX_PATTERN } from './hex-pattern';`,
+                ``,
+                `export function verifyMarker(markerPath: string, expected: string): boolean {`,
+                `    const stored = fs.readFileSync(markerPath, 'utf8');`,
+                `    if (!MARKER_HEX_PATTERN.test(stored)) return false;`,
+                `    return stored === expected;`,
+                `}`,
+                ``,
+                `export function writeMarker(markerPath: string, digestValue: string): void {`,
+                `    const tmp = markerPath + '.tmp';`,
+                `    fs.writeFileSync(tmp, digestValue);`,
+                `    fs.renameSync(tmp, markerPath);`,
+                `}`,
+                ``,
+            ].join('\n'));
+            fs.writeFileSync(path.join(dir, 'src', 'admit-crossfile.ts'), [
+                `import { verifyMarker, writeMarker } from './reader';`,
+                ``,
+                `export async function downloadWithCrossFileReverify(markerPath: string, expected: string): Promise<void> {`,
+                `    const cached = findLocalTool('thing', '1.0.0');`,
+                `    if (cached) {`,
+                `        const verified = verifyMarker(markerPath, expected);`,
+                `        if (verified) {`,
+                `            writeMarker(markerPath, expected);`,
+                `        }`,
+                `    }`,
+                `}`,
+                ``,
+            ].join('\n'));
+            fs.writeFileSync(path.join(dir, 'src', 'admit-blind.ts'), [
+                `export async function downloadBlindly(): Promise<void> {`,
+                `    const cached = findLocalTool('other-thing', '2.0.0');`,
+                `    if (cached) {`,
+                `        // no re-verification of any kind`,
+                `    }`,
+                `}`,
+                ``,
+            ].join('\n'));
+        });
+        afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+        function siteFor(fnName: string) {
+            let stdout: string;
+            try {
+                stdout = execFileSync(
+                    process.execPath,
+                    [path.join(REPO_ROOT, 'scripts/check-artifact-trust.js'), dir, '--json'],
+                    { encoding: 'utf8' },
+                );
+            } catch (err) {
+                // The blind fixture is EXPECTED to fail the gate (exit 1) — that is
+                // what this test is proving still happens. Only the JSON on stdout
+                // matters here, same as Table A above.
+                stdout = String((err as { stdout?: string }).stdout ?? '');
+                assert.ok(stdout.trim().startsWith('{'), `signature produced no JSON: ${String(err)}`);
+            }
+            const report = JSON.parse(stdout) as { sites: Array<{ fn: string; kind: string; verdict: string }> };
+            return report.sites.find((s) => s.fn === fnName && s.kind === 'CACHE-ADMIT');
+        }
+
+        it('still reports TRUSTS-CACHE-BLINDLY for a cache-admit site with no reverification at all', () => {
+            const site = siteFor('downloadBlindly');
+            assert.strictEqual(site?.verdict, 'TRUSTS-CACHE-BLINDLY',
+                'cross-file resolution must not exonerate a site that calls no reader, local or imported');
+        });
+
+        it('reports REVERIFIES-AND-GATES when the reader/writer are imported from a sibling file', () => {
+            const site = siteFor('downloadWithCrossFileReverify');
+            assert.strictEqual(site?.verdict, 'REVERIFIES-AND-GATES',
+                'a cache-admit site that calls an imported reader and gates an imported writer on its result must not read as blind merely because the pair live in another file');
+        });
     });
 });

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -11,10 +11,10 @@ import { verifyGpgSignature } from './gpg-verifier';
 import { verifyCosignSignature } from './cosign-verifier';
 import { retryAsync, parseAllowedHosts, assertEgressHostAllowed, EgressHostMessages, validateUrlPathSegment, VerificationFailure, isVerificationFailure, discardArtifactOnFailure, extractUrlTokenSecrets, redactUrl, scrubSecretsFromMessage, redactUrlUserInfo } from '@4cloudguru/pipeline-task-core';
 import { maskOperatorUrlCredentials, resolveVersionFromRegistry } from './registry-version-resolver';
-import { getPlatformString, hashFile, verifySha256 } from './tool-integrity';
+import { getPlatformString, hashFile, verifySha256, writeCacheIntegrityMarker, verifyCachedTool } from './tool-integrity';
 // Re-exported so this module's public surface is unchanged by the move to the
 // shared copy: existing importers and tests keep resolving them here (#996).
-export { getPlatformString, verifySha256 } from './tool-integrity';
+export { getPlatformString, verifySha256, writeCacheIntegrityMarker, verifyCachedTool } from './tool-integrity';
 
 // The package does not import the ADO task lib, so the discard's log line is wired here.
 const discardLog = { debug: (message: string) => tasks.debug(message) };
@@ -40,15 +40,6 @@ const MIRROR_EGRESS_MESSAGES: EgressHostMessages = {
 const terraformToolName = "terraform";
 const tofuToolName = "tofu";
 const isWindows = os.type().match(/^Win/);
-
-// File name of the local, per-cached-tool-directory integrity marker written after
-// a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
-const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
-
-// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
-// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
-// was tampered with; see verifyCachedTool (#198).
-const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 /**
  * Bounded retry for the binary download itself (#78): tools.downloadTool performs a
@@ -444,80 +435,6 @@ export function parseSha256(sha256SumsContent: string, zipFileName: string): str
     // typed as a verification failure so the cache-hit re-verification path
     // fails closed instead of degrading to "material unavailable".
     throw new VerificationFailure(`SHA256 checksum not found for ${zipFileName}`);
-}
-
-/**
- * Writes a local integrity marker recording the SHA256 of the just-verified,
- * just-cached executable, so a later job's cache hit for the same tool/version can
- * re-verify it (see verifyCachedTool) without re-downloading anything. Best-effort:
- * a write failure must never fail an install that has already been verified — it
- * only means a future cache hit for this tool degrades to the pre-existing
- * trust-the-cache behavior.
- */
-export async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
-    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
-    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
-    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
-    // a container kill -- leaves a marker that exists and is readable but is empty or
-    // truncated, and every later install of that version then compares the real digest
-    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
-    // permanently bricking the version on that agent (#198). Renaming into place means
-    // a reader only ever sees a complete digest or no marker at all.
-    const tempPath = `${markerPath}.${uuidV4()}.tmp`;
-    try {
-        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
-        fs.renameSync(tempPath, markerPath);
-    } catch (err) {
-        tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
-        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
-    }
-}
-
-/**
- * On a tool-cache hit, re-verifies the cached executable against the local
- * integrity marker written when it was originally downloaded and verified. This is
- * a purely local, offline comparison (no network call), so it can never break
- * offline/air-gapped cache usage.
- *
- * - No marker (cached before this check existed, or cached by a run where checksum
- *   verification was disabled): returns false — the caller escalates to a remote
- *   re-verification against a freshly downloaded release (see
- *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
- * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
- *   an interrupted write (#198): returns false, exactly like a missing marker. An
- *   unverifiable record is not evidence of tampering; feeding the fragment to the
- *   comparison would fail every subsequent install of that version with a
- *   tampering-shaped error and send an operator down a security-incident path for
- *   what is a torn file. The marker is NOT healed here — healing happens only after
- *   the escalated re-verification actually proves the cached executable.
- * - Marker present and it matches the cached executable's current hash: passes
- *   silently, returns true.
- * - Marker present, well-formed, and it does not match: the cached executable changed
- *   since it was verified (tampering or corruption on a shared agent) — fail closed.
- *
- * Trust-boundary note: the marker lives next to the executable it protects, so an
- * attacker who can rewrite the cached binary under the agent account can rewrite
- * the marker to match. This check is defense-in-depth against corruption and
- * cross-job verification-policy mixing, not against an attacker who already has
- * write access to the agent's tool cache (who effectively owns the agent).
- */
-export async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
-    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
-    if (!fs.existsSync(markerPath)) {
-        tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
-        return false;
-    }
-    const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
-    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
-        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
-        return false;
-    }
-    const actualHash = (await hashFile(exePath)).toLowerCase();
-    if (actualHash !== storedHash) {
-        throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
-    }
-    tasks.debug(`Cache hit for ${toolLabel}: integrity marker verified (${actualHash}).`);
-    return true;
 }
 
 /**

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/tool-integrity.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/tool-integrity.ts
@@ -1,7 +1,7 @@
 /**
- * The hashing and platform primitives shared by the three installer tasks
- * (TerraformInstallerV1, PolicyAgentInstallerV1, TerraformDocsInstallerV1):
- * computing an artifact's SHA256 and comparing it to a published checksum.
+ * The hashing, platform and cache-integrity primitives shared by the three
+ * installer tasks (TerraformInstallerV1, PolicyAgentInstallerV1,
+ * TerraformDocsInstallerV1).
  *
  * Kept byte-identical across all three tasks' `src/` directories and guarded by
  * scripts/check-shared-modules.js. Each of these bodies was previously
@@ -17,24 +17,31 @@
  * terraform-docs-installer.ts were never compared to one another. Extracting
  * them into one same-named module is what brings them into reach of both.
  *
- * DELIBERATELY NOT HERE: writeCacheIntegrityMarker and verifyCachedTool, which
- * are byte-identical in all three installers too and by rights belong beside
- * these. They cannot move yet. scripts/check-artifact-trust.js classifies a
- * CACHE-ADMIT site by resolving the call graph WITHIN A SINGLE FILE -- its
- * `recordReaders` set is built from that file's own top-level functions, and the
- * 64-hex marker validator it looks for must be a module-scope const in that same
- * file. Moving the pair out makes all four cache-admission sites report
- * TRUSTS-CACHE-BLINDLY even though the re-verification still happens: that is,
- * de-duplicating them would blind the signature that guards them. Teaching that
- * gate to follow same-directory imports is its own change, tracked separately.
+ * writeCacheIntegrityMarker and verifyCachedTool moved in last (#998):
+ * scripts/check-artifact-trust.js used to classify a CACHE-ADMIT site by
+ * resolving the call graph within a single file, so moving this pair out on its
+ * own would have made every cache-admission site in the three callers report
+ * TRUSTS-CACHE-BLINDLY even though the re-verification still happens. That gate
+ * now follows same-directory `import`s (see its own header comment), so the pair
+ * can live here with the primitives it is built on.
  */
 
 import tasks = require('azure-pipelines-task-lib/task');
 import os = require('os');
 import fs = require('fs');
+import path = require('path');
 import crypto = require('crypto');
 import { pipeline } from 'stream/promises';
 import { VerificationFailure } from '@4cloudguru/pipeline-task-core';
+
+// File name of the local, per-cached-tool-directory integrity marker written after
+// a verified download (see writeCacheIntegrityMarker / verifyCachedTool below).
+const CACHE_INTEGRITY_MARKER = ".installer-verified.sha256";
+
+// A marker's content must be exactly one 64-character SHA256 digest. Anything else --
+// empty, truncated, or non-hex -- means the marker is UNVERIFIABLE, not that the tool
+// was tampered with; see verifyCachedTool (#198).
+const CACHE_INTEGRITY_MARKER_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 export function getPlatformString(): string {
     switch (os.type()) {
@@ -61,4 +68,78 @@ export async function verifySha256(filePath: string, expectedHash: string): Prom
         throw new VerificationFailure(tasks.loc("Sha256VerificationFailed", expectedHash, actualHash));
     }
     tasks.debug(`SHA256 verification passed: ${actualHash}`);
+}
+
+/**
+ * Writes a local integrity marker recording the SHA256 of the just-verified,
+ * just-cached executable, so a later job's cache hit for the same tool/version can
+ * re-verify it (see verifyCachedTool) without re-downloading anything. Best-effort:
+ * a write failure must never fail an install that has already been verified — it
+ * only means a future cache hit for this tool degrades to the pre-existing
+ * trust-the-cache behavior.
+ */
+export async function writeCacheIntegrityMarker(toolDir: string, exePath: string): Promise<void> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    // ATOMIC: write to a temp name in the SAME directory, then rename into place. A
+    // plain writeFileSync interrupted mid-write -- agent disk full, job cancellation,
+    // a container kill -- leaves a marker that exists and is readable but is empty or
+    // truncated, and every later install of that version then compares the real digest
+    // against that fragment and fails with a tampering-shaped CachedToolVerificationFailed,
+    // permanently bricking the version on that agent (#198). Renaming into place means
+    // a reader only ever sees a complete digest or no marker at all.
+    const tempPath = `${markerPath}.${crypto.randomUUID()}.tmp`;
+    try {
+        fs.writeFileSync(tempPath, await hashFile(exePath), 'utf8');
+        fs.renameSync(tempPath, markerPath);
+    } catch (err) {
+        tasks.debug(`Could not write cache integrity marker for ${toolDir}: ${err instanceof Error ? err.message : err}`);
+        try { fs.unlinkSync(tempPath); } catch { /* best effort */ }
+    }
+}
+
+/**
+ * On a tool-cache hit, re-verifies the cached executable against the local
+ * integrity marker written when it was originally downloaded and verified. This is
+ * a purely local, offline comparison (no network call), so it can never break
+ * offline/air-gapped cache usage.
+ *
+ * - No marker (cached before this check existed, or cached by a run where checksum
+ *   verification was disabled): returns false — the caller escalates to a remote
+ *   re-verification against a freshly downloaded release (see
+ *   reverifyUnmarkedCacheEntry), closing the cross-job trust-on-first-use gap.
+ * - Marker present but MALFORMED — empty, truncated, or not 64 hex characters, i.e.
+ *   an interrupted write (#198): returns false, exactly like a missing marker. An
+ *   unverifiable record is not evidence of tampering; feeding the fragment to the
+ *   comparison would fail every subsequent install of that version with a
+ *   tampering-shaped error and send an operator down a security-incident path for
+ *   what is a torn file. The marker is NOT healed here — healing happens only after
+ *   the escalated re-verification actually proves the cached executable.
+ * - Marker present and it matches the cached executable's current hash: passes
+ *   silently, returns true.
+ * - Marker present, well-formed, and it does not match: the cached executable changed
+ *   since it was verified (tampering or corruption on a shared agent) — fail closed.
+ *
+ * Trust-boundary note: the marker lives next to the executable it protects, so an
+ * attacker who can rewrite the cached binary under the agent account can rewrite
+ * the marker to match. This check is defense-in-depth against corruption and
+ * cross-job verification-policy mixing, not against an attacker who already has
+ * write access to the agent's tool cache (who effectively owns the agent).
+ */
+export async function verifyCachedTool(toolDir: string, exePath: string, toolLabel: string): Promise<boolean> {
+    const markerPath = path.join(toolDir, CACHE_INTEGRITY_MARKER);
+    if (!fs.existsSync(markerPath)) {
+        tasks.debug(`Cache hit for ${toolLabel}: no stored integrity marker found (cached before this check existed, or without checksum verification).`);
+        return false;
+    }
+    const storedHash = fs.readFileSync(markerPath, 'utf8').trim().toLowerCase();
+    if (!CACHE_INTEGRITY_MARKER_PATTERN.test(storedHash)) {
+        tasks.debug(`Cache hit for ${toolLabel}: the stored integrity marker is not a 64-character SHA256 digest (${storedHash.length} character(s) recorded); treating the entry as unverifiable rather than tampered.`);
+        return false;
+    }
+    const actualHash = (await hashFile(exePath)).toLowerCase();
+    if (actualHash !== storedHash) {
+        throw new Error(tasks.loc("CachedToolVerificationFailed", toolLabel, storedHash, actualHash));
+    }
+    tasks.debug(`Cache hit for ${toolLabel}: integrity marker verified (${actualHash}).`);
+    return true;
 }

--- a/scripts/check-artifact-trust.js
+++ b/scripts/check-artifact-trust.js
@@ -241,6 +241,33 @@ function blockAfter(fnText, index) {
     return fnText.slice(open);
 }
 
+/**
+ * `import { a, b as c } from './x'` and the `export { a, b } from './x'` re-export
+ * form — same-directory-tree relative specifiers only, since those are the only
+ * ones a sibling top-level function can resolve to. Read off the UNMASKED source
+ * (the specifier is a string literal, blanked out in the masked text). Returns
+ * Map<localName, {importedName, specifier}>.
+ */
+function parseRelativeImports(source) {
+    const out = new Map();
+    const re = /(?:import|export)\s*\{([^}]*)\}\s*from\s*['"](\.[^'"]*)['"]/g;
+    let m;
+    while ((m = re.exec(source)) !== null) {
+        for (const raw of m[1].split(',').map((s) => s.trim()).filter(Boolean)) {
+            const [importedName, aliasName] = raw.split(/\s+as\s+/).map((s) => s.trim());
+            out.set(aliasName || importedName, { importedName, specifier: m[2] });
+        }
+    }
+    return out;
+}
+
+/** Resolves a relative import specifier from `fromFile` to one of `files`, or null. */
+function resolveImportFile(fromFile, specifier, files) {
+    let resolved = path.resolve(path.dirname(fromFile), specifier);
+    if (!files.includes(resolved)) resolved += '.ts';
+    return files.includes(resolved) ? resolved : null;
+}
+
 const files = walk(ROOT);
 if (files.length === 0) {
     console.error(`FAIL: no **/src/**/*.ts files found under ${ROOT} — the signature would pass vacuously.`);
@@ -248,6 +275,19 @@ if (files.length === 0) {
 }
 
 const sites = [];
+// Per-file state kept around after the phase 1/2 pass so the phase 3 (CACHE-ADMIT)
+// pass below can resolve names across a same-directory `import`, once every
+// file's RECORD-READ/RECORD-WRITE sites are known — see #998.
+const fileStates = [];
+// Module-scope 64-hex validator names, keyed by resolved absolute file path — read
+// once per file even when several siblings import from the same one.
+const hexConstsByFile = new Map();
+function hexConstsOf(absPath, maskedText) {
+    if (!hexConstsByFile.has(absPath)) {
+        hexConstsByFile.set(absPath, [...maskedText.matchAll(/(?:const|let)\s+(\w+)\s*(?::[^=]+)?=\s*(\/[^/\n]*\{64\}[^/\n]*\/[a-z]*)/g)].map((m) => m[1]));
+    }
+    return hexConstsByFile.get(absPath);
+}
 
 for (const file of files) {
     const source = fs.readFileSync(file, 'utf8');
@@ -260,10 +300,27 @@ for (const file of files) {
 
     const byName = new Map(fns.filter((f) => f.name !== '<anonymous>').map((f) => [f.name, f]));
     const definedNames = [...byName.keys()];
-    const graph = new Map(fns.map((f) => [f.name, calleesOf(f.text, definedNames)]));
+
+    // Names imported from a same-directory-tree sibling resolve to that sibling's
+    // OWN top-level functions (#998) — a call to one is a real graph edge, and its
+    // RECORD-READ/RECORD-WRITE classification (established when ITS file is walked)
+    // must count here too, not just when the call happens to stay in one file.
+    const imports = parseRelativeImports(source);
+    const importedNames = [...imports.keys()];
+    const graph = new Map(fns.map((f) => [f.name, calleesOf(f.text, [...definedNames, ...importedNames])]));
 
     // 64-hex validators declared at module scope, e.g. `const SHA256_HEX_PATTERN = /^[a-fA-F0-9]{64}$/;`
-    const hexConsts = [...masked.matchAll(/(?:const|let)\s+(\w+)\s*(?::[^=]+)?=\s*(\/[^/\n]*\{64\}[^/\n]*\/[a-z]*)/g)].map((m) => m[1]);
+    // — plus the same, declared beside a validator this file imports instead of
+    // defining locally, so a validator living next to its (now-shared) reader still
+    // counts (#998).
+    const hexConsts = [
+        ...hexConstsOf(file, masked),
+        ...[...imports.values()].flatMap(({ specifier }) => {
+            const resolved = resolveImportFile(file, specifier, files);
+            if (!resolved) return [];
+            return hexConstsOf(resolved, maskCommentsAndStrings(fs.readFileSync(resolved, 'utf8')));
+        }),
+    ];
     const validatesHex = (fnText) =>
         /\/\^?\[[^\]]*a-f[^\]]*\]\{64\}\$?\/[a-z]*\s*\.test\s*\(/i.test(fnText)
         || hexConsts.some((name) => new RegExp(`\\b${name}\\s*\\.test\\s*\\(`).test(fnText));
@@ -284,8 +341,12 @@ for (const file of files) {
 
     // Phases: sites discovered later depend on classifications made earlier
     // (a cache-admit verdict needs to know which functions read/write the
-    // integrity record), so the same function set is walked three times.
-    for (const phase of [1, 2, 3]) for (const fn of fns) {
+    // integrity record), so the same function set is walked twice here. Phase 3
+    // (CACHE-ADMIT) runs in its own pass below, once every file's RECORD-READ/
+    // RECORD-WRITE sites are known — it is the one phase that can reach across a
+    // same-directory `import` (#998), so it cannot run until the classifications
+    // it depends on exist for every file, not just the one being walked right now.
+    for (const phase of [1, 2]) for (const fn of fns) {
         if (fn.name === '<anonymous>') continue;
         const reach = closure(fn.name, graph);
         const reaches = (names) => names.some((n) =>
@@ -417,34 +478,6 @@ for (const file of files) {
             }
         } // end phase 2
 
-        // ---------------- CACHE-ADMIT ----------------
-        if (phase === 3) for (const call of callIndices(fn.text, CACHE_LOOKUP)) {
-            const recordReaders = [...byName.keys()].filter((n) =>
-                sites.some((s) => s.rel === rel && s.fn === n && s.kind === 'RECORD-READ'));
-            const reverifies = recordReaders.some((n) => reach.has(n));
-            const writerNames = [...byName.keys()].filter((n) =>
-                sites.some((s) => s.rel === rel && s.fn === n && s.kind === 'RECORD-WRITE'));
-            const writerCalls = writerNames.flatMap((n) => callIndices(fn.text, n));
-            const gated = writerCalls.every((w) => VERIFIED_STATUS.test(enclosingConditionText(fn.text, w.index)));
-            // "There is no record for this cache entry" is a THIRD outcome,
-            // distinct from verified and from mismatched. The reader must hand it
-            // back and the admit site must act on it; a call whose result is
-            // thrown away silently admits an entry nothing ever verified (#136).
-            const consumesVerdict = recordReaders.some((n) =>
-                new RegExp(`(?:const|let|var)\\s+\\w+\\s*(?::[^=]+)?=\\s*(?:await\\s+)?${n}\\s*\\(`).test(fn.text));
-            const verdict = !reverifies ? 'TRUSTS-CACHE-BLINDLY'
-                : !consumesVerdict ? 'TRUSTS-UNMARKED-CACHE'
-                    : !gated ? 'RECORDS-UNVERIFIED'
-                        : 'REVERIFIES-AND-GATES';
-            const WHY = {
-                'REVERIFIES-AND-GATES': 'a cache hit is re-verified against the recorded marker, an unmarked entry is escalated, and a marker is only recorded for an artifact that was actually verified',
-                'TRUSTS-CACHE-BLINDLY': 'a cache hit is used with no re-verification of any kind (#136)',
-                'TRUSTS-UNMARKED-CACHE': 'the re-verification result is discarded, so a cache entry with NO integrity record is admitted with no verification at all (#136)',
-                'RECORDS-UNVERIFIED': 'an integrity marker is recorded even when the fresh download was never verified, so a later cache hit "verifies" an unverified binary (#136)',
-            };
-            add('CACHE-ADMIT', fn, verdict, WHY[verdict], fn.start + call.index);
-        }
-
         // ---------------- LATEST resolution ----------------
         const resolvesLatest = /['"]latest['"]/i.test(fn.raw)
             && /toLowerCase\s*\(\s*\)\s*(?:!==|===)/.test(fn.text)
@@ -461,6 +494,61 @@ for (const file of files) {
                     ? 'an unreachable version endpoint silently installs a pinned, potentially stale version instead of failing (#78)'
                     : 'an unresolvable "latest" fails the task instead of silently installing a pinned stale version',
                 fn.start + fn.text.indexOf('catch'));
+        }
+    }
+
+    fileStates.push({ file, rel, fns, byName, graph, imports, lineOf });
+}
+
+// ---------------- CACHE-ADMIT (own pass — see #998) ----------------
+// Runs only after every file above has contributed its RECORD-READ/RECORD-WRITE
+// sites, and resolves recordReaders/writerNames across a same-directory `import`
+// exactly as it would within one file: a name is a candidate either because this
+// file defines it, or because this file imports it from a sibling that does —
+// either way, what matters is whether THAT name's own site (wherever it lives)
+// was classified as a marker reader/writer.
+for (const { file, rel, fns, byName, graph, imports, lineOf } of fileStates) {
+    // Every name this file can call and have it resolve to a real definition:
+    // its own top-level functions (defined here), plus whatever it imports from a
+    // sibling — each tagged with the file its RECORD-READ/RECORD-WRITE site (if
+    // any) would actually be recorded under.
+    const resolvable = [
+        ...[...byName.keys()].map((name) => ({ callName: name, defRel: rel, defName: name })),
+        ...[...imports.entries()].map(([callName, { importedName, specifier }]) => {
+            const resolved = resolveImportFile(file, specifier, files);
+            if (!resolved) return null;
+            return { callName, defRel: path.relative(ROOT, resolved).split(path.sep).join('/'), defName: importedName };
+        }).filter(Boolean),
+    ];
+    const sitesOf = (kind) => resolvable.filter(({ defRel, defName }) =>
+        sites.some((s) => s.rel === defRel && s.fn === defName && s.kind === kind));
+
+    for (const fn of fns) {
+        if (fn.name === '<anonymous>') continue;
+        const reach = closure(fn.name, graph);
+        for (const call of callIndices(fn.text, CACHE_LOOKUP)) {
+            const recordReaders = sitesOf('RECORD-READ');
+            const reverifies = recordReaders.some((r) => reach.has(r.callName));
+            const writerNames = sitesOf('RECORD-WRITE');
+            const writerCalls = writerNames.flatMap((r) => callIndices(fn.text, r.callName));
+            const gated = writerCalls.every((w) => VERIFIED_STATUS.test(enclosingConditionText(fn.text, w.index)));
+            // "There is no record for this cache entry" is a THIRD outcome,
+            // distinct from verified and from mismatched. The reader must hand it
+            // back and the admit site must act on it; a call whose result is
+            // thrown away silently admits an entry nothing ever verified (#136).
+            const consumesVerdict = recordReaders.some((r) =>
+                new RegExp(`(?:const|let|var)\\s+\\w+\\s*(?::[^=]+)?=\\s*(?:await\\s+)?${r.callName}\\s*\\(`).test(fn.text));
+            const verdict = !reverifies ? 'TRUSTS-CACHE-BLINDLY'
+                : !consumesVerdict ? 'TRUSTS-UNMARKED-CACHE'
+                    : !gated ? 'RECORDS-UNVERIFIED'
+                        : 'REVERIFIES-AND-GATES';
+            const WHY = {
+                'REVERIFIES-AND-GATES': 'a cache hit is re-verified against the recorded marker, an unmarked entry is escalated, and a marker is only recorded for an artifact that was actually verified',
+                'TRUSTS-CACHE-BLINDLY': 'a cache hit is used with no re-verification of any kind (#136)',
+                'TRUSTS-UNMARKED-CACHE': 'the re-verification result is discarded, so a cache entry with NO integrity record is admitted with no verification at all (#136)',
+                'RECORDS-UNVERIFIED': 'an integrity marker is recorded even when the fresh download was never verified, so a later cache hit "verifies" an unverified binary (#136)',
+            };
+            sites.push({ kind: 'CACHE-ADMIT', rel, fn: fn.name, verdict, why: WHY[verdict], line: lineOf(fn.start + call.index) });
         }
     }
 }


### PR DESCRIPTION
## Summary

scripts/check-artifact-trust.js classified a CACHE-ADMIT site by resolving its call graph **within a single file** — ecordReaders/writerNames were built from that file's own top-level functions, and the 64-hex marker validator it looked for had to be a module-scope const in that same file. That meant de-duplicating writeCacheIntegrityMarker/erifyCachedTool into the shared 	ool-integrity.ts (#996) would blind the signature that guards them — exactly the reason 	ool-integrity.ts carried a comment explaining why that pair could not move.

## What changed

- The phase-3 (CACHE-ADMIT) walk now runs in its own pass, after every file's RECORD-READ/RECORD-WRITE sites are known across the whole repo. A candidate reader/writer name resolves either to the current file (if defined locally) or to whatever file it's imported from via a same-directory `import { x } from './y'`/`export { x } from './y'`. hexConsts resolves the same way.
- writeCacheIntegrityMarker and erifyCachedTool now live in 	ool-integrity.ts (byte-identical across all three installers, guarded by check-shared-modules.js), removing the last hand-duplicated pair on the artifact-cache path. Each installer re-exports them alongside the existing getPlatformString/erifySha256 re-export, so existing imports (including the shared class test) are unaffected.
- Tests/ArtifactTrustL0.ts gained a synthetic two-file fixture proving the cross-file resolution is not over-widened: a cache-admit site that calls nothing still reports TRUSTS-CACHE-BLINDLY, and one that calls an imported reader/writer pair reports REVERIFIES-AND-GATES.

## Testing

- TerraformInstallerV1: 433 passing
- PolicyAgentInstallerV1: 264 passing
- TerraformDocsInstallerV1: 246 passing
- `npm run lint` clean in all three
- `node scripts/check-shared-modules.js` — all families OK, including the now-larger `tool-integrity.ts` family
- `node scripts/check-near-duplicate-modules.js` — no new findings (pre-existing unrelated local-only findings come from untracked scratch files, not from this change)
- `node scripts/check-artifact-trust.js` — zero residual instances of the class

Fixes #998.
