### PR TITLE
fix(gates): report how many source files were read, not just what was found

### DIFF
--- a/scripts/auth-parity-matrix.cjs
+++ b/scripts/auth-parity-matrix.cjs
@@ -62,11 +62,17 @@ const ROOT = path.resolve(argv.find((a) => !a.startsWith('--')) || process.cwd()
 
 // --- discovery -------------------------------------------------------------
 
-/** Every `*-command-handler.ts` under any Tasks/<task>/<version>/src directory. */
+/**
+ * Every `*-command-handler.ts` under any Tasks/<task>/<version>/src directory,
+ * and the count of `.ts` files that population was filtered out of. That count
+ * is the denominator: without it, "this repo has no auth handlers" and "this
+ * walk started at the wrong directory" are the same answer.
+ */
 function discoverHandlers(root) {
     const found = [];
+    let scanned = 0;
     const tasksDir = path.join(root, 'Tasks');
-    if (!fs.existsSync(tasksDir)) return found;
+    if (!fs.existsSync(tasksDir)) return { found, scanned };
     const walk = (dir, depth) => {
         if (depth > 6) return;
         let entries;
@@ -75,13 +81,14 @@ function discoverHandlers(root) {
             if (e.name === 'node_modules' || e.name === '.git') continue;
             const full = path.join(dir, e.name);
             if (e.isDirectory()) walk(full, depth + 1);
-            else if (e.isFile() && /-command-handler\.ts$/.test(e.name) && path.basename(dir) === 'src') {
-                found.push(full);
+            else if (e.isFile() && path.basename(dir) === 'src' && e.name.endsWith('.ts') && !e.name.endsWith('.d.ts')) {
+                scanned += 1;
+                if (/-command-handler\.ts$/.test(e.name)) found.push(full);
             }
         }
     };
     walk(tasksDir, 0);
-    return found.sort();
+    return { found: found.sort(), scanned };
 }
 
 // --- lexing helpers --------------------------------------------------------
@@ -514,7 +521,7 @@ function analyzeHandler(file, root) {
 
 // --- run -------------------------------------------------------------------
 
-const handlers = discoverHandlers(ROOT);
+const { found: handlers, scanned } = discoverHandlers(ROOT);
 let cells = [];
 for (const f of handlers) cells = cells.concat(analyzeHandler(f, ROOT));
 
@@ -530,9 +537,9 @@ cells = [...bySite.values()].sort((a, b) => (a.file + a.site).localeCompare(b.fi
 const unguarded = cells.filter((c) => c.verdict === 'UNGUARDED');
 
 if (AS_JSON) {
-    console.log(JSON.stringify({ root: ROOT, handlerFiles: handlers.length, cells, unguarded: unguarded.length }, null, 2));
+    console.log(JSON.stringify({ root: ROOT, handlerFiles: handlers.length, scanned, cells, unguarded: unguarded.length }, null, 2));
 } else if (!QUIET) {
-    console.log(`auth-parity-matrix: ${handlers.length} handler file(s) under ${ROOT}`);
+    console.log(`auth-parity-matrix: ${handlers.length} handler file(s) under ${ROOT}, out of ${scanned} source file(s) read`);
     console.log('');
     const w = (s, n) => String(s).padEnd(n).slice(0, n);
     console.log(`${w('HANDLER', 9)} ${w('BRANCH', 30)} ${w('FIELD/CELL', 26)} ${w('VERDICT', 9)} ${w('LINE', 5)} DETAIL`);

--- a/scripts/check-artifact-trust.js
+++ b/scripts/check-artifact-trust.js
@@ -577,7 +577,7 @@ const unique = sites.filter((s) => {
 const failures = unique.filter((s) => FAIL_VERDICTS.has(s.verdict));
 
 if (JSON_OUTPUT) {
-    console.log(JSON.stringify({ root: ROOT, sites: unique, failures: failures.length }, null, 2));
+    console.log(JSON.stringify({ root: ROOT, sites: unique, failures: failures.length, scanned: files.length }, null, 2));
     process.exit(failures.length > 0 ? 1 : 0);
 }
 


### PR DESCRIPTION
Both in-repo gates report what they found and nothing about how far they looked. That makes an empty result unreadable: *"this repo has none of that thing"* and *"this walk started at the wrong directory"* produce byte-identical output.

The ambiguity is load-bearing rather than cosmetic. The suite signature replay treats an empty universe as a **gate error** precisely because it cannot tell those two apart — and its own message already prescribes the remedy:

> An empty universe is how a hard-coded path fails silently. Zero sites for a repo is a red flag, not a pass. **If the universe is genuinely empty here, report `scanned` (the count of source files read) so the difference between finding nothing and looking nowhere is on the record.**

So report it.

- `auth-parity-matrix.cjs` — `discoverHandlers` now counts the `src/*.ts` population it filters `*-command-handler.ts` out of, and returns it alongside the handlers. `.d.ts` excluded, matching the sibling gate's walk.
- `check-artifact-trust.js` — already had the number in hand as `files.length` (it hard-fails on `files.length === 0` for exactly this reason); it just was not emitting it. One field added to the JSON.

## No finding changes

Verified by running both gates before and after in all three extensions:

| repo | auth: handlers / scanned | cells | unguarded | trust: sites | failures | scanned |
|---|---|---|---|---|---|---|
| terraform | 7 / 98 | 62 | 0 | 59 | 0 | 117 |
| packer | 7 / 21 | 41 | 0 | 19 | 0 | 21 |
| release-docs | 0 / 28 | 0 | 0 | 0 | 0 | 28 |

Sites, cells and failure counts are unchanged. The only new information is the denominator — and the bottom row is the point: release-docs' universe is genuinely empty, and it can now *say* so with evidence that it looked at 28 files to find out. Previously that row was indistinguishable from a gate pointed at nothing.

The existing consumers are unaffected: `ArtifactTrustL0.ts` and `CredentialFailClosedMatrixL0.ts` read `sites`/`failures` and `cells`/`unguarded` through structural types, so an added field is inert to them.

## Why all three repos in lockstep

`auth-parity-matrix.cjs` is byte-identical across the three extensions and stays that way after this change. `check-artifact-trust.js` is *not* — terraform's copy is ahead of packer's and release-docs' (it carries the cross-file import resolution from #1003/#998). This change is applied identically to both variants and does not widen that gap, but the gap is real and is worth closing separately.
