### PR TITLE
chore(deps): bump the shared signature-replay to v1.14.0

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   replay:
-    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@9ed6d3c988fb075f1023680d92eb4cf5a8e55056 # v1.14.0
     # Exactly one secret, named. NOT `secrets: inherit`.
     secrets:
       SUITE_READ_APP_KEY: ${{ secrets.SUITE_READ_APP_KEY }}


### PR DESCRIPTION
Bumps the shared `signature-replay.yml` pin from `v1.13.0` to [`v1.14.0`](https://github.com/4cloudguru/shared-workflows/releases/tag/v1.14.0).

## What this picks up

**`fix(replay)`: a fork PR can now satisfy the required `replay` context.**

A fork run receives no secrets — not the Actions store, not the Dependabot one. `secrets.SUITE_READ_APP_KEY` resolved to the empty string, `create-github-app-token` failed, and the job went red before a single signature ran. `replay` being a required, merge-blocking context, that meant the same red for a clean external contribution as for a hostile one, with the admin bypass as the only way past — a gate that can only be overridden teaches overriding.

The `replay` job now carries a job-level condition and is skipped on fork PRs. GitHub counts `skipped` among the [successful check conclusions](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks), so the context becomes satisfiable rather than permanently unanswerable. The fork's code is still replayed — by this repo's `push: branches: [main]` trigger on merge and by the daily `schedule`. What moves is *when*.

**A missing key on a same-repository run still goes red.** The condition tests one fact — whether the head repo is this repo — and is deliberately neither `continue-on-error` nor a missing-key check, either of which would have swallowed the misconfigured case the gate exists for.

**`feat(hardening)`:** also carries the enforcement that a script-ref matches the `uses:` pin beside it.

## Verification

The change is upstream and this is a one-line pin move; the evidence for the behaviour is in [4cloudguru/shared-workflows#27](https://github.com/4cloudguru/shared-workflows/pull/27). The check to watch here is `replay / replay` staying green on this PR, which confirms the new pin resolves and the same-repo path is unchanged.
