### PR TITLE
chore(ci): normalise the Dependabot updater conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -13,7 +16,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
+      prefix: "chore(deps)"
     groups:
       # Minor/patch Action bumps are low-risk and numerous; batch them into one
       # PR so a solo maintainer isn't triaging dozens of near-identical bumps
@@ -26,6 +29,9 @@ updates:
     directory: "/Tasks/TerraformTask/TerraformTaskV5"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -34,8 +40,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       # Batch low-risk devDependency minor/patch bumps into one PR per task so
       # the moderate/low-severity triage path SECURITY.md describes stays
@@ -55,6 +60,9 @@ updates:
     directory: "/Tasks/TerraformInstaller/TerraformInstallerV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -63,8 +71,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -78,6 +85,9 @@ updates:
     directory: "/Tasks/TerraformProviderMirror/TerraformProviderMirrorV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -86,8 +96,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -101,6 +110,9 @@ updates:
     directory: "/Tasks/TerraformModulePublish/TerraformModulePublishV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -109,8 +121,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -124,6 +135,9 @@ updates:
     directory: "/Tasks/PolicyAgentInstaller/PolicyAgentInstallerV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -132,8 +146,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -147,6 +160,9 @@ updates:
     directory: "/Tasks/TerraformPolicyCheck/TerraformPolicyCheckV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -155,8 +171,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -170,6 +185,9 @@ updates:
     directory: "/Tasks/TerraformDriftReport/TerraformDriftReportV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -178,8 +196,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -193,6 +210,9 @@ updates:
     directory: "/Tasks/TerraformDocsInstaller/TerraformDocsInstallerV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -201,8 +221,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -216,6 +235,9 @@ updates:
     directory: "/Tasks/TerraformDocs/TerraformDocsV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -224,8 +246,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -239,6 +260,9 @@ updates:
     directory: "/Tasks/Markdown2Html/Markdown2HtmlV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -247,8 +271,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -262,6 +285,9 @@ updates:
     directory: "/Tasks/PublishKbArticle/PublishKbArticleV1"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -270,8 +296,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 10
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -285,6 +310,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "09:00"
+      timezone: UTC
     cooldown:
       default-days: 7
     allow:
@@ -293,8 +321,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 5
+      prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -333,7 +360,7 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore(deps)"
     groups:
       commit-message-check:
         patterns:


### PR DESCRIPTION
chore(ci): normalise the Dependabot updater conventions

`.github/dependabot.yml` cannot be shared -- it must live in each repository's
own `.github/`, there is no `uses:`-style include for it, and it is not one of
the files an org-level `.github` repository supplies defaults for. Every
convention in it is therefore duplicated 19 times by construction, and it had
drifted:

  commit-message.prefix     SIX variants (chore, chore(ci), chore(deps), deps,
                            ci(deps), build(deps)) plus two stanzas with none
  schedule                  a 36/36 split between bare `weekly` and
                            `weekly monday 09:00 UTC`
  open-pull-requests-limit  18 stanzas overriding the platform default
  groups                    11 stanzas with none, so one PR per dependency

Normalised to `chore(deps)`, `weekly monday 09:00 UTC`, no explicit
open-pull-requests-limit, and a group on every stanza.

NOT normalised, deliberately: the 16 groups that select by `dependency-type:
development` or `update-types: [minor, patch]` rather than `patterns`. Those are
NARROWER than `patterns: ["*"]`; rewriting them to a wildcard would widen what
they batch. The invariant is that a stanza groups its pull requests, not that it
groups them by pattern.

Also untouched: directories and `ignore` rules. 14 of 21 distinct directories
appear in exactly one repository and 33 of 72 stanzas carry repo-specific ignore
policy, so that half is irreducibly local -- centralising it would trade visible
duplication for the harder-to-see drift this estate already documents.

Changing the prefix is changelog-safe: no release-please config in the estate
declares changelog-sections for `ci`, `deps` or `chore`.

Rewritten with ruamel so comments survive; verified per repo that the file still
parses and the comment count is unchanged.