### PR TITLE
test(gates): forbid a pending test in the smoke suite too

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV5/package.json
+++ b/Tasks/TerraformTask/TerraformTaskV5/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run compile:all && mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
     "test:coverage": "npm run compile:all && nyc mocha --timeout 10000 --forbid-pending --require ts-node/register Tests/L0.ts",
-    "test:smoke": "npm run compile:all && mocha --timeout 60000 --require ts-node/register Tests/SmokeL0.ts",
+    "test:smoke": "npm run compile:all && mocha --timeout 60000 --forbid-pending --require ts-node/register Tests/SmokeL0.ts",
     "compile": "tsc -b tsconfig.json",
     "compile:tests": "tsc -p tsconfig.tests.json",
     "compile:all": "npm run compile && npm run compile:tests",


### PR DESCRIPTION
Every other mocha script in this repo runs with `--forbid-pending`; the V5 smoke suite was the one that did not. It is a required status check (`build-and-test-v5-smoke-gate`), so a test that went pending there would have reported as neither pass nor fail while the gate stayed green.

`SmokeL0.ts` has no conditional skips, no environment gating and no early returns today, so this catches nothing now and changes no result. It closes the hole before something needs it, and makes the rule uniform: every mocha invocation across the three extensions now forbids pending.

Where a smoke test genuinely does not apply to an environment, the pattern is the `return` guard #757 established, not `this.skip()`, which marks the test pending and is exactly what this flag rejects.

Companion to sethbacon/azure-pipelines-packer#322.